### PR TITLE
sstring: fix format and optimize the performance of sstring::find().

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -245,7 +245,7 @@ public:
         const char_type* c_str = s.str();
         const char_type* c_str_end = s.str() + s.size();
 
-	if (c_str == c_str_end) {
+	    if (c_str == c_str_end) {
             /* see https://en.cppreference.com/w/cpp/string/basic_string/find
              * - an empty substring is found at pos if and only if pos <= size()
              */
@@ -255,7 +255,7 @@ public:
         while (it < end) {
             auto i = it;
             auto j = c_str;
-            while ( i < end && j < c_str_end && *i == *j) {
+            while (i < end && j < c_str_end && *i == *j) {
                 i++;
                 j++;
             }

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -243,28 +243,40 @@ public:
         const char_type* it = str() + pos;
         const char_type* end = str() + size();
         const char_type* c_str = s.str();
-        const char_type* c_str_end = s.str() + s.size();
 
-	    if (c_str == c_str_end) {
-            /* see https://en.cppreference.com/w/cpp/string/basic_string/find
-             * - an empty substring is found at pos if and only if pos <= size()
-             */
-            return (pos <= size()) ? pos : npos;
+        if (pos > size()) {
+            return npos;
         }
 
-        while (it < end) {
-            auto i = it;
-            auto j = c_str;
-            while (i < end && j < c_str_end && *i == *j) {
-                i++;
-                j++;
+        const size_t len2 = s.size();
+        if (len2 == 0) {
+            return pos;
+        }
+
+        size_t len1 = end - it;
+        if (len1 < len2) {
+            return npos;
+        }
+
+        char_type f2 = *c_str;
+        while (true) {
+            len1 = end - it;
+            if (len1 < len2) {
+                return npos;
             }
-            if (j == c_str_end) {
+
+            // find the first byte of pattern string matching in source string
+            it = traits_type::find(it, len1 - len2 + 1, f2);
+            if (it == nullptr) {
+                return npos;
+            }
+
+            if (traits_type::compare(it, c_str, len2) == 0) {
                 return it - str();
             }
-            it++;
+
+            ++it;
         }
-        return npos;
     }
 
     /**

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -54,8 +54,6 @@ BOOST_AUTO_TEST_CASE(test_add_literal_to_sstring) {
 BOOST_AUTO_TEST_CASE(test_find_sstring) {
     BOOST_REQUIRE_EQUAL(sstring("abcde").find('b'), 1u);
     BOOST_REQUIRE_EQUAL(sstring("babcde").find('b',1), 2u);
-    BOOST_REQUIRE_EQUAL(sstring("").find("", 0), 0u);
-    BOOST_REQUIRE_EQUAL(sstring("").find("", 1), sstring::npos);
 }
 
 BOOST_AUTO_TEST_CASE(test_find_sstring_compatible) {
@@ -86,10 +84,19 @@ BOOST_AUTO_TEST_CASE(test_not_find_sstring) {
 BOOST_AUTO_TEST_CASE(test_str_find_sstring) {
     BOOST_REQUIRE_EQUAL(sstring("abcde").find("bc"), 1u);
     BOOST_REQUIRE_EQUAL(sstring("abcbcde").find("bc", 2), 3u);
+    BOOST_REQUIRE_EQUAL(sstring("abcde").find("abcde"), 0u);
+    BOOST_REQUIRE_EQUAL(sstring("abcde").find("", 5), 5u);
+    BOOST_REQUIRE_EQUAL(sstring("ababcbdbef").find("bef"), 7u);
+    BOOST_REQUIRE_EQUAL(sstring("").find("", 0), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_str_not_find_sstring) {
     BOOST_REQUIRE_EQUAL(sstring("abcde").find("x"), sstring::npos);
+    BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 6), sstring::npos);
+    BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 4), sstring::npos);
+    BOOST_REQUIRE_EQUAL(sstring("ababcbdbe").find("bcd"), sstring::npos);
+    BOOST_REQUIRE_EQUAL(sstring("").find("", 1), sstring::npos);
+    BOOST_REQUIRE_EQUAL(sstring("abc").find("abcde"), sstring::npos);
 }
 
 BOOST_AUTO_TEST_CASE(test_substr_sstring) {


### PR DESCRIPTION
This patch optimize sstring::find() in two ways:

- sstring::find used to compare character one by one. The patch makes
sstring::find to get converted to calls to memchr and memcmp, which is
much more efficient.
- This patch will stop seaching earlier when source string is shorter
than pattern string to avoid unnecessary comparison.

This patch is ported from the implementation of std::string::find in LLVM:
https://github.com/llvm/llvm-project/blob/main/libcxx/include/__string#L939
