### PR TITLE
Don't use std:size_t

### DIFF
--- a/core/function_traits.hh
+++ b/core/function_traits.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <tuple>
 
 template<typename T>
@@ -33,9 +34,9 @@ struct function_traits<Ret(Args...)>
     using args_as_tuple = std::tuple<Args...>;
     using signature = Ret (Args...);
  
-    static constexpr std::size_t arity = sizeof...(Args);
+    static constexpr size_t arity = sizeof...(Args);
  
-    template <std::size_t N>
+    template <size_t N>
     struct arg
     {
         static_assert(N < arity, "no such parameter index.");


### PR DESCRIPTION
Other files use size_t. They don't always include <stddef.h> btw.