### PR TITLE
use dpdk v2.2.0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -470,7 +470,7 @@ if args.dpdk_target:
     if args.with_osv:
         libs += '-lintel_dpdk -lrt -lm -ldl'
     else:
-        libs += '-Wl,--whole-archive -lrte_pmd_vmxnet3_uio -lrte_pmd_i40e -lrte_pmd_ixgbe -lrte_pmd_e1000 -lrte_pmd_ring -Wl,--no-whole-archive -lrte_hash -lrte_kvargs -lrte_mbuf -lethdev -lrte_eal -lrte_malloc -lrte_mempool -lrte_ring -lrte_cmdline -lrte_cfgfile -lrt -lm -ldl'
+        libs += '-Wl,--whole-archive -lrte_pmd_vmxnet3_uio -lrte_pmd_i40e -lrte_pmd_ixgbe -lrte_pmd_e1000 -lrte_pmd_ring -Wl,--no-whole-archive -lrte_hash -lrte_kvargs -lrte_mbuf -lethdev -lrte_eal -lrte_mempool -lrte_ring -lrte_cmdline -lrte_cfgfile -lrt -lm -ldl'
 
 warnings = [w
             for w in warnings

--- a/kvm/README.md
+++ b/kvm/README.md
@@ -39,12 +39,12 @@ cd ~/dpdk
 ./tools/setup.sh
 
 # input numbers by following order:
-(type 9 to re-compile DPDK)
-(type 12 to insert IGB UIO module)
-(type 15, then input "64" to setup hugepage mappings)
-(type 18, then input PCI device id something like "0000:xx:yy.z",
+(type 14 to re-compile DPDK)
+(type 17 to insert IGB UIO module)
+(type 21, then input "64" to setup hugepage mappings)
+(type 23, then input PCI device id something like "0000:xx:yy.z",
 which is shown at 'Network devices using DPDK-compatible driver')
-(type 30 to exit)
+(type 34 to exit)
 
 cd ~/seastar
 # httpd example

--- a/kvm/scripts/bootstrap.sh
+++ b/kvm/scripts/bootstrap.sh
@@ -4,11 +4,11 @@ systemctl restart network
 echo nameserver 8.8.8.8 > /etc/resolv.conf
 useradd -m -p "" -g wheel seastar
 chage -d 0 seastar
-yum install -y gcc gcc-c++ libaio-devel ninja-build ragel hwloc-devel numactl-devel libpciaccess-devel cryptopp-devel xen-devel boost-devel kernel-devel libxml2-devel zlib-devel libasan libubsan git wget python3 tar pciutils xterm
+yum install -y gcc gcc-c++ libaio-devel ninja-build ragel hwloc-devel numactl-devel libpciaccess-devel cryptopp-devel xen-devel boost-devel kernel-devel libxml2-devel zlib-devel libasan libubsan git wget python3 tar pciutils xterm gnutls-devel libgnutls-dev
 cd /root
-wget http://dpdk.org/browse/dpdk/snapshot/dpdk-2.0.0.tar.gz
-tar -xpf dpdk-2.0.0.tar.gz
-mv dpdk-2.0.0 dpdk
+wget http://dpdk.org/browse/dpdk/snapshot/dpdk-2.2.0.tar.gz
+tar -xpf dpdk-2.2.0.tar.gz
+mv dpdk-2.2.0 dpdk
 cd dpdk
 cat config/common_linuxapp | sed -e "s/CONFIG_RTE_MBUF_REFCNT_ATOMIC=y/CONFIG_RTE_MBUF_REFCNT_ATOMIC=n/g" | sed -e "s/CONFIG_RTE_BUILD_SHARED_LIB=n/CONFIG_RTE_BUILD_SHARED_LIB=y/g" > /tmp/common_linuxapp
 mv /tmp/common_linuxapp config

--- a/net/dpdk.cc
+++ b/net/dpdk.cc
@@ -184,8 +184,6 @@ struct port_stats {
     struct {
         struct {
             uint64_t mcast;        // number of received multicast packets
-            uint64_t pause_xon;    // number of received PAUSE XON frames
-            uint64_t pause_xoff;   // number of received PAUSE XOFF frames
         } good;
 
         struct {
@@ -197,11 +195,6 @@ struct port_stats {
     } rx;
 
     struct {
-        struct {
-            uint64_t pause_xon;   // number of sent PAUSE XON frames
-            uint64_t pause_xoff;  // number of sent PAUSE XOFF frames
-        } good;
-
         struct {
             uint64_t total;   // total number of failed transmitted packets
         } bad;
@@ -297,16 +290,9 @@ public:
             }
 
             _stats.rx.good.mcast      = rte_stats.imcasts;
-            _stats.rx.good.pause_xon  = rte_stats.rx_pause_xon;
-            _stats.rx.good.pause_xoff = rte_stats.rx_pause_xoff;
 
-            _stats.rx.bad.crc         = rte_stats.ibadcrc;
             _stats.rx.bad.dropped     = rte_stats.imissed;
-            _stats.rx.bad.len         = rte_stats.ibadlen;
             _stats.rx.bad.total       = rte_stats.ierrors;
-
-            _stats.tx.good.pause_xon  = rte_stats.tx_pause_xon;
-            _stats.tx.good.pause_xoff = rte_stats.tx_pause_xoff;
 
             _stats.tx.bad.total       = rte_stats.oerrors;
         });
@@ -327,48 +313,9 @@ public:
             scollectd::add_polled_metric(scollectd::type_instance_id(
                           _stats_plugin_name
                         , _stats_plugin_inst
-                        , "if_rx_errors", "Bad CRC")
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.rx.bad.crc)
-        ));
-        _collectd_regs.push_back(
-            scollectd::add_polled_metric(scollectd::type_instance_id(
-                          _stats_plugin_name
-                        , _stats_plugin_inst
                         , "if_rx_errors", "Dropped")
                         , scollectd::make_typed(scollectd::data_type::DERIVE
                         , _stats.rx.bad.dropped)
-        ));
-        _collectd_regs.push_back(
-            scollectd::add_polled_metric(scollectd::type_instance_id(
-                          _stats_plugin_name
-                        , _stats_plugin_inst
-                        , "if_rx_errors", "Bad Length")
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.rx.bad.len)
-        ));
-
-        // Coupled counters:
-        // Good
-        _collectd_regs.push_back(
-            scollectd::add_polled_metric(scollectd::type_instance_id(
-                          _stats_plugin_name
-                        , _stats_plugin_inst
-                        , "if_packets", _stats_plugin_inst + " Pause XON")
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.rx.good.pause_xon)
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.tx.good.pause_xon)
-        ));
-        _collectd_regs.push_back(
-            scollectd::add_polled_metric(scollectd::type_instance_id(
-                          _stats_plugin_name
-                        , _stats_plugin_inst
-                        , "if_packets", _stats_plugin_inst + " Pause XOFF")
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.rx.good.pause_xoff)
-                        , scollectd::make_typed(scollectd::data_type::DERIVE
-                        , _stats.tx.good.pause_xoff)
         ));
 
         // Errors


### PR DESCRIPTION
(WIP)
- it fixes compilation error upon ndo_bridge_getlink parameter changes though you may not use 4.1.13-100.fc21.x86_64 or later after core updating
- a bit of changes in the main source code to cope with deprecations
