### PR TITLE
Put things in seastar namespace

### DIFF
--- a/apps/fair_queue_tester/fair_queue_tester.cc
+++ b/apps/fair_queue_tester/fair_queue_tester.cc
@@ -33,6 +33,7 @@
 #include <iomanip>
 
 using namespace std::chrono_literals;
+using namespace seastar;
 
 static auto random_seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 static std::default_random_engine random_generator(random_seed);

--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -28,7 +28,8 @@
 
 namespace bpo = boost::program_options;
 
-using namespace httpd;
+using namespace seastar;
+using namespace seastar::httpd;
 
 class handl : public httpd::handler_base {
 public:

--- a/apps/memcached/ascii.rl
+++ b/apps/memcached/ascii.rl
@@ -25,6 +25,8 @@
 #include <algorithm>
 #include <functional>
 
+using namespace seastar;
+
 %%{
 
 machine memcache_ascii_protocol;

--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -48,7 +48,8 @@
 #define VERSION "v1.0"
 #define VERSION_STRING PLATFORM " " VERSION
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 namespace bi = boost::intrusive;
 

--- a/apps/memcached/memcached.hh
+++ b/apps/memcached/memcached.hh
@@ -27,14 +27,14 @@ class cache;
 
 class item_key {
 private:
-    sstring _key;
+    seastar::sstring _key;
     size_t _hash;
 public:
     item_key() = default;
     item_key(item_key&) = default;
-    item_key(sstring key)
+    item_key(seastar::sstring key)
         : _key(key)
-        , _hash(std::hash<sstring>()(key))
+	, _hash(std::hash<seastar::sstring>()(key))
     {}
     item_key(item_key&& other)
         : _key(std::move(other._key))
@@ -45,7 +45,7 @@ public:
     size_t hash() const {
         return _hash;
     }
-    const sstring& key() const {
+    const seastar::sstring& key() const {
         return _key;
     }
     bool operator==(const item_key& other) const {

--- a/apps/seawreck/seawreck.cc
+++ b/apps/seawreck/seawreck.cc
@@ -29,6 +29,8 @@
 #include "core/future-util.hh"
 #include <chrono>
 
+using namespace seastar;
+
 template <typename... Args>
 void http_debug(const char* fmt, Args&&... args) {
 #if HTTP_DEBUG

--- a/core/align.hh
+++ b/core/align.hh
@@ -25,6 +25,8 @@
 #include <cstdint>
 #include <cstdlib>
 
+namespace seastar {
+
 template <typename T>
 inline constexpr
 T align_up(T v, T align) {
@@ -50,5 +52,7 @@ T* align_down(T* v, size_t align) {
     static_assert(sizeof(T) == 1, "align byte pointers only");
     return reinterpret_cast<T*>(align_down(reinterpret_cast<uintptr_t>(v), align));
 }
+
+} // namespace seastar
 
 #endif /* ALIGN_HH_ */

--- a/core/app-template.cc
+++ b/core/app-template.cc
@@ -28,6 +28,8 @@
 #include <fstream>
 #include <cstdlib>
 
+namespace seastar {
+
 namespace bpo = boost::program_options;
 
 app_template::app_template()
@@ -124,3 +126,5 @@ app_template::run_deprecated(int ac, char ** av, std::function<void ()>&& func) 
     smp::cleanup();
     return exit_code;
 }
+
+} // namespace seastar

--- a/core/app-template.hh
+++ b/core/app-template.hh
@@ -26,6 +26,8 @@
 #include <functional>
 #include <core/future.hh>
 
+namespace seastar {
+
 class app_template {
 private:
     boost::program_options::options_description _opts;
@@ -55,5 +57,7 @@ public:
     // successfully.
     int run(int ac, char ** av, std::function<future<> ()>&& func);
 };
+
+} // namespace seastar
 
 #endif

--- a/core/apply.hh
+++ b/core/apply.hh
@@ -25,6 +25,8 @@
 #include <tuple>
 #include <utility>
 
+namespace seastar {
+
 template <typename Func, typename Args, typename IndexList>
 struct apply_helper;
 
@@ -55,5 +57,7 @@ auto apply(Func&& func, const std::tuple<T...>& args) {
     using helper = apply_helper<Func, const std::tuple<T...>&, std::index_sequence_for<T...>>;
     return helper::apply(std::forward<Func>(func), args);
 }
+
+} // namespace seastar
 
 #endif /* APPLY_HH_ */

--- a/core/array_map.hh
+++ b/core/array_map.hh
@@ -24,6 +24,8 @@
 
 #include <array>
 
+namespace seastar {
+
 // unordered_map implemented as a simple array
 
 template <typename Value, size_t Max>
@@ -47,5 +49,6 @@ public:
 };
 
 
+} // namespace seastar
 
 #endif /* ARRAY_MAP_HH_ */

--- a/core/bitops.hh
+++ b/core/bitops.hh
@@ -22,6 +22,8 @@
 #ifndef BITOPS_HH_
 #define BITOPS_HH_
 
+namespace seastar {
+
 inline
 constexpr unsigned count_leading_zeros(unsigned x) {
     return __builtin_clz(x);
@@ -51,5 +53,7 @@ inline
 constexpr unsigned count_trailing_zeros(unsigned long long x) {
     return __builtin_ctzll(x);
 }
+
+} // namespace seastar
 
 #endif /* BITOPS_HH_ */

--- a/core/bitset-iter.hh
+++ b/core/bitset-iter.hh
@@ -17,6 +17,8 @@
 #include <bitset>
 #include <limits>
 
+namespace seastar {
+
 namespace bitsets {
 
 static constexpr int ulong_bits = std::numeric_limits<unsigned long>::digits;
@@ -167,6 +169,8 @@ static inline set_range<N> for_each_set(std::bitset<N> bitset, int offset = 0)
 }
 
 
-}
+} // namespace bitsets
+
+} // namespace seastar
 
 #endif

--- a/core/byteorder.hh
+++ b/core/byteorder.hh
@@ -24,6 +24,8 @@
 #include <endian.h>
 #include "unaligned.hh"
 
+namespace seastar {
+
 inline uint8_t cpu_to_le(uint8_t x) { return x; }
 inline uint8_t le_to_cpu(uint8_t x) { return x; }
 inline uint16_t cpu_to_le(uint16_t x) { return htole16(x); }
@@ -51,3 +53,5 @@ template <typename T>
 inline T le_to_cpu(const unaligned<T>& v) {
     return le_to_cpu(T(v));
 }
+
+} // namespace seastar

--- a/core/circular_buffer.hh
+++ b/core/circular_buffer.hh
@@ -36,6 +36,8 @@
 #include <memory>
 #include <algorithm>
 
+namespace seastar {
+
 template <typename T, typename Alloc = std::allocator<T>>
 class circular_buffer {
     struct impl : Alloc {
@@ -380,5 +382,7 @@ T&
 circular_buffer<T, Alloc>::access_element_unsafe(size_t idx) {
     return _impl.storage[mask(_impl.begin + idx)];
 }
+
+} // namespace seastar
 
 #endif /* CIRCULAR_BUFFER_HH_ */

--- a/core/deleter.hh
+++ b/core/deleter.hh
@@ -27,6 +27,8 @@
 #include <assert.h>
 #include <type_traits>
 
+namespace seastar {
+
 /// \addtogroup memory-module
 /// @{
 
@@ -271,5 +273,7 @@ make_object_deleter(deleter d, T&& obj) {
 }
 
 /// @}
+
+} // namespace seastar
 
 #endif /* DELETER_HH_ */

--- a/core/distributed.hh
+++ b/core/distributed.hh
@@ -23,5 +23,9 @@
 
 #include "sharded.hh"
 
+namespace seastar {
+
 template <typename Service>
-using distributed = seastar::sharded<Service>;
+using distributed = sharded<Service>;
+
+} // namespace seastar

--- a/core/do_with.hh
+++ b/core/do_with.hh
@@ -26,6 +26,8 @@
 #include <memory>
 #include <tuple>
 
+namespace seastar {
+
 /// \addtogroup future-util
 /// @{
 
@@ -110,5 +112,7 @@ do_with(T1&& rv1, T2&& rv2, T3_or_F&& rv3, More&&... more) {
         return std::move(fut);
     });
 }
+
+} // namespace seastar
 
 /// @}

--- a/core/dpdk_rte.cc
+++ b/core/dpdk_rte.cc
@@ -23,6 +23,8 @@
 #include <experimental/optional>
 #include <rte_pci.h>
 
+namespace seastar {
+
 namespace dpdk {
 
 bool eal::initialized = false;
@@ -109,5 +111,7 @@ size_t eal::mem_size(int num_cpus, bool hugetlbfs_membackend)
 }
 
 } // namespace dpdk
+
+} // namespace seastar
 
 #endif // HAVE_DPDK

--- a/core/dpdk_rte.hh
+++ b/core/dpdk_rte.hh
@@ -38,6 +38,8 @@
 #endif
 /******************************************************************************/
 
+namespace seastar {
+
 namespace dpdk {
 
 // DPDK Environment Abstraction Layer
@@ -57,5 +59,8 @@ public:
 };
 
 } // namespace dpdk
+
+} // namespace seastar
+
 #endif // HAVE_DPDK
 #endif // DPDK_RTE_HH_

--- a/core/enum.hh
+++ b/core/enum.hh
@@ -31,6 +31,8 @@
 #include <functional>
 #include <cstddef>
 
+namespace seastar {
+
 template <typename T>
 class enum_hash {
     static_assert(std::is_enum<T>::value, "must be an enum");
@@ -40,3 +42,5 @@ public:
         return std::hash<utype>()(static_cast<utype>(e));
     }
 };
+
+} // namespace seastar

--- a/core/fair_queue.hh
+++ b/core/fair_queue.hh
@@ -32,6 +32,8 @@
 #include <unordered_set>
 #include <cmath>
 
+namespace seastar {
+
 /// \addtogroup io-module
 /// @{
 
@@ -199,3 +201,5 @@ public:
     }
 };
 /// @}
+
+} // namespace seastar

--- a/core/file.hh
+++ b/core/file.hh
@@ -36,6 +36,8 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+namespace seastar {
+
 /// \addtogroup fileio-module
 /// @{
 
@@ -619,5 +621,7 @@ file::read_maybe_eof(uint64_t pos, size_t len, const io_priority_class& pc) {
 /// \endcond
 
 /// @}
+
+} // namespace seastar
 
 #endif /* FILE_HH_ */

--- a/core/fstream.cc
+++ b/core/fstream.cc
@@ -27,6 +27,8 @@
 #include <malloc.h>
 #include <string.h>
 
+namespace seastar {
+
 class file_data_source_impl : public data_source_impl {
     file _file;
     file_input_stream_options _options;
@@ -220,3 +222,5 @@ output_stream<char> make_file_output_stream(file f, file_output_stream_options o
     return output_stream<char>(file_data_sink(std::move(f), options), options.buffer_size, true);
 }
 
+
+} // namespace seastar

--- a/core/fstream.hh
+++ b/core/fstream.hh
@@ -32,12 +32,13 @@
 #include "iostream.hh"
 #include "shared_ptr.hh"
 
+namespace seastar {
 
 /// Data structure describing options for opening a file input stream
 struct file_input_stream_options {
     size_t buffer_size = 8192;    ///< I/O buffer size
     unsigned read_ahead = 0;      ///< Number of extra read-ahead operations
-    ::io_priority_class io_priority_class = default_priority_class();
+    seastar::io_priority_class io_priority_class = default_priority_class();
 };
 
 // Create an input_stream for a given file, with the specified options.
@@ -56,7 +57,7 @@ struct file_output_stream_options {
     unsigned buffer_size = 8192;
     unsigned preallocation_size = 1024*1024; // 1MB
     unsigned write_behind = 1; ///< Number of buffers to write in parallel
-    ::io_priority_class io_priority_class = default_priority_class();
+    seastar::io_priority_class io_priority_class = default_priority_class();
 };
 
 // Create an output_stream for writing starting at the position zero of a
@@ -73,3 +74,4 @@ output_stream<char> make_file_output_stream(
         file file,
         file_output_stream_options options);
 
+} // namespace seastar

--- a/core/function_traits.hh
+++ b/core/function_traits.hh
@@ -23,9 +23,11 @@
 
 #include <tuple>
 
+namespace seastar {
+
 template<typename T>
 struct function_traits;
- 
+
 template<typename Ret, typename... Args>
 struct function_traits<Ret(Args...)>
 {
@@ -63,3 +65,4 @@ template<typename T>
 struct function_traits<T&> : public function_traits<std::remove_reference_t<T>>
 {};
 
+} // namespace seastar

--- a/core/future-util.hh
+++ b/core/future-util.hh
@@ -34,6 +34,8 @@
 #include <vector>
 #include <experimental/optional>
 
+namespace seastar {
+
 /// \cond internal
 extern __thread size_t task_quota;
 /// \endcond
@@ -663,5 +665,7 @@ future<> now() {
 future<> later();
 
 /// @}
+
+} // namespace seastar
 
 #endif /* CORE_FUTURE_UTIL_HH_ */

--- a/core/future.hh
+++ b/core/future.hh
@@ -62,6 +62,9 @@
 
 namespace seastar {
 
+template<typename ...T>
+class shared_future;
+
 class thread_context;
 
 namespace thread_impl {
@@ -72,7 +75,6 @@ void switch_out(thread_context* from);
 
 }
 
-}
 
 
 /// \addtogroup future-module
@@ -684,7 +686,7 @@ private:
     template <typename Func>
     void schedule(Func&& func) {
         if (state()->available()) {
-            ::schedule(std::make_unique<continuation<Func, T...>>(std::move(func), std::move(*state())));
+            seastar::schedule(std::make_unique<continuation<Func, T...>>(std::move(func), std::move(*state())));
         } else {
             assert(_promise);
             _promise->schedule(std::move(func));
@@ -703,8 +705,7 @@ private:
         return std::move(*st);
     }
 
-    template<typename... U>
-    friend class shared_future;
+    friend class shared_future<T...>;
 public:
     /// \brief The data type carried by the future.
     using value_type = std::tuple<T...>;
@@ -1057,7 +1058,7 @@ inline
 void promise<T...>::make_ready() noexcept {
     if (_task) {
         _state = nullptr;
-        ::schedule(std::move(_task));
+       seastar::schedule(std::move(_task));
     }
 }
 
@@ -1114,7 +1115,7 @@ template<typename T>
 template<typename Func, typename... FuncArgs>
 typename futurize<T>::type futurize<T>::apply(Func&& func, std::tuple<FuncArgs...>&& args) noexcept {
     try {
-        return convert(::apply(std::forward<Func>(func), std::move(args)));
+	return convert(::seastar::apply(std::forward<Func>(func), std::move(args)));
     } catch (...) {
         return make_exception_future(std::current_exception());
     }
@@ -1158,7 +1159,7 @@ inline
 std::enable_if_t<!is_future<std::result_of_t<Func(FuncArgs&&...)>>::value, future<>>
 do_void_futurize_apply_tuple(Func&& func, std::tuple<FuncArgs...>&& args) noexcept {
     try {
-        ::apply(std::forward<Func>(func), std::move(args));
+        seastar::apply(std::forward<Func>(func), std::move(args));
         return make_ready_future<>();
     } catch (...) {
         return make_exception_future(std::current_exception());
@@ -1170,7 +1171,7 @@ inline
 std::enable_if_t<is_future<std::result_of_t<Func(FuncArgs&&...)>>::value, future<>>
 do_void_futurize_apply_tuple(Func&& func, std::tuple<FuncArgs...>&& args) noexcept {
     try {
-        return ::apply(std::forward<Func>(func), std::move(args));
+        return seastar::apply(std::forward<Func>(func), std::move(args));
     } catch (...) {
         return make_exception_future(std::current_exception());
     }
@@ -1190,7 +1191,7 @@ template<typename... Args>
 template<typename Func, typename... FuncArgs>
 typename futurize<future<Args...>>::type futurize<future<Args...>>::apply(Func&& func, std::tuple<FuncArgs...>&& args) noexcept {
     try {
-        return ::apply(std::forward<Func>(func), std::move(args));
+        return seastar::apply(std::forward<Func>(func), std::move(args));
     } catch (...) {
         return make_exception_future(std::current_exception());
     }
@@ -1211,7 +1212,7 @@ template <typename Arg>
 inline
 future<T>
 futurize<T>::make_exception_future(Arg&& arg) {
-    return ::make_exception_future<T>(std::forward<Arg>(arg));
+    return seastar::make_exception_future<T>(std::forward<Arg>(arg));
 }
 
 template <typename... T>
@@ -1219,14 +1220,14 @@ template <typename Arg>
 inline
 future<T...>
 futurize<future<T...>>::make_exception_future(Arg&& arg) {
-    return ::make_exception_future<T...>(std::forward<Arg>(arg));
+    return seastar::make_exception_future<T...>(std::forward<Arg>(arg));
 }
 
 template <typename Arg>
 inline
 future<>
 futurize<void>::make_exception_future(Arg&& arg) {
-    return ::make_exception_future<>(std::forward<Arg>(arg));
+    return seastar::make_exception_future<>(std::forward<Arg>(arg));
 }
 
 template <typename T>
@@ -1256,5 +1257,7 @@ futurize<void>::from_tuple(const std::tuple<>& value) {
 }
 
 /// \endcond
+
+} // namespace seastar
 
 #endif /* FUTURE_HH_ */

--- a/core/iostream-impl.hh
+++ b/core/iostream-impl.hh
@@ -25,6 +25,8 @@
 
 #include "net/packet.hh"
 
+namespace seastar {
+
 template<typename CharType>
 inline
 future<> output_stream<CharType>::write(const char_type* buf) {
@@ -370,3 +372,5 @@ output_stream<CharType>::close() {
         return _fd.close();
     });
 }
+
+} // namespace seastar

--- a/core/iostream.hh
+++ b/core/iostream.hh
@@ -39,6 +39,8 @@
 #include "temporary_buffer.hh"
 #include "scattered_message.hh"
 
+namespace seastar {
+
 namespace net { class packet; }
 
 class data_source_impl {
@@ -213,5 +215,7 @@ public:
 private:
     friend class reactor;
 };
+
+} // namespace seastar
 
 #include "iostream-impl.hh"

--- a/core/memory.hh
+++ b/core/memory.hh
@@ -27,6 +27,7 @@
 #include <functional>
 #include <vector>
 
+namespace seastar {
 
 /// \defgroup memory-module Memory management
 ///
@@ -183,7 +184,7 @@ struct memory_layout {
 // Supported only when seastar allocator is enabled.
 memory::memory_layout get_memory_layout();
 
-}
+} // namespace memory
 
 class with_alignment {
     size_t _align;
@@ -191,11 +192,14 @@ public:
     with_alignment(size_t align) : _align(align) {}
     size_t alignment() const { return _align; }
 };
+} // namespace seastar
 
-void* operator new(size_t size, with_alignment wa);
-void* operator new[](size_t size, with_alignment wa);
-void operator delete(void* ptr, with_alignment wa);
-void operator delete[](void* ptr, with_alignment wa);
+void* operator new(size_t size, seastar::with_alignment wa);
+void* operator new[](size_t size, seastar::with_alignment wa);
+void operator delete(void* ptr, seastar::with_alignment wa);
+void operator delete[](void* ptr, seastar::with_alignment wa);
+
+namespace seastar {
 
 template <typename T, size_t Align>
 class aligned_allocator {
@@ -215,5 +219,8 @@ public:
         return false;
     }
 };
+
+} // namespace seastar
+
 
 #endif /* MEMORY_HH_ */

--- a/core/posix.cc
+++ b/core/posix.cc
@@ -23,6 +23,8 @@
 #include "align.hh"
 #include <sys/mman.h>
 
+namespace seastar {
+
 file_desc
 file_desc::temporary(sstring directory) {
     // FIXME: add O_TMPFILE support one day
@@ -114,3 +116,4 @@ void pin_this_thread(unsigned cpu_id) {
     assert(r == 0);
 }
 
+} // namespace seastar

--- a/core/posix.hh
+++ b/core/posix.hh
@@ -43,6 +43,8 @@
 #include <memory>
 #include "net/api.hh"
 
+namespace seastar {
+
 inline void throw_system_error_on(bool condition, const char* what_arg = "");
 
 template <typename T>
@@ -382,5 +384,7 @@ sigset_t make_empty_sigset_mask() {
 }
 
 void pin_this_thread(unsigned cpu_id);
+
+} // namespace seastar
 
 #endif /* FILE_DESC_HH_ */

--- a/core/prefetch.hh
+++ b/core/prefetch.hh
@@ -27,6 +27,8 @@
 #include <boost/mpl/for_each.hpp>
 #include "align.hh"
 
+namespace seastar {
+
 static constexpr size_t  cacheline_size = 64;
 template <size_t N, int RW, int LOC>
 struct prefetcher;
@@ -110,5 +112,7 @@ template<size_t L, size_t C, typename T, int LOC = 3>
 void prefetchw_n(T** pptr) {
     boost::mpl::for_each< boost::mpl::range_c<size_t,0,C> >( [pptr] (size_t x) { prefetchw<L, LOC>(*(pptr + x)); } );
 }
+
+} // namespace seastar
 
 #endif

--- a/core/print.hh
+++ b/core/print.hh
@@ -28,6 +28,8 @@
 #include <chrono>
 #include "core/sstring.hh"
 
+namespace seastar {
+
 inline void
 apply_format(boost::format& fmt) {
 }
@@ -121,5 +123,7 @@ log(A&&... a) {
     std::cout << usecfmt(std::chrono::high_resolution_clock::now()) << " ";
     print(std::forward<A>(a)...);
 }
+
+} // namespace seastar
 
 #endif /* PRINT_HH_ */

--- a/core/queue.hh
+++ b/core/queue.hh
@@ -27,6 +27,8 @@
 #include <queue>
 #include <experimental/optional>
 
+namespace seastar {
+
 template <typename T>
 class queue {
     std::queue<T, circular_buffer<T>> _q;
@@ -216,5 +218,7 @@ future<> queue<T>::not_full() {
         return _not_full->get_future();
     }
 }
+
+} // namespace seastar
 
 #endif /* QUEUE_HH_ */

--- a/core/ragel.hh
+++ b/core/ragel.hh
@@ -31,6 +31,8 @@
 #include <experimental/optional>
 #include "future.hh"
 
+namespace seastar {
+
 // Support classes for Ragel parsers
 
 // Builds an sstring that can be scattered across multiple packets.
@@ -136,5 +138,7 @@ public:
         return make_ready_future<unconsumed_remainder>();
     }
 };
+
+} // namespace seastar
 
 #endif /* RAGEL_HH_ */

--- a/core/reactor.cc
+++ b/core/reactor.cc
@@ -79,7 +79,9 @@
 
 using namespace std::chrono_literals;
 
-using namespace net;
+namespace seastar {
+
+using namespace seastar::net;
 
 std::atomic<lowres_clock::rep> lowres_clock::_now;
 constexpr std::chrono::milliseconds lowres_clock::_granularity;
@@ -2109,9 +2111,13 @@ void schedule(std::unique_ptr<task> t) {
     engine().add_task(std::move(t));
 }
 
+} // namespace seastar;
+
 bool operator==(const ::sockaddr_in a, const ::sockaddr_in b) {
     return (a.sin_addr.s_addr == b.sin_addr.s_addr) && (a.sin_port == b.sin_port);
 }
+
+namespace seastar {
 
 void network_stack_registry::register_stack(sstring name,
         boost::program_options::options_description opts,
@@ -2864,3 +2870,5 @@ network_stack_registrator nsr_posix{"posix",
     },
     true
 };
+
+} // namespace seastar

--- a/core/reactor.hh
+++ b/core/reactor.hh
@@ -74,6 +74,8 @@
 #include <osv/newpoll.hh>
 #endif
 
+namespace seastar {
+
 using shard_id = unsigned;
 
 namespace scollectd { class registration; }
@@ -188,6 +190,7 @@ private:
     std::unique_ptr<pollable_fd_state> _s;
 };
 
+} // namespace seastar
 
 namespace std {
 
@@ -201,6 +204,8 @@ struct hash<::sockaddr_in> {
 }
 
 bool operator==(const ::sockaddr_in a, const ::sockaddr_in b);
+
+namespace seastar {
 
 class network_stack_registrator {
 public:
@@ -1324,5 +1329,7 @@ inline
 typename timer<Clock>::time_point timer<Clock>::get_timeout() {
     return _expiry;
 }
+
+} // namespace seastar
 
 #endif /* REACTOR_HH_ */

--- a/core/resource.cc
+++ b/core/resource.cc
@@ -22,6 +22,8 @@
 #include "resource.hh"
 #include "core/align.hh"
 
+namespace seastar {
+
 namespace resource {
 
 size_t calculate_memory(configuration c, size_t available_memory, float panic_factor = 1) {
@@ -41,7 +43,9 @@ size_t calculate_memory(configuration c, size_t available_memory, float panic_fa
     return mem;
 }
 
-}
+} // namespace resource
+
+} // namespace seastar
 
 #ifdef HAVE_HWLOC
 
@@ -50,6 +54,8 @@ size_t calculate_memory(configuration c, size_t available_memory, float panic_fa
 #include <hwloc.h>
 #include <unordered_map>
 #include <boost/range/irange.hpp>
+
+namespace seastar {
 
 cpu_set_t cpuid_to_cpuset(unsigned cpuid) {
     cpu_set_t cs;
@@ -289,13 +295,16 @@ unsigned nr_processing_units() {
     return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
 }
 
-}
+} // namespace resource
+
+} // namespace seastar
 
 #else
 
 #include "resource.hh"
 #include <unistd.h>
 
+namespace seastar {
 namespace resource {
 
 // Without hwloc, we don't support tuning the number of IO queues. So each CPU gets their.
@@ -338,6 +347,8 @@ unsigned nr_processing_units() {
     return ::sysconf(_SC_NPROCESSORS_ONLN);
 }
 
-}
+} // namespace resource
+
+} // namespace seastar
 
 #endif

--- a/core/resource.hh
+++ b/core/resource.hh
@@ -27,6 +27,8 @@
 #include <vector>
 #include <set>
 
+namespace seastar {
+
 cpu_set_t cpuid_to_cpuset(unsigned cpuid);
 
 namespace resource {
@@ -76,6 +78,8 @@ struct resources {
 resources allocate(configuration c);
 unsigned nr_processing_units();
 
-}
+} // namespace resource
+
+} // namespace seastar
 
 #endif /* RESOURCE_HH_ */

--- a/core/rwlock.hh
+++ b/core/rwlock.hh
@@ -24,6 +24,8 @@
 
 #include "semaphore.hh"
 
+namespace seastar {
+
 /// \cond internal
 // lock / unlock semantics for rwlock, so it can be used with with_lock()
 class rwlock;
@@ -134,5 +136,7 @@ inline void rwlock_for_write::unlock() {
 /// \endcond
 
 /// @}
+
+} // namespace seastar
 
 #endif /* CORE_RWLOCK_HH_ */

--- a/core/scattered_message.hh
+++ b/core/scattered_message.hh
@@ -30,6 +30,8 @@
 #include <vector>
 #include <experimental/string_view>
 
+namespace seastar {
+
 template <typename CharType>
 class scattered_message {
 private:
@@ -101,5 +103,7 @@ public:
         return _p.len();
     }
 };
+
+} // namespace seastar
 
 #endif

--- a/core/scollectd.cc
+++ b/core/scollectd.cc
@@ -34,6 +34,8 @@
 #include "net/api.hh"
 #include "scollectd_api.hh"
 
+namespace seastar {
+
 bool scollectd::type_instance_id::operator<(
         const scollectd::type_instance_id& id2) const {
     auto& id1 = *this;
@@ -515,4 +517,6 @@ std::vector<data_type> get_collectd_types(
 std::vector<scollectd::type_instance_id> get_collectd_ids() {
     return get_impl().get_instance_ids();
 }
-}
+
+} // namespace scollectd
+} // namespace seastar

--- a/core/scollectd.hh
+++ b/core/scollectd.hh
@@ -39,6 +39,8 @@
 #include "core/shared_ptr.hh"
 #include "core/sstring.hh"
 
+namespace seastar {
+
 /**
  * Implementation of rudimentary collectd data gathering.
  *
@@ -441,7 +443,7 @@ static type_instance_id add_polled_metric(const type_instance_id & id,
         _Args&& ... args) {
     typedef decltype(make_type_instance(std::forward<_Args>(args)...)) impl_type;
     add_polled(id,
-            ::make_shared<impl_type>(
+	       ::seastar::make_shared<impl_type>(
                     make_type_instance(std::forward<_Args>(args)...)));
     return id;
 }
@@ -463,6 +465,8 @@ static notify_function create_explicit_metric(const type_instance_id & id,
 
 // Send a message packet (string)
 future<> send_notification(const type_instance_id & id, const sstring & msg);
-};
+
+} // namespace scollectd
+} // namespace seastar
 
 #endif /* SCOLLECTD_HH_ */

--- a/core/scollectd_api.hh
+++ b/core/scollectd_api.hh
@@ -7,6 +7,8 @@
 
 #include "core/scollectd.hh"
 
+namespace seastar {
+
 namespace scollectd {
 
 struct collectd_value {
@@ -53,6 +55,8 @@ std::vector<collectd_value> get_collectd_value(
 
 std::vector<scollectd::type_instance_id> get_collectd_ids();
 
-}
+} // namespace scollectd
+
+} // namespace seastar
 
 #endif /* CORE_SCOLLECTD_API_HH_ */

--- a/core/seastar.hh
+++ b/core/seastar.hh
@@ -44,6 +44,8 @@
 #include "sstring.hh"
 #include "future.hh"
 
+namespace seastar {
+
 // iostream.hh
 template <class CharType> class input_stream;
 template <class CharType> class output_stream;
@@ -277,3 +279,4 @@ future<> link_file(sstring oldpath, sstring newpath);
 future<fs_type> file_system_at(sstring name);
 
 /// @}
+} // namespace seastar

--- a/core/semaphore.hh
+++ b/core/semaphore.hh
@@ -28,6 +28,8 @@
 #include <exception>
 #include "timer.hh"
 
+namespace seastar {
+
 /// \addtogroup fiber-module
 /// @{
 
@@ -265,5 +267,7 @@ with_semaphore(semaphore& sem, size_t units, Func&& func) {
 }
 
 /// @}
+
+} // namespace seastar
 
 #endif /* CORE_SEMAPHORE_HH_ */

--- a/core/shared_mutex.hh
+++ b/core/shared_mutex.hh
@@ -160,4 +160,4 @@ with_lock(shared_mutex& sm, Func&& func) {
 
 /// @}
 
-}
+} // namespace seastar

--- a/core/shared_ptr.hh
+++ b/core/shared_ptr.hh
@@ -29,6 +29,8 @@
 #include <iostream>
 #include "util/is_smart_ptr.hh"
 
+namespace seastar {
+
 // This header defines two shared pointer facilities, lw_shared_ptr<> and
 // shared_ptr<>, both modeled after std::shared_ptr<>.
 //
@@ -703,28 +705,31 @@ struct shared_ptr_value_hash {
     }
 };
 
+template<typename T>
+struct is_smart_ptr<::seastar::shared_ptr<T>> : std::true_type {};
+
+template<typename T>
+struct is_smart_ptr<::seastar::lw_shared_ptr<T>> : std::true_type {};
+
+} // namespace seastar
+
 namespace std {
 
 template <typename T>
-struct hash<lw_shared_ptr<T>> : private hash<T*> {
-    size_t operator()(const lw_shared_ptr<T>& p) const {
+struct hash<seastar::lw_shared_ptr<T>> : private hash<T*> {
+    size_t operator()(const ::seastar::lw_shared_ptr<T>& p) const {
         return hash<T*>::operator()(p.get());
     }
 };
 
 template <typename T>
-struct hash<::shared_ptr<T>> : private hash<T*> {
-    size_t operator()(const ::shared_ptr<T>& p) const {
+struct hash<::seastar::shared_ptr<T>> : private hash<T*> {
+    size_t operator()(const ::seastar::shared_ptr<T>& p) const {
         return hash<T*>::operator()(p.get());
     }
 };
 
-}
+} // namespace std
 
-template<typename T>
-struct is_smart_ptr<::shared_ptr<T>> : std::true_type {};
-
-template<typename T>
-struct is_smart_ptr<::lw_shared_ptr<T>> : std::true_type {};
 
 #endif /* SHARED_PTR_HH_ */

--- a/core/shared_ptr_debug_helper.hh
+++ b/core/shared_ptr_debug_helper.hh
@@ -26,6 +26,8 @@
 #include <thread>
 #include <cassert>
 
+namespace seastar {
+
 // A counter that is only comfortable being incremented on the cpu
 // it was created on.  Useful for verifying that a shared_ptr
 // or lw_shared_ptr isn't misued across cores.
@@ -61,6 +63,8 @@ private:
         assert(_cpu == std::this_thread::get_id());
     }
 };
+
+} // namespace seastar
 
 #endif
 

--- a/core/slab.hh
+++ b/core/slab.hh
@@ -34,9 +34,9 @@
 #include "core/align.hh"
 #include "core/memory.hh"
 
-static constexpr uint16_t SLAB_MAGIC_NUMBER = 0x51AB; // meant to be 'SLAB' :-)
+namespace seastar {
 
-namespace bi = boost::intrusive;
+static constexpr uint16_t SLAB_MAGIC_NUMBER = 0x51AB; // meant to be 'SLAB' :-)
 
 /*
  * Item requirements
@@ -52,8 +52,8 @@ namespace bi = boost::intrusive;
  */
 struct slab_page_desc {
 private:
-    bi::list_member_hook<> _lru_link;
-    bi::list_member_hook<> _free_pages_link;
+    boost::intrusive::list_member_hook<> _lru_link;
+    boost::intrusive::list_member_hook<> _free_pages_link;
     void *_slab_page;
     std::vector<uintptr_t> _free_objects;
     uint32_t _refcnt;
@@ -126,7 +126,7 @@ public:
 };
 
 class slab_item_base {
-    bi::list_member_hook<> _lru_link;
+    boost::intrusive::list_member_hook<> _lru_link;
 
     template<typename Item>
     friend class slab_class;
@@ -135,11 +135,11 @@ class slab_item_base {
 template<typename Item>
 class slab_class {
 private:
-    bi::list<slab_page_desc,
-        bi::member_hook<slab_page_desc, bi::list_member_hook<>,
+    boost::intrusive::list<slab_page_desc,
+     boost::intrusive::member_hook<slab_page_desc, boost::intrusive::list_member_hook<>,
         &slab_page_desc::_free_pages_link>> _free_slab_pages;
-    bi::list<slab_item_base,
-        bi::member_hook<slab_item_base, bi::list_member_hook<>,
+    boost::intrusive::list<slab_item_base,
+      boost::intrusive::member_hook<slab_item_base, boost::intrusive::list_member_hook<>,
         &slab_item_base::_lru_link>> _lru;
     size_t _size; // size of objects
     uint8_t _slab_class_id;
@@ -282,8 +282,8 @@ private:
     // erase_func() is used to remove the item from the cache using slab.
     std::function<void (Item& item_ref)> _erase_func;
     std::vector<slab_page_desc*> _slab_pages_vector;
-    bi::list<slab_page_desc,
-        bi::member_hook<slab_page_desc, bi::list_member_hook<>,
+    boost::intrusive::list<slab_page_desc,
+        boost::intrusive::member_hook<slab_page_desc, boost::intrusive::list_member_hook<>,
         &slab_page_desc::_lru_link>> _slab_page_desc_lru;
     uint64_t _max_object_size;
     uint64_t _available_slab_pages;
@@ -568,5 +568,7 @@ public:
         return (slab_class) ? slab_class->size() : 0;
     }
 };
+
+} // namespace seastar
 
 #endif /* __SLAB_ALLOCATOR__ */

--- a/core/sleep.hh
+++ b/core/sleep.hh
@@ -29,6 +29,8 @@
 #include "core/reactor.hh"
 #include "core/future.hh"
 
+namespace seastar {
+
 template <typename Clock = steady_clock_type, typename Rep, typename Period>
 future<> sleep(std::chrono::duration<Rep, Period> dur) {
     struct sleeper {
@@ -44,3 +46,5 @@ future<> sleep(std::chrono::duration<Rep, Period> dur) {
     future<> fut = s->done.get_future();
     return fut.then([s] { delete s; });
 }
+
+} // namespace seastar

--- a/core/sstring.hh
+++ b/core/sstring.hh
@@ -35,6 +35,8 @@
 #include <experimental/string_view>
 #include "core/temporary_buffer.hh"
 
+namespace seastar {
+
 template <typename char_type, typename Size, Size max_size>
 class basic_sstring;
 
@@ -628,16 +630,21 @@ operator>>(std::basic_istream<char_type, char_traits>& is,
     return is;
 }
 
+} // namespace seastar
+
 namespace std {
 
 template <typename char_type, typename size_type, size_type max_size>
-struct hash<basic_sstring<char_type, size_type, max_size>> {
-    size_t operator()(const basic_sstring<char_type, size_type, max_size>& s) const {
-        return std::hash<std::experimental::basic_string_view<char_type>>()(s);
+struct hash<seastar::basic_sstring<char_type, size_type, max_size>> {
+    size_t operator()(const seastar::basic_sstring<char_type, size_type,
+		      max_size>& s) const {
+	return std::hash<std::experimental::basic_string_view<char_type>>()(s);
     }
 };
 
-}
+} // namespace std
+
+namespace seastar {
 
 static inline
 char* copy_str_to(char* dst) {
@@ -663,6 +670,8 @@ inline string_type to_sstring(T value) {
     return sstring::to_sstring<string_type>(value);
 }
 
+} // namespace seastar
+
 namespace std {
 template <typename T>
 inline
@@ -680,6 +689,6 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
     os << "}";
     return os;
 }
-}
+} // namespace std
 
 #endif /* SSTRING_HH_ */

--- a/core/stream.hh
+++ b/core/stream.hh
@@ -26,6 +26,8 @@
 #include <exception>
 #include <cassert>
 
+namespace seastar {
+
 // A stream/subscription pair is similar to a promise/future pair,
 // but apply to a sequence of values instead of a single value.
 //
@@ -233,5 +235,7 @@ future<>
 subscription<T...>::done() {
     return _stream->_done.get_future();
 }
+
+} // namespace seastar
 
 #endif /* STREAM_HH_ */

--- a/core/systemwide_memory_barrier.cc
+++ b/core/systemwide_memory_barrier.cc
@@ -29,6 +29,8 @@
 #include <sys/syscall.h>
 #endif
 
+namespace seastar {
+
 // cause all threads to invoke a full memory barrier (mprotect version)
 void
 systemwide_memory_barrier_mprotect() {
@@ -85,3 +87,5 @@ void
 systemwide_memory_barrier() {
     (*systemwide_memory_barrier_fn)();
 }
+
+} // namespace seastar

--- a/core/systemwide_memory_barrier.hh
+++ b/core/systemwide_memory_barrier.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+namespace seastar {
+
 /// \cond internal
 
 // cause all threads to invoke a full memory barrier
@@ -28,3 +30,5 @@ void systemwide_memory_barrier();
 
 
 /// \endcond
+
+} // namespace seastar

--- a/core/task.hh
+++ b/core/task.hh
@@ -23,6 +23,8 @@
 
 #include <memory>
 
+namespace seastar {
+
 class task {
 public:
     virtual ~task() noexcept {}
@@ -46,3 +48,5 @@ std::unique_ptr<task>
 make_task(Func&& func) {
     return std::make_unique<lambda_task<Func>>(std::forward<Func>(func));
 }
+
+} // namespace seastar

--- a/core/temporary_buffer.hh
+++ b/core/temporary_buffer.hh
@@ -26,6 +26,8 @@
 #include "util/eclipse.hh"
 #include <malloc.h>
 
+namespace seastar {
+
 /// \addtogroup memory-module
 /// @{
 
@@ -197,5 +199,7 @@ public:
 };
 
 /// @}
+
+} // namespace seastar
 
 #endif /* TEMPORARY_BUFFER_HH_ */

--- a/core/timer-set.hh
+++ b/core/timer-set.hh
@@ -21,7 +21,6 @@
 #include <boost/intrusive/list.hpp>
 #include "bitset-iter.hh"
 
-namespace bi = boost::intrusive;
 
 namespace seastar {
 /**
@@ -35,11 +34,11 @@ namespace seastar {
  * get_timeout() which returns Timer::time_point which denotes
  * timer's expiration.
  */
-template<typename Timer, bi::list_member_hook<> Timer::*link>
+template<typename Timer, boost::intrusive::list_member_hook<> Timer::*link>
 class timer_set {
 public:
     using time_point = typename Timer::time_point;
-    using timer_list_t = bi::list<Timer, bi::member_hook<Timer, bi::list_member_hook<>, link>>;
+    using timer_list_t = boost::intrusive::list<Timer, boost::intrusive::member_hook<Timer, boost::intrusive::list_member_hook<>, link>>;
 private:
     using duration = typename Timer::duration;
     using timestamp_t = typename Timer::duration::rep;

--- a/core/timer.hh
+++ b/core/timer.hh
@@ -27,6 +27,8 @@
 #include "future.hh"
 #include "timer-set.hh"
 
+namespace seastar {
+
 using steady_clock_type = std::chrono::steady_clock;
 
 template <typename Clock = steady_clock_type>
@@ -69,3 +71,5 @@ public:
     friend class seastar::timer_set<timer, &timer::_link>;
 };
 
+
+} // namespace seastar

--- a/core/transfer.hh
+++ b/core/transfer.hh
@@ -37,6 +37,8 @@
 #include <type_traits>
 #include <utility>
 
+namespace seastar {
+
 template <typename T, typename Alloc>
 inline
 void
@@ -68,5 +70,7 @@ transfer_pass2(Alloc& a, T* from, T* to,
         typename std::enable_if<!std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
     a.destroy(from);
 }
+
+} // namespace seastar
 
 #endif /* TRANSFER_HH_ */

--- a/core/unaligned.hh
+++ b/core/unaligned.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+namespace seastar {
+
 // The following unaligned_cast<T*>(p) is a portable replacement for
 // reinterpret_cast<T*>(p) which should be used every time address p
 // is not guaranteed to be properly aligned to alignof(T).
@@ -64,3 +66,5 @@ template <typename T, typename F>
 inline auto unaligned_cast(const F* p) {
     return reinterpret_cast<const unaligned<std::remove_pointer_t<T>>*>(p);
 }
+
+} // namespace seastar

--- a/core/units.hh
+++ b/core/units.hh
@@ -22,8 +22,12 @@
 #ifndef UNITS_HH_
 #define UNITS_HH_
 
+namespace seastar {
+
 static constexpr size_t KB = 1 << 10;
 static constexpr size_t MB = 1 << 20;
 static constexpr size_t GB = 1 << 30;
+
+} // namespace seastar
 
 #endif

--- a/core/vector-data-sink.hh
+++ b/core/vector-data-sink.hh
@@ -24,6 +24,8 @@
 
 #include "core/reactor.hh"
 
+namespace seastar {
+
 class vector_data_sink final : public data_sink_impl {
 public:
     using vector_type = std::vector<net::packet>;
@@ -42,5 +44,7 @@ public:
         return make_ready_future<>();
     }
 };
+
+} // namespace seastar
 
 #endif

--- a/core/vla.hh
+++ b/core/vla.hh
@@ -27,6 +27,8 @@
 #include <assert.h>
 #include <type_traits>
 
+namespace seastar {
+
 // Some C APIs have a structure with a variable length array at the end.
 // This is a helper function to help allocate it.
 //
@@ -53,5 +55,6 @@ make_struct_with_vla(E S::*last, size_t nr) {
 }
 
 
+} // namespace seatar
 
 #endif /* VLA_HH_ */

--- a/core/xen/evtchn.cc
+++ b/core/xen/evtchn.cc
@@ -27,6 +27,8 @@
 #include "evtchn.hh"
 #include "osv_xen.hh"
 
+namespace seastar {
+
 namespace xen {
 
 void evtchn::make_ready_port(int port) {
@@ -216,4 +218,5 @@ evtchn *evtchn::instance(bool userspace, unsigned otherend)
     return _instance;
 }
 
-}
+} // namespace xen
+} // namespace seastar

--- a/core/xen/evtchn.hh
+++ b/core/xen/evtchn.hh
@@ -21,6 +21,7 @@
 #include "core/posix.hh"
 #include "core/future.hh"
 
+namespace seastar {
 namespace xen {
 
 class evtchn;
@@ -62,6 +63,7 @@ public:
     port bind(int p) { return port(p); };
 };
 
-}
+} // namespace xen
+} // namespace seastar
 
 #endif

--- a/core/xen/gntalloc.cc
+++ b/core/xen/gntalloc.cc
@@ -25,6 +25,7 @@
 #include "osv_xen.hh"
 #include "gntalloc.hh"
 
+namespace seastar {
 namespace xen {
 
 gntref invalid_ref;
@@ -236,4 +237,5 @@ gntalloc *gntalloc::instance() {
     return _instance;
 }
 
-}
+} // namespace xen
+} // namespace seastar

--- a/core/xen/gntalloc.hh
+++ b/core/xen/gntalloc.hh
@@ -20,6 +20,7 @@
 
 #include "core/posix.hh"
 
+namespace seastar {
 namespace xen {
 
 class gntref {
@@ -64,6 +65,7 @@ public:
 
 extern gntref invalid_ref;
 
-}
+} // namespace xen
+} // namespace seastar
 
 #endif

--- a/core/xen/xenstore.cc
+++ b/core/xen/xenstore.cc
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <string>
 
+namespace seastar {
+
 using xenstore_transaction = xenstore::xenstore_transaction;
 
 xenstore_transaction xenstore::_xs_null = xenstore::xenstore_transaction();
@@ -92,3 +94,5 @@ std::list<std::string> xenstore::ls(std::string path, xenstore_transaction &t)
 
     return names;
 }
+
+} // namespace seastar

--- a/core/xen/xenstore.hh
+++ b/core/xen/xenstore.hh
@@ -28,6 +28,7 @@ extern "C" {
     #include <xenstore.h>
 }
 
+namespace seastar {
 class xenstore {
 public:
     class xenstore_transaction {
@@ -82,6 +83,7 @@ public:
     template <typename T>
     void write(std::string path, T val, xenstore_transaction &t = _xs_null) { return write(path, std::to_string(val), t); }
 };
+} // namespace seastar
 
 
 #endif /* XENSTORE_HH_ */

--- a/http/api_docs.cc
+++ b/http/api_docs.cc
@@ -26,9 +26,11 @@
 
 using namespace std;
 
+namespace seastar {
 namespace httpd {
 
 const sstring api_registry_builder::DEFAULT_PATH = "/api-doc";
 const sstring api_registry_builder::DEFAULT_DIR = ".";
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/api_docs.hh
+++ b/http/api_docs.hh
@@ -27,6 +27,7 @@
 #include "transformers.hh"
 #include <string>
 
+namespace seastar {
 namespace httpd {
 
 struct api_doc : public json::json_base {
@@ -154,6 +155,7 @@ public:
     }
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* API_DOCS_HH_ */

--- a/http/common.cc
+++ b/http/common.cc
@@ -21,6 +21,7 @@
 
 #include "common.hh"
 
+namespace seastar {
 namespace httpd {
 
 operation_type str2type(const sstring& type) {
@@ -36,4 +37,5 @@ operation_type str2type(const sstring& type) {
     return GET;
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/common.hh
+++ b/http/common.hh
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include "core/sstring.hh"
 
+namespace seastar {
 namespace httpd {
 
 
@@ -68,6 +69,7 @@ enum operation_type {
  */
 operation_type str2type(const sstring& type);
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* COMMON_HH_ */

--- a/http/exception.hh
+++ b/http/exception.hh
@@ -25,6 +25,7 @@
 #include "reply.hh"
 #include "json/json_elements.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -134,6 +135,7 @@ private:
     }
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* EXCEPTION_HH_ */

--- a/http/file_handler.cc
+++ b/http/file_handler.cc
@@ -28,6 +28,7 @@
 #include "core/app-template.hh"
 #include "exception.hh"
 
+namespace seastar {
 namespace httpd {
 
 directory_handler::directory_handler(const sstring& doc_root,
@@ -131,4 +132,5 @@ future<std::unique_ptr<reply>> file_handler::handle(const sstring& path,
     return read(file, std::move(req), std::move(rep));
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/file_handler.hh
+++ b/http/file_handler.hh
@@ -24,6 +24,7 @@
 
 #include "handlers.hh"
 
+namespace seastar {
 namespace httpd {
 /**
  * This is a base class for file transformer.
@@ -156,6 +157,7 @@ private:
     bool force_path;
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* HTTP_FILE_HANDLER_HH_ */

--- a/http/function_handlers.hh
+++ b/http/function_handlers.hh
@@ -25,6 +25,7 @@
 #include <functional>
 #include "json/json_elements.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -113,4 +114,5 @@ protected:
     sstring _type;
 };
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/handlers.hh
+++ b/http/handlers.hh
@@ -29,6 +29,7 @@
 
 #include <unordered_map>
 
+namespace seastar {
 namespace httpd {
 
 typedef const httpd::request& const_req;
@@ -68,6 +69,7 @@ public:
 
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* HANDLERS_HH_ */

--- a/http/http_response_parser.rl
+++ b/http/http_response_parser.rl
@@ -23,6 +23,8 @@
 #include <memory>
 #include <unordered_map>
 
+using namespace seastar;
+
 struct http_response {
     sstring _version;
     std::unordered_map<sstring, sstring> _headers;

--- a/http/httpd.cc
+++ b/http/httpd.cc
@@ -37,6 +37,8 @@
 #include <vector>
 #include "httpd.hh"
 
+namespace seastar {
+
 using namespace std::chrono_literals;
 
 namespace httpd {
@@ -59,4 +61,5 @@ http_stats::http_stats(http_server& server)
                     [&server] { return server.requests_served(); })),
     } {
 }
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/httpd.hh
+++ b/http/httpd.hh
@@ -45,6 +45,7 @@
 #include "reply.hh"
 #include "http/routes.hh"
 
+namespace seastar {
 namespace httpd {
 
 class http_server;
@@ -435,6 +436,7 @@ public:
     }
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* APPS_HTTPD_HTTPD_HH_ */

--- a/http/json_path.cc
+++ b/http/json_path.cc
@@ -21,6 +21,7 @@
 
 #include "json_path.hh"
 
+namespace seastar {
 namespace httpd {
 
 using namespace std;
@@ -65,4 +66,5 @@ path_description::path_description(const sstring& path, operation_type method,
 
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/json_path.hh
+++ b/http/json_path.hh
@@ -30,6 +30,7 @@
 #include "routes.hh"
 #include "function_handlers.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -133,5 +134,6 @@ struct path_description {
     void set(routes& _routes, const future_json_function& f) const;
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 #endif /* JSON_PATH_HH_ */

--- a/http/matcher.cc
+++ b/http/matcher.cc
@@ -23,6 +23,8 @@
 
 #include <iostream>
 
+namespace seastar {
+
 namespace httpd {
 
 using namespace std;
@@ -67,4 +69,5 @@ size_t str_matcher::match(const sstring& url, size_t ind, parameters& param) {
     return sstring::npos;
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/matcher.hh
+++ b/http/matcher.hh
@@ -26,6 +26,7 @@
 
 #include "core/sstring.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -105,6 +106,7 @@ private:
     unsigned _len;
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* MATCHER_HH_ */

--- a/http/matchrules.hh
+++ b/http/matchrules.hh
@@ -29,6 +29,7 @@
 #include "core/sstring.hh"
 #include <vector>
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -113,6 +114,7 @@ private:
     handler_base* _handler;
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* MATCH_RULES_HH_ */

--- a/http/mime_types.cc
+++ b/http/mime_types.cc
@@ -10,6 +10,7 @@
 
 #include "mime_types.hh"
 
+namespace seastar {
 namespace httpd {
 namespace mime_types {
 
@@ -41,4 +42,5 @@ const char* extension_to_type(const sstring& extension)
 
 } // namespace mime_types
 
-} // httpd
+} // namespace httpd
+} // namespace seastar

--- a/http/mime_types.hh
+++ b/http/mime_types.hh
@@ -13,6 +13,7 @@
 
 #include "core/sstring.hh"
 
+namespace seastar {
 namespace httpd {
 
 namespace mime_types {
@@ -28,5 +29,6 @@ const char* extension_to_type(const sstring& extension);
 } // namespace mime_types
 
 } // namespace httpd
+} // namespace seastar
 
 #endif // HTTP_MIME_TYPES_HH

--- a/http/reply.cc
+++ b/http/reply.cc
@@ -30,6 +30,7 @@
 //
 #include "reply.hh"
 
+namespace seastar {
 namespace httpd {
 
 namespace status_strings {
@@ -102,4 +103,5 @@ sstring reply::response_line() {
     return "HTTP/" + _version + status_strings::to_string(_status);
 }
 
-} // namespace server
+} // namespace httpd
+} // namespace seastar

--- a/http/reply.hh
+++ b/http/reply.hh
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include "http/mime_types.hh"
 
+namespace seastar {
 namespace httpd {
 /**
  * A reply to be sent to a client.
@@ -130,3 +131,4 @@ struct reply {
 };
 
 } // namespace httpd
+} // namespace seastar

--- a/http/request.hh
+++ b/http/request.hh
@@ -37,6 +37,7 @@
 #include <strings.h>
 #include "common.hh"
 
+namespace seastar {
 namespace httpd {
 class connection;
 
@@ -115,5 +116,6 @@ struct request {
 };
 
 } // namespace httpd
+} // namespace seastar
 
 #endif // HTTP_REQUEST_HPP

--- a/http/request_parser.rl
+++ b/http/request_parser.rl
@@ -26,7 +26,8 @@
 #include <unordered_map>
 #include "http/request.hh"
 
-using namespace httpd;
+using namespace seastar;
+using namespace seastar::httpd;
 
 %% machine request;
 

--- a/http/routes.cc
+++ b/http/routes.cc
@@ -23,6 +23,7 @@
 #include "reply.hh"
 #include "exception.hh"
 
+namespace seastar {
 namespace httpd {
 
 using namespace std;
@@ -142,4 +143,5 @@ routes& routes::add(operation_type type, const url& url,
     return add(rule, type);
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/routes.hh
+++ b/http/routes.hh
@@ -32,6 +32,7 @@
 #include <vector>
 #include "core/future-util.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -202,6 +203,7 @@ public:
  */
 void verify_param(const httpd::request& req, const sstring& param);
 
-}
+} // namespace httpd
+} // namespace seastar
 
 #endif /* ROUTES_HH_ */

--- a/http/transformers.cc
+++ b/http/transformers.cc
@@ -23,6 +23,7 @@
 #include "transformers.hh"
 #include <experimental/string_view>
 
+namespace seastar {
 namespace httpd {
 
 using namespace std;
@@ -37,4 +38,5 @@ void content_replace::transform(sstring& content, const request& req,
     boost::replace_all(content, "{{Protocol}}", req.get_protocol_name());
 }
 
-}
+} // namespace httpd
+} // namespace seastar

--- a/http/transformers.hh
+++ b/http/transformers.hh
@@ -25,6 +25,7 @@
 #include "handlers.hh"
 #include "file_handler.hh"
 
+namespace seastar {
 namespace httpd {
 
 /**
@@ -53,5 +54,6 @@ private:
     sstring extension;
 };
 
-}
+} // namespace httpd
+} // namespace seastar
 #endif /* TRANSFORMERS_HH_ */

--- a/json/formatter.cc
+++ b/json/formatter.cc
@@ -24,6 +24,7 @@
 
 using namespace std;
 
+namespace seastar {
 namespace json {
 
 sstring formatter::to_json(const sstring& str) {
@@ -83,4 +84,5 @@ sstring formatter::to_json(unsigned long l) {
     return to_string(l);
 }
 
-}
+} // namespace json
+} // namespace seastar

--- a/json/formatter.hh
+++ b/json/formatter.hh
@@ -28,6 +28,7 @@
 #include <sstream>
 #include "core/sstring.hh"
 
+namespace seastar {
 namespace json {
 
 struct jsonable;
@@ -140,5 +141,6 @@ private:
 
 };
 
-}
+} // namespace json
+} // namespace seastar
 #endif /* FORMATTER_HH_ */

--- a/json/json2code.py
+++ b/json/json2code.py
@@ -297,6 +297,7 @@ def create_h_file(data, hfile_name, api_name, init_method, base_api):
                        'json_elements.hh"', '"http/json_path.hh"'])
 
     add_include(hfile, ['<iostream>', '<boost/range/irange.hpp>'])
+    open_namespace(hfile, "seastar")
     open_namespace(hfile, "httpd")
     open_namespace(hfile, api_name)
 
@@ -417,6 +418,7 @@ def create_h_file(data, hfile_name, api_name, init_method, base_api):
                 fprintln(hfile, '});')
                 fprintln(hfile, enum_definitions)
 
+    close_namespace(hfile)
     close_namespace(hfile)
     close_namespace(hfile)
     hfile.write("#endif //__JSON_AUTO_GENERATED_HEADERS\n")

--- a/json/json_elements.cc
+++ b/json/json_elements.cc
@@ -27,6 +27,7 @@
 
 using namespace std;
 
+namespace seastar {
 namespace json {
 
 /**
@@ -110,4 +111,5 @@ bool json_base::is_verify() const {
     return true;
 }
 
-}
+} // namespace json
+} // namespace seastar

--- a/json/json_elements.hh
+++ b/json/json_elements.hh
@@ -29,6 +29,7 @@
 #include "formatter.hh"
 #include "core/sstring.hh"
 
+namespace seastar {
 namespace json {
 
 /**
@@ -256,6 +257,7 @@ struct json_return_type {
     json_return_type& operator=(json_return_type&&) = default;
 };
 
-}
+} // namespace json
+} // namespace seastar
 
 #endif /* JSON_ELEMENTS_HH_ */

--- a/net/api.hh
+++ b/net/api.hh
@@ -35,6 +35,8 @@
 #include <sys/socket.h>
 #include <netinet/ip.h>
 
+namespace seastar {
+
 struct ipv4_addr;
 
 class socket_address {
@@ -262,5 +264,7 @@ public:
     }
     virtual bool has_per_core_namespace() = 0;
 };
+
+} // namespace seastar
 
 #endif

--- a/net/arp.cc
+++ b/net/arp.cc
@@ -21,6 +21,7 @@
 
 #include "arp.hh"
 
+namespace seastar {
 namespace net {
 
 arp_for_protocol::arp_for_protocol(arp& a, uint16_t proto_num)
@@ -77,4 +78,5 @@ arp::process_packet(packet p, ethernet_address from) {
     return make_ready_future<>();
 }
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/arp.hh
+++ b/net/arp.hh
@@ -30,6 +30,7 @@
 #include "core/print.hh"
 #include <unordered_map>
 
+namespace seastar {
 namespace net {
 
 class arp;
@@ -256,6 +257,7 @@ arp_for<L3>::handle_request(arp_hdr* ah) {
     return make_ready_future<>();
 }
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* ARP_HH_ */

--- a/net/byteorder.hh
+++ b/net/byteorder.hh
@@ -28,6 +28,8 @@
 
 #include "core/unaligned.hh"
 
+namespace seastar {
+
 inline uint64_t ntohq(uint64_t v) {
     return __builtin_bswap64(v);
 }
@@ -115,6 +117,7 @@ T hton(const T& x) {
     return tmp;
 }
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* BYTEORDER_HH_ */

--- a/net/const.hh
+++ b/net/const.hh
@@ -21,6 +21,7 @@
 
 #ifndef CONST_HH_
 #define CONST_HH_
+namespace seastar {
 namespace net {
 
 enum class ip_protocol_num : uint8_t {
@@ -37,5 +38,7 @@ const uint8_t ipv4_hdr_len_min = 20;
 const uint8_t ipv6_hdr_len_min = 40;
 const uint16_t ip_packet_len_max = 65535;
 
-}
+} // namespace net
+} // namespace seastar
+
 #endif

--- a/net/dhcp.cc
+++ b/net/dhcp.cc
@@ -29,6 +29,8 @@
 #include "udp.hh"
 #include "stack.hh"
 
+namespace seastar {
+
 using namespace std::literals::chrono_literals;
 
 class net::dhcp::impl : public ip_packet_filter {
@@ -465,3 +467,5 @@ net::dhcp::result_type net::dhcp::renew(const lease & l, const steady_clock_type
 net::ip_packet_filter* net::dhcp::get_ipv4_filter() {
     return _impl.get();
 }
+
+} // namespace seastar

--- a/net/dhcp.hh
+++ b/net/dhcp.hh
@@ -25,6 +25,7 @@
 #include "ip.hh"
 #include "core/reactor.hh"
 
+namespace seastar {
 namespace net {
 
 /*
@@ -78,6 +79,7 @@ private:
     std::unique_ptr<impl> _impl;
 };
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* NET_DHCP_HH_ */

--- a/net/dpdk.cc
+++ b/net/dpdk.cc
@@ -53,6 +53,9 @@
 #include <rte_cycles.h>
 #include <rte_memzone.h>
 
+namespace seastar {
+
+
 #if RTE_VERSION <= RTE_VERSION_NUM(2,0,0,16)
 
 static
@@ -2211,5 +2214,7 @@ get_dpdk_net_options_description()
 #endif
     return opts;
 }
+
+} // namespace seastar
 
 #endif // HAVE_DPDK

--- a/net/dpdk.hh
+++ b/net/dpdk.hh
@@ -28,6 +28,8 @@
 #include "net.hh"
 #include "core/sstring.hh"
 
+namespace seastar {
+
 std::unique_ptr<net::device> create_dpdk_net_device(
                                     uint8_t port_idx = 0,
                                     uint8_t num_queues = 1,
@@ -42,6 +44,8 @@ namespace dpdk {
  */
 uint32_t qp_mempool_obj_size(bool hugetlbfs_membackend);
 }
+
+} // namespace seastar
 
 #endif // _SEASTAR_DPDK_DEV_H
 

--- a/net/ethernet.cc
+++ b/net/ethernet.cc
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string.hpp>
 #include <string>
 
+namespace seastar {
 namespace net {
 
 std::ostream& operator<<(std::ostream& os, ethernet_address ea) {
@@ -48,7 +49,9 @@ ethernet_address parse_ethernet_address(std::string addr)
     }
     return a;
 }
-}
+
+} // namespace net
+} // namespace seastar
 
 
 

--- a/net/ethernet.hh
+++ b/net/ethernet.hh
@@ -26,6 +26,7 @@
 #include "byteorder.hh"
 #include "core/print.hh"
 
+namespace seastar {
 namespace net {
 
 struct ethernet_address {
@@ -67,6 +68,8 @@ struct eth_hdr {
 } __attribute__((packed));
 
 ethernet_address parse_ethernet_address(std::string addr);
-}
+
+} // namespace net
+} // namespace seastar
 
 #endif /* ETHERNET_HH_ */

--- a/net/ip.cc
+++ b/net/ip.cc
@@ -26,6 +26,7 @@
 #include "core/shared_ptr.hh"
 #include "toeplitz.hh"
 
+namespace seastar {
 namespace net {
 
 std::ostream& operator<<(std::ostream& os, ipv4_address a) {
@@ -473,4 +474,5 @@ void icmp::received(packet p, ipaddr from, ipaddr to) {
     }
 }
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/ip.hh
+++ b/net/ip.hh
@@ -41,6 +41,7 @@
 #include "toeplitz.hh"
 #include "net/udp.hh"
 
+namespace seastar {
 namespace net {
 
 class ipv4;
@@ -78,17 +79,19 @@ static inline bool is_unspecified(ipv4_address addr) { return addr.ip == 0; }
 
 std::ostream& operator<<(std::ostream& os, ipv4_address a);
 
-}
+} // namespace net
+} // namespace seastar
 
 namespace std {
 
 template <>
-struct hash<net::ipv4_address> {
-    size_t operator()(net::ipv4_address a) const { return a.ip; }
+struct hash<seastar::net::ipv4_address> {
+    size_t operator()(seastar::net::ipv4_address a) const { return a.ip; }
 };
 
-}
+} // namespace std
 
+namespace seastar {
 namespace net {
 
 struct ipv4_traits {
@@ -439,6 +442,7 @@ struct l4connid<InetTraits>::connid_hash : private std::hash<ipaddr>, private st
 
 void arp_learn(ethernet_address l2, ipv4_address l3);
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* IP_HH_ */

--- a/net/ip_checksum.cc
+++ b/net/ip_checksum.cc
@@ -23,6 +23,7 @@
 #include "net.hh"
 #include <arpa/inet.h>
 
+namespace seastar {
 namespace net {
 
 void checksummer::sum(const char* data, size_t len) {
@@ -71,4 +72,5 @@ uint16_t ip_checksum(const void* data, size_t len) {
 }
 
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/ip_checksum.hh
+++ b/net/ip_checksum.hh
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <arpa/inet.h>
 
+namespace seastar {
 namespace net {
 
 uint16_t ip_checksum(const void* data, size_t len);
@@ -69,6 +70,7 @@ struct checksummer {
     uint16_t get() const;
 };
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* IP_CHECKSUM_HH_ */

--- a/net/native-stack-impl.hh
+++ b/net/native-stack-impl.hh
@@ -25,6 +25,7 @@
 #include "core/reactor.hh"
 #include "stack.hh"
 
+namespace seastar {
 namespace net {
 
 template <typename Protocol>
@@ -165,7 +166,8 @@ native_connected_socket_impl<Protocol>::get_nodelay() const {
     return true;
 }
 
-}
+} // namespace net
+} // namespace seastar
 
 
 

--- a/net/native-stack.cc
+++ b/net/native-stack.cc
@@ -40,6 +40,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+namespace seastar {
 namespace net {
 
 enum class xen_info {
@@ -341,4 +342,5 @@ network_stack_registrator nns_registrator{
     "native", nns_options(), native_network_stack::create
 };
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/native-stack.hh
+++ b/net/native-stack.hh
@@ -25,10 +25,12 @@
 #include "net/net.hh"
 #include <boost/program_options.hpp>
 
+namespace seastar {
 namespace net {
 
 void create_native_stack(boost::program_options::variables_map opts, std::shared_ptr<device> dev);
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* STACK_HH_ */

--- a/net/net.cc
+++ b/net/net.cc
@@ -26,6 +26,7 @@
 #include <utility>
 #include "toeplitz.hh"
 
+namespace seastar {
 using std::move;
 
 ipv4_addr::ipv4_addr(const std::string &addr) {
@@ -364,4 +365,5 @@ future<> interface::dispatch_packet(packet p) {
     return make_ready_future<>();
 }
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/net.hh
+++ b/net/net.hh
@@ -33,6 +33,7 @@
 #include "const.hh"
 #include <unordered_map>
 
+namespace seastar {
 namespace net {
 
 class packet;
@@ -292,6 +293,7 @@ public:
     }
 };
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* NET_HH_ */

--- a/net/packet-data-source.hh
+++ b/net/packet-data-source.hh
@@ -21,6 +21,7 @@
 #include "core/reactor.hh"
 #include "net/packet.hh"
 
+namespace seastar {
 namespace net {
 
 class packet_data_source final : public data_source_impl {
@@ -47,6 +48,7 @@ input_stream<char> as_input_stream(packet&& p) {
     return input_stream<char>(data_source(std::make_unique<packet_data_source>(std::move(p))));
 }
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif

--- a/net/packet-util.hh
+++ b/net/packet-util.hh
@@ -26,6 +26,7 @@
 #include <map>
 #include <iostream>
 
+namespace seastar {
 namespace net {
 
 template <typename Offset, typename Tag>
@@ -152,5 +153,6 @@ public:
     }
 };
 
-}
+} // namespace net
+} // namespace seastar
 #endif

--- a/net/packet.cc
+++ b/net/packet.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cctype>
 
+namespace seastar {
 namespace net {
 
 constexpr size_t packet::internal_data_size;
@@ -119,4 +120,5 @@ std::ostream& operator<<(std::ostream& os, const packet& p) {
     return os;
 }
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/packet.hh
+++ b/net/packet.hh
@@ -31,6 +31,7 @@
 #include <iosfwd>
 #include <experimental/optional>
 
+namespace seastar {
 namespace net {
 
 struct fragment {
@@ -580,6 +581,7 @@ packet packet::share(size_t offset, size_t len) {
     return n;
 }
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif /* PACKET_HH_ */

--- a/net/posix-stack.cc
+++ b/net/posix-stack.cc
@@ -25,6 +25,7 @@
 #include "api.hh"
 #include <netinet/tcp.h>
 
+namespace seastar {
 namespace net {
 
 class posix_connected_socket_impl final : public connected_socket_impl {
@@ -332,4 +333,5 @@ posix_udp_channel::receive() {
     });
 }
 
-}
+} // namespace net
+} // namespace seastar

--- a/net/posix-stack.hh
+++ b/net/posix-stack.hh
@@ -26,6 +26,7 @@
 #include "stack.hh"
 #include <boost/program_options.hpp>
 
+namespace seastar {
 namespace net {
 
 data_source posix_data_source(pollable_fd& fd);
@@ -114,6 +115,7 @@ public:
     }
 };
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif

--- a/net/proxy.cc
+++ b/net/proxy.cc
@@ -19,6 +19,7 @@
 #include "proxy.hh"
 #include <utility>
 
+namespace seastar {
 namespace net {
 
 class proxy_net_device : public qp {
@@ -72,4 +73,6 @@ uint32_t proxy_net_device::send(circular_buffer<packet>& p)
 std::unique_ptr<qp> create_proxy_net_device(unsigned master_cpu, device* dev) {
     return std::make_unique<proxy_net_device>(master_cpu, dev);
 }
-}
+
+} // namespace net
+} // namespace seastar

--- a/net/proxy.hh
+++ b/net/proxy.hh
@@ -22,9 +22,11 @@
 #include "net.hh"
 #include "packet.hh"
 
+namespace seastar {
 namespace net {
 
 std::unique_ptr<qp> create_proxy_net_device(unsigned master_cpu, device* dev);
 
-}
+} // namespace net
+} // namespace seastar
 #endif

--- a/net/stack.cc
+++ b/net/stack.cc
@@ -22,6 +22,8 @@
 #include "stack.hh"
 #include "core/reactor.hh"
 
+namespace seastar {
+
 net::udp_channel::udp_channel()
 {}
 
@@ -117,3 +119,4 @@ socket_address::socket_address(ipv4_addr addr)
     : socket_address(make_ipv4_address(addr))
 {}
 
+} // namespace seastar

--- a/net/stack.hh
+++ b/net/stack.hh
@@ -22,6 +22,7 @@
 
 #include "api.hh"
 
+namespace seastar {
 namespace net {
 
 /// \cond internal
@@ -55,5 +56,6 @@ public:
 
 /// \endcond
 
-}
+} // namespace net
+} // namespace seastar
 

--- a/net/tcp-stack.hh
+++ b/net/tcp-stack.hh
@@ -30,6 +30,7 @@ class listen_options;
 class server_socket;
 class connected_socket;
 
+namespace seastar {
 namespace net {
 
 class ipv4_traits;
@@ -42,6 +43,7 @@ tcpv4_listen(tcp<ipv4_traits>& tcpv4, uint16_t port, listen_options opts);
 future<connected_socket>
 tcpv4_connect(tcp<ipv4_traits>& tcpv4, socket_address sa);
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif

--- a/net/tcp.cc
+++ b/net/tcp.cc
@@ -26,6 +26,7 @@
 #include "core/future.hh"
 #include "native-stack-impl.hh"
 
+namespace seastar {
 namespace net {
 
 void tcp_option::parse(uint8_t* beg, uint8_t* end) {
@@ -159,5 +160,6 @@ tcpv4_connect(tcp<ipv4_traits>& tcpv4, socket_address sa) {
     });
 }
 
-}
+} // namespace net
+} // namespace seastar
 

--- a/net/tcp.hh
+++ b/net/tcp.hh
@@ -46,6 +46,7 @@
 
 using namespace std::chrono_literals;
 
+namespace seastar {
 namespace net {
 
 class tcp_hdr;
@@ -1933,7 +1934,8 @@ constexpr std::chrono::milliseconds tcp<InetTraits>::tcb::_rto_clk_granularity;
 template <typename InetTraits>
 typename tcp<InetTraits>::tcb::isn_secret tcp<InetTraits>::tcb::_isn_secret;
 
-}
+} // namespace net
+} // namespace seastar
 
 
 

--- a/net/tls.cc
+++ b/net/tls.cc
@@ -30,6 +30,8 @@
 #include "tls.hh"
 #include "stack.hh"
 
+namespace seastar {
+
 class net::get_impl {
 public:
     static std::unique_ptr<connected_socket_impl> get(connected_socket s) {
@@ -39,7 +41,7 @@ public:
 
 class blob_wrapper: public gnutls_datum_t {
 public:
-    blob_wrapper(const seastar::tls::blob& in)
+    blob_wrapper(const tls::blob& in)
             : gnutls_datum_t {
                     reinterpret_cast<uint8_t *>(const_cast<char *>(in.data())),
                     unsigned(in.size()) } {
@@ -111,7 +113,7 @@ static void gtls_chk(int res) {
     }
 }
 
-class seastar::tls::dh_params::impl : gnutlsobj {
+class tls::dh_params::impl : gnutlsobj {
 public:
     impl()
             : _params([] {
@@ -145,27 +147,27 @@ private:
     gnutls_dh_params_t _params;
 };
 
-seastar::tls::dh_params::dh_params(level lvl) : _impl(std::make_unique<impl>(lvl))
+tls::dh_params::dh_params(level lvl) : _impl(std::make_unique<impl>(lvl))
 {}
 
-seastar::tls::dh_params::dh_params(const blob& b, x509_crt_format fmt)
+tls::dh_params::dh_params(const blob& b, x509_crt_format fmt)
         : _impl(std::make_unique<impl>(b, fmt)) {
 }
 
-seastar::tls::dh_params::~dh_params() {
+tls::dh_params::~dh_params() {
 }
 
-seastar::tls::dh_params::dh_params(dh_params&&) noexcept = default;
-seastar::tls::dh_params& seastar::tls::dh_params::operator=(dh_params&&) noexcept = default;
+tls::dh_params::dh_params(dh_params&&) noexcept = default;
+tls::dh_params& tls::dh_params::operator=(dh_params&&) noexcept = default;
 
-future<seastar::tls::dh_params> seastar::tls::dh_params::from_file(
+future<tls::dh_params> tls::dh_params::from_file(
         const sstring& filename, x509_crt_format fmt) {
     return read_fully(filename, "dh parameters").then([fmt](temporary_buffer<char> buf) {
         return make_ready_future<dh_params>(dh_params(blob(buf.get()), fmt));
     });
 }
 
-class seastar::tls::x509_cert::impl : gnutlsobj {
+class tls::x509_cert::impl : gnutlsobj {
 public:
     impl()
             : _cert([] {
@@ -193,22 +195,22 @@ private:
     gnutls_x509_crt_t _cert;
 };
 
-seastar::tls::x509_cert::x509_cert(::shared_ptr<impl> impl)
+tls::x509_cert::x509_cert(seastar::shared_ptr<impl> impl)
         : _impl(std::move(impl)) {
 }
 
-seastar::tls::x509_cert::x509_cert(const blob& b, x509_crt_format fmt)
-        : x509_cert(::make_shared<impl>(b, fmt)) {
+tls::x509_cert::x509_cert(const blob& b, x509_crt_format fmt)
+    : x509_cert(seastar::make_shared<impl>(b, fmt)) {
 }
 
-future<seastar::tls::x509_cert> seastar::tls::x509_cert::from_file(
+future<tls::x509_cert> tls::x509_cert::from_file(
         const sstring& filename, x509_crt_format fmt) {
     return read_fully(filename, "x509 certificate").then([fmt](temporary_buffer<char> buf) {
         return make_ready_future<x509_cert>(x509_cert(blob(buf.get()), fmt));
     });
 }
 
-class seastar::tls::certificate_credentials::impl: public gnutlsobj {
+class tls::certificate_credentials::impl: public gnutlsobj {
 public:
     impl()
             : _creds([] {
@@ -256,68 +258,68 @@ public:
                 gnutls_certificate_set_x509_simple_pkcs12_mem(_creds, &w,
                         gnutls_x509_crt_fmt_t(fmt), password.c_str()));
     }
-    void dh_params(::shared_ptr<tls::dh_params> dh) {
+    void dh_params(seastar::shared_ptr<tls::dh_params> dh) {
         gnutls_certificate_set_dh_params(*this, *dh->_impl);
         _dh_params = std::move(dh);
     }
 
     future<> set_system_trust() {
-        return seastar::async([this] {
+        return async([this] {
             gtls_chk(gnutls_certificate_set_x509_system_trust(_creds));
         });
     }
 private:
     gnutls_certificate_credentials_t _creds;
-    ::shared_ptr<tls::dh_params> _dh_params;
+    seastar::shared_ptr<tls::dh_params> _dh_params;
 };
 
-seastar::tls::certificate_credentials::certificate_credentials()
+tls::certificate_credentials::certificate_credentials()
         : _impl(std::make_unique<impl>()) {
 }
 
-seastar::tls::certificate_credentials::~certificate_credentials() {
+tls::certificate_credentials::~certificate_credentials() {
 }
 
-seastar::tls::certificate_credentials::certificate_credentials(
+tls::certificate_credentials::certificate_credentials(
         certificate_credentials&&) noexcept = default;
-seastar::tls::certificate_credentials& seastar::tls::certificate_credentials::operator=(
+tls::certificate_credentials& tls::certificate_credentials::operator=(
         certificate_credentials&&) noexcept = default;
 
-void seastar::tls::certificate_credentials::set_x509_trust(const blob& b,
+void tls::certificate_credentials::set_x509_trust(const blob& b,
         x509_crt_format fmt) {
     _impl->set_x509_trust(b, fmt);
 }
 
-void seastar::tls::certificate_credentials::set_x509_crl(const blob& b,
+void tls::certificate_credentials::set_x509_crl(const blob& b,
         x509_crt_format fmt) {
     _impl->set_x509_crl(b, fmt);
 
 }
-void seastar::tls::certificate_credentials::set_x509_key(const blob& cert,
+void tls::certificate_credentials::set_x509_key(const blob& cert,
         const blob& key, x509_crt_format fmt) {
     _impl->set_x509_key(cert, key, fmt);
 }
 
-void seastar::tls::certificate_credentials::set_simple_pkcs12(const blob& b,
+void tls::certificate_credentials::set_simple_pkcs12(const blob& b,
         x509_crt_format fmt, const sstring& password) {
     _impl->set_simple_pkcs12(b, fmt, password);
 }
 
-future<> seastar::tls::certificate_credentials::set_x509_trust_file(
+future<> tls::certificate_credentials::set_x509_trust_file(
         const sstring& cafile, x509_crt_format fmt) {
     return read_fully(cafile, "trust file").then([this, fmt](temporary_buffer<char> buf) {
         _impl->set_x509_trust(blob(buf.get(), buf.size()), fmt);
     });
 }
 
-future<> seastar::tls::certificate_credentials::set_x509_crl_file(
+future<> tls::certificate_credentials::set_x509_crl_file(
         const sstring& crlfile, x509_crt_format fmt) {
     return read_fully(crlfile, "crl file").then([this, fmt](temporary_buffer<char> buf) {
         _impl->set_x509_crl(blob(buf.get(), buf.size()), fmt);
     });
 }
 
-future<> seastar::tls::certificate_credentials::set_x509_key_file(
+future<> tls::certificate_credentials::set_x509_key_file(
         const sstring& cf, const sstring& kf, x509_crt_format fmt) {
     return read_fully(cf, "certificate file").then([this, fmt, kf](temporary_buffer<char> buf) {
         return read_fully(kf, "key file").then([this, fmt, buf = std::move(buf)](temporary_buffer<char> buf2) {
@@ -326,7 +328,7 @@ future<> seastar::tls::certificate_credentials::set_x509_key_file(
     });
 }
 
-future<> seastar::tls::certificate_credentials::set_simple_pkcs12_file(
+future<> tls::certificate_credentials::set_simple_pkcs12_file(
         const sstring& pkcs12file, x509_crt_format fmt,
         const sstring& password) {
     return read_fully(pkcs12file, "pkcs12 file").then([this, fmt, password](temporary_buffer<char> buf) {
@@ -334,19 +336,18 @@ future<> seastar::tls::certificate_credentials::set_simple_pkcs12_file(
     });
 }
 
-future<> seastar::tls::certificate_credentials::set_system_trust() {
+future<> tls::certificate_credentials::set_system_trust() {
     return _impl->set_system_trust();
 }
 
-seastar::tls::server_credentials::server_credentials(::shared_ptr<dh_params> dh) {
+tls::server_credentials::server_credentials(seastar::shared_ptr<dh_params> dh) {
     _impl->dh_params(std::move(dh));
 }
 
-seastar::tls::server_credentials::server_credentials(server_credentials&&) noexcept = default;
-seastar::tls::server_credentials& seastar::tls::server_credentials::operator=(
+tls::server_credentials::server_credentials(server_credentials&&) noexcept = default;
+tls::server_credentials& tls::server_credentials::operator=(
         server_credentials&&) noexcept = default;
 
-namespace seastar {
 namespace tls {
 
 /**
@@ -365,8 +366,8 @@ public:
             CLIENT = GNUTLS_CLIENT, SERVER = GNUTLS_SERVER,
     };
 
-    session(type t, ::shared_ptr<certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
+    session(type t, seastar::shared_ptr<certificate_credentials> creds,
+	    std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
             : _type(t), _sock(std::move(sock)), _creds(std::move(creds)), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()), _output_pending(
                     make_ready_future<>()), _session([t] {
@@ -391,8 +392,8 @@ public:
         gnutls_session_set_verify_function(_session, &verify_wrapper);
 #endif
     }
-    session(type t, ::shared_ptr<certificate_credentials> creds,
-            ::connected_socket sock, sstring name = { })
+    session(type t, seastar::shared_ptr<certificate_credentials> creds,
+            connected_socket sock, sstring name = { })
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
                     std::move(name)) {
     }
@@ -664,7 +665,7 @@ private:
     type _type;
 
     std::unique_ptr<net::connected_socket_impl> _sock;
-    ::shared_ptr<certificate_credentials> _creds;
+    seastar::shared_ptr<certificate_credentials> _creds;
     const sstring _hostname;
     data_source _in;
     data_sink _out;
@@ -680,7 +681,7 @@ private:
 };
 
 
-class session::source_impl: public ::data_source_impl {
+class session::source_impl: public seastar::data_source_impl {
 public:
     source_impl(session& s)
             : _session(s) {
@@ -738,7 +739,7 @@ private:
 // produced, cannot exist outside the direct life span of
 // the connected_socket itself. This is consistent with
 // other sockets in seastar, though I am than less fond of it...
-class session::sink_impl: public ::data_sink_impl {
+class session::sink_impl: public data_sink_impl {
 public:
     sink_impl(session& s)
             : _session(s) {
@@ -798,15 +799,15 @@ private:
 
 class server_session : public net::server_socket_impl {
 public:
-    server_session(::shared_ptr<server_credentials> creds, ::server_socket sock)
+    server_session(seastar::shared_ptr<server_credentials> creds, server_socket sock)
             : _creds(std::move(creds)), _sock(std::move(sock)) {
     }
     future<connected_socket, socket_address> accept() override {
         // We're not actually doing anything very SSL until we get
         // an actual connection. Then we create a "server" session
         // and wrap it up after handshaking.
-        return _sock.accept().then([this](::connected_socket s, ::socket_address addr) {
-            return wrap_server(_creds, std::move(s)).then([addr](::connected_socket s) {
+        return _sock.accept().then([this](connected_socket s, socket_address addr) {
+            return wrap_server(_creds, std::move(s)).then([addr](connected_socket s) {
                 return make_ready_future<connected_socket, socket_address>(std::move(s), addr);
             });
         });
@@ -815,58 +816,59 @@ public:
         _sock.abort_accept();
     }
 private:
-    ::shared_ptr<server_credentials> _creds;
-    ::server_socket _sock;
+    seastar::shared_ptr<server_credentials> _creds;
+    server_socket _sock;
 };
 
 }
-}
 
-data_source seastar::tls::session::source() {
+data_source tls::session::source() {
     return data_source(std::make_unique<source_impl>(*this));
 }
 
-data_sink seastar::tls::session::sink() {
+data_sink tls::session::sink() {
     return data_sink(std::make_unique<sink_impl>(*this));
 }
 
 
-future<::connected_socket> seastar::tls::connect(::shared_ptr<certificate_credentials> cred, socket_address sa, sstring name) {
-    return engine().connect(sa).then([cred = std::move(cred), name = std::move(name)](::connected_socket s) mutable {
+future<connected_socket> tls::connect(seastar::shared_ptr<certificate_credentials> cred, socket_address sa, sstring name) {
+    return engine().connect(sa).then([cred = std::move(cred), name = std::move(name)](connected_socket s) mutable {
         return wrap_client(cred, std::move(s), std::move(name));
     });
 }
 
-future<::connected_socket> seastar::tls::connect(::shared_ptr<certificate_credentials> cred, socket_address sa, socket_address local, sstring name) {
-    return engine().connect(sa, local).then([cred = std::move(cred), name = std::move(name)](::connected_socket s) mutable {
+future<connected_socket> tls::connect(seastar::shared_ptr<certificate_credentials> cred, socket_address sa, socket_address local, sstring name) {
+    return engine().connect(sa, local).then([cred = std::move(cred), name = std::move(name)](connected_socket s) mutable {
         return wrap_client(cred, std::move(s), std::move(name));
     });
 }
 
-future<::connected_socket> seastar::tls::wrap_client(::shared_ptr<certificate_credentials> cred, ::connected_socket&& s, sstring name) {
+future<connected_socket> tls::wrap_client(seastar::shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
     auto sess = std::make_unique<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name));
     auto f = sess->handshake();
     return f.then([sess = std::move(sess)]() mutable {
-        ::connected_socket ssls(std::move(sess));
-        return make_ready_future<::connected_socket>(std::move(ssls));
+        connected_socket ssls(std::move(sess));
+        return make_ready_future<connected_socket>(std::move(ssls));
     });
 }
 
-future<::connected_socket> seastar::tls::wrap_server(::shared_ptr<server_credentials> cred, ::connected_socket&& s) {
+future<connected_socket> tls::wrap_server(seastar::shared_ptr<server_credentials> cred, connected_socket&& s) {
     auto sess = std::make_unique<session>(session::type::SERVER, std::move(cred), std::move(s));
     auto f = sess->handshake();
     return f.then([sess = std::move(sess)]() mutable {
-        ::connected_socket ssls(std::move(sess));
-        return make_ready_future<::connected_socket>(std::move(ssls));
+        connected_socket ssls(std::move(sess));
+        return make_ready_future<connected_socket>(std::move(ssls));
     });
 }
 
-::server_socket seastar::tls::listen(::shared_ptr<server_credentials> creds, ::socket_address sa, ::listen_options opts) {
+server_socket tls::listen(shared_ptr<server_credentials> creds, socket_address sa, listen_options opts) {
     return listen(std::move(creds), engine().listen(sa, opts));
 }
 
-::server_socket seastar::tls::listen(::shared_ptr<server_credentials> creds, ::server_socket ss) {
-    ::server_socket ssls(std::make_unique<server_session>(creds, std::move(ss)));
-    return ::server_socket(std::move(ssls));
+server_socket tls::listen(shared_ptr<server_credentials> creds, server_socket ss) {
+    server_socket ssls(std::make_unique<server_session>(creds, std::move(ss)));
+    return server_socket(std::move(ssls));
 }
 
+
+} // namespace seastar

--- a/net/tls.hh
+++ b/net/tls.hh
@@ -26,6 +26,8 @@
 #include "core/future.hh"
 #include "core/sstring.hh"
 
+namespace seastar {
+
 class connected_socket;
 
 /**
@@ -38,7 +40,6 @@ class connected_socket;
  * with OpenSSL or similar.
  *
  */
-namespace seastar {
 namespace tls {
     enum class x509_crt_format {
         DER,
@@ -91,8 +92,8 @@ namespace tls {
         static future<x509_cert> from_file(const sstring&, x509_crt_format);
     private:
         class impl;
-        x509_cert(::shared_ptr<impl>);
-        ::shared_ptr<impl> _impl;
+        x509_cert(shared_ptr<impl>);
+        shared_ptr<impl> _impl;
     };
 
     /**
@@ -154,7 +155,7 @@ namespace tls {
      */
     class server_credentials : public certificate_credentials {
     public:
-        server_credentials(::shared_ptr<dh_params>);
+        server_credentials(shared_ptr<dh_params>);
 
         server_credentials(server_credentials&&) noexcept;
         server_credentials& operator=(server_credentials&&) noexcept;
@@ -172,14 +173,14 @@ namespace tls {
      * \param name An optional expected server name for the remote end point
      */
     /// @{
-    future<::connected_socket> connect(::shared_ptr<certificate_credentials>, ::socket_address, sstring name = {});
-    future<::connected_socket> connect(::shared_ptr<certificate_credentials>, ::socket_address, ::socket_address local, sstring name = {});
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name = {});
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name = {});
     /// @}
 
     /** Wraps an existing connection in SSL/TLS. */
     /// @{
-    future<::connected_socket> wrap_client(::shared_ptr<certificate_credentials>, ::connected_socket&&, sstring name = {});
-    future<::connected_socket> wrap_server(::shared_ptr<server_credentials>, ::connected_socket&&);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
+    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 
     /**
@@ -189,9 +190,10 @@ namespace tls {
      * for the server and optionally trust/crl data.
      */
     /// @{
-    ::server_socket listen(::shared_ptr<server_credentials>, ::socket_address sa, ::listen_options opts = listen_options());
+    server_socket listen(shared_ptr<server_credentials>, socket_address sa, listen_options opts = listen_options());
     // Wraps an existing server socket in SSL
-    ::server_socket listen(::shared_ptr<server_credentials>, ::server_socket);
+    server_socket listen(shared_ptr<server_credentials>, server_socket);
     /// @}
-}
-}
+
+} // namespace tls
+} // namespace seastar

--- a/net/toeplitz.hh
+++ b/net/toeplitz.hh
@@ -46,6 +46,8 @@
 
 #include <vector>
 
+namespace seastar {
+
 using rss_key_type = std::vector<uint8_t>;
 
 // Mellanox Linux's driver key
@@ -90,4 +92,6 @@ toeplitz_hash(const rss_key_type& key, const T& data)
 	}
 	return (hash);
 }
+
+} // namespace seastar
 #endif

--- a/net/udp.cc
+++ b/net/udp.cc
@@ -22,8 +22,7 @@
 #include "ip.hh"
 #include "stack.hh"
 
-using namespace net;
-
+namespace seastar {
 namespace net {
 namespace ipv4_udp_impl {
 
@@ -219,3 +218,4 @@ ipv4_udp::make_channel(ipv4_addr addr) {
 }
 
 } /* namespace net */
+} // namespace seastar

--- a/net/udp.hh
+++ b/net/udp.hh
@@ -31,6 +31,7 @@
 #include "const.hh"
 #include "net.hh"
 
+namespace seastar {
 namespace net {
 
 struct udp_hdr {
@@ -54,6 +55,7 @@ struct udp_channel_state {
     void complete_send(size_t len) { _user_queue_space.signal(len); }
 };
 
-}
+} // namespace net
+} // namespace seastar
 
 #endif

--- a/net/virtio.cc
+++ b/net/virtio.cc
@@ -44,6 +44,8 @@
 #include <osv/virtio-assign.hh>
 #endif
 
+namespace seastar {
+
 using namespace net;
 
 namespace virtio {
@@ -1015,6 +1017,8 @@ get_virtio_net_options_description()
 std::unique_ptr<net::device> create_virtio_net_device(boost::program_options::variables_map opts) {
     return std::make_unique<virtio::device>(opts);
 }
+
+} // namespace seastar
 
 // Locks the shared object in memory and forces on-load function resolution.
 // Needed if the function passed to enable_interrupt() is run at interrupt

--- a/net/virtio.hh
+++ b/net/virtio.hh
@@ -26,7 +26,11 @@
 #include "net.hh"
 #include "core/sstring.hh"
 
+namespace seastar {
+
 std::unique_ptr<net::device> create_virtio_net_device(boost::program_options::variables_map opts = boost::program_options::variables_map());
 boost::program_options::options_description get_virtio_net_options_description();
+
+} // namespace seastar
 
 #endif /* VIRTIO_HH_ */

--- a/net/xenfront.cc
+++ b/net/xenfront.cc
@@ -47,7 +47,8 @@
 #include "xenfront.hh"
 #include <unordered_set>
 
-using namespace net;
+namespace seastar {
+using namespace seastar::net;
 
 namespace xen {
 
@@ -454,4 +455,5 @@ std::unique_ptr<net::device> create_xenfront_net_device(boost::program_options::
     return std::make_unique<xenfront_device>(opts, userspace);
 }
 
-}
+} // namespace xen
+} // namespace seastar

--- a/net/xenfront.hh
+++ b/net/xenfront.hh
@@ -28,6 +28,7 @@
 #include "core/xen/gntalloc.hh"
 #include "core/queue.hh"
 
+namespace seastar {
 namespace xen {
 
 std::unique_ptr<net::device> create_xenfront_net_device(boost::program_options::variables_map opts, bool userspace);
@@ -150,6 +151,7 @@ private:
     xenfront_qp& _dev;
 };
 
-}
+} // namespace xen
+} // namespace seastar
 
 #endif /* XENFRONT_HH_ */

--- a/rpc/rpc.cc
+++ b/rpc/rpc.cc
@@ -1,5 +1,8 @@
 #include "rpc.hh"
 
+namespace seastar {
 namespace rpc {
   no_wait_type no_wait;
-}
+
+} // namespace rpc
+} // namespace seastar

--- a/rpc/rpc.hh
+++ b/rpc/rpc.hh
@@ -30,6 +30,7 @@
 #include "core/shared_ptr.hh"
 #include "rpc/rpc_types.hh"
 
+namespace seastar {
 namespace rpc {
 
 using id_type = int64_t;
@@ -311,6 +312,8 @@ private:
         _handlers.emplace(t, std::move(handler));
     }
 };
-}
+
+} // namespace rpc
+} // namespace seastar
 
 #include "rpc_impl.hh"

--- a/rpc/rpc_impl.hh
+++ b/rpc/rpc_impl.hh
@@ -28,6 +28,7 @@
 #include "util/is_smart_ptr.hh"
 #include "core/byteorder.hh"
 
+namespace seastar {
 namespace rpc {
 
 enum class exception_type : uint32_t {
@@ -437,7 +438,7 @@ inline void reply(wait_type, future<RetTypes...>&& ret, int64_t msg_id, lw_share
             client.get_stats_internal().pending++;
             client.get_stats_internal().sent_messages++;
             try {
-                data = ::apply(marshall<Serializer, const RetTypes&...>,
+		data = ::seastar::apply(marshall<Serializer, const RetTypes&...>,
                         std::tuple_cat(std::make_tuple(std::ref(client.serializer()), 12), std::move(ret.get())));
             } catch (std::exception& ex) {
                 uint32_t len = std::strlen(ex.what());
@@ -899,7 +900,8 @@ protocol<Serializer, MsgType>::client::client(protocol& proto, ipv4_addr addr, f
 
 template<typename Serializer, typename MsgType>
 protocol<Serializer, MsgType>::client::client(protocol<Serializer, MsgType>& proto, ipv4_addr addr, ipv4_addr local)
-    : client(proto, addr, ::connect(addr, local))
+    : client(proto, addr, seastar::connect(addr, local))
 {}
 
-}
+} // namespace rpc
+} // namespace seastar

--- a/rpc/rpc_types.hh
+++ b/rpc/rpc_types.hh
@@ -27,6 +27,7 @@
 #include <boost/any.hpp>
 #include <experimental/optional>
 
+namespace seastar {
 namespace rpc {
 
 // used to tag a type for serializers
@@ -107,3 +108,4 @@ public:
 };
 
 } // namespace rpc
+} // namespace seastar

--- a/tests/alloc_test.cc
+++ b/tests/alloc_test.cc
@@ -22,6 +22,7 @@
 #include "tests/test-utils.hh"
 #include "core/memory.hh"
 
+using namespace seastar;
 
 SEASTAR_TEST_CASE(alloc_almost_all_and_realloc_it_with_a_smaller_size) {
 #ifndef DEFAULT_ALLOCATOR

--- a/tests/allocator_test.cc
+++ b/tests/allocator_test.cc
@@ -31,6 +31,8 @@
 #include <chrono>
 #include <boost/program_options.hpp>
 
+using namespace seastar;
+
 template <size_t N>
 void test_aligned_allocator() {
     using aptr = std::unique_ptr<char[]>;

--- a/tests/blkdiscard_test.cc
+++ b/tests/blkdiscard_test.cc
@@ -25,6 +25,8 @@
 #include "core/file.hh"
 #include "core/reactor.hh"
 
+using namespace seastar;
+
 namespace bpo = boost::program_options;
 
 struct file_test {

--- a/tests/directory_test.cc
+++ b/tests/directory_test.cc
@@ -25,6 +25,8 @@
 #include "core/print.hh"
 #include "core/shared_ptr.hh"
 
+using namespace seastar;
+
 int main(int ac, char** av) {
     class lister {
         file _f;

--- a/tests/distributed_test.cc
+++ b/tests/distributed_test.cc
@@ -25,6 +25,8 @@
 #include "core/future-util.hh"
 #include "core/sleep.hh"
 
+using namespace seastar;
+
 struct async : public seastar::async_sharded_service<async> {
     thread_local static bool deleted;
     ~async() {

--- a/tests/echotest.cc
+++ b/tests/echotest.cc
@@ -28,7 +28,8 @@
 #include <utility>
 #include <algorithm>
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 void dump_packet(const packet& p) {
     std::cout << "rx:";

--- a/tests/fair_queue_test.cc
+++ b/tests/fair_queue_test.cc
@@ -32,6 +32,8 @@
 #include <boost/range/irange.hpp>
 #include <chrono>
 
+using namespace seastar;
+
 using namespace std::chrono_literals;
 
 struct test_env {

--- a/tests/fileiotest.cc
+++ b/tests/fileiotest.cc
@@ -25,6 +25,8 @@
 #include "core/file.hh"
 #include "core/reactor.hh"
 
+using namespace seastar;
+
 struct file_test {
     file_test(file&& f) : f(std::move(f)) {}
     file f;

--- a/tests/foreign_ptr_test.cc
+++ b/tests/foreign_ptr_test.cc
@@ -24,6 +24,8 @@
 #include "core/distributed.hh"
 #include "core/shared_ptr.hh"
 
+using namespace seastar;
+
 SEASTAR_TEST_CASE(make_foreign_ptr_from_lw_shared_ptr) {
     auto p = make_foreign(make_lw_shared<sstring>("foo"));
     BOOST_REQUIRE(p->size() == 3);

--- a/tests/fstream_test.cc
+++ b/tests/fstream_test.cc
@@ -29,6 +29,8 @@
 #include "core/seastar.hh"
 #include "test-utils.hh"
 
+using namespace seastar;
+
 struct writer {
     output_stream<char> out;
     writer(file f) : out(make_file_output_stream(std::move(f))) {}

--- a/tests/futures_test.cc
+++ b/tests/futures_test.cc
@@ -29,6 +29,8 @@
 #include "core/thread.hh"
 #include <boost/iterator/counting_iterator.hpp>
 
+using namespace seastar;
+
 class expected_exception : std::runtime_error {
 public:
     expected_exception() : runtime_error("expected") {}

--- a/tests/httpd.cc
+++ b/tests/httpd.cc
@@ -13,7 +13,8 @@
 #include "core/future-util.hh"
 #include "tests/test-utils.hh"
 
-using namespace httpd;
+using namespace seastar;
+using namespace seastar::httpd;
 
 class handl : public httpd::handler_base {
 public:

--- a/tests/ip_test.cc
+++ b/tests/ip_test.cc
@@ -25,7 +25,8 @@
 #include "core/reactor.hh"
 #include "net/virtio.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 int main(int ac, char** av) {
     boost::program_options::variables_map opts;

--- a/tests/l3_test.cc
+++ b/tests/l3_test.cc
@@ -23,7 +23,8 @@
 #include "core/reactor.hh"
 #include "net/virtio.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 void dump_arp_packets(l3_protocol& proto) {
     proto.receive([&proto] (packet p, ethernet_address from) {

--- a/tests/linecount.cc
+++ b/tests/linecount.cc
@@ -28,6 +28,8 @@
 #include "core/reactor.hh"
 #include <algorithm>
 
+using namespace seastar;
+
 struct reader {
 public:
     reader(file f) : is(make_file_input_stream(std::move(f))) {}

--- a/tests/memcached/test_ascii_parser.cc
+++ b/tests/memcached/test_ascii_parser.cc
@@ -27,7 +27,8 @@
 #include "apps/memcached/ascii.hh"
 #include "core/future-util.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 using namespace memcache;
 
 using parser_type = memcache_ascii_parser;

--- a/tests/output_stream_test.cc
+++ b/tests/output_stream_test.cc
@@ -29,7 +29,8 @@
 #include "test-utils.hh"
 #include <vector>
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 static sstring to_sstring(const packet& p) {
     sstring res(sstring::initialized_later(), p.len());

--- a/tests/packet_test.cc
+++ b/tests/packet_test.cc
@@ -27,7 +27,8 @@
 #include "net/packet.hh"
 #include <array>
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 BOOST_AUTO_TEST_CASE(test_headers_are_contiguous) {
     using tcp_header = std::array<char, 20>;

--- a/tests/rpc.cc
+++ b/tests/rpc.cc
@@ -24,6 +24,8 @@
 #include "rpc/rpc.hh"
 #include "core/sleep.hh"
 
+using namespace seastar;
+
 struct serializer {
 };
 

--- a/tests/shared_ptr_test.cc
+++ b/tests/shared_ptr_test.cc
@@ -26,6 +26,8 @@
 #include <boost/test/included/unit_test.hpp>
 #include "core/shared_ptr.hh"
 
+using namespace seastar;
+
 struct expected_exception : public std::exception {};
 
 struct A {

--- a/tests/slab_test.cc
+++ b/tests/slab_test.cc
@@ -25,7 +25,11 @@
 #include <assert.h>
 #include "core/slab.hh"
 
+using namespace seastar;
+
 static constexpr size_t max_object_size = 1024*1024;
+
+namespace bi = boost::intrusive;
 
 class item : public slab_item_base {
 public:

--- a/tests/smp_test.cc
+++ b/tests/smp_test.cc
@@ -23,6 +23,8 @@
 #include "core/app-template.hh"
 #include "core/print.hh"
 
+using namespace seastar;
+
 future<bool> test_smp_call() {
     return smp::submit_to(1, [] {
         return make_ready_future<int>(3);

--- a/tests/sstring_test.cc
+++ b/tests/sstring_test.cc
@@ -22,9 +22,12 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE core
 
+
 #include <boost/test/included/unit_test.hpp>
 #include "core/sstring.hh"
 #include <list>
+
+using namespace seastar;
 
 BOOST_AUTO_TEST_CASE(test_equality) {
     BOOST_REQUIRE_EQUAL(sstring("aaa"), sstring("aaa"));

--- a/tests/tcp_client.cc
+++ b/tests/tcp_client.cc
@@ -23,7 +23,8 @@
 #include "core/future-util.hh"
 #include "core/distributed.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 using namespace std::chrono_literals;
 
 static int rx_msg_size = 4 * 1024;

--- a/tests/tcp_server.cc
+++ b/tests/tcp_server.cc
@@ -26,6 +26,8 @@
 #include <vector>
 #include <iostream>
 
+using namespace seastar;
+
 static std::string str_ping{"ping"};
 static std::string str_txtx{"txtx"};
 static std::string str_rxrx{"rxrx"};

--- a/tests/tcp_test.cc
+++ b/tests/tcp_test.cc
@@ -23,7 +23,8 @@
 #include "net/virtio.hh"
 #include "net/tcp.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 
 struct tcp_test {
     ipv4& inet;

--- a/tests/test-utils.cc
+++ b/tests/test-utils.cc
@@ -27,6 +27,8 @@
 #include "core/app-template.hh"
 #include <boost/test/included/unit_test.hpp>
 
+using namespace seastar;
+
 void seastar_test::run() {
     // HACK: please see https://github.com/cloudius-systems/seastar/issues/10
     BOOST_REQUIRE(true);

--- a/tests/test-utils.hh
+++ b/tests/test-utils.hh
@@ -29,6 +29,8 @@
 #include "core/future.hh"
 #include "test_runner.hh"
 
+namespace seastar {
+
 class seastar_test {
 public:
     seastar_test();
@@ -38,13 +40,14 @@ public:
     virtual future<> run_test_case() = 0;
     void run();
 };
+} // namespace seatar
 
 #define SEASTAR_TEST_CASE(name) \
-    struct name : public seastar_test { \
+    struct name : public ::seastar::seastar_test {		  \
         const char* get_test_file() override { return __FILE__; } \
         const char* get_name() override { return #name; } \
-        future<> run_test_case() override; \
+	::seastar::future<> run_test_case() override;	  \
     }; \
     static name name ## _instance; \
-    future<> name::run_test_case()
+    ::seastar::future<> name::run_test_case()
 

--- a/tests/test_runner.cc
+++ b/tests/test_runner.cc
@@ -26,6 +26,8 @@
 #include "core/reactor.hh"
 #include "test_runner.hh"
 
+using namespace seastar;
+
 static test_runner instance;
 
 struct stop_execution : public std::exception {};

--- a/tests/test_runner.hh
+++ b/tests/test_runner.hh
@@ -28,18 +28,20 @@
 #include "core/posix.hh"
 #include "exchanger.hh"
 
+namespace seastar {
 class posix_thread;
 
 class test_runner {
 private:
-    std::unique_ptr<posix_thread> _thread;
+    std::unique_ptr<seastar::posix_thread> _thread;
     std::atomic<bool> _started{false};
     exchanger<std::function<future<>()>> _task;
     bool _done = false;
 public:
     void start(int argc, char** argv);
     ~test_runner();
-    void run_sync(std::function<future<>()> task);
+    void run_sync(std::function<seastar::future<>()> task);
 };
+} // namespace seastar
 
-test_runner& global_test_runner();
+seastar::test_runner& global_test_runner();

--- a/tests/timertest.cc
+++ b/tests/timertest.cc
@@ -25,6 +25,7 @@
 #include <chrono>
 
 using namespace std::chrono_literals;
+using namespace seastar;
 
 #define BUG() do { \
         std::cerr << "ERROR @ " << __FILE__ << ":" << __LINE__ << std::endl; \

--- a/tests/udp_client.cc
+++ b/tests/udp_client.cc
@@ -24,7 +24,8 @@
 #include "core/reactor.hh"
 #include "net/api.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 using namespace std::chrono_literals;
 
 class client {

--- a/tests/udp_server.cc
+++ b/tests/udp_server.cc
@@ -23,7 +23,8 @@
 #include "core/app-template.hh"
 #include "core/future-util.hh"
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 using namespace std::chrono_literals;
 
 class udp_server {

--- a/tests/udp_zero_copy.cc
+++ b/tests/udp_zero_copy.cc
@@ -28,7 +28,8 @@
 #include <random>
 #include <iomanip>
 
-using namespace net;
+using namespace seastar;
+using namespace seastar::net;
 using namespace std::chrono_literals;
 namespace bpo = boost::program_options;
 

--- a/util/conversions.cc
+++ b/util/conversions.cc
@@ -26,6 +26,8 @@
 #include "core/print.hh"
 #include <boost/lexical_cast.hpp>
 
+namespace seastar {
+
 size_t parse_memory_size(std::string s) {
     size_t factor = 1;
     if (s.size()) {
@@ -40,6 +42,6 @@ size_t parse_memory_size(std::string s) {
     }
     return boost::lexical_cast<size_t>(s) * factor;
 }
-
+} // namespace seastar
 
 #endif /* CONVERSIONS_CC_ */

--- a/util/conversions.hh
+++ b/util/conversions.hh
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+namespace seastar {
+
 // Convert a string to a memory size, allowing binary SI
 // suffixes (intentionally, even though SI suffixes are
 // decimal, to follow existing usage).
@@ -43,5 +45,7 @@ static inline std::vector<char> string2vector(std::string str) {
     v.push_back('\0');
     return v;
 }
+
+} // namespace seastar
 
 #endif /* CONVERSIONS_HH_ */

--- a/util/is_smart_ptr.hh
+++ b/util/is_smart_ptr.hh
@@ -23,8 +23,12 @@
 
 #include <memory> // for std::unique_ptr
 
+namespace seastar {
+
 template<typename T>
 struct is_smart_ptr : std::false_type {};
 
 template<typename T>
 struct is_smart_ptr<std::unique_ptr<T>> : std::true_type {};
+
+} // namespace seastar


### PR DESCRIPTION
We should put things we export in the seastar namespace, especially things with
names like "shared_ptr". It's just cleaner and generally nicer.

Signed-off-by: Adam C. Emerson <aemerson@redhat.com>