### PR TITLE
std-coroutine: include for LLVM-14

### DIFF
--- a/include/seastar/core/std-coroutine.hh
+++ b/include/seastar/core/std-coroutine.hh
@@ -21,8 +21,8 @@
 
 #pragma once
 
-// Clang < 15 only supports the TS
-#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 15)
+// Clang < 14 only supports the TS
+#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 14)
 #include <coroutine>
 #define SEASTAR_INTERNAL_COROUTINE_NAMESPACE std
 #elif __has_include(<experimental/coroutine>)


### PR DESCRIPTION
since std::experimental::coroutine_traits will be removed in LLVM 15,
but are available in LLVM-14.

Update the check to prevent the warning for LLVM-14, as well..

This is a followup to 0a8eea3d7e9efba6fefb0ac783a8b988bb1feffb

Signed-off-by: Ben Pope <ben@redpanda.com>