### PR TITLE
configure.py: add aarch64 machine for Seastar_DPDK_MACHINE

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -23,6 +23,7 @@ import seastar_cmake
 import subprocess
 import sys
 import tempfile
+import platform
 
 tempfile.tempdir = "./build/tmp"
 
@@ -141,7 +142,11 @@ def infer_dpdk_machine(user_cflags):
 
     The default if no architecture is indicated is 'native'.
     """
-    arch = 'native'
+    if platform.machine()=='aarch64':
+        arch = 'armv8-a'
+    else:
+        arch = 'native'
+    
 
     # `-march` may be repeated, and we want the last one.
     # strip features, leave only the arch: armv8-a+crc+crypto -> armv8-a


### PR DESCRIPTION
Add aarch64 machine type for default type, Use python's platform() library to select.
On arm server, seastar compile fail with corei7 unrecognized. But my server and CONFIG_RTE_MACHINE is armv8a, there's problem with Seastar_DPDK_MACHINE initialization. So, I add the platform library to recognized the machine type I use.