### PR TITLE
Avoid false-positive warnings in Gcc 12.1.1

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -692,7 +692,15 @@ string_type to_sstring_sprintf(T value, const char* fmt) {
     char tmp[sizeof(value) * 3 + 2];
     auto len = std::sprintf(tmp, fmt, value);
     using ch_type = typename string_type::value_type;
+#pragma GCC diagnostic push
+    // GCC warns that the following line may read more than the size tmp,
+    // not realizing that the size of tmp was calculated as the maximum
+    // possible value of "len" (for the types and formats we use it for).
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
     return string_type(reinterpret_cast<ch_type*>(tmp), len);
+#pragma GCC diagnostic pop
 }
 
 template <typename string_type>


### PR DESCRIPTION
Gcc 12.1.1 discovers what it thinks are two bugs in Seastar and warns about them  - breaking the build.
But in fact both cases are deliberate choices which we made in our implementation, and are correct. 
So we need to use "pragma"s to tell Gcc that these are in fact correct.

After these two patches, Seastar can be built with Gcc on Fedora 36 (with clang, it already worked).

Fixes #1116