### PR TITLE
sstring: Fix boost::lexical_cast to sstring

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -36,6 +36,7 @@
 #include <type_traits>
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <boost/lexical_cast.hpp>
 
 namespace seastar {
 
@@ -776,4 +777,24 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
     os << "}";
     return os;
 }
+}
+
+namespace boost {
+    template<typename Target, typename Source>
+    inline Target lexical_cast(const Source& s);
+
+    template<>
+    inline seastar::sstring lexical_cast(const std::string& s) {
+        return s;
+    }
+
+    template<>
+    inline seastar::sstring lexical_cast(const char* const& s) {
+        return s;
+    }
+
+    template<>
+    inline seastar::sstring lexical_cast(char* const& s) {
+        return s;
+    }
 }

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -184,3 +184,39 @@ BOOST_AUTO_TEST_CASE(test_nul_termination) {
         BOOST_REQUIRE(!strncmp(s1.c_str(), s2.c_str(), std::min(s1.size(), s2.size())));
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_boost_lexical_cast) {
+    std::string std1 = "abcdefg";
+    sstring s1 = boost::lexical_cast<sstring>(std1);
+    BOOST_REQUIRE_EQUAL(s1, std1);
+
+    std::string std2 = "one two three\nfour five";
+    sstring s2 = boost::lexical_cast<sstring>(std2);
+    BOOST_REQUIRE_EQUAL(s2, std2);
+
+    std::string std3("a\0b", 3);
+    sstring s3 = boost::lexical_cast<sstring>(std3);
+    BOOST_REQUIRE_EQUAL(s3, std3);
+    BOOST_REQUIRE_EQUAL(s3.size(), 3);
+
+    sstring s4 = "abcdefg";
+    std::string std4 = boost::lexical_cast<std::string>(s4);
+    BOOST_REQUIRE_EQUAL(s4, std4);
+
+    sstring s5 = "one two three\nfour five";
+    std::string std5 = boost::lexical_cast<std::string>(s5);
+    BOOST_REQUIRE_EQUAL(s5, std5);    
+
+    sstring s6("a\0b", 3);
+    std::string std6 = boost::lexical_cast<std::string>(s6);
+    BOOST_REQUIRE_EQUAL(s6, std6);
+    BOOST_REQUIRE_EQUAL(std6.size(), 3);
+
+    char* cstr7 = std2.data();
+    sstring s7 = boost::lexical_cast<sstring>(cstr7);
+    BOOST_REQUIRE(!strncmp(cstr7, s7.c_str(), strlen(cstr7)));
+
+    const char* cstr8 = std2.c_str();
+    sstring s8 = boost::lexical_cast<sstring>(cstr8);
+    BOOST_REQUIRE(!strncmp(cstr8, s8.c_str(), strlen(cstr8)));
+}


### PR DESCRIPTION
Fix exception which would occur when calling `boost::lexical_cast<sstring>` with source string containing whitespace:

```cpp
std::string s = "string with spaces";
seastar::sstring s2 = boost::lexical_cast<seastar::sstring>(s); // this line would cause exception
```

Due to C++ requiring full template specialization for functions, the solution does not cover all possible`basic_sstring` target types or all source types.

Fixes https://github.com/scylladb/scylla/issues/2905, as boost option parsing internally calls `boost::lexical_cast<sstring>` from `std::string` which would crash if command line argument contained space (for example: `--cluster-name="Test Cluster"`).