### PR TITLE
perftune.py: fix regression after last commit

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -503,19 +503,15 @@ class NetPerfTuner(PerfTunerBase):
         # did not receive an acknowledgment from connecting client.
         fwriteln_and_log('/proc/sys/net/ipv4/tcp_max_syn_backlog', '4096')
 
-    @property
     def nic_is_bond_iface(self, nic):
         return self.__nic_is_bond_iface[nic]
 
-    @property
     def nic_exists(self, nic):
         return self.__iface_exists(nic)
 
-    @property
     def nic_is_hw_iface(self, nic):
         return self.__dev_is_hw_iface(nic)
 
-    @property
     def slaves(self, nic):
         """
         Returns an iterator for all slaves of the nic.


### PR DESCRIPTION
  a2fc9d72c31b97840bc75ae49dbd6f4b6d394e25 introduced regression causing the script to fail with following error:
    ERROR: nic_is_bond_iface() missing 1 required positional argument: 'nic'. Your system can't be tuned until the issue is fixed.