### PR TITLE
util: log: change logging_settings::with_color to be the last member

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -503,9 +503,9 @@ struct logging_settings final {
     log_level default_level;
     bool stdout_enabled;
     bool syslog_enabled;
-    bool with_color;
     logger_timestamp_style stdout_timestamp_style = logger_timestamp_style::real;
     logger_ostream_type logger_ostream = logger_ostream_type::stderr;
+    bool with_color = true;
 };
 
 /// Shortcut for configuring the logging system all at once.


### PR DESCRIPTION
To prevent constructor calls that don't use designated initializers
from failing, move the new member to the end where it doesn't confuse
things. Also initialize it so we don't end with undefined behavior.