### PR TITLE
doc: fix redundant double wording in tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -79,7 +79,7 @@ As we do in this example, each Seastar program must define and run, an `app_temp
 
 The `return make_ready_future<>();` causes the event loop, and the whole application, to exit immediately after printing the "Hello World" message. In a more typical Seastar application, we will want event loop to remain alive and process incoming packets (for example), until explicitly exited. Such applications will return a _future_ which determines when to exit the application. We will introduce futures and how to use them below. In any case, the regular C `exit()` should not be used, because it prevents Seastar or the application from cleaning up appropriately.
 
-As shown in this example, all Seastar functions and types live in the "`seastar`" namespace. An user can either type this namespace prefix every time, or use shortcuts like "`using seastar::app_template`" or even "`using namespace seastar`" to avoid typing this prefix. We generally recommend to use the namespace prefixes `seastar` and `std` explicitly, and will will follow this style in all the examples below.
+As shown in this example, all Seastar functions and types live in the "`seastar`" namespace. An user can either type this namespace prefix every time, or use shortcuts like "`using seastar::app_template`" or even "`using namespace seastar`" to avoid typing this prefix. We generally recommend to use the namespace prefixes `seastar` and `std` explicitly, and will follow this style in all the examples below.
 
 To compile this program (it's present in the `demos/hello-world.cc` file) you can just use Docker.
 


### PR DESCRIPTION
Just started reading the tutorial, thought I'd make an easy contribution on the way :)