### PR TITLE
utils/log.cc: fix nested_exception logging (again)

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -542,28 +542,20 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
         // Print more information on some familiar exception types
         try {
             throw;
-        } catch (const seastar::nested_exception& ne) {
-            out << fmt::format(": {} (while cleaning up after {})", ne.inner, ne.outer);
-        } catch(const std::system_error &e) {
+        } catch (const std::system_error &e) {
             out << " (error " << e.code() << ", " << e.what() << ")";
-        } catch(const std::exception& e) {
+        } catch (const std::exception &e) {
             out << " (" << e.what() << ")";
-            try {
-                std::rethrow_if_nested(e);
-            } catch (...) {
-                out << ": " << std::current_exception();
-            }
-        } catch (const std::nested_exception& ne) {
-            // if we got here, it means that the nested_exception is not mixed in
-            // with an object of type std::exception. It can happen in one of two
-            // cases:
-            // 1. The std::nested_exception was built and thrown using a normal
-            //    throw and not in the context of another catch with std::throw_with_nested
-            // 2. Somewhere in the code there is a throw of a type which doesn't derive from
-            //    std::exception and then it is rethrown using std::throw_with_nested.
-            out << ": " << "unknown nested type: " << ne.nested_ptr();
-        } catch(...) {
-            out << " (" << "no extra info" << ")";
+        } catch (...) {
+            // no extra info
+        }
+
+        try {
+            throw;
+        } catch (const std::nested_exception &ne) {
+            out << ": " << ne.nested_ptr();
+        } catch (...) {
+            // do nothing
         }
     }
     return out;


### PR DESCRIPTION
After multiple attempts nested_exception logging is still not robust.

In particular if std::system_error appears in the middle on the nested
exception chain the logging will break and very important information
(e.g. the object that initiated the exception chain) is going to be lost.

Take a look at this example:

```
#############################################
class my_exception : public std::exception {
    const char* my_name = "my_exception";

public:
    const char* what() const noexcept {
        return my_name;
    }
};

class very_important_exception : public std::exception {
    const char* my_name = "very important information";

public:
    const char* what() const noexcept {
        return my_name;
    }
};

int main() {
    try {
        throw very_important_exception();
	} catch (...) {
        try {
            std::throw_with_nested(std::system_error(1, std::generic_category(), "my error"));
        } catch (...) {
            try {
                std::throw_with_nested(my_exception());
            } catch (...) {
                std::cout << std::current_exception() << std::endl;
            }
        }
    }
    return 0;
}
#############################################
```
With the current implementation of
`std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr)`
it would print the following:
```
std::_Nested_exception<my_exception>  (my_exception): std::_Nested_exception<std::system_error>  (error generic:1, my error: Operation not permitted)
```
And with the version from this patch it would print:
```
std::_Nested_exception<my_exception>  (my_exception): std::_Nested_exception<std::system_error>  (error generic:1, my error: Operation not permitted): very_important_exception  (very important information)
```
As may be noticed without this patch we would be missing a "very important information".

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>