### PR TITLE
gitignore .cooking_memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cooking_memory
 .cproject
 .project
 .settings


### PR DESCRIPTION
This file is a build artifact, so should be ignored.