### PR TITLE
http server: https using tls support

### DIFF
--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -62,7 +62,7 @@ struct request {
     connection* connection_ptr;
     parameters param;
     sstring content;
-    sstring protocol_name;
+    sstring protocol_name = "http";
 
     /**
      * Search for the first header of a given name
@@ -94,7 +94,7 @@ struct request {
      * Get the request protocol name. Can be either "http" or "https".
      */
     sstring get_protocol_name() const {
-        return "http";
+        return protocol_name;
     }
 
     /**

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -191,6 +191,9 @@ future<> connection::read_one() {
         }
         ++_server._requests_served;
         std::unique_ptr<httpd::request> req = _parser.get_parsed_request();
+        if (_server._credentials) {
+            req->protocol_name = "https";
+        }
         return read_request_body(_read_buf, std::move(req)).then([this] (std::unique_ptr<httpd::request> req) {
             return _replies.not_full().then([req = std::move(req), this] () mutable {
                 return generate_reply(std::move(req));


### PR DESCRIPTION
This series adds https support to the http-server.

to use https, the http-server should use tls credentials before calling its listen method.

The series also changed the protocol name in the request, so that when the server uses https the protocol in the request will be set to https.