### PR TITLE
seastar/rpc: add fmt::ostream_formatter<> for rpc::connection_id

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -388,3 +388,7 @@ struct tuple_element<I, seastar::rpc::tuple<T...>> : tuple_element<I, tuple<T...
 };
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_formatter {};
+#endif


### PR DESCRIPTION
this is a follow-up of 2975b61264694cb4ce229ca82f0d9b553bef0d76,
the fmt::formatter for rpc::connection_id is used by
connection::get_stream(), but this function is not compiled by
our regular CI test, so it was missed.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>