### PR TITLE
"git submodule" operation required before running configure.py

### DIFF
--- a/doc/building-fedora.md
+++ b/doc/building-fedora.md
@@ -7,6 +7,11 @@ Installing required packages:
 sudo ./install-dependencies.sh
 ```
 
+update git submodules:
+'''
+git submodule update --init
+'''
+
 You then need to run the following to create the "build.ninja" file:
 ```
 ./configure.py


### PR DESCRIPTION
I got this when running configure.py on a freshly-cloned repository.

Notice: -fsanitize=vptr is broken, disabling; some debug mode tests are bypassed.
Notice: disabling -Wattributes due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80947
Traceback (most recent call last):
  File "./configure.py", line 796, in <module>
    raise Exception(cares_dir + ' is empty. Run "git submodule update --init".')
Exception: c-ares is empty. Run "git submodule update --init".