### PR TITLE
log: add colored logging support

### DIFF
--- a/include/seastar/util/log-cli.hh
+++ b/include/seastar/util/log-cli.hh
@@ -81,6 +81,10 @@ struct options : public program_options::option_group {
     /// Default: \p false.
     program_options::value<bool> log_to_syslog;
 
+    /// Print colored tag prefix in log messages sent to output stream.
+    ///
+    /// Default: \p true.
+    program_options::value<bool> log_with_color;
     /// \cond internal
     options(program_options::option_group* parent_group);
     /// \endcond

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -424,6 +424,11 @@ public:
     ///
     /// \param width the minimal width of the shard id field
     static void set_shard_field_width(unsigned width) noexcept;
+
+    /// enable/disable the colored tag in ostream
+    ///
+    /// \note this is a noop if fmtlib's version is less than 6.0
+    static void set_with_color(bool enabled) noexcept;
 };
 
 /// \brief used to keep a static registry of loggers
@@ -498,6 +503,7 @@ struct logging_settings final {
     log_level default_level;
     bool stdout_enabled;
     bool syslog_enabled;
+    bool with_color;
     logger_timestamp_style stdout_timestamp_style = logger_timestamp_style::real;
     logger_ostream_type logger_ostream = logger_ostream_type::stderr;
 };


### PR DESCRIPTION

in order to improve visual debugging experience, logging message
with colored prefix could be helpful.

in this change, an command line option named "--log-with-color" is added.
this option is enabled by default.

this change utilizes the color output from fmtlib. the colored
printing support was introduced to fmtlib 5.2.1 in the sense we
can find it in fmt/color.h. but the format helpers was added in
fmtlib 6.0.0. so the minimal fmt version required for enabling
"Seastar_COLORED_LOG" is 6.0.0.

because, apparently, this features is implemented using ANSI
escape code, this adds the amount of text printed to the specified
output, so if this extra overhead is a concern, it might be
advisable to disable this feature in production. i.e., to pass
`--log-with-color 0` to your Seastar application.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>