### PR TITLE
build: add a space after function name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,7 +930,7 @@ if (Seastar_HWLOC)
     PRIVATE hwloc::hwloc)
 endif ()
 
-set_option_if_package_is_found(Seastar_IO_URING LibUring)
+set_option_if_package_is_found (Seastar_IO_URING LibUring)
 if (Seastar_IO_URING)
   list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_URING)
   target_link_libraries (seastar


### PR DESCRIPTION
more consistent this way

Signed-off-by: Kefu Chai <tchaikov@gmail.com>