### PR TITLE
coroutine: exception: deprecate return_exception(exception_ptr)

### DIFF
--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -117,6 +117,12 @@ inline exception return_exception_ptr(std::exception_ptr ex) noexcept {
     return exception(std::move(ex));
 }
 
+[[deprecated("Use co_await coroutine::return_exception_ptr instead")]]
+[[nodiscard]]
+inline exception return_exception(std::exception_ptr ex) noexcept {
+    return exception(std::move(ex));
+}
+
 template<typename T>
 [[nodiscard]]
 exception return_exception(T&& t) noexcept {


### PR DESCRIPTION
Following up on 1b07c80c978d21660179d911c68bd338337a59cb,
it is still possible to silently call coroutine::return_exception
with an exception_ptr, rather than calling
coroutine::return_exception_ptr.

This will cause the passed exception_ptr to be wrapped
in yet another exception_ptr so it effectively loses its type
(i.e. it won't be caught properly with:
try {
  std::rethrow_exception(ex);
} catch (some_exception& e)

since the rethrown exception type is no std::exception_ptr.

To encourage the proper use of coroutine::return_exception_ptr,
deprecate coroutine::return_exception(std::exception_ptr)
and instruct the caller to use coroutine::return_exception_ptr
instead.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>