### PR TITLE
Update building-docker.md

### DIFF
--- a/doc/building-docker.md
+++ b/doc/building-docker.md
@@ -3,7 +3,7 @@
 To build a Docker image:
 
 ```
-docker build -t seastar-dev docker/dev
+docker build -t seastar-dev -f docker/dev/Dockerfile .
 ```
 
 Building is done with two commands:


### PR DESCRIPTION
I tried the instruction in https://github.com/scylladb/seastar/blob/master/doc/building-docker.md and hit the following error:

```
(base) [~/dev/seastar]$ docker build -t seastar-dev docker/dev                                                                                                                                                                                                        *[master]
[+] Building 1.2s (7/8)
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 1.10kB                                                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:jammy                                                                                                                                                                                                            1.1s
 => [1/4] FROM docker.io/library/ubuntu:jammy@sha256:b6b83d3c331794420340093eb706a6f152d9c1fa51b262d9bf34594887c2c7ac                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => CACHED [2/4] RUN apt -y update     && apt -y install build-essential     && apt -y install gcc-11 g++-11 gcc-10 g++-10 gcc-9 g++-9 pandoc     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11     && update-alternatives --install /usr/bin/g++   0.0s
 => ERROR [3/4] COPY install-dependencies.sh /tmp/                                                                                                                                                                                                                         0.0s
------
 > [3/4] COPY install-dependencies.sh /tmp/:
------
failed to compute cache key: "/install-dependencies.sh" not found: not found
```

I'm on a MacOS 12.3 with docker desktop installed. Not sure if this error exists on other platform, but I think it's due to that this command messed up the working directory so that "install-dependencies.sh" couldn't be found.

Changing the invocation to what this PR does works for me. I'm now able to build seastar in the docker container.