### PR TITLE
abortable_fifo: stop dereferencing null pointers

### DIFF
--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -220,8 +220,7 @@ public:
     /// Cannot be called on an element that si already associated
     /// with an abort source.
     void make_back_abortable(abort_source& as) {
-        entry* e;
-        e = &*_front;
+        entry* e = _front.get();
         if (!_list.empty()) {
             e = &_list.back();
         }


### PR DESCRIPTION
Use `_front.get()` instead of `&*_front`, as `_front` may be a `nullptr`
and dereferencing `nullptr`s is UB.

Fixes #1033.