### PR TITLE
Wrong name used in an example in mini tutorial.

### DIFF
--- a/doc/mini-tutorial.md
+++ b/doc/mini-tutorial.md
@@ -179,7 +179,7 @@ This is shown below:
 
 ```C++
 
-future<my_type> my_future();
+future<my_type> receive();
 
 void f() {
     receive().then_wrapped([] (future<my_type> f) {


### PR DESCRIPTION
There was probably some mistake, function `my_future` is declared, but lated a function `receive` is used. I suppose this is a simple mistake.