### PR TITLE
Add dq and dq_split

### DIFF
--- a/scripts/perftune.yaml
+++ b/scripts/perftune.yaml
@@ -2,6 +2,8 @@
 #   - 'mq'
 #   - 'sq'
 #   - 'sq_split'
+#   - 'dq'
+#   - 'dq_split'
 #mode: 'sq_split'
 
 # Name of the NIC to tune, e.g. eth7.


### PR DESCRIPTION
Currently there exist sq, sq_split, mq and no_irq_restrictions. But on very
powerful systems, these setting cause a bottleneck on IRQ processing. 2
new options have been added: dq and dq_split. dq stands for double queue.
    
Mode: dq
    
This will create 2 IRQ CPUs:
- CPU 0 of NUMA node 0
- CPU 0 of NUMA node 1.
    
Mode: dq_split
    
This will create 4 IRQ CPUs:
- CPU 0 and its sibling of NUMA node 0
- CPU 0 and its sibling of NUMA node 1
    
The one that is most valuable is the dq_split. On systems with many cores
the 2 IRQ CPUs provided by sq_split are not sufficient to process the
IRQs. So by usin dq_split, there is double the IRQ processing power.