### PR TITLE
core: log in on_internal_error even when throwing

### DIFF
--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -38,13 +38,14 @@ void seastar::on_internal_error(logger& logger, std::string_view msg) {
         logger.error("{}, at: {}", msg, current_backtrace());
         abort();
     } else {
+        logger.error(msg);
         throw_with_backtrace<std::runtime_error>(std::string(msg));
     }
 }
 
 void seastar::on_internal_error(logger& logger, std::exception_ptr ex) {
+    logger.error("{}", ex);
     if (abort_on_internal_error.load()) {
-        logger.error("{}", ex);
         abort();
     } else {
         std::rethrow_exception(std::move(ex));


### PR DESCRIPTION
We don't know if the exception thrown by `on_internal_error` (if we're
not aborting) will propagate to the top-level and/or will be logged.

It's still valuable to log the error immediately when
`on_internal_error` is called.