### PR TITLE
cmake: attach property to Valgrind not to hwloc

### DIFF
--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -44,7 +44,7 @@ set (Valgrind_INCLUDE_DIRS ${Valgrind_INCLUDE_DIR})
 if (Valgrind_FOUND AND NOT (TARGET Valgrind::valgrind))
   add_library (Valgrind::valgrind INTERFACE IMPORTED)
 
-  set_target_properties (hwloc::hwloc
+  set_target_properties (Valgrind::valgrind
     PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES ${Valgrind_INCLUDE_DIRS})
 endif ()


### PR DESCRIPTION
we should attach INTERFACE_INCLUDE_DIRECTORIES to Valgrind::valgrind
not to hwloc::hwloc.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>