### PR TITLE
Fix freed memory access after pollable_fd closing with ongoing kernel completion on linux-aio backend.

### DIFF
--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -55,6 +55,7 @@ struct aio_general_context {
     void queue(internal::linux_abi::iocb* iocb);
     // submit all queued iocbs and return their count.
     size_t flush();
+    int cancel(internal::linux_abi::iocb* iocb);
 };
 
 class aio_storage_context {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -665,3 +665,7 @@ seastar_add_test (closeable
 
 seastar_add_test (pipe
   SOURCES pipe_test.cc)
+
+seastar_add_test (pollable_fd_close
+  SOURCES pollable_fd_close_test.cc
+)

--- a/tests/unit/pollable_fd_close_test.cc
+++ b/tests/unit/pollable_fd_close_test.cc
@@ -1,0 +1,48 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License"). See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+#include <boost/test/tools/old/interface.hpp>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include "seastar/core/future.hh"
+#include <seastar/core/thread.hh>
+#include <seastar/core/internal/pollable_fd.hh>
+
+using namespace seastar;
+
+SEASTAR_TEST_CASE(ongoing_readable_close_aborted_test) {
+    return async([]() {
+        int pipe_ends[2] = {};
+
+        BOOST_REQUIRE_EQUAL(pipe2(pipe_ends, O_NONBLOCK|O_DIRECT|O_CLOEXEC), 0);
+
+        auto write_end = pollable_fd(file_desc::from_fd(pipe_ends[1]));
+        auto read_end = pollable_fd(file_desc::from_fd(pipe_ends[0]));
+
+        char buf[32];
+        auto future_read = read_end.read_some(buf, sizeof(buf));
+        read_end.close();
+
+        BOOST_REQUIRE_THROW(future_read.get() , broken_promise);
+    });
+}


### PR DESCRIPTION
When one closes a `pollable_fd`, selected reactor backend tries to remove associated completions from it.
    
If there is an ongoing poll:
 * on epoll backend, it perform `EPOLL_CTL_DEL` and may continue safely with following `pollable_fd` deletion.
 * on linux-aio backend, it simply deletes `pollable_fd`, but next time `io_pgetevents` would return pointer to completion which had been deleted already, trying to execute `complete_with` would lead to UB. See `reactor_backend_aio::await_events`, after `io_pgetevents` returns, `event.data` would point to freed memory, because associated completion has been already freed at `reactor_backend_aio::forget` `delete pfg`.
 
This MR helps with given issue adding code path, which cancels ongoing polls on given pollable_fd, and gives linux-aio backend opportunity to reap completions safely and after that delete `pollable_fd` object.

Epoll backend throws `broken_promise` in that case, we mimic same behaviour on linux-aio for compitability reasons. There is another MR: #1093, which addresses issue with `broken_promise`.

---

This MR also introduces test for correct pollable_fd closing with ongoing readable kernel_completion. linux-aio backend has been failing this test before, because reap completions may happen after completion object has been deleted and pointer to it expired.
