### PR TITLE
build: add protobuf-compiler installation to Dockerfile

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -19,6 +19,7 @@ RUN dnf install -y \
     lz4-devel \
     systemtap-sdt-devel \
     protobuf-devel \
+    protobuf-compiler \ 
     lksctp-tools-devel \
     yaml-cpp-devel \
     libasan \


### PR DESCRIPTION
add package `protobuf-compiler` installation in Dockerfile and reorganized text