### PR TITLE
Allow use of llvm-addr2line as the command

### DIFF
--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -109,6 +109,15 @@ cmdline_parser.add_argument(
         ' By default no matching is performed.')
 
 cmdline_parser.add_argument(
+        '-a',
+        '--addr2line',
+        type=str,
+        metavar='CMD_PATH',
+        default='addr2line',
+        help='The path or name of the addr2line command, which should behave as and '
+        'accept the same options as binutils addr2line or llvm-addr2line.')
+
+cmdline_parser.add_argument(
         '-v',
         '--verbose',
         action='store_true',
@@ -205,7 +214,8 @@ else:
     else:
         lines = sys.stdin
 
-with BacktraceResolver(executable=args.executable, before_lines=args.before, context_re=args.match, verbose=args.verbose) as resolve:
+with BacktraceResolver(executable=args.executable, before_lines=args.before, context_re=args.match,
+        verbose=args.verbose, cmd_path=args.addr2line) as resolve:
     p = re.compile(r'\W+')
     for line in lines:
         resolve(line)


### PR DESCRIPTION
Prior to this change the addr2line.py script always uses addr2line as the
binary to decode stack frames. This change allows the path and/or name
of the binary to be provided explicitly on the command line.

This allows the of llvm-addr2line, an alternative implementation
based on llvm-symbolizer, which in my experiments is over *200* times as
fast as addr2line in decoding some redpanda stack traces.

See https://sourceware.org/bugzilla/show_bug.cgi?id=29010 for more
on the addr2line slowness.

This change also slightly changes the 'dummy line' strategy used to
detect when addr2line has finished outputting frames for the current
address to make it compatible with llvm-addr2line.

Fixes #1035.