### PR TITLE
json/formatter: Escape strings

### DIFF
--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -121,63 +121,63 @@ class formatter {
 public:
 
     /**
-     * return a json formated string
+     * return a json formatted string
      * @param str the string to format
      * @return the given string in a json format
      */
     static sstring to_json(const sstring& str);
 
     /**
-     * return a json formated int
+     * return a json formatted int
      * @param n the int to format
      * @return the given int in a json format
      */
     static sstring to_json(int n);
 
     /**
-     * return a json formated unsigned
+     * return a json formatted unsigned
      * @param n the unsigned to format
      * @return the given unsigned in a json format
      */
     static sstring to_json(unsigned n);
 
     /**
-     * return a json formated long
+     * return a json formatted long
      * @param n the long to format
      * @return the given long in a json format
      */
     static sstring to_json(long n);
 
     /**
-     * return a json formated float
+     * return a json formatted float
      * @param f the float to format
      * @return the given float in a json format
      */
     static sstring to_json(float f);
 
     /**
-     * return a json formated double
+     * return a json formatted double
      * @param d the double to format
      * @return the given double in a json format
      */
     static sstring to_json(double d);
 
     /**
-     * return a json formated char* (treated as string)
-     * @param str the char* to foramt
-     * @return the given char* in a json foramt
+     * return a json formatted char* (treated as string)
+     * @param str the char* to format
+     * @return the given char* in a json format
      */
     static sstring to_json(const char* str);
 
     /**
-     * return a json formated bool
+     * return a json formatted bool
      * @param d the bool to format
      * @return the given bool in a json format
      */
     static sstring to_json(bool d);
 
     /**
-     * return a json formated list of a given vector of params
+     * return a json formatted list of a given vector of params
      * @param vec the vector to format
      * @return the given vector in a json format
      */
@@ -197,21 +197,21 @@ public:
     }
 
     /**
-     * return a json formated date_time
+     * return a json formatted date_time
      * @param d the date_time to format
      * @return the given date_time in a json format
      */
     static sstring to_json(const date_time& d);
 
     /**
-     * return a json formated json object
+     * return a json formatted json object
      * @param obj the date_time to format
      * @return the given json object in a json format
      */
     static sstring to_json(const jsonable& obj);
 
     /**
-     * return a json formated unsigned long
+     * return a json formatted unsigned long
      * @param l unsigned long to format
      * @return the given unsigned long in a json format
      */
@@ -220,7 +220,7 @@ public:
 
 
     /**
-     * return a json formated string
+     * return a json formatted string
      * @param str the string to format
      * @return the given string in a json format
      */
@@ -229,7 +229,7 @@ public:
     }
 
     /**
-     * return a json formated int
+     * return a json formatted int
      * @param n the int to format
      * @return the given int in a json format
      */
@@ -238,7 +238,7 @@ public:
     }
 
     /**
-     * return a json formated long
+     * return a json formatted long
      * @param n the long to format
      * @return the given long in a json format
      */
@@ -247,7 +247,7 @@ public:
     }
 
     /**
-     * return a json formated float
+     * return a json formatted float
      * @param f the float to format
      * @return the given float in a json format
      */
@@ -256,7 +256,7 @@ public:
     }
 
     /**
-     * return a json formated double
+     * return a json formatted double
      * @param d the double to format
      * @return the given double in a json format
      */
@@ -265,16 +265,16 @@ public:
     }
 
     /**
-     * return a json formated char* (treated as string)
-     * @param str the char* to foramt
-     * @return the given char* in a json foramt
+     * return a json formatted char* (treated as string)
+     * @param str the char* to format
+     * @return the given char* in a json format
      */
     static future<> write(output_stream<char>& s, const char* str) {
         return s.write(to_json(str));
     }
 
     /**
-     * return a json formated bool
+     * return a json formatted bool
      * @param d the bool to format
      * @return the given bool in a json format
      */
@@ -283,7 +283,7 @@ public:
     }
 
     /**
-     * return a json formated list of a given vector of params
+     * return a json formatted list of a given vector of params
      * @param vec the vector to format
      * @return the given vector in a json format
      */
@@ -303,7 +303,7 @@ public:
     }
 
     /**
-     * return a json formated date_time
+     * return a json formatted date_time
      * @param d the date_time to format
      * @return the given date_time in a json format
      */
@@ -312,7 +312,7 @@ public:
      }
 
     /**
-     * return a json formated json object
+     * return a json formatted json object
      * @param obj the date_time to format
      * @return the given json object in a json format
      */
@@ -321,7 +321,7 @@ public:
      }
 
     /**
-     * return a json formated unsigned long
+     * return a json formatted unsigned long
      * @param l unsigned long to format
      * @return the given unsigned long in a json format
      */

--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -163,9 +163,18 @@ public:
     static sstring to_json(double d);
 
     /**
-     * return a json formatted char* (treated as string)
+     * return a json formatted char* (treated as string), possibly with zero-chars in the middle
+     * @param str the char* to format
+     * @param len number of bytes to read from the \p str
+     * @return the given char* in a json format
+     */
+    static sstring to_json(const char* str, size_t len);
+
+    /**
+     * return a json formatted char* (treated as string), assuming there are no zero-chars in the middle
      * @param str the char* to format
      * @return the given char* in a json format
+     * @deprecated A more robust overload should be preferred: \ref to_json(const char*, size_t)
      */
     static sstring to_json(const char* str);
 

--- a/src/json/formatter.cc
+++ b/src/json/formatter.cc
@@ -22,6 +22,7 @@
 #include <seastar/json/formatter.hh>
 #include <seastar/json/json_elements.hh>
 #include <cmath>
+#include <algorithm>
 
 namespace seastar {
 
@@ -45,16 +46,70 @@ sstring formatter::end(state s) {
     }
 }
 
+static inline bool is_control_char(char c) {
+    return c >= 0 && c <= 0x1F;
+}
+
+static bool needs_escaping(const string_view& str) {
+    return std::any_of(str.begin(), str.end(), [] (char c) {
+        return is_control_char(c) || c == '"' || c == '\\';
+    });
+}
+
+static sstring string_view_to_json(const string_view& str) {
+    if (!needs_escaping(str)) {
+        return format("\"{}\"", str);
+    }
+
+    ostringstream oss;
+    oss << std::hex << std::uppercase << std::setfill('0');
+    oss.put('"');
+    for (char c : str) {
+        switch (c) {
+        case '"':
+            oss.put('\\').put('"');
+            break;
+        case '\\':
+            oss.put('\\').put('\\');
+            break;
+        case '\b':
+            oss.put('\\').put('b');
+            break;
+        case '\f':
+            oss.put('\\').put('f');
+            break;
+        case '\n':
+            oss.put('\\').put('n');
+            break;
+        case '\r':
+            oss.put('\\').put('r');
+            break;
+        case '\t':
+            oss.put('\\').put('t');
+            break;
+        default:
+            if (is_control_char(c)) {
+                oss.put('\\').put('u') << std::setw(4) << static_cast<int>(c);
+            } else {
+                oss.put(c);
+            }
+            break;
+        }
+    }
+    oss.put('"');
+    return oss.str();
+}
 
 sstring formatter::to_json(const sstring& str) {
-    return to_json(str.c_str());
+    return string_view_to_json(str);
 }
 
 sstring formatter::to_json(const char* str) {
-    sstring res = "\"";
-    res += str;
-    res += "\"";
-    return res;
+    return string_view_to_json(str);
+}
+
+sstring formatter::to_json(const char* str, size_t len) {
+    return string_view_to_json(string_view{str, len});
 }
 
 sstring formatter::to_json(int n) {

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -36,7 +36,16 @@ SEASTAR_TEST_CASE(test_simple_values) {
     BOOST_CHECK_EQUAL("3.5", formatter::to_json(3.5));
     BOOST_CHECK_EQUAL("true", formatter::to_json(true));
     BOOST_CHECK_EQUAL("false", formatter::to_json(false));
-    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa"));
+
+    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa")); // to_json(const char*)
+    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json(sstring("apa"))); // to_json(const sstring&)
+    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa", 3)); // to_json(const char*, size_t)
+
+    using namespace std::string_literals;
+    sstring str = "\0 COWA\bU\nGA [{\r}]\x1a"s,
+            expected = "\"\\u0000 COWA\\bU\\nGA [{\\r}]\\u001A\""s;
+    BOOST_CHECK_EQUAL(expected, formatter::to_json(str)); // to_json(const sstring&)
+    BOOST_CHECK_EQUAL(expected, formatter::to_json(str.c_str(), str.size())); // to_json(const char*, size_t)
 
     return make_ready_future();
 }


### PR DESCRIPTION
Background: until now strings in JSON were only quoted, not escaped, as noted by @nyh here: https://github.com/scylladb/seastar/issues/460#issuecomment-1038855017 . This resulted in problems like https://github.com/scylladb/scylla/issues/9061

The code for escaping was based on https://github.com/scylladb/scylla/blob/69fcc053bbb9156b8b88116a8dc8cc976148d86d/cql3/type_json.cc#L31 - just adapted to work on `string_view`s.
Also, the overload `formatter::to_json(const char*)` was marked as deprecated in Doxygen, because it would drop the contents following the first `\0` (and having `\0`s in the middle of a JSON is a valid practice). Scylla is not ready yet for the in-code `[[deprecated]]` attribute.

Fixes #460