### PR TITLE
drop unused parameters

### DIFF
--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -42,7 +42,7 @@ SEASTAR_CONCEPT(
 // This class satisfies 'aborter' concept and is used by default
 template<typename... T>
 struct noop_aborter {
-    void operator()(T... x) noexcept {};
+    void operator()(T...) noexcept {};
 };
 
 

--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -139,7 +139,7 @@ private:
             return *this;
         }
         // postfix
-        cbiterator<CB, ValueType> operator++(int unused) noexcept {
+        cbiterator<CB, ValueType> operator++(int) noexcept {
             auto v = *this;
             idx++;
             return v;
@@ -150,7 +150,7 @@ private:
             return *this;
         }
         // postfix
-        cbiterator<CB, ValueType> operator--(int unused) noexcept {
+        cbiterator<CB, ValueType> operator--(int) noexcept {
             auto v = *this;
             idx--;
             return v;

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -505,7 +505,7 @@ iterator_range_estimate_vector_capacity(Iterator const&, Sentinel const&, Iterat
 template <typename Iterator, typename Sentinel>
 inline
 size_t
-iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, std::forward_iterator_tag category) {
+iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, std::forward_iterator_tag) {
     // May be linear time below random_access_iterator_tag, but still better than reallocation
     return std::distance(begin, end);
 }

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -637,7 +637,7 @@ impl::metric_definition_impl make_summary(metric_name_type name,
 template<typename T>
 impl::metric_definition_impl make_total_bytes(metric_name_type name,
         T&& val, description d=description(), std::vector<label_instance> labels = {},
-        instance_id_type instance = impl::shard()) {
+        instance_id_type = impl::shard()) {
     return make_counter(name, std::forward<T>(val), d, labels).set_type("total_bytes");
 }
 
@@ -651,7 +651,7 @@ impl::metric_definition_impl make_total_bytes(metric_name_type name,
 template<typename T>
 impl::metric_definition_impl make_current_bytes(metric_name_type name,
         T&& val, description d=description(), std::vector<label_instance> labels = {},
-        instance_id_type instance = impl::shard()) {
+        instance_id_type = impl::shard()) {
     return make_gauge(name, std::forward<T>(val), d, labels).set_type("bytes");
 }
 
@@ -665,7 +665,7 @@ impl::metric_definition_impl make_current_bytes(metric_name_type name,
 template<typename T>
 impl::metric_definition_impl make_queue_length(metric_name_type name,
         T&& val, description d=description(), std::vector<label_instance> labels = {},
-        instance_id_type instance = impl::shard()) {
+        instance_id_type = impl::shard()) {
     return make_gauge(name, std::forward<T>(val), d, labels).set_type("queue_length");
 }
 
@@ -679,7 +679,7 @@ impl::metric_definition_impl make_queue_length(metric_name_type name,
 template<typename T>
 impl::metric_definition_impl make_total_operations(metric_name_type name,
         T&& val, description d=description(), std::vector<label_instance> labels = {},
-        instance_id_type instance = impl::shard()) {
+        instance_id_type = impl::shard()) {
     return make_counter(name, std::forward<T>(val), d, labels).set_type("total_operations");
 }
 

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -197,7 +197,7 @@ inline unsigned long scheduling_group_key_id(scheduling_group_key key) noexcept 
  * for suporting \ref make_scheduling_group_key_config
  */
 template<typename ConstructorType, typename Tuple, size_t...Idx>
-void apply_constructor(void* pre_alocated_mem, Tuple args, std::index_sequence<Idx...> idx_seq) {
+void apply_constructor(void* pre_alocated_mem, Tuple args, std::index_sequence<Idx...>) {
     new (pre_alocated_mem) ConstructorType(std::get<Idx>(args)...);
 }
 }

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -673,7 +673,7 @@ future<> sharded_call_stop<true>::call(Service& instance) {
 template <>
 template <typename Service>
 inline
-future<> sharded_call_stop<false>::call(Service& instance) {
+future<> sharded_call_stop<false>::call(Service&) {
     return make_ready_future<>();
 }
 

--- a/include/seastar/core/transfer.hh
+++ b/include/seastar/core/transfer.hh
@@ -66,7 +66,7 @@ transfer_pass1(Alloc& a, T* from, T* to,
 template <typename T, typename Alloc>
 inline
 void
-transfer_pass2(Alloc& a, T* from, T* to,
+transfer_pass2(Alloc& a, T* from, T*,
         typename std::enable_if<!std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
     std::allocator_traits<Alloc>::destroy(a, from);
 }

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -749,7 +749,7 @@ public:
             rpc::server(&proto, addr, memory_limit) {}
         server(protocol& proto, server_options opts, const socket_address& addr, resource_limits memory_limit = resource_limits()) :
             rpc::server(&proto, opts, addr, memory_limit) {}
-        server(protocol& proto, server_socket socket, resource_limits memory_limit = resource_limits(), server_options opts = server_options{}) :
+        server(protocol& proto, server_socket socket, resource_limits memory_limit = resource_limits(), server_options = server_options{}) :
             rpc::server(&proto, std::move(socket), memory_limit) {}
         server(protocol& proto, server_options opts, server_socket socket, resource_limits memory_limit = resource_limits()) :
             rpc::server(&proto, opts, std::move(socket), memory_limit) {}

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -62,7 +62,7 @@ struct rovers<T, capped_release::yes> {
 
     rovers(T limit) noexcept : tail(0), head(0), ceil(limit) {}
 
-    T max_extra(T limit) const noexcept {
+    T max_extra(T) const noexcept {
         return wrapping_difference(ceil.load(std::memory_order_relaxed), head.load(std::memory_order_relaxed));
     }
 
@@ -78,13 +78,13 @@ struct rovers<T, capped_release::no> {
     atomic_rover tail;
     atomic_rover head;
 
-    rovers(T limit) noexcept : tail(0), head(0) {}
+    rovers(T) noexcept : tail(0), head(0) {}
 
     T max_extra(T limit) const noexcept {
         return wrapping_difference(tail.load(std::memory_order_relaxed) + limit, head.load(std::memory_order_relaxed));
     }
 
-    void release(T tokens) {
+    void release(T) {
         std::abort(); // FIXME shouldn't even be compiled
     }
 };


### PR DESCRIPTION
to silence warnings from Clang-14, like
```
seastar/include/seastar/core/transfer.hh:69:38: error: unused parameter 'to' [-Werror,-Wunused-parameter]
 transfer_pass2(Alloc& a, T* from, T* to,
                                      ^
 1 error generated.
```
these are leftovers of 551c144757d092f2ab7c449042a8bc9af66c5d26

Signed-off-by: Kefu Chai <tchaikov@gmail.com>