### PR TITLE
test: futures: add test_get_on_exceptional_promise

### DIFF
--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -224,6 +224,13 @@ public:
     }
 };
 
+SEASTAR_TEST_CASE(test_get_on_exceptional_promise) {
+    auto p = promise<>();
+    p.set_exception(test_exception("test"));
+    BOOST_REQUIRE_THROW(p.get_future().get(), test_exception);
+    return make_ready_future();
+}
+
 static void check_finally_exception(std::exception_ptr ex) {
   BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
         "seastar::nested_exception: test_exception (bar) (while cleaning up after test_exception (foo))");


### PR DESCRIPTION
Test we can set_exception on promise
before we call p.get_future, similar to
setting the promise's value.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>