### PR TITLE
reactor: adjust max_networking_aio_io_control_blocks to lower size when fs.aio-max-nr is small

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -445,6 +445,7 @@ private:
     void pin(unsigned cpu_id);
     void allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_config cfg);
     void create_thread(std::function<void ()> thread_loop);
+    unsigned adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs);
 public:
     static unsigned count;
 };


### PR DESCRIPTION
When fs.aio-max-nr does not have enough size, try to adjust
max_networking_aio_io_control_blocks size to fit fs.aio-max-nr.

See scylladb/scylla#9096

Signed-off-by: Takuya ASADA <syuu@scylladb.com>