### PR TITLE
semaphore: add semaphore_unit operator bool

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -505,6 +505,11 @@ public:
     size_t count() const noexcept {
         return _n;
     }
+
+    /// Returns true iff there any units held
+    explicit operator bool() const noexcept {
+        return _n != 0;
+    }
 };
 
 /// \brief Take units from semaphore temporarily


### PR DESCRIPTION
So it could be used as an optimized optional.

Add a respective unit test.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>