### PR TITLE
coroutine: change access specifier of seastar::task member

### DIFF
--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -28,7 +28,9 @@
 namespace seastar {
 
 class task {
+protected:
     scheduling_group _sg;
+private:
 #ifdef SEASTAR_TASK_BACKTRACE
     shared_backtrace _bt;
 #endif


### PR DESCRIPTION
When seastar::internal::coroutine_traits_base\<T\> was instantiated, a compiler
error occured because coroutine_traits_base\<T\>::promise_type::set_scheduling_group
method accessed private member _sg of promise_type's base class seastar::task.

Variable member _sg of type scheduling_group in seastar::task accessed
in derived class has its access specifier changed to protected.

Fixes: #1142