### PR TITLE
core: memory: Add a shortcut for stats().free_memory

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -284,6 +284,9 @@ struct memory_layout {
 // Supported only when seastar allocator is enabled.
 memory::memory_layout get_memory_layout();
 
+/// Returns the size of free memory in bytes.
+size_t free_memory();
+
 /// Returns the value of free memory low water mark in bytes.
 /// When free memory is below this value, reclaimers are invoked until it goes above again.
 size_t min_free_memory();

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1554,6 +1554,10 @@ statistics stats() {
         alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees), alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
 }
 
+size_t free_memory() {
+    return get_cpu_mem().nr_free_pages * page_size;
+}
+
 bool drain_cross_cpu_freelist() {
     return get_cpu_mem().drain_cross_cpu_freelist();
 }


### PR DESCRIPTION
Scylla reads memory::stats().free_memory multiple times in its hot path.
Since stats() can't be inlined there, this causes a read of all memory
stats every time, even though only free_memory is relevant.

It adds up to several hundred wasted instructions per query.
This patch adds a shortcut for free_memory to get rid of that waste.