### PR TITLE
rpc: lower log level for 'failed to connect' errors

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -720,10 +720,18 @@ namespace rpc {
           std::exception_ptr ep;
           if (f.failed()) {
               ep = f.get_exception();
-              if (is_stream()) {
-                  log_exception(*this, log_level::error, _connected ? "client stream connection dropped" : "stream fail to connect", ep);
+              if (_connected) {
+                  if (is_stream()) {
+                      log_exception(*this, log_level::error, "client stream connection dropped", ep);
+                  } else {
+                      log_exception(*this, log_level::error, "client connection dropped", ep);
+                  }
               } else {
-                  log_exception(*this, log_level::error, _connected ? "client connection dropped" : "fail to connect", ep);
+                  if (is_stream()) {
+                      log_exception(*this, log_level::debug, "stream fail to connect", ep);
+                  } else {
+                      log_exception(*this, log_level::debug, "fail to connect", ep);
+                  }
               }
           }
           _error = true;


### PR DESCRIPTION
Some distributed applications want to try contacting remote endpoints
periodically even when they think that those endpoints are down. For
example, the Scylla gossip module tries to contact remotes every second,
even if some of them are marked down by the failure detector. This
causes an unwanted spam of error messages in the logs.

Lower the log level for when the RPC module fails to establish a
connection to `debug`. It will still report a message on `error` level
if an error occurs on an already established connection.