### PR TITLE
git: use absolute submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "dpdk"]
 	path = dpdk
-	url = ../dpdk
+	url = https://github.com/scylladb/dpdk.git
 [submodule "fmt"]
 	path = fmt
-	url = ../fmt
+	url = https://github.com/scylladb/fmt.git
 [submodule "c-ares"]
 	path = c-ares
-	url = ../c-ares
+	url = https://github.com/scylladb/c-ares.git


### PR DESCRIPTION
when working with a fork of seastar, git will expect to have forks of
all submodules given the use of the relative urls in gitsubmodule. these
should explicitly refer to the scylladb forks instead.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>