### PR TITLE
tls: vec_push: handle async errors rather than throwing on_internal_error

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1363,15 +1363,14 @@ public:
         try {
             ssize_t n; // Set on the good path and unused on the bad path
 
-          // FIXME indentation
-          if (!_output_pending.failed()) {
-            scattered_message<char> msg;
-            for (int i = 0; i < iovcnt; ++i) {
-                msg.append(std::string_view(reinterpret_cast<const char *>(iov[i].iov_base), iov[i].iov_len));
+            if (!_output_pending.failed()) {
+                scattered_message<char> msg;
+                for (int i = 0; i < iovcnt; ++i) {
+                    msg.append(std::string_view(reinterpret_cast<const char *>(iov[i].iov_base), iov[i].iov_len));
+                }
+                n = msg.size();
+                _output_pending = _out.put(std::move(msg).release());
             }
-            n = msg.size();
-            _output_pending = _out.put(std::move(msg).release());
-          }
             if (_output_pending.failed()) {
                 // exception is copied back into _output_pending
                 // by the catch handlers below


### PR DESCRIPTION
This series deals with handling of async errors in vec_push _output_pending.

First, `handle_output_error` is called in `do_handshake` before calling `send_alert`, fixing #1180
and on top, the "unhandled error" internal error in vec_push was demoted and is just reported and returned back, since it was determined that it can be hit by normal circumstances when _output_pending fails in background and gnutls is calling vec_push a number of times in a row. This fixes #1181.

debug logging and and error injection test that reproduces the above issue without the fix were also added.

Refs https://github.com/scylladb/scylladb/issues/11252