### PR TITLE
metrics: Fix dtest->ulong conversion error

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -140,6 +140,10 @@ metric_value metric_value::operator+(const metric_value& c) {
     return res;
 }
 
+void metric_value::ulong_conversion_error(double d) {
+    throw std::range_error(format("cannot convert double value {} to unsigned long", d));
+}
+
 metric_definition_impl::metric_definition_impl(
         metric_name_type name,
         metric_type type,

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -132,11 +132,10 @@ static std::string to_str(seastar::metrics::impl::data_type dt) {
     case seastar::metrics::impl::data_type::HISTOGRAM:
         return "histogram";
     case seastar::metrics::impl::data_type::DERIVE:
-        // Prometheus server does not respect derive parameters
+    case seastar::metrics::impl::data_type::ABSOLUTE:
+        // Prometheus server does not respect derive/absolute parameters
         // So we report them as counter
         return "counter";
-    default:
-        break;
     }
     return "untyped";
 }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -146,9 +146,9 @@ static std::string to_str(const seastar::metrics::impl::metric_value& v) {
     case seastar::metrics::impl::data_type::GAUGE:
         return std::to_string(v.d());
     case seastar::metrics::impl::data_type::COUNTER:
-        return std::to_string(v.i());
-    case seastar::metrics::impl::data_type::DERIVE:
         return std::to_string(v.ui());
+    case seastar::metrics::impl::data_type::DERIVE:
+        return std::to_string(v.i());
     default:
         break;
     }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -115,7 +115,8 @@ static void fill_metric(pm::MetricFamily& mf, const metrics::impl::metric_value&
         mf.set_type(pm::MetricType::HISTOGRAM);
         break;
     }
-    default:
+    case scollectd::data_type::COUNTER:
+    case scollectd::data_type::ABSOLUTE:
         add_label(mf.add_metric(), id, ctx)->mutable_counter()->set_value(c.ui());
         mf.set_type(pm::MetricType::COUNTER);
         break;

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -146,10 +146,11 @@ static std::string to_str(const seastar::metrics::impl::metric_value& v) {
     case seastar::metrics::impl::data_type::GAUGE:
         return std::to_string(v.d());
     case seastar::metrics::impl::data_type::COUNTER:
+    case seastar::metrics::impl::data_type::ABSOLUTE:
         return std::to_string(v.ui());
     case seastar::metrics::impl::data_type::DERIVE:
         return std::to_string(v.i());
-    default:
+    case seastar::metrics::impl::data_type::HISTOGRAM:
         break;
     }
     return ""; // we should never get here but it makes the compiler happy

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -214,10 +214,12 @@ struct cpwriter {
                 write_le(tmpi);
                 break;
             }
-            case data_type::COUNTER:
             case data_type::DERIVE:
+                write(v.i()); // signed int 64, big endian
+                break;
+            case data_type::COUNTER:
             case data_type::ABSOLUTE:
-                write(v.ui()); // big endian
+                write(v.ui()); // unsigned int 64, big endian
                 break;
             default:
                 assert(0);


### PR DESCRIPTION
prometheus: to_str(metric_value): fix conversion type for COUNTER and DERIVE
    
It looks like they got reversed.
    
Be consistent with metrics::impl::data_type documentation:
```
    enum class data_type : uint8_t {
        COUNTER, // unsigned int 64
        GAUGE, // double
        DERIVE, // signed int 64
        ABSOLUTE, // unsigned int 64
        HISTOGRAM,
    };
```
    
Fixes #899 

Test: heat_weighted_load_balancing_test.py:HeatWeightedLB.heat_weighted_load_balancing_cl_TWO_test(debug)
Verified that node logs show no ubsan errors not the added conversion warning.
