### PR TITLE
Fix docker build deps to include xfsprogs-devel

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -2,4 +2,4 @@ FROM fedora:21
 
 RUN yum install -y gcc-c++ clang libasan libubsan hwloc hwloc-devel numactl-devel \
                            python3 libaio-devel ninja-build boost-devel git ragel xen-devel \
-                           cryptopp-devel libpciaccess-devel libxml2-devel zlib-devel
+                           cryptopp-devel libpciaccess-devel libxml2-devel zlib-devel xfsprogs-devel


### PR DESCRIPTION
I had to add this to get seastar to compile in the docker container per README.

I also found that, at least under OS X using docker-machine, the README's suggested `seabuild` function doesn't work. The `-u` option passed causes the docker container to see the mounted disk as owned by the docker-machine VM root user not the current userid passed and so has no write permissions. If I simply remove the `-u` flags it seems to work fine.

Should I add that to the README too? I'm not sure what those options do achieve on other native-docker setups?