### PR TITLE
semaphore, rwlock: add method for checking if locks can be acquired without waiting

### DIFF
--- a/include/seastar/core/rwlock.hh
+++ b/include/seastar/core/rwlock.hh
@@ -140,6 +140,16 @@ public:
         return _sem.try_wait(max_ops);
     }
 
+    /// Returns true iff the lock can be acquired in read mode without waiting.
+    bool can_read_lock() const noexcept {
+        return _sem.can_acquire_immediately(1);
+    }
+
+    /// Returns true iff the lock can be acquired in write mode without waiting.
+    bool can_write_lock() const noexcept {
+        return _sem.can_acquire_immediately(max_ops);
+    }
+
     using holder = semaphore_units<semaphore_default_exception_factory, Clock>;
 
     /// hold_read_lock() waits for a read lock and returns an object which,

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -364,6 +364,21 @@ public:
             return false;
         }
     }
+
+    /// Returns true iff the specified number of units can be reduced from the counter without waiting.
+    ///
+    /// If sufficient units are available in the counter, and if no
+    /// other fiber is waiting, then the function returns true.  Otherwise,
+    /// nothing happens.  This is useful for "opportunistic" waits where
+    /// useful work can happen if the counter happens to be ready, but
+    /// when it is not worthwhile to wait.
+    ///
+    /// \param nr number of units to reduce the counter by (default 1).
+    /// \return `true` if the counter had sufficient units and no other fiber is waiting.
+    bool can_acquire_immediately(size_t nr = 1) const noexcept {
+        return may_proceed(nr);
+    }
+
     /// Returns the number of units available in the counter.
     ///
     /// Does not take into account any waiters.

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -38,21 +38,33 @@ using namespace std::chrono_literals;
 SEASTAR_THREAD_TEST_CASE(test_rwlock) {
     rwlock l;
 
+    BOOST_REQUIRE(l.can_write_lock());
+    BOOST_REQUIRE(l.can_read_lock());
     l.for_write().lock().get();
+    BOOST_REQUIRE(!l.can_write_lock());
     BOOST_REQUIRE(!l.try_write_lock());
+    BOOST_REQUIRE(!l.can_read_lock());
     BOOST_REQUIRE(!l.try_read_lock());
     l.for_write().unlock();
 
     l.for_read().lock().get();
+    BOOST_REQUIRE(!l.can_write_lock());
     BOOST_REQUIRE(!l.try_write_lock());
+    BOOST_REQUIRE(l.can_read_lock());
     BOOST_REQUIRE(l.try_read_lock());
+    BOOST_REQUIRE(l.can_read_lock());
     l.for_read().lock().get();
     l.for_read().unlock();
     l.for_read().unlock();
     l.for_read().unlock();
 
+    BOOST_REQUIRE(l.can_write_lock());
     BOOST_REQUIRE(l.try_write_lock());
+    BOOST_REQUIRE(!l.can_write_lock());
+    BOOST_REQUIRE(!l.can_read_lock());
     l.for_write().unlock();
+    BOOST_REQUIRE(l.can_write_lock());
+    BOOST_REQUIRE(l.can_read_lock());
 }
 
 SEASTAR_TEST_CASE(test_with_lock_mutable) {

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -38,16 +38,21 @@ using namespace std::chrono_literals;
 
 SEASTAR_TEST_CASE(test_semaphore_consume) {
     semaphore sem(0);
+    BOOST_REQUIRE(!sem.can_acquire_immediately(1));
     sem.consume(1);
     BOOST_REQUIRE_EQUAL(sem.current(), 0u);
     BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
 
     BOOST_REQUIRE_EQUAL(sem.try_wait(0), false);
+    BOOST_REQUIRE(!sem.can_acquire_immediately(1));
     auto fut = sem.wait(1);
     BOOST_REQUIRE_EQUAL(fut.available(), false);
     BOOST_REQUIRE_EQUAL(sem.waiters(), 1u);
     sem.signal(2);
     BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
+    BOOST_REQUIRE(!sem.can_acquire_immediately(1));
+    sem.signal(1);
+    BOOST_REQUIRE(sem.can_acquire_immediately(1));
     return make_ready_future<>();
 }
 


### PR DESCRIPTION
Useful for testing the negative condition and e.g. returning early if the lock can not be acquired without waiting.
Planned to be used by scylla compaction_manager to check if a read lock can be acquired or not, without having to call `try_read_lock` and `read_unlock` is succeeded (See https://github.com/scylladb/scylla/pull/10954)