### PR TITLE
seastar-addr2line: support sct syslogs

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -94,10 +94,10 @@ class BacktraceResolver(object):
             addr = "0x[0-9a-f]+"
             path = "\S+"
             token = f"(?:{path}\+)?{addr}"
-            full_addr_match = f"(?:({path})\+)?({addr})"
+            full_addr_match = f"(?:(?P<path>{path})\+)?(?P<addr>{addr})"
             self.oneline_re = re.compile(f"^((?:.*(?:(?:at|backtrace):?|:))?(?:\s+))?({token}(?:\s+{token})*)(?:\).*|\s*)$", flags=re.IGNORECASE)
             self.address_re = re.compile(full_addr_match, flags=re.IGNORECASE)
-            self.asan_re = re.compile(f"^(?:.*\s+)\(({full_addr_match})\)\s*$", flags=re.IGNORECASE)
+            self.asan_re = re.compile(f"^(?:.*\s+)\({full_addr_match}\)\s*$", flags=re.IGNORECASE)
             self.separator_re = re.compile('^\W*-+\W*$')
 
         def __call__(self, line):
@@ -115,7 +115,7 @@ class BacktraceResolver(object):
                 for obj in m.group(2).split():
                     m = re.match(self.address_re, obj)
                     #print(f"  >>> '{obj}': address {m.groups()}")
-                    addresses.append({'path': m.group(1), 'addr': m.group(2)})
+                    addresses.append({'path': m.group('path'), 'addr': m.group('addr')})
                 ret['addresses'] = addresses
                 return ret
 
@@ -124,7 +124,7 @@ class BacktraceResolver(object):
                 #print(f">>> '{line}': asan {m.groups()}")
                 ret = {'type': self.Type.ADDRESS}
                 ret['prefix'] = None
-                ret['addresses'] = [{'path': m.group(2), 'addr': m.group(3)}]
+                ret['addresses'] = [{'path': m.group('path'), 'addr': m.group('addr')}]
                 return ret
 
             match = re.match(self.separator_re, line)

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -151,8 +151,8 @@ if args.test:
         ('/my/path+0x12f34', {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': '/my/path', 'addr': '0x12f34'}]}),
         (' /my/path+0x12f34', {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': '/my/path', 'addr': '0x12f34'}]}),
 
-        ('Some prefix 0x12f34', None),
-        ('Some prefix /my/path+0x12f34', None),
+        ('Some prefix 0x12f34', {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': None, 'addr': '0x12f34'}]}),
+        ('Some prefix /my/path+0x12f34', {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': '/my/path', 'addr': '0x12f34'}]}),
 
         ('Reactor stalled on shard 1. Backtrace: 0x12f34',
                 {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': 'Reactor stalled on shard 1. Backtrace:',
@@ -192,6 +192,28 @@ if args.test:
                  'prefix': 'seastar::nested_exception: seastar::internal::backtraced<std::runtime_error> (inner Backtrace: 0x42bc95 /lib64/libc.so.6+0x281e1 0x412cfd)'
                            ' (while cleaning up after seastar::internal::backtraced<std::runtime_error> (outer Backtrace:',
                  'addresses': [{'path': None, 'addr': '0x1234'}, {'path': '/lib64/libc.so.6', 'addr': '0x5678'}, {'path': None, 'addr': '0xabcd'}]}),
+
+        ("2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO | "
+         "scylla: sstables/consumer.hh:610: future<> data_consumer::continuous_data_consumer"
+         "<sstables::index_consume_entry_context<sstables::index_consumer>>::fast_forward_to"
+         "(size_t, size_t) [StateProcessor = sstables::index_consume_entry_context"
+         "<sstables::index_consumer>]: Assertion `begin >= _stream_position.position' failed.", None),
+        ('2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO |   Backtrace:', None),
+        ('2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO |   0x199d312',
+                {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
+                 'prefix': None,
+                 'addresses': [{'path': None, 'addr': '0x199d312'}]}),
+        ('2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO |   (throw_with_backtrace_exception_logging Backtrace: 0x42bc95 /lib64/libc.so.6+0x281e1 0x412cfd)',
+                {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
+                 'prefix': '2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO |   (throw_with_backtrace_exception_logging Backtrace:',
+                 'addresses': [{'path': None, 'addr': '0x42bc95'}, {'path': '/lib64/libc.so.6', 'addr': '0x281e1'}, {'path': None, 'addr': '0x412cfd'}]}),
+
+        ('[2022-04-19T23:09:28.311Z] Segmentation fault on shard 1.', None),
+        ('[2022-04-19T23:09:28.311Z] Backtrace:', None),
+        ('[2022-04-19T23:09:28.311Z]   0x461bbb8',
+                {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': None, 'addr': '0x461bbb8'}]}),
+        ('[2022-04-19T23:09:28.311Z]   /lib64/libpthread.so.0+0x92a4',
+                {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': '/lib64/libpthread.so.0', 'addr': '0x92a4'}]})
     ]
     parser = BacktraceResolver.BacktraceParser()
     for line, expected in data:


### PR DESCRIPTION
This series adds support for parsing lines printed to scylla cluster tests syslogs that contain a prefix we currently don't support, such as:
```
[2022-04-19T23:09:28.311Z]   0x461bbb8
```
or
```
2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO |   0x199d312
```

The intention is to use this in the https://github.com/scylladb/scylla_s3_reloc_server/ project (by updating the seastar submodule there)