### PR TITLE
tls: vec_push: handle synchronous error from put

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1371,6 +1371,11 @@ public:
             }
             auto n = msg.size();
             _output_pending = _out.put(std::move(msg).release());
+            if (_output_pending.failed()) {
+                // exception is copied back into _output_pending
+                // by the catch handlers below
+                std::rethrow_exception(_output_pending.get_exception());
+            }
             return n;
         } catch (const std::system_error& e) {
             gnutls_transport_set_errno(*this, e.code().value());


### PR DESCRIPTION
_out.put() may return an exceptional future
synchronously, e.g. when the socket is disconnected.

In that case vec_push must not return a successful
byte-count result, but rather call gnutls_transport_set_errno
and return -1, otherwise gnutls may just call vec_push again,
where it will see _output_pending.failed() and abort on_internal_error,
as the error should have been handled by wait_for_output.

Fixes #1160

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>