### PR TITLE
http: handle 'match all' rule correctly

### DIFF
--- a/include/seastar/http/matchrules.hh
+++ b/include/seastar/http/matchrules.hh
@@ -68,6 +68,9 @@ public:
      */
     handler_base* get(const sstring& url, parameters& params) {
         size_t ind = 0;
+        if (_match_list.empty()) {
+            return _handler;
+        }
         for (unsigned int i = 0; i < _match_list.size(); i++) {
             ind = _match_list.at(i)->match(url, ind, params);
             if (ind == sstring::npos) {


### PR DESCRIPTION
To handle 'match all' rule correctly, we need to return a handler unconditionally
when no URL added to the rule.

Fixes #821