### PR TITLE
AIO contexts checks wraps around when aio-nr > aio-max-nr

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3846,8 +3846,8 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
     static unsigned constexpr storage_iocbs = reactor::max_aio;
     static unsigned constexpr preempt_iocbs = 2;
 
-    auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
-    auto aio_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-nr");
+    auto aio_max_nr = read_first_line_as<signed>("/proc/sys/fs/aio-max-nr");
+    auto aio_nr = read_first_line_as<signed>("/proc/sys/fs/aio-nr");
     auto available_aio = aio_max_nr - aio_nr;
     auto requested_aio_network = network_iocbs * smp::count;
     auto requested_aio_other = (storage_iocbs + preempt_iocbs) * smp::count;

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1139,8 +1139,8 @@ static bool detect_aio_poll() {
 }
 
 bool reactor_backend_selector::has_enough_aio_nr() {
-    auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
-    auto aio_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-nr");
+    auto aio_max_nr = read_first_line_as<signed>("/proc/sys/fs/aio-max-nr");
+    auto aio_nr = read_first_line_as<signed>("/proc/sys/fs/aio-nr");
     /* reactor_backend_selector::available() will be execute in early stage,
      * it's before io_setup() issued, and not per-cpu basis.
      * So this method calculates:


### PR DESCRIPTION
It turns out that an user can rightfully have a aio-nr value bigger than aio-max-nr. Such situation happens when aio-max-nr value is modified on the fly and the running system has active AIO contexts.

Fixes #1062