### PR TITLE
inet_address: fix #959 - usage of `htonl` for clang

### DIFF
--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -155,7 +155,7 @@ seastar::net::inet_address::operator ::in_addr() const {
 seastar::net::inet_address::operator ::in6_addr() const noexcept {
     if (_in_family == family::INET) {
         in6_addr in6 = IN6ADDR_ANY_INIT;
-        in6.s6_addr32[2] = ::htonl(0xffff);
+        in6.s6_addr32[2] = htonl(0xffff);
         in6.s6_addr32[3] = _in.s_addr;
         return in6;
     }


### PR DESCRIPTION
Fixes `error: expected unqualified-id` when `htonl` macro is expanded in `::htonl`'.