### PR TITLE
*: add fmt::ostream_formatter<> so {fmt} can use operator<<

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -387,3 +387,7 @@ public:
 /// @}
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::fair_queue_ticket> : fmt::ostream_formatter {};
+#endif

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -34,6 +34,7 @@
 #include <functional>
 #include <cstdio>
 #include <type_traits>
+#include <fmt/ostream.h>
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/temporary_buffer.hh>
 
@@ -804,3 +805,8 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
     return os;
 }
 }
+
+#if FMT_VERSION >= 90000
+template <typename T> struct fmt::formatter<std::vector<T>> : fmt::ostream_formatter {};
+template <typename... Args> struct fmt::formatter<std::unordered_map<Args...>> : fmt::ostream_formatter {};
+#endif

--- a/include/seastar/net/inet_address.hh
+++ b/include/seastar/net/inet_address.hh
@@ -126,3 +126,8 @@ struct hash<seastar::net::inet_address> {
     size_t operator()(const seastar::net::inet_address&) const;
 };
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::net::inet_address> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<seastar::net::inet_address::family> : fmt::ostream_formatter {};
+#endif

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -184,3 +184,9 @@ struct hash<seastar::transport> {
 };
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::socket_address> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<seastar::ipv4_addr> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<seastar::ipv6_addr> : fmt::ostream_formatter {};
+#endif

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -162,6 +162,10 @@ struct hash<seastar::tasktrace> {
 
 }
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::tasktrace> : fmt::ostream_formatter {};
+#endif
+
 namespace seastar {
 
 using saved_backtrace = tasktrace;

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -520,4 +520,10 @@ std::ostream& operator<<(std::ostream&, const std::exception&);
 std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<std::exception_ptr> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<std::exception> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<std::system_error> : fmt::ostream_formatter {};
+#endif
+
 /// @}

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -176,6 +176,13 @@ struct hash<seastar::allocation_site> {
 
 }
 
+#if FMT_VERSION >= 90000
+namespace seastar::memory {
+struct human_readable_value;
+}
+template <> struct fmt::formatter<struct seastar::memory::human_readable_value> : fmt::ostream_formatter {};
+#endif
+
 namespace seastar {
 
 using allocation_site_ptr = const allocation_site*;

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -55,6 +55,10 @@ std::ostream& operator<<(std::ostream& os, const opt_family& f) {
 
 }
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::net::opt_family> : fmt::ostream_formatter {};
+#endif
+
 #include <seastar/util/log.hh>
 
 namespace seastar {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -5,6 +5,10 @@
 #include <seastar/core/future-util.hh>
 #include <boost/range/adaptor/map.hpp>
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::rpc::streaming_domain_type> : fmt::ostream_formatter {};
+#endif
+
 namespace seastar {
 
 namespace rpc {


### PR DESCRIPTION
so Seastar can be compiled with {fmt} v9.0 and up without
defining `FMT_DEPRECATED_OSTREAM` macro. quote from {fmt} v9.0's
changelog:

> Disabled automatic std::ostream insertion operator (operator<<)
> discovery when fmt/ostream.h is included to prevent ODR violations.
> You can get the old behavior by defining FMT_DEPRECATED_OSTREAM
> but this will be removed in the next major release. Use
> fmt::streamed or fmt::ostream_formatter to enable formatting via
> std::ostream instead.

so in this change, fmt::formatter<T> is speclialized for types
we want to print using {fmt}.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>