### PR TITLE
semaphore: derive named_semaphore_aborted exception from semaphore_aborted

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -109,7 +109,7 @@ public:
     virtual const char* what() const noexcept;
 };
 
-class named_semaphore_aborted : public abort_requested_exception {
+class named_semaphore_aborted : public semaphore_aborted {
     sstring _msg;
 public:
     named_semaphore_aborted(std::string_view msg) noexcept;


### PR DESCRIPTION
Change 13e168bf12d66a89d46a127ac78f7adaae74e303 introduced
both semaphore_aborted and named_semaphore_aborted,
but defined both as derived from abort_requested_exception.

While correct by itself, the convention for semaphore
exception factories is to derive the exceptions from the
basic semaphore exceptions so they can be handled
as a class of errors regardless of the particular type
of semaphore.

This is causing scylladb/scylla#10666
after scylladb/scylla@8f39547d89991dc251256fc9a57b3eeea5175e2b

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>