### PR TITLE
Optimize future::finally

### DIFF
--- a/core/future.hh
+++ b/core/future.hh
@@ -931,7 +931,8 @@ public:
      * nested will be propagated.
      */
     template <typename Func>
-    future<T...> finally(Func&& func) noexcept {
+    std::enable_if_t<is_future<std::result_of_t<Func()>>::value, future<T...>>
+    finally(Func&& func) noexcept {
         return then_wrapped([func = std::forward<Func>(func)](future<T...> result) mutable {
             using futurator = futurize<std::result_of_t<Func()>>;
             return futurator::apply(std::forward<Func>(func)).then_wrapped([result = std::move(result)](auto f_res) mutable {
@@ -965,6 +966,27 @@ public:
                     }
                 }
             });
+        });
+    }
+
+    /**
+     * Specialization of the finally continuation for the common case
+     * where the specified function is guaranteed to not return a future.
+     */
+    template <typename Func>
+    std::enable_if_t<!is_future<std::result_of_t<Func()>>::value, future<T...>>
+    finally(Func&& func) noexcept {
+        return then_wrapped([func = std::forward<Func>(func)](future<T...> result) mutable {
+            try {
+                func();
+                if (!result.failed()) {
+                    return std::move(result);
+                } else {
+                    return make_exception_future<T...>(result.get_exception());
+                }
+            } catch (...) {
+                return make_exception_future<T...>(std::current_exception());
+            }
         });
     }
 

--- a/tests/futures_test.cc
+++ b/tests/futures_test.cc
@@ -57,6 +57,23 @@ SEASTAR_TEST_CASE(test_finally_is_called_on_success_and_failure) {
     });
 }
 
+SEASTAR_TEST_CASE(test_finally_waits_for_inner) {
+    auto finally = make_shared<bool>();
+    auto p = make_shared<promise<>>();
+
+    auto f = make_ready_future().then([] {
+    }).finally([=] {
+        return p->get_future().then([=] {
+            *finally = true;
+        });
+    }).then([=] {
+        BOOST_REQUIRE(*finally);
+    });
+    BOOST_REQUIRE(!*finally);
+    p->set_value();
+    return f;
+}
+
 SEASTAR_TEST_CASE(test_finally_is_called_on_success_and_failure__not_ready_to_armed) {
     auto finally1 = make_shared<bool>();
     auto finally2 = make_shared<bool>();


### PR DESCRIPTION
This patch introduces a specialization of the finally() combinator for
the common case where the continuation doesn't return a future.

Fixes #92

Signed-off-by: Duarte Nunes <duarte.m.nunes@gmail.com>