### PR TITLE
core, rpc: silence couple warnings from GCC-12

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -198,7 +198,7 @@ struct lw_shared_ptr_accessors_esft {
     static void dispose(T* value_ptr) {
         delete value_ptr;
     }
-    static void instantiate_to_value(lw_shared_ptr_counter_base* p) {
+    static void instantiate_to_value(lw_shared_ptr_counter_base*) {
         // since to_value() is defined above, we don't need to do anything special
         // to force-instantiate it
     }

--- a/include/seastar/core/simple-stream.hh
+++ b/include/seastar/core/simple-stream.hh
@@ -28,7 +28,7 @@ namespace seastar {
 class measuring_output_stream {
     size_t _size = 0;
 public:
-    void write(const char* data, size_t size) {
+    void write(const char*, size_t size) {
         _size += size;
     }
 

--- a/include/seastar/core/simple-stream.hh
+++ b/include/seastar/core/simple-stream.hh
@@ -95,7 +95,7 @@ public:
     }
 
     [[gnu::always_inline]]
-    const size_t size() const {
+    size_t size() const {
         return _size;
     }
 
@@ -171,7 +171,7 @@ public:
             std::fill_n(fragment.begin(), fragment.size(), c);
         });
     }
-    const size_t size() const {
+    size_t size() const {
         return _size;
     }
 
@@ -364,7 +364,7 @@ public:
     }
 
     [[gnu::always_inline]]
-    const size_t size() const {
+    size_t size() const {
         return _size;
     }
 };
@@ -427,7 +427,7 @@ public:
             bv.copy_to(out);
         });
     }
-    const size_t size() const {
+    size_t size() const {
         return _size;
     }
 

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -673,7 +673,7 @@ auto protocol<Serializer, MsgType>::register_handler(MsgType t, scheduling_group
     using want_time_point = typename sig_type::want_time_point;
     auto recv = recv_helper<Serializer>(clean_sig_type(), std::forward<Func>(func),
             want_client_info(), want_time_point());
-    register_receiver(t, rpc_handler{sg, make_copyable_function(std::move(recv))});
+    register_receiver(t, rpc_handler{sg, make_copyable_function(std::move(recv)), {}});
     return make_client(clean_sig_type(), t);
 }
 


### PR DESCRIPTION
* do not qualify return type with "const"
* do not pass unused parameter
* init all member variables

Signed-off-by: Kefu Chai <tchaikov@gmail.com>