### PR TITLE
tests/perf: make perf_tests::internal::duration formattable

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -185,6 +185,18 @@ static inline std::ostream& operator<<(std::ostream& os, duration d)
 
 }
 
+#if FMT_VERSION >= 90000
+
+}}
+
+template<>
+struct fmt::formatter<perf_tests::internal::duration> : fmt::ostream_formatter{};
+
+namespace perf_tests {
+namespace internal {
+
+#endif
+
 static constexpr auto header_format_string = "{:<40} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}\n";
 static constexpr auto        format_string = "{:<40} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11.3f} {:>11.3f} {:>11.1f}\n";
 


### PR DESCRIPTION
fmt v9 requires a specialisation of `fmt::formatter` if it is to use `operator<<` - this allows the tests to be built with libfmt v9 without enabling `FMT_DEPRECATED_OSTREAM`
