### PR TITLE
Reset _total_stats before each run

### DIFF
--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -171,6 +171,7 @@ public:
     [[gnu::always_inline]] [[gnu::hot]]
     void start_run(linux_perf_event* instructions_retired_counter = nullptr) {
         _total_time = { };
+        _total_stats = {};
         auto t = clock_type::now();
         _run_start_time = t;
         _start_time = t;


### PR DESCRIPTION
_total_stats were not being reset before each run, meaning
that values were inflated by a factor of R for a benchmark
with R runs (e.g., by 5x for the default of 5 runs).

This affected only non-time metrics tracked in perf_stats:
allocs, tasks and instruction count.