### PR TITLE
src/net/proxy: remove unused variable

### DIFF
--- a/src/net/proxy.cc
+++ b/src/net/proxy.cc
@@ -50,7 +50,7 @@ uint32_t proxy_net_device::send(circular_buffer<packet>& p)
         return 0;
     }
 
-    for (size_t i = 0; !p.empty() && _send_depth < _send_queue_length; i++, _send_depth++) {
+    for (; !p.empty() && _send_depth < _send_queue_length; _send_depth++) {
         _moving.push_back(std::move(p.front()));
         p.pop_front();
     }


### PR DESCRIPTION
clang 15 emits unused-but-set-variable warning for variable i in loop (i doesn't occur in the body):

for (size_t i = 0; !p.empty() && _send_depth < _send_queue_length; i++, _send_depth++) {