### PR TITLE
resource: improve insufficient PU error message

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -447,6 +447,10 @@ resources allocate(configuration c) {
     hwloc_topology_init(&topology);
     auto free_hwloc = defer([&] { hwloc_topology_destroy(topology); });
     hwloc_topology_load(topology);
+
+    // number of processing units before potentially restricting
+    // the topology with cpu_set
+    unsigned unrestricted_available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
     if (c.cpu_set) {
         auto bm = hwloc_bitmap_alloc();
         auto free_bm = defer([&] { hwloc_bitmap_free(bm); });
@@ -484,6 +488,9 @@ resources allocate(configuration c) {
     unsigned available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
     unsigned procs = c.cpus.value_or(available_procs);
     if (procs > available_procs) {
+        if (c.cpu_set && unrestricted_available_procs > available_procs) {
+            seastar_logger.warn("cpuset configuration restricted the number of available processing units from {} to {}", unrestricted_available_procs, available_procs);
+        }
         throw std::runtime_error(format("insufficient processing units: requested {} available {}", procs, available_procs));
     }
     // limit memory address to fit in 36-bit, see core/memory.cc:Memory map

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -484,7 +484,7 @@ resources allocate(configuration c) {
     unsigned available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
     unsigned procs = c.cpus.value_or(available_procs);
     if (procs > available_procs) {
-        throw std::runtime_error("insufficient processing units");
+        throw std::runtime_error(format("insufficient processing units: requested {} available {}", procs, available_procs));
     }
     // limit memory address to fit in 36-bit, see core/memory.cc:Memory map
     constexpr size_t max_mem_per_proc = 1UL << 36;


### PR DESCRIPTION
The first commit improves the "insufficient processing units" error message by adding an information about how many processing units were requested and how many are available.

The second commit adds a warning about how cpuset configuration restricted the number of available processing units. This warning is shown ONLY before "insufficient processing units" error. It makes it easier to troubleshoot for the user why "insufficient processing units" error was thrown, even though the machine has a larger number of PUs.

A motivation for this Pull Request was this user comment: https://github.com/scylladb/kafka-connect-scylladb/issues/34#issuecomment-820498659. The logs before this PR did not describe how many PUs Seastar detected and that cpuset restriction was applied, making it harder to troubleshoot the issue.