### PR TITLE
stream_range_as_array: always close output stream

### DIFF
--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -317,7 +317,7 @@ struct json_return_type {
 template<typename Container, typename Func>
 SEASTAR_CONCEPT( requires requires (Container c, Func aa, output_stream<char> s) { { formatter::write(s, aa(*c.begin())) } -> std::same_as<future<>>; } )
 std::function<future<>(output_stream<char>&&)> stream_range_as_array(Container val, Func fun) {
-    return [val = std::move(val), fun = std::move(fun)](output_stream<char>&& s) {
+    return [val = std::move(val), fun = std::move(fun)](output_stream<char>&& s) mutable {
         return do_with(output_stream<char>(std::move(s)), Container(std::move(val)), Func(std::move(fun)), true, [](output_stream<char>& s, const Container& val, const Func& f, bool& first){
             return s.write("[").then([&val, &s, &first, &f] () {
                 return do_for_each(val, [&s, &first, &f](const typename Container::value_type& v){
@@ -344,7 +344,7 @@ std::function<future<>(output_stream<char>&&)> stream_range_as_array(Container v
  */
 template<class T>
 std::function<future<>(output_stream<char>&&)> stream_object(T val) {
-    return [val = std::move(val)](output_stream<char>&& s) {
+    return [val = std::move(val)](output_stream<char>&& s) mutable {
         return do_with(output_stream<char>(std::move(s)), T(std::move(val)), [](output_stream<char>& s, const T& val){
             return formatter::write(s, val).then([&s] {
                 return s.close();

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -297,8 +297,11 @@ struct json_return_type {
    json_return_type(json_return_type&& o) noexcept : _res(std::move(o._res)), _body_writer(std::move(o._body_writer)) {
    }
     json_return_type& operator=(json_return_type&& o) noexcept {
+      // FIXME: indentation
+      if (this != &o) {
         _res = std::move(o._res);
         _body_writer = std::move(o._body_writer);
+      }
         return *this;
     }
 

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -328,9 +328,9 @@ std::function<future<>(output_stream<char>&&)> stream_range_as_array(Container v
                     });
                 });
             }).then([&s](){
-                return s.write("]").then([&s] {
-                    return s.close();
-                });
+                return s.write("]");
+            }).finally([&s] {
+                return s.close();
             });
         });
     };
@@ -346,7 +346,7 @@ template<class T>
 std::function<future<>(output_stream<char>&&)> stream_object(T val) {
     return [val = std::move(val)](output_stream<char>&& s) mutable {
         return do_with(output_stream<char>(std::move(s)), T(std::move(val)), [](output_stream<char>& s, const T& val){
-            return formatter::write(s, val).then([&s] {
+            return formatter::write(s, val).finally([&s] {
                 return s.close();
             });
         });

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -297,11 +297,10 @@ struct json_return_type {
    json_return_type(json_return_type&& o) noexcept : _res(std::move(o._res)), _body_writer(std::move(o._body_writer)) {
    }
     json_return_type& operator=(json_return_type&& o) noexcept {
-      // FIXME: indentation
-      if (this != &o) {
-        _res = std::move(o._res);
-        _body_writer = std::move(o._body_writer);
-      }
+        if (this != &o) {
+            _res = std::move(o._res);
+            _body_writer = std::move(o._body_writer);
+        }
         return *this;
     }
 


### PR DESCRIPTION
Make sure to always close output streams when streaming objects as json
in  stream_range_as_array and stream_object.

Otherwise, the assertion that the output_stream was closed before its destroyed might fail.
(See 78b918ce6018a54d4e75e3da62c6313b50d71193), causing https://github.com/scylladb/scylla/issues/10592.

Refs https://github.com/scylladb/scylla/issues/10592

(Refs rather than Fixes, as the fix will happen when scylla updates its seastar submodule with this patch)