### PR TITLE
coroutine: exception: retain exception_ptr type

### DIFF
--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -96,6 +96,7 @@ template<typename T>
 [[deprecated("Use co_await coroutine::return_exception or co_return coroutine::exception instead")]]
 [[nodiscard]]
 exception make_exception(T&& t) noexcept {
+    log_exception_trace();
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 
@@ -119,6 +120,7 @@ inline exception return_exception_ptr(std::exception_ptr ex) noexcept {
 template<typename T>
 [[nodiscard]]
 exception return_exception(T&& t) noexcept {
+    log_exception_trace();
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -86,7 +86,14 @@ struct exception {
 /// ```
 /// co_return coroutine::make_exception(std::runtime_error("something failed miserably"));
 /// ```
+[[deprecated("Use co_await coroutine::return_exception or co_return coroutine::exception instead")]]
+[[nodiscard]]
+inline exception make_exception(std::exception_ptr ex) noexcept {
+    return exception(std::move(ex));
+}
+
 template<typename T>
+[[deprecated("Use co_await coroutine::return_exception or co_return coroutine::exception instead")]]
 [[nodiscard]]
 exception make_exception(T&& t) noexcept {
     return exception(std::make_exception_ptr(std::forward<T>(t)));
@@ -104,6 +111,11 @@ exception make_exception(T&& t) noexcept {
 /// ```
 /// co_await coroutine::return_exception(std::runtime_error("something failed miserably"));
 /// ```
+[[nodiscard]]
+inline exception return_exception_ptr(std::exception_ptr ex) noexcept {
+    return exception(std::move(ex));
+}
+
 template<typename T>
 [[nodiscard]]
 exception return_exception(T&& t) noexcept {

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -30,7 +30,7 @@ namespace internal {
 struct exception_awaiter {
     std::exception_ptr eptr;
 
-    explicit exception_awaiter(std::exception_ptr&& eptr) : eptr(std::move(eptr)) {}
+    explicit exception_awaiter(std::exception_ptr&& eptr) noexcept : eptr(std::move(eptr)) {}
 
     exception_awaiter(const exception_awaiter&) = delete;
     exception_awaiter(exception_awaiter&&) = delete;
@@ -68,7 +68,7 @@ namespace coroutine {
 /// ```
 struct exception {
     std::exception_ptr eptr;
-    explicit exception(std::exception_ptr eptr) : eptr(std::move(eptr)) {}
+    explicit exception(std::exception_ptr eptr) noexcept : eptr(std::move(eptr)) {}
 };
 
 /// Allows propagating an exception from a coroutine directly rather than
@@ -88,7 +88,7 @@ struct exception {
 /// ```
 template<typename T>
 [[nodiscard]]
-exception make_exception(T&& t) {
+exception make_exception(T&& t) noexcept {
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 
@@ -106,7 +106,7 @@ exception make_exception(T&& t) {
 /// ```
 template<typename T>
 [[nodiscard]]
-exception return_exception(T&& t) {
+exception return_exception(T&& t) noexcept {
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -475,6 +475,10 @@ SEASTAR_TEST_CASE(test_coroutine_return_exception_ptr) {
         auto ex = std::make_exception_ptr(std::runtime_error("threw"));
         co_await coroutine::return_exception_ptr(std::move(ex));
     });
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<> {
+        auto ex = std::make_exception_ptr(std::runtime_error("threw"));
+        co_await coroutine::return_exception_ptr(ex);
+    });
     co_await check_coroutine_throws<int>([] (int& counter) -> future<> {
         co_await coroutine::return_exception_ptr(std::make_exception_ptr(3));
     });

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -450,10 +450,6 @@ SEASTAR_TEST_CASE(test_coroutine_exception) {
         counter_ref ref{counter};
         co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
     });
-    co_await check_coroutine_throws<std::logic_error>([] (int& counter) -> future<bool> {
-        counter_ref ref{counter};
-        co_return coroutine::make_exception(std::logic_error("threw"));
-    });
     co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<int> {
         counter_ref ref{counter};
         co_await coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
@@ -463,6 +459,24 @@ SEASTAR_TEST_CASE(test_coroutine_exception) {
         counter_ref ref{counter};
         co_await coroutine::return_exception(std::logic_error("threw"));
         co_return;
+    });
+    co_await check_coroutine_throws<int>([] (int& counter) -> future<> {
+        counter_ref ref{counter};
+        co_await coroutine::return_exception(42);
+        co_return;
+    });
+}
+
+SEASTAR_TEST_CASE(test_coroutine_return_exception_ptr) {
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<> {
+        co_await coroutine::return_exception(std::runtime_error("threw"));
+    });
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<> {
+        auto ex = std::make_exception_ptr(std::runtime_error("threw"));
+        co_await coroutine::return_exception_ptr(std::move(ex));
+    });
+    co_await check_coroutine_throws<int>([] (int& counter) -> future<> {
+        co_await coroutine::return_exception_ptr(std::make_exception_ptr(3));
     });
 }
 
@@ -662,7 +676,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future) {
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);
-        co_return coroutine::make_exception(std::runtime_error("exception"));
+        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("exception")));
     };
     f = co_await coroutine::as_future(gen_exception());
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
@@ -682,7 +696,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future_without_preemption_check) {
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);
-        co_return coroutine::make_exception(std::runtime_error("exception"));
+        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("exception")));
     };
     f = co_await coroutine::as_future_without_preemption_check(gen_exception());
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);


### PR DESCRIPTION
Currently, make_exception/return_exception call
std::make_exception_ptr unconditionally.
When called over a std::exception_ptr, std::make_exception_ptr
loses the arg's exception type and creates an untyped
exception_ptr.

Instead, use a templated constructor for struct exception
that just moves the given exception_ptr into its member
to retain its type.  It's also a bit more efficient
since it save the construction of a new exception ptr
and one move of it (into the constructor's parameter).

Added a respective unit test.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>