### PR TITLE
Updates in Dockerfile

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -2,4 +2,4 @@ FROM fedora:23
 
 RUN dnf install -y gcc-c++ clang libasan libubsan gnutls-devel hwloc hwloc-devel numactl-devel \
                            python3 libaio-devel ninja-build boost-devel git ragel xen-devel \
-                           cryptopp-devel libpciaccess-devel libxml2-devel zlib-devel
+                           cryptopp-devel libpciaccess-devel libxml2-devel zlib-devel xfsprogs-devel

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,5 +1,5 @@
-FROM fedora:21
+FROM fedora:23
 
-RUN yum install -y gcc-c++ clang libasan libubsan hwloc hwloc-devel numactl-devel \
+RUN dnf install -y gcc-c++ clang libasan libubsan gnutls-devel hwloc hwloc-devel numactl-devel \
                            python3 libaio-devel ninja-build boost-devel git ragel xen-devel \
                            cryptopp-devel libpciaccess-devel libxml2-devel zlib-devel


### PR DESCRIPTION
- Bump the Fedora version to its most current version.
- Add 'gnutls-devel' package as a required dependency.
- Use 'dnf' package manager instead of 'yum' as it is deprecated in recent Fedora.