### PR TITLE
install-dependencies: support Manjaro

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -222,7 +222,7 @@ case "$ID" in
     opensuse-leap)
         zypper install -y "${opensuse_packages[@]}"
     ;;
-    arch)
+    arch|manjaro)
         if [ "$EUID" -eq "0" ]; then
             pacman -Sy --needed --noconfirm "${arch_packages[@]}"
         else


### PR DESCRIPTION
This PR allows `./install-dependencies.sh` to run on [Manjaro](https://wiki.manjaro.org/index.php?title=Pacman_Overview)

```
$ uname --all
Linux workstation 5.9.11-3-MANJARO #1 SMP PREEMPT Sat Nov 28 09:08:57 UTC 2020 x86_64 GNU/Linux
```

```
$ cat /etc/arch-release
Manjaro Linux
```