### PR TITLE
Fix list of disk available schedulers

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1151,7 +1151,7 @@ class DiskPerfTuner(PerfTunerBase):
         # ...with one or more schedulers where currently selected scheduler is the one in brackets.
         #
         # Return the scheduler with the highest priority among those that are supported for the current device.
-        supported_schedulers = frozenset([scheduler.lstrip("[").rstrip("]") for scheduler in lines[0].split(" ")])
+        supported_schedulers = frozenset([scheduler.rstrip('\n').lstrip("[").rstrip("]") for scheduler in lines[0].split(" ")])
         return next((scheduler for scheduler in self.__io_schedulers if scheduler in supported_schedulers), None)
 
     def __tune_disk(self, device):


### PR DESCRIPTION
On some systems during /opt/scylladb/scripts/scylla_prepare scrypt execution I recieve 
`Not setting I/O Scheduler for sdo1 - required schedulers (['none', 'noop']) are not supported
`
When in __get_io_scheduler method  function readlines(feature_file) returned this list:
`['[mq-deadline] kyber bfq none\n']`
scheduler 'none' parced incorrectly.
