### PR TITLE
log: do not inherit formatter<seastar::log_level> from formatter<string_view>

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -57,10 +57,14 @@
 using namespace std::chrono_literals;
 
 namespace fmt {
-template <> struct formatter<seastar::log_level>: formatter<std::string_view> {
+template <> struct formatter<seastar::log_level> {
     using log_level = seastar::log_level;
     static constexpr size_t nr_levels = static_cast<size_t>(log_level::trace) + 1;
     static bool colored;
+
+    // format specifier not supported
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
     auto format(seastar::log_level c, FormatContext& ctx) const {
@@ -82,11 +86,11 @@ template <> struct formatter<seastar::log_level>: formatter<std::string_view> {
             { int(log_level::error), fg(terminal_color::red)    },
         };
         if (colored) {
-            return formatter<std::string_view>::format(
-                fmt::format(style[index], "{}", name), ctx);
+            return fmt::format_to(ctx.out(), "{}",
+                fmt::format(style[index], "{}", name));
         }
 #endif
-        return formatter<std::string_view>::format(name, ctx);
+        return fmt::format_to(ctx.out(), "{}", name);
     }
 };
 bool formatter<seastar::log_level>::colored = true;


### PR DESCRIPTION
it turns out, in fmt v7.1.3, `formatter<std::string_view>::format()` is
not marked as const yet. the change which marked the formatters `const`
was introduced in
https://github.com/fmtlib/fmt/commit/bbd6ed5bc57adba7a3fc11804770e75299673761.

before that we cannot assume the constness of this method. so let's
just don't mark this format() const yet.

this change should address the FTBFS with fmt v7.1.3.

Fixes #1189
Signed-off-by: Kefu Chai <tchaikov@gmail.com>