### PR TITLE
prometheus: make the help string optional

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -578,8 +578,8 @@ std::string get_value_as_string(std::stringstream& s, const mi::metric_value& va
     return value_str;
 }
 
-future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m) {
-    return seastar::async([&ctx, &out, &m] () mutable {
+future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m, bool show_help) {
+    return seastar::async([&ctx, &out, &m, show_help] () mutable {
         bool found = false;
         std::stringstream s;
         for (metric_family& metric_family : m) {
@@ -587,17 +587,17 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
             found = false;
             metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels);
             bool should_aggregate = !metric_family.metadata().aggregate_labels.empty();
-            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate](auto value, auto value_info) mutable {
+            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help](auto value, auto value_info) mutable {
                 s.clear();
                 s.str("");
                 if (value_info.should_skip_when_empty && value.is_empty()) {
                     return;
                 }
                 if (!found) {
-                    if (metric_family.metadata().d.str() != "") {
-                        s << "# HELP " << name << " " <<  metric_family.metadata().d.str() << "\n";
+                    if (show_help && metric_family.metadata().d.str() != "") {
+                        s << "# HELP " << name << " " <<  metric_family.metadata().d.str() << '\n';
                     }
-                    s << "# TYPE " << name << " " << to_str(metric_family.metadata().type) << "\n";
+                    s << "# TYPE " << name << " " << to_str(metric_family.metadata().type) << '\n';
                     found = true;
                 }
                 if (should_aggregate) {
@@ -661,15 +661,16 @@ public:
     future<std::unique_ptr<httpd::reply>> handle(const sstring& path,
         std::unique_ptr<httpd::request> req, std::unique_ptr<httpd::reply> rep) override {
         sstring metric_family_name = req->get_query_param("name");
+        bool show_help = req->get_query_param("help") != "false";
         bool prefix = trim_asterisk(metric_family_name);
 
-        rep->write_body("txt", [this, metric_family_name, prefix] (output_stream<char>&& s) {
+        rep->write_body("txt", [this, metric_family_name, prefix, show_help] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),
-                    [this, prefix, &metric_family_name] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
-                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name]() mutable {
+                    [this, prefix, &metric_family_name, show_help] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
+                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name, show_help]() mutable {
                     return do_with(get_range(families, metric_family_name, prefix),
-                            [&s, this](metric_family_range& m) {
-                        return write_text_representation(s, _ctx, m);
+                            [&s, this, show_help](metric_family_range& m) {
+                        return write_text_representation(s, _ctx, m, show_help);
                     });
                 }).finally([&s] () mutable {
                     return s.close();


### PR DESCRIPTION
The Prometheus protocol allows adding help strings to be part of the
message.
While this is helpful when looking at the metrics, the Prometheus server
itself ignores those help strings.

This patch adds an optional query parameter `help` when set to `false` the
Prometheus message will not include help strings.

For example:
curl http://localhost:9180/metrics - will contain the help string
curl http://localhost:9180/metrics?help=false - will not contain the
help string

Prometheus server configuration supports adding query string
parameters.
Fixes #1124