### PR TITLE
intent: drop unused headers

### DIFF
--- a/include/seastar/core/io_intent.hh
+++ b/include/seastar/core/io_intent.hh
@@ -21,13 +21,9 @@
 
 #pragma once
 
-#include <boost/intrusive/list.hpp>
-#include <boost/intrusive/slist.hpp>
 #include <boost/container/small_vector.hpp>
 #include <seastar/core/internal/io_intent.hh>
 #include <seastar/core/io_priority_class.hh>
-
-namespace bi = boost::intrusive;
 
 namespace seastar {
 


### PR DESCRIPTION
neither of these headers is used in this header file. and neither
is `bi` namespace alias used.

so in this change, the unused headers and unused namespace alias
are removed.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>