### PR TITLE
Logger flush

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -218,6 +218,10 @@ public:
     ///       this should be rare (will have to fill the pipe buffer
     ///       before syslogd can clear it) but can happen.
     static void set_syslog_enabled(bool enabled);
+
+    /// Flush the logger output.
+    ///
+    static void flush();
 };
 
 /// \brief used to keep a static registry of loggers

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1166,6 +1166,10 @@ class backtrace_buffer {
     unsigned _pos = 0;
     char _buf[_max_size];
 public:
+    backtrace_buffer() {
+        logger::flush();
+    }
+
     void flush() noexcept {
         print_safe(_buf, _pos);
         _pos = 0;

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -247,6 +247,10 @@ bool logger::is_shard_zero() {
     return engine().cpu_id() == 0;
 }
 
+void logger::flush() {
+    std::cout.flush();
+}
+
 void
 logger_registry::set_all_loggers_level(log_level level) {
     std::lock_guard<std::mutex> g(_mutex);


### PR DESCRIPTION
Flush logger before printing backtrace.
    
This will first flush any buffered log output to the standard output
and then print the backtrace message.
    
The main reason for doing that is not losing log messages
when aborting the program.  Also, it will improve the correlation
of the backtrace to other events printed to the log.
