### PR TITLE
sharded: use std::invoke() to call mapper function

### DIFF
--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -347,7 +347,7 @@ public:
         auto wrapped_map = [this, map] (unsigned c) {
             return smp::submit_to(c, [this, map] {
                 auto inst = get_local_service();
-                return map(*inst);
+                return std::invoke(map, *inst);
             });
         };
         return ::seastar::map_reduce(smp::all_cpus().begin(), smp::all_cpus().end(),
@@ -364,7 +364,7 @@ public:
         auto wrapped_map = [this, map] (unsigned c) {
             return smp::submit_to(c, [this, map] {
                 auto inst = get_local_service();
-                return map(*inst);
+                return std::invoke(map, *inst);
             });
         };
         return ::seastar::map_reduce(smp::all_cpus().begin(), smp::all_cpus().end(),


### PR DESCRIPTION
instead of using `map(*instance)`, use `std::invoke(map, *instance)`,
so we are able to pass a pointer of member function as the `map`
parameter to `sharded<>::map_reduce0()`, just like we can do the same
to `sharded<>::map_reduce()`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>