### PR TITLE
http reply: avoid copying content

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -120,10 +120,10 @@ struct reply {
         return *this;
     }
 
-    reply& set_status(status_type status, const sstring& content = "") {
+    reply& set_status(status_type status, sstring content = "") {
         _status = status;
         if (content != "") {
-            _content = content;
+            _content = std::move(content);
         }
         return *this;
     }
@@ -187,7 +187,7 @@ struct reply {
      * This would set the the content and content type of the message along
      * with any additional information that is needed to send the message.
      */
-    void write_body(const sstring& content_type, const sstring& content);
+    void write_body(const sstring& content_type, sstring content);
 
 private:
     future<> write_reply_to_connection(connection& con);

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -221,8 +221,8 @@ void reply::write_body(const sstring& content_type, noncopyable_function<future<
     _body_writer  = std::move(body_writer);
 }
 
-void reply::write_body(const sstring& content_type, const sstring& content) {
-    _content = content;
+void reply::write_body(const sstring& content_type, sstring content) {
+    _content = std::move(content);
     done(content_type);
 }
 


### PR DESCRIPTION
The original write_body() function variant with sstring content and
set_status() took the content as a const ref sstring. This forces at
least one copy. Turning it to pass-by-value covers both copy and move
semantics with an overhead of just an extra cheap move operation.