### PR TITLE
fmt 9 ostream fix

### DIFF
--- a/include/seastar/net/ethernet.hh
+++ b/include/seastar/net/ethernet.hh
@@ -94,3 +94,7 @@ ethernet_address parse_ethernet_address(std::string addr);
 }
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::net::ethernet_address> : fmt::ostream_formatter {};
+#endif

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -160,7 +160,6 @@ struct result {
     double inst = 0.;
 };
 
-namespace {
 
 struct duration {
     double value;
@@ -181,8 +180,6 @@ static inline std::ostream& operator<<(std::ostream& os, duration d)
         os << fmt::format("{:.3f}s", value / 1'000'000'000);
     }
     return os;
-}
-
 }
 
 static constexpr auto header_format_string = "{:<40} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}\n";

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -41,6 +41,13 @@
 
 #include <signal.h>
 
+#if FMT_VERSION >= 90000
+namespace perf_tests::internal {
+    struct duration;
+}
+template <> struct fmt::formatter<perf_tests::internal::duration> : fmt::ostream_formatter {};
+#endif
+
 namespace perf_tests {
 namespace internal {
 


### PR DESCRIPTION
include fmt/core.h before check FMT_VERSION
define deprecation macro as a workaround as struct defined in anonymous namespace