### PR TITLE
map reduce: save mapper

### DIFF
--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -34,42 +34,42 @@ namespace seastar {
 
 /// \cond internal
 
-template <typename T, bool IsFuture>
+template <typename T, typename Ptr, bool IsFuture>
 struct reducer_with_get_traits;
 
-template <typename T>
-struct reducer_with_get_traits<T, false> {
+template <typename T, typename Ptr>
+struct reducer_with_get_traits<T, Ptr, false> {
     using result_type = decltype(std::declval<T>().get());
     using future_type = future<result_type>;
-    static future_type maybe_call_get(future<> f, lw_shared_ptr<T> r) {
+    static future_type maybe_call_get(future<> f, Ptr r) {
         return f.then([r = std::move(r)] () mutable {
-            return make_ready_future<result_type>(std::move(*r).get());
+            return make_ready_future<result_type>(std::move(r->reducer).get());
         });
     }
 };
 
-template <typename T>
-struct reducer_with_get_traits<T, true> {
+template <typename T, typename Ptr>
+struct reducer_with_get_traits<T, Ptr, true> {
     using future_type = decltype(std::declval<T>().get());
-    static future_type maybe_call_get(future<> f, lw_shared_ptr<T> r) {
+    static future_type maybe_call_get(future<> f, Ptr r) {
         return f.then([r = std::move(r)] () mutable {
-            return r->get();
+            return r->reducer.get();
         }).then_wrapped([r] (future_type f) {
             return f;
         });
     }
 };
 
-template <typename T, typename V = void>
+template <typename T, typename Ptr = lw_shared_ptr<T>, typename V = void>
 struct reducer_traits {
     using future_type = future<>;
-    static future_type maybe_call_get(future<> f, lw_shared_ptr<T> r) {
+    static future_type maybe_call_get(future<> f, Ptr r) {
         return f.then([r = std::move(r)] {});
     }
 };
 
-template <typename T>
-struct reducer_traits<T, decltype(std::declval<T>().get(), void())> : public reducer_with_get_traits<T, is_future<std::invoke_result_t<decltype(&T::get),T>>::value> {};
+template <typename T, typename Ptr>
+struct reducer_traits<T, Ptr, decltype(std::declval<T>().get(), void())> : public reducer_with_get_traits<T, Ptr, is_future<std::invoke_result_t<decltype(&T::get),T>>::value> {};
 
 /// \endcond
 
@@ -96,21 +96,24 @@ auto
 map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&& r)
     -> typename reducer_traits<Reducer>::future_type
 {
-    auto r_ptr = make_lw_shared(std::forward<Reducer>(r));
+    struct state {
+        Reducer reducer;
+    };
+    auto s = make_lw_shared(state{std::forward<Reducer>(r)});
     future<> ret = make_ready_future<>();
     while (begin != end) {
-        ret = futurize_invoke(mapper, *begin++).then_wrapped([ret = std::move(ret), r_ptr] (auto f) mutable {
-            return ret.then_wrapped([f = std::move(f), r_ptr] (auto rf) mutable {
+        ret = futurize_invoke(mapper, *begin++).then_wrapped([ret = std::move(ret), s] (auto f) mutable {
+            return ret.then_wrapped([f = std::move(f), s] (auto rf) mutable {
                 if (rf.failed()) {
                     f.ignore_ready_future();
                     return rf;
                 } else {
-                    return futurize_invoke(*r_ptr, std::move(f.get0()));
+                    return futurize_invoke(s->reducer, std::move(f.get0()));
                 }
             });
         });
     }
-    return reducer_traits<Reducer>::maybe_call_get(std::move(ret), r_ptr);
+    return reducer_traits<Reducer, lw_shared_ptr<state>>::maybe_call_get(std::move(ret), s);
 }
 
 /// Asynchronous map/reduce transformation.

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -386,7 +386,7 @@ public:
     inline future<std::vector<return_type>> map(Mapper mapper) {
         return do_with(std::vector<return_type>(), std::move(mapper),
                 [this] (std::vector<return_type>& vec, Mapper& mapper) mutable {
-            vec.resize(smp::count);
+            vec.resize(_instances.size());
             return parallel_for_each(boost::irange<unsigned>(0, _instances.size()), [this, &vec, &mapper] (unsigned c) {
                 return smp::submit_to(c, [this, &mapper] {
                     auto inst = get_local_service();

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -297,9 +297,9 @@ public:
     {
         return ::seastar::map_reduce(boost::make_counting_iterator<unsigned>(0),
                             boost::make_counting_iterator<unsigned>(_instances.size()),
-            [this, &func, args = std::make_tuple(std::forward<Args>(args)...)] (unsigned c) mutable {
-                return smp::submit_to(c, [this, func, args] () mutable {
-                    return std::apply([this, func] (Args&&... args) mutable {
+            [this, func = std::forward<Func>(func), args = std::make_tuple(std::forward<Args>(args)...)] (unsigned c) mutable {
+                return smp::submit_to(c, [this, &func, args] () mutable {
+                    return std::apply([this, &func] (Args&&... args) mutable {
                         auto inst = get_local_service();
                         return std::invoke(func, *inst, std::forward<Args>(args)...);
                     }, std::move(args));
@@ -314,9 +314,9 @@ public:
     {
         return ::seastar::map_reduce(boost::make_counting_iterator<unsigned>(0),
                             boost::make_counting_iterator<unsigned>(_instances.size()),
-            [this, &func, args = std::make_tuple(std::forward<Args>(args)...)] (unsigned c) {
-                return smp::submit_to(c, [this, func, args] () {
-                    return std::apply([this, func] (Args&&... args) {
+            [this, func = std::forward<Func>(func), args = std::make_tuple(std::forward<Args>(args)...)] (unsigned c) {
+                return smp::submit_to(c, [this, &func, args] () {
+                    return std::apply([this, &func] (Args&&... args) {
                         auto inst = get_local_service();
                         return std::invoke(func, *inst, std::forward<Args>(args)...);
                     }, std::move(args));

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -384,11 +384,11 @@ public:
     /// \return  Result vector of invoking `map` with each instance in parallel
     template <typename Mapper, typename Future = futurize_t<std::invoke_result_t<Mapper,Service&>>, typename return_type = decltype(internal::untuple(std::declval<typename Future::tuple_type>()))>
     inline future<std::vector<return_type>> map(Mapper mapper) {
-        return do_with(std::vector<return_type>(),
-                [&mapper, this] (std::vector<return_type>& vec) mutable {
+        return do_with(std::vector<return_type>(), std::move(mapper),
+                [this] (std::vector<return_type>& vec, Mapper& mapper) mutable {
             vec.resize(smp::count);
-            return parallel_for_each(boost::irange<unsigned>(0, _instances.size()), [this, &vec, mapper] (unsigned c) {
-                return smp::submit_to(c, [this, mapper] {
+            return parallel_for_each(boost::irange<unsigned>(0, _instances.size()), [this, &vec, &mapper] (unsigned c) {
+                return smp::submit_to(c, [this, &mapper] {
                     auto inst = get_local_service();
                     return mapper(*inst);
                 }).then([&vec, c] (auto res) {

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -391,8 +391,8 @@ public:
                 return smp::submit_to(c, [this, &mapper] {
                     auto inst = get_local_service();
                     return mapper(*inst);
-                }).then([&vec, c] (auto res) {
-                    vec[c] = res;
+                }).then([&vec, c] (auto&& res) {
+                    vec[c] = std::move(res);
                 });
             }).then([&vec] {
                 return make_ready_future<std::vector<return_type>>(std::move(vec));

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/print.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/util/later.hh>
 #include <mutex>
 
 using namespace seastar;
@@ -126,6 +127,45 @@ SEASTAR_TEST_CASE(test_map_reduce) {
                 if (result != (n * (n + 1) * (2*n + 1)) / 6) {
                     throw std::runtime_error("map_reduce failed");
                 }
+            });
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
+    struct map {
+        bool destroyed = false;
+        ~map() {
+            destroyed = true;
+        }
+        auto operator()(const X& x) {
+            return yield().then([this, &x] {
+                BOOST_REQUIRE(!destroyed);
+                return x.cpu_id_squared();
+            });
+        }
+    };
+    struct reduce {
+        long& res;
+        bool destroyed = false;
+        ~reduce() {
+            destroyed = true;
+        }
+        auto operator()(int x) {
+            return yield().then([this, x] {
+                BOOST_REQUIRE(!destroyed);
+                res += x;
+            });
+        }
+    };
+    return do_with_distributed<X>([] (distributed<X>& x) {
+        return x.start().then([&x] {
+            return do_with(0L, [&x] (auto& result) {
+                return x.map_reduce(reduce{result}, map{}).then([&result] {
+                    long n = smp::count - 1;
+                    long expected = (n * (n + 1) * (2*n + 1)) / 6;
+                    BOOST_REQUIRE_EQUAL(result, expected);
+                });
             });
         });
     });


### PR DESCRIPTION
Make sure the mapper is kept alive until its returned future is resolved.

This was seen in https://jenkins.scylladb.com/job/releng/job/Scylla-CI/678/artifact/testlog/x86_64_debug/scylla-7.log
```
Scylla version 5.1.dev-0.20220605.c0578a1d6fff with build-id 31805e0a2d21ae65a50281c217deea947bc1a932 starting ...

api/storage_service.cc:1173:68: runtime error: member call on misaligned address 0x10004f39211c for type 'seastar::basic_sstring<char, unsigned int, 15, true>', which requires 8 byte alignment
0x10004f39211c: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior api/storage_service.cc:1173:68 in 
/jenkins/workspace/releng/Scylla-CI/scylla/seastar/include/seastar/core/sstring.hh:463:10: runtime error: member call on misaligned address 0x10004f39211c for type 'const seastar::basic_sstring<char, unsigned int, 15, true> *', which requires 8 byte alignment
0x10004f39211c: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /jenkins/workspace/releng/Scylla-CI/scylla/seastar/include/seastar/core/sstring.hh:463:10 in 
/jenkins/workspace/releng/Scylla-CI/scylla/seastar/include/seastar/core/sstring.hh:464:18: runtime error: member access within misaligned address 0x10004f39211c for type 'const struct internal_type', which requires 8 byte alignment
0x10004f39211c: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /jenkins/workspace/releng/Scylla-CI/scylla/seastar/include/seastar/core/sstring.hh:464:18 in 
AddressSanitizer:DEADLYSIGNAL
=================================================================
==15383==ERROR: AddressSanitizer: SEGV on unknown address 0x020089e6a425 (pc 0x000013d3cfb4 bp 0x7ffe79cd2b40 sp 0x7ffe79cd29d0 T0)
==15383==The signal is caused by a READ memory access.
```

That turned out to be stack-use-after-return in a map_reduce call.

Keeping the mapper was required both at the "naked" map_reduce level as well as the sharded::map_reduce function.
This series fixes those sites and adds respective unit tests that reproduce the issue (in debug mode) without the fix and pass with it.
