### PR TITLE
perftune.py: make RPS CPU set to be a full CPU set

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -372,6 +372,14 @@ class PerfTunerBase(metaclass=abc.ABCMeta):
         self.__irq_cpu_mask = PerfTunerBase.irqs_cpu_mask_for_mode(self.__mode, self.__args.cpu_mask)
 
     @property
+    def cpu_mask(self):
+        """
+        Return the CPU mask we operate on (the total CPU set)
+        """
+
+        return self.__args.cpu_mask
+
+    @property
     def compute_cpu_mask(self):
         """
         Return the CPU mask to use for seastar application binding.
@@ -781,7 +789,7 @@ class NetPerfTuner(PerfTunerBase):
             perftune_print("Distributing all IRQs")
             distribute_irqs(all_irqs, self.irqs_cpu_mask)
 
-        self.__setup_rps(iface, self.compute_cpu_mask)
+        self.__setup_rps(iface, self.cpu_mask)
         self.__setup_xps(iface)
 
     def __setup_bonding_iface(self):


### PR DESCRIPTION
Enable RPS on all requested CPUs (or all present CPUs if
cpu_mask is not given).

This makes networking more efficient for applications that are bound
to IRQ CPUs.

Fixes #818

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>