### PR TITLE
Fix condition_variable initialization bug

### DIFF
--- a/core/condition-variable.hh
+++ b/core/condition-variable.hh
@@ -74,6 +74,11 @@ class condition_variable {
     };
     basic_semaphore<condition_variable_exception_factory> _sem;
 public:
+    /// Constructs a condition_variable object.
+    /// Initialzie the semaphore with a default value of 0 to enusre
+    /// the first call to wait() before signal() won't be waken up immediately.
+    condition_variable() : _sem(0) {}
+
     /// Waits until condition variable is signaled, may wake up without condition been met
     ///
     /// \return a future that becomes ready when \ref signal() is called


### PR DESCRIPTION
Initialize the semaphore inside the condition_variable with a default value of 0 to ensure the first call to wait() before signal() won't be waken up immediately.
