### PR TITLE
thread_cputime_clock: avoid unused variable warnings in NDEBUG builds.

### DIFF
--- a/include/seastar/core/thread_cputime_clock.hh
+++ b/include/seastar/core/thread_cputime_clock.hh
@@ -39,6 +39,7 @@ public:
         struct timespec tp;
         auto ret = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tp);
         assert(ret == 0);
+        static_cast<void>(ret);
         return time_point(tp.tv_nsec * 1ns + tp.tv_sec * 1s);
     }
 };


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>