### PR TITLE
WIP adding assert_fmt

### DIFF
--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -145,4 +145,13 @@ fmt_print(std::ostream& os, const char* format, A&&... a) {
     return os;
 }
 
+template <typename... A>
+void
+assert_fmt(bool condition, const char* format, A&&... a) {
+    if (__builtin_expect(condition, false)) {
+        fmt::print(std::cerr, format, std::forward<A>(a)...);
+        std::terminate();
+    }
+}
+
 }


### PR DESCRIPTION
We should use a non-disable-able (?is that a word) seastar-assert mode. 

Example: 

```
// cause all threads to invoke a full memory barrier
void
systemwide_memory_barrier() {
    if (try_native_membarrier()) {
        return;
    }

    // FIXME: use sys_membarrier() when available
    static thread_local char* mem = [] {
       void* mem = mmap(nullptr, getpagesize(),
               PROT_READ | PROT_WRITE,
               MAP_PRIVATE | MAP_ANONYMOUS,
               -1, 0) ;
       assert(mem != MAP_FAILED);
       return reinterpret_cast<char*>(mem);
    }();
    // Force page into memory to make madvise() have real work to do
    *mem = 3;
    // Evict page to force kernel to send IPI to all threads, with
    // a side effect of executing a memory barrier on those threads
    // FIXME: does this work on ARM?
    int r2 = madvise(mem, getpagesize(), MADV_DONTNEED);
    assert(r2 == 0);
}


``` 

passing `./a.out --lock-memory 1` will cause assert to fail when not enough memory (a good thing, i want to be notified).  

Now CMake defaults to disabling asserts by default, as per seastar's build: 

```
#
# We want asserts enabled on all modes, but cmake defaults to passing
# -DNDEBUG in some modes. We add -UNDEBUG to our private options to
# reenable it. To force asserts off pass -DNDEBUG in
# Seastar_CXX_FLAGS.
#
# To disable -Werror, pass -Wno-error to Seastar_CXX_FLAGS.
#
# We disable _FORTIFY_SOURCE because it generates false positives with longjmp() (src/core/thread.cc)
#

```
However, for consumers of seastar that want consistent flags across many dependent libraries say this:

```
set(CMAKE_CXX_FLAGS_DEBUG "-O0 -gsplit-dwarf -Wl,--gdb-index")
set(CMAKE_CXX_FLAGS_RELEASE "-O2 -g -DNDEBUG")
set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -DNDEBUG")
```

We always have to special case seastar because we want those checks enabled. 

I propose a small template func to replace all instances of assert()
 
```
template <typename... A>
void assert_fmt(bool condition, const char* format, A&&... a) {
    if(__builtin_expect(condition, false){
        fmt::print(std::cerr, format, std::forward<A>(a)...);
       std::terminate();   
    }  
}
```

Thoughts?


Related: https://github.com/scylladb/seastar/issues/116