### PR TITLE
http: add missing HTTP methods

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -59,7 +59,7 @@ public:
 };
 
 enum operation_type {
-    GET, POST, PUT, DELETE, NUM_OPERATION
+    GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, CONNECT, NUM_OPERATION
 };
 
 /**

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -35,6 +35,18 @@ operation_type str2type(const sstring& type) {
     if (type == "PUT") {
         return PUT;
     }
+    if (type == "HEAD") {
+        return HEAD;
+    }
+    if (type == "OPTIONS") {
+        return OPTIONS;
+    }
+    if (type == "TRACE") {
+        return TRACE;
+    }
+    if (type == "CONNECT") {
+        return CONNECT;
+    }
     return GET;
 }
 


### PR DESCRIPTION
Seastar httpd currently does not support support some HTTP methods such as
HEAD and OPTIONS, not able to handle by apps.
Add unsupported methods (HEAD, OPTIONS, TRACE, CONNECT) and let apps to handle
them.