### PR TITLE
Prometheus enhancement

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -256,6 +256,7 @@ enum class data_type : uint8_t {
     REAL_COUNTER,
     GAUGE,
     HISTOGRAM,
+    SUMMARY,
 };
 
 template <bool callable, typename T>
@@ -593,6 +594,18 @@ template<typename T>
 impl::metric_definition_impl make_histogram(metric_name_type name,
         description d, T&& val) {
     return  {name, {impl::data_type::HISTOGRAM, "histogram"}, make_function(std::forward<T>(val), impl::data_type::HISTOGRAM), d, {}};
+}
+
+/*!
+ * \brief create a summary metric.
+ *
+ * Summaries are a different kind of histograms. It reports in quantiles.
+ * For example, the p99 and p95 latencies.
+ */
+template<typename T>
+impl::metric_definition_impl make_summary(metric_name_type name,
+        description d, T&& val) {
+    return  {name, {impl::data_type::SUMMARY, "summary"}, make_function(std::forward<T>(val), impl::data_type::SUMMARY), d, {}};
 }
 
 

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -372,10 +372,12 @@ struct metric_definition_impl {
     description d;
     bool enabled = true;
     skip_when_empty _skip_when_empty = skip_when_empty::no;
+    std::vector<std::string> aggregate_labels;
     std::map<sstring, sstring> labels;
     metric_definition_impl& operator ()(bool enabled);
     metric_definition_impl& operator ()(const label_instance& label);
     metric_definition_impl& operator ()(skip_when_empty skip) noexcept;
+    metric_definition_impl& aggregate(const std::vector<label>& labels) noexcept;
     metric_definition_impl& set_skip_when_empty(bool skip=true) noexcept;
     metric_definition_impl& set_type(const sstring& type_name);
     metric_definition_impl(
@@ -383,7 +385,8 @@ struct metric_definition_impl {
         metric_type type,
         metric_function f,
         description d,
-        std::vector<label_instance> labels);
+        std::vector<label_instance> labels,
+        std::vector<label> aggregate_labels = {});
 };
 
 class metric_groups_def {

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -161,6 +161,7 @@ struct metric_family_info {
 struct metric_info {
     metric_id id;
     bool enabled;
+    skip_when_empty should_skip_when_empty;
 };
 
 
@@ -185,7 +186,7 @@ class registered_metric {
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
-    registered_metric(metric_id id, metric_function f, bool enabled=true);
+    registered_metric(metric_id id, metric_function f, bool enabled=true, skip_when_empty skip=skip_when_empty::no);
     virtual ~registered_metric() {}
     virtual metric_value operator()() const {
         return _f();
@@ -198,7 +199,9 @@ public:
     void set_enabled(bool b) {
         _info.enabled = b;
     }
-
+    void set_skip_when_empty(skip_when_empty skip) noexcept {
+        _info.should_skip_when_empty = skip;
+    }
     const metric_id& get_id() const {
         return _info.id;
     }
@@ -330,7 +333,7 @@ public:
         return _value_map;
     }
 
-    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled);
+    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip);
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -152,6 +152,7 @@ struct metric_family_info {
     metric_type_def inherit_type;
     description d;
     sstring name;
+    std::vector<std::string> aggregate_labels;
 };
 
 
@@ -333,7 +334,7 @@ public:
         return _value_map;
     }
 
-    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip);
+    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip, const std::vector<std::string>& aggregate_labels);
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -365,6 +365,8 @@ histogram& histogram::operator+=(const histogram& c) {
             buckets[i].count += c.buckets[i].count;
         }
     }
+    sample_count += c.sample_count;
+    sample_sum += c.sample_sum;
     return *this;
 }
 


### PR DESCRIPTION
Motivation:
Histograms are the Prometheus killer. They are big to send over the
network and are big to store in Prometheus.
Histograms' size is always an issue, but with Seastar, it becomes even trickier.
Typically, each shard would collect its histograms, so the overall data
is multiplied by the number of shards.

This series addresses the need to report quantile information like latency
without generating massive metrics reports.

A summary is a Prometheus metric type that holds a quantile summary (i.e.
p95, p99).

The downside of summaries is that they cannot be aggregated, which is 
needed for a distributed system (i.e., calculate the p99 latency of a cluster).

The series adds four tools for Prometheus performance:
1. Add summaries.
2. Optionally, remove empty metrics. It's common to register metrics for
   optional services. It is now possible to mark those metrics as
   skip_when_empty and they will not be reported if they were never used. 
3. Allow aggregating metrics. The most common case is reporting per-node
   histogram instead of per shard. For example, for multi-nodes quantile calculation,
   we need a per-node histogram. It is now possible to mark a registered
   metric for aggregation. The metrics layer will aggregate this
   metric based on a list of labels. (Typically, this will be by shard,
   but it could be any other combination of labels).
4. Reuse the stringstream instead of recreating an object on each
   iteration.

V6
changed the name of the skip_when_empty variable to should_skip_when_empty to make the compiler happy.

V5
Main changes: 
* split the aggregate and skip_on_empty into two patches
* Use bool_class for skip_when_empty this also allows using the parenthesis
operator to mark that a metric should use skip_when_empty.
* Fix some typos in the comments
* Add noexcept when needed
* Change "\n" to '\n' when possible.

V4
Aggregation and skip_when_empty are now generalized in a sense that it's
a per metric configuration and can be used on any metric, not just
histogram.

The 'aggregate by' now accept labels instead of string which makes the API
cleaner.

The stringstream that is used inside Prometheus text reporting is now
reused instead of recreating on each iteration.

The aggregator object in Prometheus was rename and some comments were
added to make its use clearer.

V3
The main issue with the previous version was that it was too specific.
This version breaks the functionality and pushes some of the logic to
whoever uses the metrics layer.

Summaries are now just another kind of histogram, with no special magic
around them and no need for their own type.

A user can use any combination of labels for aggregation.
It's currently only applied to histograms, but we can do it with other
metrics if it will be helpful.

In the current implementation, to report a summary per shard and a single
histogram per node, the user of the metrics layer would register two metrics,
one for the summary and one for the histogram.
