### PR TITLE
std-coroutine: include <coroutine> for LLVM-15

### DIFF
--- a/include/seastar/core/std-coroutine.hh
+++ b/include/seastar/core/std-coroutine.hh
@@ -21,8 +21,8 @@
 
 #pragma once
 
-// Clang currently only supports the TS
-#if __has_include(<coroutine>) && !defined(__clang__)
+// Clang < 15 only supports the TS
+#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 15)
 #include <coroutine>
 #define SEASTAR_INTERNAL_COROUTINE_NAMESPACE std
 #elif __has_include(<experimental/coroutine>)


### PR DESCRIPTION
since std::experimental::coroutine_traits will be removed in LLVM 15,
let's prepare for this change by including <coroutine> when compiling
clang-15 and up.

without this change, when compiling an application using Seastar
coroutine, we could run into following warning:

```
/home/kefu/dev/redpanda/src/v/net/server.cc:141:19: error: support for std::experimental::coroutine_traits will be removed in LLVM 15; use std::coroutine_traits instead [-Werror,-Wdeprecated-experimental-coroutine]
                  co_return ss::stop_iteration::yes;
                  ^
/home/kefu/dev/redpanda/build/deps_install/include/seastar/core/std-coroutine.hh:124:7: note: 'coroutine_traits' declared here
class coroutine_traits { };
      ^
1 error generated.
```
after this change, the warning is gone.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>