### PR TITLE
net/tls: vec_push: call on_internal_error if _output_pending already failed

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1358,6 +1358,12 @@ public:
             gnutls_transport_set_errno(*this, EAGAIN);
             return -1;
         }
+        if (_output_pending.failed()) {
+            // copy exception for on_internal_error
+            auto ex = _output_pending.get_exception();
+            _output_pending = make_exception_future<>(ex);
+            on_internal_error(seastar_logger, format("tls: session: vec_push: unhandled pending output error: {}", ex));
+        }
         try {
             scattered_message<char> msg;
             for (int i = 0; i < iovcnt; ++i) {
@@ -1367,6 +1373,7 @@ public:
             _output_pending = _out.put(std::move(msg).release());
             return n;
         } catch (...) {
+            // FIXME: extract error code if system_error
             gnutls_transport_set_errno(*this, EIO);
             _output_pending = make_exception_future<>(std::current_exception());
         }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1372,8 +1372,10 @@ public:
             auto n = msg.size();
             _output_pending = _out.put(std::move(msg).release());
             return n;
+        } catch (const std::system_error& e) {
+            gnutls_transport_set_errno(*this, e.code().value());
+            _output_pending = make_exception_future<>(std::current_exception());
         } catch (...) {
-            // FIXME: extract error code if system_error
             gnutls_transport_set_errno(*this, EIO);
             _output_pending = make_exception_future<>(std::current_exception());
         }


### PR DESCRIPTION
Otherwise, we overwrite an exceptional future as seen in
https://github.com/scylladb/scylla/issues/10127

Not handling the _output_pending failure is an
internal error, as confirmed by Carl Wilund <calle@scylladb.com>
so call on_internal_error to throw / abort if configured so.
