### PR TITLE
abort_source: assert request_abort called exactly once

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -116,7 +116,11 @@ public:
     void request_abort() noexcept {
         assert(_subscriptions);
         auto subs = std::exchange(_subscriptions, std::nullopt);
-        subs->clear_and_dispose([] (subscription* s) { s->on_abort(); });
+        while (!subs->empty()) {
+            subscription& s = subs->front();
+            s.unlink();
+            s.on_abort();
+        }
     }
 
     /// Returns whether an abort has been requested.

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -112,8 +112,11 @@ public:
 
     /// Requests that the target operation be aborted. Current subscriptions
     /// are invoked inline with this call, and no new ones can be registered.
+    /// Must be called exactly once, otherwise the program will be aborted.
     void request_abort() noexcept {
-        std::exchange(_subscriptions, std::nullopt)->clear_and_dispose([] (subscription* s) { s->on_abort(); });
+        assert(_subscriptions);
+        auto subs = std::exchange(_subscriptions, std::nullopt);
+        subs->clear_and_dispose([] (subscription* s) { s->on_abort(); });
     }
 
     /// Returns whether an abort has been requested.


### PR DESCRIPTION
This series turns undefined-behavior due to dereferencing a disengaged optional _subscriptions list
into terminate() if and when std::bad_optional_access is thrown when accessing that optional member the second time.

Also, it prevents a potential UB in boost::intrusive code in case the abort handler of one subscription happens to unlink the next subscription in the list.

Refs https://github.com/scylladb/scylla/issues/10668