### PR TITLE
util/log: make the width shard_id field fixed in log message

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -87,6 +87,7 @@ class logger {
     static std::ostream* _out;
     static std::atomic<bool> _ostream;
     static std::atomic<bool> _syslog;
+    static unsigned _shard_field_width;
     static inline thread_local bool silent = false;
 
 public:
@@ -414,6 +415,15 @@ public:
     ///       this should be rare (will have to fill the pipe buffer
     ///       before syslogd can clear it) but can happen.
     static void set_syslog_enabled(bool enabled) noexcept;
+
+    /// Set the width of shard id field in log messages
+    ///
+    /// \c this_shard_id() is printed as a part of the prefix in logging
+    /// messages, like "[shard 42]", where \c 42 is the decimal number of the
+    /// current shard id printed with a minimal width.
+    ///
+    /// \param width the minimal width of the shard id field
+    static void set_shard_field_width(unsigned width) noexcept;
 };
 
 /// \brief used to keep a static registry of loggers

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -64,6 +64,7 @@
 #include "cgroup.hh"
 #include "uname.hh"
 #include <cassert>
+#include <cmath>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/eventfd.h>
@@ -3935,6 +3936,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         nr_cpus = cpu_set.size();
     }
     smp::count = nr_cpus;
+    logger::set_shard_field_width(std::ceil(std::log10(smp::count)));
     std::vector<reactor*> reactors(nr_cpus);
     if (smp_opts.memory) {
         rc.total_memory = parse_memory_size(smp_opts.memory.get_value());


### PR DESCRIPTION
util/log: make the width of shard_id 2 in log message

the "server: stopping" lines are pratically the same, except that
they are from different shard. but the unaligned logging messages
are distracting if we just want to skim through them.

after this change, the logging messages now look like:
```
DEBUG 2022-07-27 11:22:26,306 [shard  0] aloha - server: running!
INFO  2022-07-27 11:22:26,306 [shard  0] aloha - stopping
DEBUG 2022-07-27 11:22:26,306 [shard  0] aloha - server: stopping
DEBUG 2022-07-27 11:22:26,307 [shard 28] aloha - server: stopping
```
the logging messages are aligned.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>