### PR TITLE
Correct swapped AIO detection/setup calls

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1167,7 +1167,7 @@ reactor_backend_selector reactor_backend_selector::default_backend() {
 
 std::vector<reactor_backend_selector> reactor_backend_selector::available() {
     std::vector<reactor_backend_selector> ret;
-    if (detect_aio_poll() && has_enough_aio_nr()) {
+    if (has_enough_aio_nr() && detect_aio_poll()) {
         ret.push_back(reactor_backend_selector("linux-aio"));
     }
     ret.push_back(reactor_backend_selector("epoll"));


### PR DESCRIPTION
reactor_backend_selector::available will first detect_aio_poll() and - only after it suceeds - it will evaluate whether the system has_enough_aio_nr(). This logic is incorrect, as we must first evaluate whether we first have enough AIO NRs before detecting the AIO poll, as AIO poll throws upon failure to invoke io_setup().

Fix this by reversing the check order.