### PR TITLE
register one default priority class for queue

### DIFF
--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -52,10 +52,12 @@ struct local_fq_and_class {
         , sfq(sfg, seastar::fair_queue::config())
     {
         fq.register_priority_class(cid, 1);
+        sfq.register_priority_class(cid, 1);
     }
 
     ~local_fq_and_class() {
         fq.unregister_priority_class(cid);
+        sfq.unregister_priority_class(cid);
     }
 };
 


### PR DESCRIPTION
The shared queue didn't have any priority class registered
in this test, causing methods like queue() to segfault.

Fixes #1175.