### PR TITLE
core: memory: Replace overlooked uses of cpu_mem with get_cpu_mem()

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1550,7 +1550,7 @@ void configure(std::vector<resource::memory> m, bool mbind,
 
 statistics stats() {
     return statistics{alloc_stats::get(alloc_stats::types::allocs), alloc_stats::get(alloc_stats::types::frees), alloc_stats::get(alloc_stats::types::cross_cpu_frees),
-        cpu_mem.nr_pages * page_size, cpu_mem.nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
+        get_cpu_mem().nr_pages * page_size, get_cpu_mem().nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
         alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees), alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
 }
 


### PR DESCRIPTION
Accessing cpu_mem directly involves redundant tls_init calls.
We avoid them by going through get_cpu_mem().