### PR TITLE
Closing connection after handling (Fixes: Assertion `!_in_batch' failed)

### DIFF
--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1305,6 +1305,8 @@ public:
                     return conn->_proto.handle(conn->_in, conn->_out).then([conn] {
                         return conn->_out.flush();
                     });
+                }).finally([conn] {
+                    return conn->_out.close().finally([conn] {});
                 });
             });
         }).or_terminate();


### PR DESCRIPTION
Fix for the issue: "memcached crashes on setting first key #64"

Best regards,
Mike