### PR TITLE
response_parser.rf : add parsing of status in http_response

### DIFF
--- a/apps/seawreck/seawreck.cc
+++ b/apps/seawreck/seawreck.cc
@@ -89,6 +89,8 @@ public:
                         return make_ready_future<>();
                     }
                     auto _rsp = _parser.get_parsed_response();
+                    http_debug("status = %d\n", _rsp->_status);
+
                     auto it = _rsp->_headers.find("Content-Length");
                     if (it == _rsp->_headers.end()) {
                         fmt::print("Error: HTTP response does not contain: Content-Length\n");

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -27,6 +27,7 @@ namespace seastar {
 
 struct http_response {
     sstring _version;
+    int _status;
     std::unordered_map<sstring, sstring> _headers;
 };
 
@@ -42,6 +43,10 @@ action mark {
 
 action store_version {
     _rsp->_version = str();
+}
+
+action store_status {
+    _rsp->_status = std::stoi(str());
 }
 
 action store_field_name {
@@ -77,10 +82,11 @@ ht = '\t';
 sp_ht = sp | ht;
 
 http_version = 'HTTP/' (digit '.' digit) >mark %store_version;
+http_status = (digit digit digit) >mark %store_status;
 
 field = tchar+ >mark %store_field_name;
 value = any* >mark %store_value;
-start_line = http_version space digit digit digit space (any - cr - lf)* crlf;
+start_line = http_version space http_status space (any - cr - lf)* crlf;
 header_1st = (field sp_ht* ':' value :> crlf) %assign_field;
 header_cont = (sp_ht+ value sp_ht* crlf) %extend_field;
 header = header_1st header_cont*;


### PR DESCRIPTION
seawreck being an example of http client built on top of seastar,
it seems useful to include status of response in http_response struct.

Signed-off-by: Peter Goron <peter.goron@gmail.com>