### PR TITLE
Support specifying the "build root" in configure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -58,6 +58,9 @@ def standard_supported(standard, compiler='g++'):
 
 arg_parser = argparse.ArgumentParser('Configure seastar')
 arg_parser.add_argument('--mode', action='store', choices=seastar_cmake.SUPPORTED_MODES + ['all'], default='all')
+arg_parser.add_argument('--build-root', action='store', default=seastar_cmake.DEFAULT_BUILD_ROOT, type=str,
+                        help='The name of the build root build directoy: using a different name allows multiple '
+                        'configurations to co-exist in the same repository')
 arg_parser.add_argument('--cflags', action = 'store', dest = 'user_cflags', default = '',
                         help = 'Extra flags for the C++ compiler')
 arg_parser.add_argument('--ldflags', action = 'store', dest = 'user_ldflags', default = '',
@@ -176,7 +179,7 @@ tr = seastar_cmake.translate_arg
 MODE_TO_CMAKE_BUILD_TYPE = {'release' : 'RelWithDebInfo', 'debug' : 'Debug', 'dev' : 'Dev', 'sanitize' : 'Sanitize' }
 
 def configure_mode(mode):
-    BUILD_PATH = seastar_cmake.BUILD_PATHS[mode]
+    BUILD_PATH = seastar_cmake.build_path(mode, build_root=args.build_root)
 
     CFLAGS = seastar_cmake.convert_strings_to_cmake_list(
         args.user_cflags,
@@ -239,7 +242,8 @@ def configure_mode(mode):
         # When building without cooked dependencies, we can invoke cmake directly. We can't call
         # cooking.sh, because without any -i parameters, it will try to build
         # everything.
-        ARGS = ['cmake', '-G', 'Ninja', '../..']
+        root_relative_to_build = os.path.relpath(seastar_cmake.ROOT_PATH, BUILD_PATH)
+        ARGS = ['cmake', '-G', 'Ninja', root_relative_to_build]
         dir = BUILD_PATH
     # filter out empty args, their values are actually "guess",
     # CMake should be able to figure it out.

--- a/seastar_cmake.py
+++ b/seastar_cmake.py
@@ -21,9 +21,15 @@ SUPPORTED_MODES = ['release', 'debug', 'dev', 'sanitize']
 
 ROOT_PATH = os.path.realpath(os.path.dirname(__file__))
 
-BUILD_PATHS = { mode: os.path.join(ROOT_PATH, 'build', mode) for mode in SUPPORTED_MODES }
+DEFAULT_BUILD_ROOT = 'build'
 
 COOKING_BASIC_ARGS = ['./cooking.sh']
+
+def build_path(mode, build_root):
+    """Return the absolute path to the build directory for the given mode,
+    i.e., seastar_dir/<build_root>/<mode>"""
+    assert mode in SUPPORTED_MODES, f'Unsupported build mode: {mode}'
+    return os.path.join(ROOT_PATH, build_root, mode)
 
 def is_release_mode(mode):
     return mode == 'release'

--- a/test.py
+++ b/test.py
@@ -27,6 +27,9 @@ if __name__ == "__main__":
     parser.add_argument('--fast',  action="store_true", help="Run only fast tests")
     parser.add_argument('--name',  action="store", help="Run only test whose name contains given string")
     parser.add_argument('--mode', choices=seastar_cmake.SUPPORTED_MODES, help="Run only tests for given build mode")
+    parser.add_argument('--build-root', action='store', default=seastar_cmake.DEFAULT_BUILD_ROOT, type=str,
+                        help="The name of the build root build directoy: "
+                        "using a different name allows multiple configurations to co-exist in the same repository")
     parser.add_argument('--timeout', action="store",default="300",type=int, help="timeout value for test execution")
     parser.add_argument('--jenkins', action="store",help="jenkins output file prefix")
     parser.add_argument('--smp', '-c', action="store",default='2',type=int,help="Number of threads for multi-core tests")
@@ -37,7 +40,7 @@ if __name__ == "__main__":
     MODES = [args.mode] if args.mode else seastar_cmake.SUPPORTED_MODES
 
     def run_tests(mode):
-        BUILD_PATH = seastar_cmake.BUILD_PATHS[mode]
+        BUILD_PATH = seastar_cmake.build_path(mode, args.build_root)
 
         # For convenience.
         tr = seastar_cmake.translate_arg


### PR DESCRIPTION
This allows specifying the root of the build directoires,
which is currently hardcoded to build. This allows you have several
differently-configured builds at once, e.g, build-gcc for
gcc, build-clang-14 for clang-14, whatever.

Within the directory, you'll find the usual mode subdirectories,
i.e., release, debug, etc.