### PR TITLE
Enable the exception hack on debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,10 +135,6 @@ option (Seastar_DPDK
   "Enable DPDK support."
   OFF)
 
-option (Seastar_EXCEPTION_SCALABILITY_WORKAROUND
-  "Enable a workaround for C++ exception scalability issues by overriding the definition of `dl_iterate_phdr`. Disabled for non-release builds."
-  ON)
-
 option (Seastar_EXCLUDE_APPS_FROM_ALL
   "When enabled alongside Seastar_APPS, do not build applications by default."
   OFF)
@@ -720,10 +716,6 @@ if (Seastar_DPDK)
 
   target_link_libraries (seastar
     PUBLIC dpdk::dpdk)
-endif ()
-
-if ((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (NOT Seastar_EXCEPTION_SCALABILITY_WORKAROUND))
-  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_NO_EXCEPTION_HACK)
 endif ()
 
 if (Seastar_HWLOC)

--- a/configure.py
+++ b/configure.py
@@ -95,11 +95,6 @@ add_tristate(
     help = 'allocation failure injection')
 add_tristate(
     arg_parser,
-    name = 'exception-scalability-workaround',
-    dest = 'exception_workaround',
-    help = 'a workaround for C++ exception scalability issues by overriding the definition of `dl_iterate_phdr`')
-add_tristate(
-    arg_parser,
     name = 'experimental-coroutines-ts',
     dest = "coroutines_ts",
     help = 'experimental support for Coroutines TS')
@@ -188,7 +183,6 @@ def configure_mode(mode):
         tr(args.hwloc, 'HWLOC', value_when_none='yes'),
         tr(args.gcc6_concepts, 'GCC6_CONCEPTS'),
         tr(args.alloc_failure_injection, 'ALLOC_FAILURE_INJECTION'),
-        tr(args.exception_workaround, 'EXCEPTION_SCALABILITY_WORKAROUND', value_when_none='yes'),
         tr(args.alloc_page_size, 'ALLOC_PAGE_SIZE'),
         tr(args.cpp17_goodies, 'STD_OPTIONAL_VARIANT_STRINGVIEW'),
         tr(args.split_dwarf, 'SPLIT_DWARF'),

--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -62,9 +62,9 @@
 #include <seastar/util/backtrace.hh>
 
 namespace seastar {
-#ifndef SEASTAR_NO_EXCEPTION_HACK
 using dl_iterate_fn = int (*) (int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data);
 
+[[gnu::no_sanitize_address]]
 static dl_iterate_fn dl_iterate_phdr_org() {
     static dl_iterate_fn org = [] {
         auto org = (dl_iterate_fn)dlsym (RTLD_NEXT, "dl_iterate_phdr");
@@ -74,17 +74,21 @@ static dl_iterate_fn dl_iterate_phdr_org() {
     return org;
 }
 
-static std::vector<dl_phdr_info> phdrs_cache;
+// phdrs_cache has to remain valid until very late in the process
+// life, and that time is not a mirror image of when it is first used.
+// Given that, we avoid a static constructor/destructor pair and just
+// never destroy it.
+static std::vector<dl_phdr_info> *phdrs_cache = nullptr;
 
 void init_phdr_cache() {
     // Fill out elf header cache for access without locking.
     // This assumes no dynamic object loading/unloading after this point
+    phdrs_cache = new std::vector<dl_phdr_info>();
     dl_iterate_phdr_org()([] (struct dl_phdr_info *info, size_t size, void *data) {
-        phdrs_cache.push_back(*info);
+        phdrs_cache->push_back(*info);
         return 0;
     }, nullptr);
 }
-#endif
 
 #ifndef NO_EXCEPTION_INTERCEPT
 seastar::logger exception_logger("exception");
@@ -103,17 +107,17 @@ void log_exception_trace() noexcept {}
 
 }
 
-#ifndef SEASTAR_NO_EXCEPTION_HACK
 extern "C"
 [[gnu::visibility("default")]]
 [[gnu::used]]
+[[gnu::no_sanitize_address]]
 int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data) {
-    if (!seastar::local_engine || !seastar::phdrs_cache.size()) {
+    if (!seastar::local_engine || !seastar::phdrs_cache) {
         // Cache is not yet populated, pass through to original function
         return seastar::dl_iterate_phdr_org()(callback, data);
     }
     int r = 0;
-    for (auto h : seastar::phdrs_cache) {
+    for (auto h : *seastar::phdrs_cache) {
         // Pass dl_phdr_info size that does not include dlpi_adds and dlpi_subs.
         // This forces libgcc to disable caching which is not thread safe and
         // requires dl_iterate_phdr to serialize calls to callback. Since we do
@@ -125,7 +129,6 @@ int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, voi
     }
     return r;
 }
-#endif
 
 #ifndef NO_EXCEPTION_INTERCEPT
 extern "C"


### PR DESCRIPTION
This removes another source of difference from debug to release builds by enabling our exception scalability hack.

While looking at this file, also remove the exception tracer to fix the --static-stdc++ build.
