### PR TITLE
rpc: add an option for an asynchronous connection isolation function

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <list>
+#include <variant>
 #include <seastar/core/future.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/net/api.hh>
@@ -96,7 +97,10 @@ struct resource_limits {
     size_t max_memory = rpc_semaphore::max_counter(); ///< Maximum amount of memory that may be consumed by all requests
     /// Configures isolation for a connection based on its isolation cookie. May throw,
     /// in which case the connection will be terminated.
-    std::function<isolation_config (sstring isolation_cookie)> isolate_connection = default_isolate_connection;
+    using syncronous_isolation_function = std::function<isolation_config (sstring isolation_cookie)>;
+    using asyncronous_isolation_function = std::function<future<isolation_config> (sstring isolation_cookie)>;
+    using isolation_function_alternatives = std::variant<syncronous_isolation_function, asyncronous_isolation_function>;
+    isolation_function_alternatives isolate_connection = default_isolate_connection;
 };
 
 struct client_options {


### PR DESCRIPTION
The current RPC API has an option to configure a synchronous function
which determines which scheduling group (isolation configuration) to use
for a connection based on a cookie sent during negotiation.
This API lacks an asynchronous option of doing the same, which means
that no preparations can be made in order to accommodate the isolation.
The most obvious example is that the scheduling group used to isolate
the connection can't be created during handshake, forcing an immediate
rejection of the connection in the application side.
This change adds the possibility for an asynchronous function.
It doesn't break applications that uses the old API.

We also add here unit tests for the new API.
Tests: unit tests (dev, debug)

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>

Fixes #1085 