### PR TITLE
reactor: don't count make_exception_future etc. in cpp_exceptions metric

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -169,6 +169,8 @@ public:
 
 size_t scheduling_group_count();
 
+void increase_thrown_exceptions_counter() noexcept;
+
 }
 
 class kernel_completion;
@@ -680,7 +682,7 @@ private:
     friend class internal::poller;
     friend class scheduling_group;
     friend void add_to_flush_poller(output_stream<char>* os);
-    friend void seastar::log_exception_trace() noexcept;
+    friend void seastar::internal::increase_thrown_exceptions_counter() noexcept;
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
     friend void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);
     metrics::metric_groups _metric_groups;

--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -90,11 +90,14 @@ void init_phdr_cache() {
     }, nullptr);
 }
 
+void internal::increase_thrown_exceptions_counter() noexcept {
+    seastar::engine()._cxx_exceptions++;
+}
+
 #ifndef NO_EXCEPTION_INTERCEPT
 seastar::logger exception_logger("exception");
 
 void log_exception_trace() noexcept {
-    seastar::engine()._cxx_exceptions++;
     static thread_local bool nested = false;
     if (!nested && exception_logger.is_enabled(log_level::trace)) {
         nested = true;
@@ -143,6 +146,7 @@ int _Unwind_RaiseException(struct _Unwind_Exception *h) {
         org = (throw_fn)dlsym (RTLD_NEXT, "_Unwind_RaiseException");
     }
     if (seastar::local_engine) {
+        seastar::internal::increase_thrown_exceptions_counter();
         seastar::log_exception_trace();
     }
     return org(h);


### PR DESCRIPTION
The `reactor_cpp_exceptions` metric originally meant how many times
exceptions were thrown on the current shard. Throwing an exception is a
computationally expensive operation, therefore such a metric is helpful
when optimizing the error handling logic.

In f5133d05a9, the code increasing this counter was moved from
_Unwind_RaiseException to log_exception_trace. The latter function is
not only called when an exception is thrown but also in
`make_exception_future` and, in the future, possibly in other places
such as `coroutine::exception`.

This commit brings back the old semantic, i.e. only throws are counted.