### PR TITLE
Support for Default HTTP Handler

### DIFF
--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -121,6 +121,14 @@ public:
     routes& add(operation_type type, const url& url, handler_base* handler);
 
     /**
+     * Add a default handler - handles any HTTP Method and Path (/\*) combination:
+     * Example  routes.add_default_handler(handler);
+     * @param handler
+     * @return
+     */
+    routes& add_default_handler(handler_base* handler);
+
+    /**
      * the main entry point.
      * the general handler calls this method with the request
      * the method takes the headers from the request and find the
@@ -168,6 +176,8 @@ public:
 private:
     rule_cookie _rover = 0;
     std::map<rule_cookie, match_rule*> _rules[NUM_OPERATION];
+    //default Handler -- for any HTTP Method and Path (/*)
+    handler_base* _default_handler = nullptr;
 public:
     using exception_handler_fun = std::function<std::unique_ptr<reply>(std::exception_ptr eptr)>;
     using exception_handler_id = size_t;

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -127,7 +127,7 @@ handler_base* routes::get_handler(operation_type type, const sstring& url,
         }
         params.clear();
     }
-    return nullptr;
+    return _default_handler;
 }
 
 routes& routes::add(operation_type type, const url& url,
@@ -138,6 +138,11 @@ routes& routes::add(operation_type type, const url& url,
         rule->add_param(url._param, true);
     }
     return add(rule, type);
+}
+
+routes& routes::add_default_handler(handler_base* handler) {
+    _default_handler = handler;
+    return *this;
 }
 
 template <typename Map, typename Key>


### PR DESCRIPTION
This adds support where external framework integrations are needed.
If i need to integrate a new web framework, I can use seastar httpd as the base and provide the framework functionality on top of it.
Any matching rules will always over-ride the default handler.