### PR TITLE
perftune.py: fix assignment after extend and add asserts

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1308,7 +1308,9 @@ def extend_and_unique(orig_list, iterable):
     """
     Extend items to a list, and make the list items unique
     """
-    orig_list = orig_list.extend(iterable)
+    assert(isinstance(orig_list, list))
+    assert(isinstance(iterable, list))
+    orig_list.extend(iterable)
     return list(set(orig_list))
 
 def parse_options_file(prog_args):


### PR DESCRIPTION
extend() doesn't return the extened list, the assignment is wrong.

And we expected both the option in cmdline and the option dumped from
the config file are all list type. So added the assert check.

Fixes https://github.com/scylladb/scylla/issues/8008

Signed-off-by: Amos Kong <amos@scylladb.com>