### PR TITLE
sstring: restore compatibility with std::string

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -171,7 +171,7 @@ static auto get_gtls_string = [](auto func, auto... args) noexcept {
         return std::make_pair(ret, sstring{});
     }
     assert(size != 0);
-    sstring res(sstring::initialized_later{}, size - 1);
+    sstring res = uninitialized_string(size - 1);
     ret = func(args..., res.data(), &size);
     return std::make_pair(ret, res);
 };

--- a/src/util/short_streams.cc
+++ b/src/util/short_streams.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 
 namespace seastar {
@@ -49,7 +50,7 @@ future<sstring> read_entire_stream_contiguous(input_stream<char>& inp) {
         for (auto&& buf : bufs) {
             total_size += buf.size();
         }
-        sstring ret(sstring::initialized_later(), total_size);
+        sstring ret = uninitialized_string(total_size);
         size_t pos = 0;
         for (auto&& buf : bufs) {
             std::copy(buf.begin(), buf.end(), ret.data() + pos);


### PR DESCRIPTION
I failed to build seastar with the option `Seastar_SSTRING=OFF`