### PR TITLE
Add overall python code QA and guidelines with flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 build
 build.ninja
 cscope.*
+.cache
+.tox
+*.egg-info
+__pycache__

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="seastar",
+    description='High performance server-side application framework',
+    url='https://github.com/scylladb/seastar',
+    download_url='https://github.com/scylladb/seastar/tags',
+    license='AGPL',
+    platforms='any',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+usedevelop=True
+skipdist=True
+
+[testenv]
+deps =
+    pytest
+    pytest-flake8
+
+commands =
+    pytest --flake8 -k 'not tests'
+
+[flake8]
+max-line-length = 120
+exclude = .ropeproject,.tox,tests
+show-source = False
+
+[pytest]
+flake8-ignore =
+    E501


### PR DESCRIPTION
Seastar loves python & python loves Seastar.

It would benefit the project to	start enforcing	some code guidelines
and basic QA with a linter along a PEP8 respect thanks to flake8.

This patch adds a tox config to at least start with an assessment
of the work to be done on all .py files in the code base.

To reduce its noise, tests on long lines (> 80char) are ignored
for now.

If this is accepted, this will be used as a base to propose patches to fix the various corrections found on .py files in the code base.