### PR TITLE
core: add alien() getter to reactor

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -243,6 +243,10 @@ public:
     };
     friend void io_completion::complete_with(ssize_t);
 
+    /// Obtains an alien::instance object that can be used to send messages
+    /// to Seastar shards from non-Seastar threads.
+    alien::instance& alien() { return _alien; }
+
 private:
     std::shared_ptr<smp> _smp;
     alien::instance& _alien;


### PR DESCRIPTION
We already have an alien() getter on app_template, but unit tests
using SEASTAR_THREAD_TEST_CASE do not have visibility
of the app_template created during test init.  Instead,
they can fetch an alien::instance via ss::engine().

An example of a unit test that consumes this function is in redpanda at https://github.com/vectorizedio/redpanda/pull/1989/commits/dccc7264362906166a5986dd398471153e4dd43c , where we test a class called `executor` that takes an alien::instance in its constructor.