### PR TITLE
Add missing Ubuntu 14.04 dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ninja-build
 
 Installing required packages:
 ```
-sudo apt-get install libaio-dev ninja-build ragel libhwloc-dev libnuma-dev libpciaccess-dev libcrypto++-dev libboost-all-dev
+sudo apt-get install libaio-dev ninja-build ragel libhwloc-dev libnuma-dev libpciaccess-dev libcrypto++-dev libboost-all-dev libxen-dev libxml2-dev
 ```
 
 Installing GCC 4.9 for gnu++1y. Unlike the Fedora case above, this will


### PR DESCRIPTION
Added libxml2-dev and libxen-dev as Ubuntu 14.04 dependencies,
for consistency with the Fedora 21 dependencies.