### PR TITLE
memory: stats: mark functions noexcept

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -298,19 +298,19 @@ void set_min_free_pages(size_t pages);
 /// Warn when allocation above a given threshold are performed.
 ///
 /// \param threshold size (in bytes) above which an allocation will be logged
-void set_large_allocation_warning_threshold(size_t threshold);
+void set_large_allocation_warning_threshold(size_t threshold) noexcept;
 
 /// Gets the current large allocation warning threshold.
-size_t get_large_allocation_warning_threshold();
+size_t get_large_allocation_warning_threshold() noexcept;
 
 /// Disable large allocation warnings.
-void disable_large_allocation_warning();
+void disable_large_allocation_warning() noexcept;
 
 /// Set a different large allocation warning threshold for a scope.
 class scoped_large_allocation_warning_threshold {
     size_t _old_threshold;
 public:
-    explicit scoped_large_allocation_warning_threshold(size_t threshold)
+    explicit scoped_large_allocation_warning_threshold(size_t threshold) noexcept
             : _old_threshold(get_large_allocation_warning_threshold()) {
         set_large_allocation_warning_threshold(threshold);
     }
@@ -329,7 +329,7 @@ public:
 class scoped_large_allocation_warning_disable {
     size_t _old_threshold;
 public:
-    scoped_large_allocation_warning_disable()
+    scoped_large_allocation_warning_disable() noexcept
             : _old_threshold(get_large_allocation_warning_threshold()) {
         disable_large_allocation_warning();
     }

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -196,7 +196,7 @@ public:
     reclaimer(std::function<reclaiming_result (request)> reclaim, reclaimer_scope scope = reclaimer_scope::async);
     ~reclaimer();
     reclaiming_result do_reclaim(size_t bytes_to_reclaim) { return _reclaim(request{bytes_to_reclaim}); }
-    reclaimer_scope scope() const { return _scope; }
+    reclaimer_scope scope() const noexcept { return _scope; }
 };
 
 extern std::pmr::polymorphic_allocator<char>* malloc_allocator;

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -186,7 +186,6 @@ public:
         // If less is released then the reclaimer may be invoked again.
         size_t bytes_to_reclaim;
     };
-    using reclaim_fn = std::function<reclaiming_result ()>;
 private:
     std::function<reclaiming_result (request)> _reclaim;
     reclaimer_scope _scope;

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -222,7 +222,7 @@ void set_reclaim_hook(
 class statistics;
 
 /// Capture a snapshot of memory allocation statistics for this lcore.
-statistics stats();
+statistics stats() noexcept;
 
 /// Memory allocation statistics.
 class statistics {
@@ -240,38 +240,38 @@ class statistics {
 private:
     statistics(uint64_t mallocs, uint64_t frees, uint64_t cross_cpu_frees,
             uint64_t total_memory, uint64_t free_memory, uint64_t reclaims, uint64_t large_allocs,
-            uint64_t foreign_mallocs, uint64_t foreign_frees, uint64_t foreign_cross_frees)
+            uint64_t foreign_mallocs, uint64_t foreign_frees, uint64_t foreign_cross_frees) noexcept
         : _mallocs(mallocs), _frees(frees), _cross_cpu_frees(cross_cpu_frees)
         , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims), _large_allocs(large_allocs)
         , _foreign_mallocs(foreign_mallocs), _foreign_frees(foreign_frees)
         , _foreign_cross_frees(foreign_cross_frees) {}
 public:
     /// Total number of memory allocations calls since the system was started.
-    uint64_t mallocs() const { return _mallocs; }
+    uint64_t mallocs() const noexcept { return _mallocs; }
     /// Total number of memory deallocations calls since the system was started.
-    uint64_t frees() const { return _frees; }
+    uint64_t frees() const noexcept { return _frees; }
     /// Total number of memory deallocations that occured on a different lcore
     /// than the one on which they were allocated.
-    uint64_t cross_cpu_frees() const { return _cross_cpu_frees; }
+    uint64_t cross_cpu_frees() const noexcept { return _cross_cpu_frees; }
     /// Total number of objects which were allocated but not freed.
-    size_t live_objects() const { return mallocs() - frees(); }
+    size_t live_objects() const noexcept { return mallocs() - frees(); }
     /// Total free memory (in bytes)
-    size_t free_memory() const { return _free_memory; }
+    size_t free_memory() const noexcept { return _free_memory; }
     /// Total allocated memory (in bytes)
-    size_t allocated_memory() const { return _total_memory - _free_memory; }
+    size_t allocated_memory() const noexcept { return _total_memory - _free_memory; }
     /// Total memory (in bytes)
-    size_t total_memory() const { return _total_memory; }
+    size_t total_memory() const noexcept { return _total_memory; }
     /// Number of reclaims performed due to low memory
-    uint64_t reclaims() const { return _reclaims; }
+    uint64_t reclaims() const noexcept { return _reclaims; }
     /// Number of allocations which violated the large allocation threshold
-    uint64_t large_allocations() const { return _large_allocs; }
+    uint64_t large_allocations() const noexcept { return _large_allocs; }
     /// Number of foreign allocations
-    uint64_t foreign_mallocs() const { return _foreign_mallocs; }
+    uint64_t foreign_mallocs() const noexcept { return _foreign_mallocs; }
     /// Number of foreign frees
-    uint64_t foreign_frees() const { return _foreign_frees; }
+    uint64_t foreign_frees() const noexcept { return _foreign_frees; }
     /// Number of foreign frees on reactor threads
-    uint64_t foreign_cross_frees() const { return _foreign_cross_frees; }
-    friend statistics stats();
+    uint64_t foreign_cross_frees() const noexcept { return _foreign_cross_frees; }
+    friend statistics stats() noexcept;
 };
 
 struct memory_layout {
@@ -281,16 +281,17 @@ struct memory_layout {
 
 // Discover virtual address range used by the allocator on current shard.
 // Supported only when seastar allocator is enabled.
-memory::memory_layout get_memory_layout();
+memory::memory_layout get_memory_layout() noexcept;
 
 /// Returns the size of free memory in bytes.
-size_t free_memory();
+size_t free_memory() noexcept;
 
 /// Returns the value of free memory low water mark in bytes.
 /// When free memory is below this value, reclaimers are invoked until it goes above again.
-size_t min_free_memory();
+size_t min_free_memory() noexcept;
 
 /// Sets the value of free memory low water mark in memory::page_size units.
+/// Throws runtime_error if number of pages is tool large.
 void set_min_free_pages(size_t pages);
 
 /// Enable the large allocation warning threshold.

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -563,7 +563,7 @@ static thread_local cpu_pages cpu_mem;
 std::atomic<unsigned> cpu_pages::cpu_id_gen;
 cpu_pages* cpu_pages::all_cpus[max_cpus];
 
-static cpu_pages& get_cpu_mem();
+static cpu_pages& get_cpu_mem() noexcept;
 
 #ifdef SEASTAR_HEAPPROF
 
@@ -1357,7 +1357,7 @@ static void init_cpu_mem() {
 }
 
 [[gnu::always_inline]]
-static inline cpu_pages& get_cpu_mem()
+static inline cpu_pages& get_cpu_mem() noexcept
 {
     // cpu_pages has a non-trivial constructor which means that the compiler
     // must make sure the instance local to the current thread has been

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1489,15 +1489,15 @@ reclaimer::~reclaimer() {
     r.erase(std::find(r.begin(), r.end(), this));
 }
 
-void set_large_allocation_warning_threshold(size_t threshold) {
+void set_large_allocation_warning_threshold(size_t threshold) noexcept {
     get_cpu_mem().large_allocation_warning_threshold = threshold;
 }
 
-size_t get_large_allocation_warning_threshold() {
+size_t get_large_allocation_warning_threshold() noexcept {
     return get_cpu_mem().large_allocation_warning_threshold;
 }
 
-void disable_large_allocation_warning() {
+void disable_large_allocation_warning() noexcept {
     get_cpu_mem().large_allocation_warning_threshold = std::numeric_limits<size_t>::max();
 }
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -218,11 +218,11 @@ using stats_atomic_array = std::array<std::atomic_uint64_t, static_cast<std::siz
 static thread_local SEASTAR_CONSTINIT stats_array stats{};
 std::array<stats_atomic_array, max_cpus> alien_stats{};
 
-static void increment_local(types stat_type, uint64_t size = 1) {
+static void increment_local(types stat_type, uint64_t size = 1) noexcept {
     stats[static_cast<std::size_t>(stat_type)] += size;
 }
 
-static void increment(types stat_type, uint64_t size=1)
+static void increment(types stat_type, uint64_t size=1) noexcept
 {
     // fast path, reactor threads takes thread local statistics
     if (is_reactor_thread) {
@@ -234,7 +234,7 @@ static void increment(types stat_type, uint64_t size=1)
     }
 }
 
-static uint64_t get(types stat_type)
+static uint64_t get(types stat_type) noexcept
 {
     auto i = static_cast<std::size_t>(stat_type);
     // fast path, reactor threads takes thread local statistics
@@ -555,7 +555,7 @@ struct cpu_pages {
     void replace_memory_backing(allocate_system_memory_fn alloc_sys_mem);
     void check_large_allocation(size_t size);
     void warn_large_allocation(size_t size);
-    memory::memory_layout memory_layout();
+    memory::memory_layout memory_layout() noexcept;
     ~cpu_pages();
 };
 
@@ -1159,7 +1159,7 @@ void cpu_pages::schedule_reclaim() {
     });
 }
 
-memory::memory_layout cpu_pages::memory_layout() {
+memory::memory_layout cpu_pages::memory_layout() noexcept {
     assert(is_initialized());
     return {
         reinterpret_cast<uintptr_t>(memory),
@@ -1548,13 +1548,13 @@ void configure(std::vector<resource::memory> m, bool mbind,
     }
 }
 
-statistics stats() {
+statistics stats() noexcept {
     return statistics{alloc_stats::get(alloc_stats::types::allocs), alloc_stats::get(alloc_stats::types::frees), alloc_stats::get(alloc_stats::types::cross_cpu_frees),
         cpu_mem.nr_pages * page_size, cpu_mem.nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
         alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees), alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
 }
 
-size_t free_memory() {
+size_t free_memory() noexcept {
     return get_cpu_mem().nr_free_pages * page_size;
 }
 
@@ -1562,11 +1562,11 @@ bool drain_cross_cpu_freelist() {
     return get_cpu_mem().drain_cross_cpu_freelist();
 }
 
-memory_layout get_memory_layout() {
+memory_layout get_memory_layout() noexcept {
     return get_cpu_mem().memory_layout();
 }
 
-size_t min_free_memory() {
+size_t min_free_memory() noexcept {
     return get_cpu_mem().min_free_pages * page_size;
 }
 


### PR DESCRIPTION
Mark trivial and simple stats-related functions in in memory.{cc,hh}.

The motivation comes from marking functions in scylla logalloc facility that call these function noexcept.

Test: unit(dev)
