### PR TITLE
rpc-impl: turn send_helper() send-recv into a .then-chain

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -476,10 +476,9 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
             write_le<uint32_t>(p + 16, data.size - 28);
 
             // prepare reply handler, if return type is now_wait_type this does nothing, since no reply will be sent
-            using wait = wait_signature_t<Ret>;
-            return when_all(dst.send(std::move(data), timeout, cancel), wait_for_reply<Serializer>(wait(), timeout, cancel, dst, msg_id, sig)).then([] (auto r) {
-                    std::get<0>(r).ignore_ready_future();
-                    return std::move(std::get<1>(r)); // return future of wait_for_reply
+            return dst.send(std::move(data), timeout, cancel).then([this, timeout, cancel, &dst, msg_id] {
+                using wait = wait_signature_t<Ret>;
+                return wait_for_reply<Serializer>(wait(), timeout, cancel, dst, msg_id, sig);
             });
         }
         auto operator()(rpc::client& dst, const InArgs&... args) {


### PR DESCRIPTION
quote from the description of the issue:

> This place deserves being a standard continuation chain to avoid
> when_all state allocation (and extra task to collect result) for no
> gain.

fixes #1104
Signed-off-by: Kefu Chai <tchaikov@gmail.com>