### PR TITLE
Specify context for docker run command

### DIFF
--- a/doc/building-docker.md
+++ b/doc/building-docker.md
@@ -3,7 +3,7 @@
 To build a Docker image:
 
 ```
-docker build -t seastar-dev docker/dev
+docker build -t seastar-dev -f docker/dev/Dockerfile .
 ```
 
 Create an shell function for building insider the container (bash syntax given):


### PR DESCRIPTION
When building with modern docker, the docker build would run
with an empty context, if no directory is specified.

Hence the `docker build` would fail finding repository's files:

```
 docker build -t seastar-dev docker/dev
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM fedora:29
29: Pulling from library/fedora
01eb078129a0: Pull complete
Digest: sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a
Status: Downloaded newer image for fedora:29
 ---> d09302f77cfc
Step 2/3 : COPY install-dependencies.sh .
COPY failed: stat /var/lib/docker/tmp/docker-builder314166541/install-dependencies.sh: no such file or directory
```

The new command would specify the docker build context
as the `seastar` git repository, and specify where the
`Dockerfile` in the repository is.