### PR TITLE
Fix test compile error on clang++-13

### DIFF
--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -50,7 +50,8 @@ struct fake_file {
     }
 };
 
-struct io_queue_for_tests {
+class io_queue_for_tests {
+public:
     io_group_ptr group;
     internal::io_sink sink;
     io_queue queue;


### PR DESCRIPTION
```
➜  seastar git:(master) ninja -C build/release
ninja: Entering directory `build/release'
[7/185] Building CXX object tests/unit/CMakeFiles/test_unit_io_queue.dir/io_queue_test.cc.o
FAILED: tests/unit/CMakeFiles/test_unit_io_queue.dir/io_queue_test.cc.o
/usr/lib/ccache/clang++-13  -DBOOST_TEST_DYN_LINK -DFMT_LOCALE -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_LZ4_COMPRESS_DEFAULT -DSEASTAR_HAVE_NUMA -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_TESTING_MAIN -I../../tests/unit -I../../src -I../../include -Igen/include -O3 -DNDEBUG   -std=gnu++17 -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Wno-error=unused-result "-Wno-error=#warnings" -fvisibility=hidden -UNDEBUG -Wall -Werror -Wno-array-bounds -Wno-error=deprecated-declarations -gz -std=gnu++17 -MD -MT tests/unit/CMakeFiles/test_unit_io_queue.dir/io_queue_test.cc.o -MF tests/unit/CMakeFiles/test_unit_io_queue.dir/io_queue_test.cc.o.d -o tests/unit/CMakeFiles/test_unit_io_queue.dir/io_queue_test.cc.o -c ../../tests/unit/io_queue_test.cc
../../tests/unit/io_queue_test.cc:53:1: error: 'io_queue_for_tests' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
struct io_queue_for_tests {
^
../../include/seastar/core/io_queue.hh:33:1: note: did you mean struct here?
class io_queue_for_tests;
^~~~~
struct
1 error generated.
```