### PR TITLE
program_options: enable optional selection_value

### DIFF
--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -576,7 +576,8 @@ public:
         , _selected_candidate(find_candidate(default_candidate))
     { }
     selection_value(option_group& group, std::string name, candidates candidates, std::string description)
-        : selection_value(group, std::move(name), std::move(candidates), {}, std::move(description))
+        : basic_value(group, true, std::move(name), std::move(description))
+        , _candidates(std::move(candidates))
     { }
     /// Construct an unused value.
     selection_value(option_group& group, std::string name, unused)


### PR DESCRIPTION
before this change, we have to pass a valid candidate value for
selection_value, otherwise `find_candidate()` would throw as it
cannot find a matched `_selected_candidate` if none of the name
of candidates is empty.

but this restriction leaves us no option, if we want to have an
optional selection_value.

in this change, the constructor of
`selection_value(option_group&, std::string name, candidates, std::string description)`
does not delegate to
`selection_value(option_group&, std::string name, candidates,
std::string default_candidate, std::string description)` with
an empty `default_candiate` anymore. instead, it leave
`_selected_candidate` to its in-class initializer. so it is
`no_selected_candidate` in that case. and we can just tell if
the `selection_value` is set or not as we do to other `value`s.

currently, the only two users of `selection_value` in Seastar
are `network_stack_factory` and `reactor_backend_selector`.
both of them provides non-empty default value to the `selection_value`
constructor. so this change should have no impact on Seastar's
inner users.

When it comes to outer users of Seastar applications, if any of
the Seastar application uses `selection_value` and provides an empty
string as the value of the expected default candidates, its selected
candidate would changed to `no_selected_candidate`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>