### PR TITLE
core: memory: Add memory::free_memory() also in Debug mode

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2250,6 +2250,10 @@ statistics stats() {
     return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0};
 }
 
+size_t free_memory() {
+    return stats().free_memory();
+}
+
 bool drain_cross_cpu_freelist() {
     return false;
 }


### PR DESCRIPTION
Due to an oversight, 61cfb3d5 added memory::free_memory() only in
one branch of an #ifdef, so it's missing in Debug builds.
Fix that.