### PR TITLE
Fix alloc-dealloc-mismatch error in DPDK mode

### DIFF
--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -260,9 +260,9 @@ public:
     ~dpdk_xstats()
     {
         if (_xstats)
-            delete _xstats;
+            delete[] _xstats;
         if (_xstat_names)
-            delete _xstat_names;
+            delete[] _xstat_names;
     }
 
     enum xstat_id {


### PR DESCRIPTION
Both `_xstats` and `_xstat_names` are allocated using `new[]`, they should be freed with `delete[]`.