### PR TITLE
support bond eth

### DIFF
--- a/net/config.cc
+++ b/net/config.cc
@@ -35,7 +35,7 @@ namespace seastar {
 namespace net {
 
     // list of supported config keys
-    std::string config_keys[]{ "pci-address", "port-index", "ip", "gateway", "netmask", "dhcp", "lro", "tso", "ufo", "hw-fc", "event-index", "csum-offload","ring-size" };
+    std::string config_keys[]{ "pci-address", "port-index", "ip", "gateway", "netmask", "dhcp", "lro", "tso", "ufo", "hw-fc", "event-index", "csum-offload","ring-size","bond","slave-ports-index" };
 
     std::unordered_map<std::string, device_config>
     parse_config(std::istream& input) {
@@ -110,6 +110,14 @@ struct convert<seastar::net::device_config> {
 
         if (node["port-index"]) {
             dev_cfg.hw_cfg.port_index = node["port-index"].as<unsigned>();
+        }
+
+        if (node["bond"]) {
+            dev_cfg.hw_cfg.bond = node["bond"].as<int>();
+        }
+
+        if (node["slave-ports-index"]) {
+            dev_cfg.hw_cfg.slave_ports_index = node["slave-ports-index"].as<std::string>();
         }
 
         if (node["lro"]) {

--- a/net/config.hh
+++ b/net/config.hh
@@ -40,6 +40,8 @@ namespace net {
     struct hw_config {
         std::string pci_address;
         stdx::optional<unsigned> port_index;
+        stdx::optional<int> bond;
+        stdx::optional<std::string> slave_ports_index;
         bool lro{ true };
         bool tso{ true };
         bool ufo{ true };

--- a/net/dpdk.cc
+++ b/net/dpdk.cc
@@ -57,6 +57,8 @@
 #include <rte_memzone.h>
 #include <rte_eth_bond.h>
 
+#define BOND_ENABLED(x) ((x) >= BONDING_MODE_ROUND_ROBIN && (x) <= BONDING_MODE_ALB) 
+
 #if RTE_VERSION <= RTE_VERSION_NUM(2,0,0,16)
 
 static
@@ -409,7 +411,7 @@ public:
         /*
          * reset _port_idx for stats, because port id change in bond mode
          */
-        if (_bond >= BONDING_MODE_ROUND_ROBIN && _bond <= BONDING_MODE_ALB) {
+        if (BOND_ENABLED(_bond)) {
             _xstats.set_port_id(_port_idx);
         }
         
@@ -1706,7 +1708,7 @@ int dpdk_device::init_port_start()
     printf("Port %u init ... ", _port_idx);
     fflush(stdout);
 
-    if (_bond >= BONDING_MODE_ROUND_ROBIN && _bond <= BONDING_MODE_ALB) {  
+    if (BOND_ENABLED(_bond)) {  
         /* 
          * bond mode require slave port_conf are equal
          * all ports set the same _num_queues and port_conf 
@@ -1804,8 +1806,7 @@ void dpdk_device::init_port_fini()
     // Changing FC requires HW reset, so set it before the port is initialized.
     set_hw_flow_control();
 
-    if (_bond >= BONDING_MODE_ROUND_ROBIN && _bond <= BONDING_MODE_ALB)   
-    {  
+    if (BOND_ENABLED(_bond)) {  
         for (uint8_t i = 0; i < _slave_port_count; ++i)
         {
             if (rte_eth_dev_start(_slave_ports[i]) < 0) {    
@@ -2024,7 +2025,7 @@ dpdk_qp<HugetlbfsMemBackend>::dpdk_qp(dpdk_device* dev, uint8_t qid,
     static_assert((inline_mbuf_data_size & (inline_mbuf_data_size - 1)) == 0,
                   "inline_mbuf_data_size has to be a power of two!");
 
-    if (_dev->bond_mode() >= BONDING_MODE_ROUND_ROBIN && _dev->bond_mode() <= BONDING_MODE_ALB) {   
+    if (BOND_ENABLED(_dev->bond_mode())) {   
         for (uint8_t i = 0; i < _dev->_slave_port_count; ++i)  
         {  
             if (rte_eth_rx_queue_setup(_dev->_slave_ports[i], _qid, default_ring_size,  

--- a/net/dpdk.cc
+++ b/net/dpdk.cc
@@ -58,8 +58,6 @@
 #include <rte_memzone.h>
 #include <rte_eth_bond.h>
 
-#define BOND_ENABLED(x) ((x) >= BONDING_MODE_ROUND_ROBIN && (x) <= BONDING_MODE_ALB) 
-
 #if RTE_VERSION <= RTE_VERSION_NUM(2,0,0,16)
 
 static
@@ -90,6 +88,19 @@ using namespace seastar::net;
 namespace seastar {
 
 namespace dpdk {
+
+/*
+ * Test bond enabled
+ */
+static
+inline
+bool 
+bond_enabled(int bond) {
+    if (bond >= BONDING_MODE_ROUND_ROBIN && bond <= BONDING_MODE_ALB) {
+        return true;
+    }
+    return false;
+}
 
 /******************* Net device related constatns *****************************/
 static constexpr uint16_t default_ring_size      = 512;
@@ -409,7 +420,7 @@ public:
         , _slave_ports(slave_ports_index)
         , _xstats(port_idx)
     {
-        if (BOND_ENABLED(_bond)) {
+        if (bond_enabled(_bond)) {
             int ret = init_bond_params();
             if (ret != 0) {
                 rte_exit(EXIT_FAILURE, "Cannot bond params conflict");
@@ -425,7 +436,7 @@ public:
         /*
          * reset _port_idx for stats, because port id change in bond mode
          */
-        if (BOND_ENABLED(_bond)) {
+        if (bond_enabled(_bond)) {
             _xstats.set_port_id(_port_idx);
         }
         
@@ -1743,7 +1754,7 @@ int dpdk_device::init_port_start()
     printf("Port %u init ... ", _port_idx);
     fflush(stdout);
 
-    if (BOND_ENABLED(_bond)) {  
+    if (bond_enabled(_bond)) {  
         /* 
          * bond mode require slave port_conf are equal
          * all ports set the same _num_queues and port_conf 
@@ -1841,7 +1852,7 @@ void dpdk_device::init_port_fini()
     // Changing FC requires HW reset, so set it before the port is initialized.
     set_hw_flow_control();
 
-    if (BOND_ENABLED(_bond)) {  
+    if (bond_enabled(_bond)) {  
         for (uint8_t i = 0; i < _slave_port_count; ++i) {
             if (rte_eth_dev_start(_slave_ports[i]) < 0) {    
                 rte_exit(EXIT_FAILURE, "Cannot start slave port %d\n", i); 
@@ -2059,7 +2070,7 @@ dpdk_qp<HugetlbfsMemBackend>::dpdk_qp(dpdk_device* dev, uint8_t qid,
     static_assert((inline_mbuf_data_size & (inline_mbuf_data_size - 1)) == 0,
                   "inline_mbuf_data_size has to be a power of two!");
 
-    if (BOND_ENABLED(_dev->bond_mode())) {   
+    if (bond_enabled(_dev->bond_mode())) {   
         for (uint8_t i = 0; i < _dev->_slave_port_count; ++i)  
         {  
             if (rte_eth_rx_queue_setup(_dev->_slave_ports[i], _qid, default_ring_size,  

--- a/net/dpdk.hh
+++ b/net/dpdk.hh
@@ -35,10 +35,11 @@ std::unique_ptr<net::device> create_dpdk_net_device(
                                     uint8_t port_idx = 0,
                                     uint8_t num_queues = 1,
                                     bool use_lro = true,
-                                    bool enable_fc = true);
+                                    bool enable_fc = true,
+                                    int bond = -1);
 
 std::unique_ptr<net::device> create_dpdk_net_device(
-                                    const net::hw_config& hw_cfg);
+                                    const net::hw_config& hw_cfg, int bond = -1);
 
 
 boost::program_options::options_description get_dpdk_net_options_description();

--- a/net/dpdk.hh
+++ b/net/dpdk.hh
@@ -36,10 +36,13 @@ std::unique_ptr<net::device> create_dpdk_net_device(
                                     uint8_t num_queues = 1,
                                     bool use_lro = true,
                                     bool enable_fc = true,
-                                    int bond = -1);
+                                    int bond = -1,
+                                    std::vector<uint8_t> slave_ports_index = {});
 
 std::unique_ptr<net::device> create_dpdk_net_device(
-                                    const net::hw_config& hw_cfg, int bond = -1);
+                                    const net::hw_config& hw_cfg, 
+                                    int bond = -1,
+                                    std::vector<uint8_t> slave_ports_index = {});
 
 
 boost::program_options::options_description get_dpdk_net_options_description();

--- a/net/native-stack.cc
+++ b/net/native-stack.cc
@@ -71,7 +71,8 @@ void create_native_net_device(boost::program_options::variables_map opts) {
         if ( opts.count("dpdk-pmd")) {
              dev = create_dpdk_net_device(opts["dpdk-port-index"].as<unsigned>(), smp::count,
                 !(opts.count("lro") && opts["lro"].as<std::string>() == "off"),
-                !(opts.count("hw-fc") && opts["hw-fc"].as<std::string>() == "off"));   
+                !(opts.count("hw-fc") && opts["hw-fc"].as<std::string>() == "off"),
+                !(opts.count("bond") && opts["bond"].as<int>()));   
        } else 
 #endif  
         dev = create_virtio_net_device(opts);
@@ -87,7 +88,8 @@ void create_native_net_device(boost::program_options::variables_map opts) {
             auto& hw_config = device_config.second.hw_cfg;   
 #ifdef SEASTAR_HAVE_DPDK
             if ( hw_config.port_index || !hw_config.pci_address.empty() ) {
-	            dev = create_dpdk_net_device(hw_config);
+	            dev = create_dpdk_net_device(hw_config, 
+                    !(opts.count("bond") && opts["bond"].as<int>()));
 	        } else 
 #endif  
             {


### PR DESCRIPTION
# Content
In our production environment, bond eth is a must. Although dpdk support bond mode, seastar not utilize to abundant functions. This commit to resolve it. It is running on our industrial environment to serve to millions of people.
# Use
Add config to seastar.conf，eg "bond=1 or bond=2......" at most 6, becase bond have 6 modes.
About bond mode see:[bond network protocol](https://en.wikipedia.org/wiki/Link_aggregation)
Also, add parameter "--bond=1 or --bond=2...... " ，is ok.
# Example
Introduce how to use in our scene——dpdk + native-stack + vf([Virtual Function](https://en.wikipedia.org/wiki/Virtual_function)) + bond

1. setup dkdp environment, [DPDK](https://dpdk.org/)
2. seastar-dpdk bind on one eth , other programs can not use this eth. vf is a solution.
    [vf setup](https://access.redhat.com/documentation/zh-cn/red_hat_enterprise_linux_openstack_platform/7/html/networking_guide/sec-sr-iov)
3. Multiple vf must set **the same mac** , otherwise bond(lacp) will not work normally.
4. seastar.conf look like:
```
network-stack=native
host-ipv4-addr=xx.xx.xx.xx
gw-ipv4-addr=xx.xx.xx.xx
netmask-ipv4-addr=xx.xx.xx.xx
dpdk-pmd=1 
poll-mode=1
bond=6    // 0-6 for choice, default -1, non-bond
```

# Notice
 Multiple vf must set the same mac, it is important.