### PR TITLE
io_queue: Add bandwidth limiter

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -475,6 +475,8 @@ public:
     /// \param shares the new shares value
     /// \return a future that is ready when the share update is applied
     future<> update_shares_for_class(io_priority_class pc, uint32_t shares);
+
+    future<> update_limiter_for_class(io_priority_class pc, size_t rate, size_t burst);
     static future<> rename_priority_class(io_priority_class pc, sstring new_name) noexcept;
 
     void configure(boost::program_options::variables_map config);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -188,6 +188,13 @@ reactor::update_shares_for_class(io_priority_class pc, uint32_t shares) {
 }
 
 future<>
+reactor::update_limiter_for_class(io_priority_class pc, size_t rate, size_t burst) {
+    return parallel_for_each(_io_queues, [pc, rate, burst] (auto& queue) {
+        return queue.second->update_limiter_for_class(pc, rate, burst);
+    });
+}
+
+future<>
 reactor::rename_priority_class(io_priority_class pc, sstring new_name) noexcept {
 
     return futurize_invoke([pc, new_name = std::move(new_name)] () mutable {


### PR DESCRIPTION
This patch introduces the bandwidth limiter for the io queue. It uses
the classic token bucket algorithm to limit the max number of bytes per
second allowed for each queue. All the existing scheduling mechanisms
are still in play.

Signed-off-by: Asias He <asias@scylladb.com>