### PR TITLE
Use RECV syscall instead of READ in do_read_some()

### DIFF
--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -225,13 +225,13 @@ public:
         throw_system_error_on(r == -1, "read");
         return { size_t(r) };
     }
-    std::optional<ssize_t> recv(void* buffer, size_t len, int flags) {
+    std::optional<size_t> recv(void* buffer, size_t len, int flags) {
         auto r = ::recv(_fd, buffer, len, flags);
         if (r == -1 && errno == EAGAIN) {
             return {};
         }
         throw_system_error_on(r == -1, "recv");
-        return { ssize_t(r) };
+        return { size_t(r) };
     }
     std::optional<size_t> recvmsg(msghdr* mh, int flags) {
         auto r = ::recvmsg(_fd, mh, flags);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -257,7 +257,7 @@ future<> reactor::do_connect(pollable_fd_state& pfd, socket_address& sa) {
 future<size_t>
 reactor::do_read_some(pollable_fd_state& fd, void* buffer, size_t len) {
     return readable(fd).then([this, &fd, buffer, len] () mutable {
-        auto r = fd.fd.read(buffer, len);
+        auto r = fd.fd.recv(buffer, len, 0);
         if (!r) {
             return do_read_some(fd, buffer, len);
         }
@@ -272,7 +272,7 @@ future<temporary_buffer<char>>
 reactor::do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
     return fd.readable().then([this, &fd, ba] {
         auto buffer = ba->allocate_buffer();
-        auto r = fd.fd.read(buffer.get_write(), buffer.size());
+        auto r = fd.fd.recv(buffer.get_write(), buffer.size(), 0);
         if (!r) {
             // Speculation failure, try again with real polling this time
             // Note we release the buffer and will reallocate it when poll


### PR DESCRIPTION
`recv` has a slight performance advantage over the more generic `read`. Seastar is already using `send` instead of `write` on the transmit side. 

N.B. I had to change the return type from `ssize_t` to `size_t` in posix.hh to get it working.