### PR TITLE
core: clean up memory metric definitions

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -570,7 +570,7 @@ template<typename T>
 impl::metric_definition_impl make_current_bytes(metric_name_type name,
         T&& val, description d=description(), std::vector<label_instance> labels = {},
         instance_id_type instance = impl::shard()) {
-    return make_derive(name, std::forward<T>(val), d, labels).set_type("bytes");
+    return make_gauge(name, std::forward<T>(val), d, labels).set_type("bytes");
 }
 
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2175,9 +2175,9 @@ void reactor::register_metrics() {
             sm::make_derive("free_operations", [] { return memory::stats().frees(); }, sm::description("Total number of free operations")),
             sm::make_derive("cross_cpu_free_operations", [] { return memory::stats().cross_cpu_frees(); }, sm::description("Total number of cross cpu free")),
             sm::make_gauge("malloc_live_objects", [] { return memory::stats().live_objects(); }, sm::description("Number of live objects")),
-            sm::make_current_bytes("free_memory", [] { return memory::stats().free_memory(); }, sm::description("Free memeory size in bytes")),
-            sm::make_current_bytes("total_memory", [] { return memory::stats().total_memory(); }, sm::description("Total memeory size in bytes")),
-            sm::make_current_bytes("allocated_memory", [] { return memory::stats().allocated_memory(); }, sm::description("Allocated memeory size in bytes")),
+            sm::make_current_bytes("free_memory", [] { return memory::stats().free_memory(); }, sm::description("Free memory size in bytes")),
+            sm::make_current_bytes("total_memory", [] { return memory::stats().total_memory(); }, sm::description("Total memory size in bytes")),
+            sm::make_current_bytes("allocated_memory", [] { return memory::stats().allocated_memory(); }, sm::description("Allocated memory size in bytes")),
             sm::make_derive("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations"))
     });
 


### PR DESCRIPTION
This PR updates the type of memory size statistics (free_memory, total_memory, allocated_memory) to be gauges rather than counters.

The difference doesn't affect the numeric value presented in prometheus output, so it shouldn't break any dashboards, but having the correct type is useful when generating new dashboards.

While we're here, also correct the docstrings for these stats to say "memory" instead of "memeory".
