### PR TITLE
Fix build error with c++17

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1195,7 +1195,7 @@ cpu_stall_detector_linux_perf_event::~cpu_stall_detector_linux_perf_event() {
 void
 cpu_stall_detector_linux_perf_event::arm_timer() {
     uint64_t ns = (_threshold * _report_at + _slack) / 1ns;
-    if (_enabled && _current_period == ns) [[likely]] {
+    if (__builtin_expect(_enabled && _current_period == ns, 1)) {
         // Common case - we're re-arming with the same period, the counter
         // is already enabled.
         _fd.ioctl(PERF_EVENT_IOC_RESET, 0);


### PR DESCRIPTION
Fix build error with GCC 9, which does not have cpp concepts in c++2a. This also allows compilers without c++2a to be able to build this framework