### PR TITLE
add missing dpdk dependency on Fedora

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -104,6 +104,7 @@ fedora_packages=(
     libasan
     libatomic
     valgrind-devel
+    dpdk-devel
 )
 
 centos7_packages=(


### PR DESCRIPTION
The dpdk depedency is not installed when running ./install-dependencies.sh on Fedora (36), and prevents building the project with ninja