### PR TITLE
SLES: additionally check irqbalance.service under /usr/lib

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -135,7 +135,8 @@ def restart_irqbalance(banned_irqs):
     # If this file exists - this a "new (systemd) style" irqbalance packaging.
     # This type of packaging uses IRQBALANCE_ARGS as an option key name, "old (init.d) style"
     # packaging uses an OPTION key.
-    if os.path.exists('/lib/systemd/system/irqbalance.service'):
+    if os.path.exists('/lib/systemd/system/irqbalance.service') or \
+        os.path.exists('/usr/lib/systemd/system/irqbalance.service'):
         options_key = 'IRQBALANCE_ARGS'
         systemd = True
 


### PR DESCRIPTION
On CentOS7, /lib point to /usr/lib. But on SLES15 they are different directory.
'scripts/perftune.py' only checked the /lib/systemd/system/irqbalance.service,
which doesn't exist on SLES15.

Fixes #930

Signed-off-by: Amos Kong <amos@scylladb.com>

/Cc @vladzcloudius 