### PR TITLE
reactor: fallback to epoll backend when fs.aio-max-nr is too small

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -183,6 +183,7 @@ private:
     friend class internal::reactor_stall_sampler;
     friend class reactor_backend_epoll;
     friend class reactor_backend_aio;
+    friend class reactor_backend_selector;
 public:
     class poller {
         std::unique_ptr<pollfn> _pollfn;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -187,6 +187,7 @@ public:
 class reactor_backend_selector {
     std::string _name;
 private:
+    static bool has_enough_aio_nr();
     explicit reactor_backend_selector(std::string name) : _name(std::move(name)) {}
 public:
     std::unique_ptr<reactor_backend> create(reactor* r);


### PR DESCRIPTION
Fallback to epoll backend when fs.aio-max-nr is too small.

Fixes #640