### PR TITLE
Prometheus filter by labels

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -323,6 +323,7 @@ class impl {
     config _config;
     bool _dirty = true;
     shared_ptr<metric_metadata> _metadata;
+    std::set<sstring> _labels;
     std::vector<std::vector<metric_function>> _current_metrics;
 public:
     value_map& get_value_map() {
@@ -353,6 +354,10 @@ public:
 
     void dirty() {
         _dirty = true;
+    }
+
+    std::set<sstring> get_labels() const {
+        return _labels;
     }
 };
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -336,6 +336,9 @@ void impl::add_registration(const metric_id& id, data_type type, metric_function
             throw std::runtime_error("registering metrics " + name + " registered with different type.");
         }
         metric[id.labels()] = rm;
+        for (auto&& i : id.labels()) {
+            _labels.insert(i.first);
+        }
     } else {
         _value_map[name].info().type = type;
         _value_map[name].info().d = d;


### PR DESCRIPTION
There were a few requests in the past to flexibility to the Prometheus API.
One option that was added choosing a metric by its name.

This series extends that API to support labels, it works in a similar way to the filtering by name,
to filter by label, add a query parameter using the wanted label and a value.

Like with names, a prefix match is accepted using trailing asterisk.

Usage example, if the promtheus is listening on port 9180, the following are valid queries:
localhost:9180/metrics?shard=0
http://localhost:9180/metrics?type=queue*

Multiple labels can be used together