### PR TITLE
rpc::compressor: Fix static init fiasco with names

### DIFF
--- a/include/seastar/rpc/lz4_compressor.hh
+++ b/include/seastar/rpc/lz4_compressor.hh
@@ -31,14 +31,9 @@ namespace rpc {
     class lz4_compressor : public compressor {
     public:
         class factory: public rpc::compressor::factory {
-            static const sstring _name;
         public:
-            virtual const sstring& supported() const override {
-                return _name;
-            }
-            virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
-                return feature == _name ? std::make_unique<rpc::lz4_compressor>() : nullptr;
-            }
+            virtual const sstring& supported() const override;
+            virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override;
         };
     public:
         ~lz4_compressor() {}

--- a/include/seastar/rpc/lz4_fragmented_compressor.hh
+++ b/include/seastar/rpc/lz4_fragmented_compressor.hh
@@ -30,14 +30,9 @@ namespace rpc {
 class lz4_fragmented_compressor final : public compressor {
 public:
     class factory final : public rpc::compressor::factory {
-        static const sstring _name;
     public:
-        virtual const sstring& supported() const override {
-            return _name;
-        }
-        virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
-            return feature == _name ? std::make_unique<rpc::lz4_fragmented_compressor>() : nullptr;
-        }
+        virtual const sstring& supported() const override;
+        virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override;
     };
 public:
     virtual snd_buf compress(size_t head_space, snd_buf data) override;

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -26,7 +26,14 @@ namespace seastar {
 
 namespace rpc {
 
-const sstring lz4_compressor::factory::_name = "LZ4";
+const sstring& lz4_compressor::factory::supported() const {
+    const static sstring name = "LZ4";
+    return name;
+}
+
+std::unique_ptr<rpc::compressor> lz4_compressor::factory::negotiate(sstring feature, bool is_server) const {
+    return feature == supported() ? std::make_unique<lz4_compressor>() : nullptr;
+}
 
 // Reusable contiguous buffers needed for LZ4 compression and decompression functions.
 class reusable_buffer {

--- a/src/rpc/lz4_fragmented_compressor.cc
+++ b/src/rpc/lz4_fragmented_compressor.cc
@@ -27,7 +27,14 @@
 namespace seastar {
 namespace rpc {
 
-const sstring lz4_fragmented_compressor::factory::_name = "LZ4_FRAGMENTED";
+const sstring& lz4_fragmented_compressor::factory::supported() const {
+    const static sstring name = "LZ4_FRAGMENTED";
+    return name;
+}
+
+std::unique_ptr<rpc::compressor> lz4_fragmented_compressor::factory::negotiate(sstring feature, bool is_server) const {
+    return feature == supported() ? std::make_unique<lz4_fragmented_compressor>() : nullptr;
+}
 
 // Compressed message format:
 // The message consists of one or more data chunks each preceeded by a 4 byte header.


### PR DESCRIPTION
Fixes #744

rpc::lz4_fragmented_compressor::factory and his cousins
use a static (non-constexpr) var as supported() / _name.
Fine and dandy, except that
rpc::multi_algo_compressor_factory sort of invites usage
as a static const itself (and indeed is used as such).

However, if constant init goes the wrong way, any
multi_algo_compressor_factory instance may end up with
a supported() set of ",,...". Probably not the intent.

Now, caller should perhaps deal with this (and avoid
constants), but we can make the types themselves resistant
against this as well.

This just moves the names to function-local statics and
adjusts using code accordingly.