### PR TITLE
coroutine/exception: make it work with co_await

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -53,6 +53,10 @@ public:
             _promise.set_exception(std::move(ce.eptr));
         }
 
+        void set_exception(std::exception_ptr&& eptr) noexcept {
+            _promise.set_exception(std::move(eptr));
+        }
+
         [[deprecated("Forwarding coroutine returns are deprecated as too dangerous. Use 'co_return co_await ...' until explicit syntax is available.")]]
         void return_value(future<T>&& fut) noexcept {
             fut.forward_to(std::move(_promise));
@@ -94,6 +98,10 @@ public:
 
         void return_void() noexcept {
             _promise.set_value();
+        }
+
+        void set_exception(std::exception_ptr&& eptr) noexcept {
+            _promise.set_exception(std::move(eptr));
         }
 
         void unhandled_exception() noexcept {

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -23,18 +23,47 @@
 
 #include <seastar/core/coroutine.hh>
 
-namespace seastar::coroutine {
+namespace seastar {
+
+namespace internal {
+
+struct exception_awaiter {
+    std::exception_ptr eptr;
+
+    explicit exception_awaiter(std::exception_ptr&& eptr) : eptr(std::move(eptr)) {}
+
+    exception_awaiter(const exception_awaiter&) = delete;
+    exception_awaiter(exception_awaiter&&) = delete;
+
+    bool await_ready() const noexcept {
+        return false;
+    }
+
+    template<typename U>
+    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+        hndl.promise().set_exception(std::move(eptr));
+        hndl.destroy();
+    }
+
+    void await_resume() noexcept {}
+};
+
+} // internal
+
+namespace coroutine {
 
 /// Wrapper for propagating an exception directly rather than
-/// throwing it.
+/// throwing it. The wrapper can be used with both co_await and co_return.
 ///
-/// \note It will not work on coroutines which return future<>, due to the fact
-/// that it's not legal to specify both return_value and return_void.
-/// The mechanism works fine for future<T> though.
+/// \note It is not possible to co_return the wrapper in coroutines which
+/// return future<> due to language limitations (it's not possible to specify
+/// both return_value and return_void in the promise_type). You can use co_await
+/// instead which works in coroutines which return either future<> or future<T>.
 ///
 /// Example usage:
 ///
 /// ```
+/// co_await coroutine::exception(std::make_exception_ptr(std::runtime_error("something failed miserably")));
 /// co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("something failed miserably")));
 /// ```
 struct exception {
@@ -42,7 +71,15 @@ struct exception {
     explicit exception(std::exception_ptr eptr) : eptr(std::move(eptr)) {}
 };
 
-/// Helper for creating a coroutine::exception instance
+/// Allows propagating an exception from a coroutine directly rather than
+/// throwing it.
+///
+/// `make_exception()` returns an object which must be co_returned.
+/// Co_returning the object will immediately resolve the current coroutine
+/// to the given exception.
+///
+/// \note Due to language limitations, this function doesn't work in coroutines
+/// which return future<>. Consider using return_exception instead.
 ///
 /// Example usage:
 ///
@@ -50,8 +87,33 @@ struct exception {
 /// co_return coroutine::make_exception(std::runtime_error("something failed miserably"));
 /// ```
 template<typename T>
+[[nodiscard]]
 exception make_exception(T&& t) {
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 
+/// Allows propagating an exception from a coroutine directly rather than
+/// throwing it.
+///
+/// `return_exception()` returns an object which must be co_awaited.
+/// Co_awaiting the object will immediately resolve the current coroutine
+/// to the given exception.
+///
+/// Example usage:
+///
+/// ```
+/// co_await coroutine::return_exception(std::runtime_error("something failed miserably"));
+/// ```
+template<typename T>
+[[nodiscard]]
+exception return_exception(T&& t) {
+    return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
+
+} // coroutine
+
+inline auto operator co_await(coroutine::exception ex) noexcept {
+    return internal::exception_awaiter(std::move(ex.eptr));
+}
+
+} // seastar

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -412,23 +412,54 @@ SEASTAR_TEST_CASE(test_all_throw_in_input_func) {
     BOOST_REQUIRE(exception_seen);
 }
 
-SEASTAR_TEST_CASE(test_coroutine_exception) {
-    auto i_am_exceptional = [] () -> future<int> {
-        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
-    };
-    BOOST_REQUIRE_THROW(co_await i_am_exceptional(), std::runtime_error);
-    co_await i_am_exceptional().then_wrapped([] (future<int> f) {
-        BOOST_REQUIRE(f.failed());
-        BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), std::runtime_error);
-    });
+struct counter_ref {
+private:
+    int& _counter;
 
-    auto i_am_exceptional_as_well = [] () -> future<bool> {
-        co_return coroutine::make_exception(std::logic_error("threw"));
-    };
-    BOOST_REQUIRE_THROW(co_await i_am_exceptional_as_well(), std::logic_error);
-    co_await i_am_exceptional_as_well().then_wrapped([] (future<bool> f) {
+public:
+    explicit counter_ref(int& cnt)
+            : _counter(cnt) {
+        ++_counter;
+    }
+
+    ~counter_ref() {
+        --_counter;
+    }
+};
+
+template<typename Ex>
+static future<> check_coroutine_throws(auto fun) {
+    // The counter keeps track of the number of alive "counter_ref" objects.
+    // If it is not zero then it means that some destructors weren't run
+    // while quitting the coroutine.
+    int counter = 0;
+    BOOST_REQUIRE_THROW(co_await fun(counter), Ex);
+    BOOST_REQUIRE_EQUAL(counter, 0);
+    co_await fun(counter).then_wrapped([&counter] (auto f) {
         BOOST_REQUIRE(f.failed());
-        BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), std::logic_error);
+        BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), Ex);
+        BOOST_REQUIRE_EQUAL(counter, 0);
+    });
+}
+
+SEASTAR_TEST_CASE(test_coroutine_exception) {
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<int> {
+        counter_ref ref{counter};
+        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
+    });
+    co_await check_coroutine_throws<std::logic_error>([] (int& counter) -> future<bool> {
+        counter_ref ref{counter};
+        co_return coroutine::make_exception(std::logic_error("threw"));
+    });
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<int> {
+        counter_ref ref{counter};
+        co_await coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
+        co_return 42;
+    });
+    co_await check_coroutine_throws<std::logic_error>([] (int& counter) -> future<> {
+        counter_ref ref{counter};
+        co_await coroutine::return_exception(std::logic_error("threw"));
+        co_return;
     });
 }
 


### PR DESCRIPTION
The seastar::coroutine::exception wrapper was introduced in order to
return exceptions from coroutines without throwing. A wrapped exception
is supposed to be co_returned from a coroutine.

Unfortunately, due to limitations of the language, coroutines returning
a void future are not allowed to `co_return anything;`,
only `co_return;`, which prevents usage of the wrapper in coroutines
returning void futures.

This commit introduces the possibility of using the wrapper with
co_await. Co_awaiting a wrapper has the same effect as co_returning it,
but unlike co_return it is also legal to do in coroutines returning a
void future.

A helper function seastar::coroutine::return_exception is introduced
which works similarly to seastar::coroutine::make_exception but has a
name which expresses the intent better when used along with co_await.