### PR TITLE
update Boost download URL

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -134,7 +134,7 @@ cooking_ingredient (zlib
 cooking_ingredient (Boost
   EXTERNAL_PROJECT_ARGS
     # The 1.67.0 release has a bug in Boost Lockfree around a missing header.
-    URL https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.gz
     URL_MD5 319c6ffbbeccc366f14bb68767a6db79
     PATCH_COMMAND
       ./bootstrap.sh


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

The old download URL is retired: https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html