### PR TITLE
README: Update document web link

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Getting started
 
 There is a [mini tutorial](doc/mini-tutorial.md) and a [more comprehensive one](doc/tutorial.md).
 
-The documentation is available on the [web](http://docs.seastar-project.org/).
+The documentation is available on the [web](http://docs.seastar.io).
 
 
 Resources


### PR DESCRIPTION
The current url(http://docs.seastar-project.org/) will return a 404 response.