### PR TITLE
tls_test: Fix spurious fail in test_x509_client_with_builder_system_t…

### DIFF
--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -66,40 +66,53 @@ static std::string certfile(const std::string& file) {
 using namespace seastar;
 
 static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> certs, socket_address addr, const sstring& name = {}) {
-    return tls::connect(certs, addr, name).then([](connected_socket s) {
-        return do_with(std::move(s), [](connected_socket& s) {
-            return do_with(s.output(), [&s](auto& os) {
-                static const sstring msg("GET / HTTP/1.0\r\n\r\n");
-                auto f = os.write(msg);
-                return f.then([&s, &os]() mutable {
-                    auto f = os.flush();
-                    return f.then([&s]() mutable {
-                        return do_with(s.input(), sstring{}, [](auto& in, sstring& buffer) {
-                            return do_until(std::bind(&input_stream<char>::eof, std::cref(in)), [&buffer, &in] {
-                                auto f = in.read();
-                                return f.then([&](temporary_buffer<char> buf) {
-                                    buffer.append(buf.get(), buf.size());
+    return repeat_until_value([=]() mutable {
+        return tls::connect(certs, addr, name).then([](connected_socket s) {
+            return do_with(std::move(s), [](connected_socket& s) {
+                return do_with(s.output(), [&s](auto& os) {
+                    static const sstring msg("GET / HTTP/1.0\r\n\r\n");
+                    auto f = os.write(msg);
+                    return f.then([&s, &os]() mutable {
+                        auto f = os.flush();
+                        return f.then([&s]() mutable {
+                            return do_with(s.input(), sstring{}, [](auto& in, sstring& buffer) {
+                                return do_until(std::bind(&input_stream<char>::eof, std::cref(in)), [&buffer, &in] {
+                                    auto f = in.read();
+                                    return f.then([&](temporary_buffer<char> buf) {
+                                        buffer.append(buf.get(), buf.size());
+                                    });
+                                }).then([&buffer]() -> future<std::optional<bool>> {
+                                    if (buffer.empty()) {
+                                        // # 1127 google servers have a (pretty short) timeout between connect and expected first
+                                        // write. If we are delayed inbetween connect and write above (cert verification, scheduling
+                                        // solar spots or just time sharing on AWS) we could get a short read here. Just retry.
+                                        // If we get an actual error, it is either on protocol level (exception) or HTTP error.
+                                        return make_ready_future<std::optional<bool>>(std::nullopt);
+                                    }
+                                    BOOST_CHECK(buffer.size() > 8);
+                                    BOOST_CHECK_EQUAL(buffer.substr(0, 5), sstring("HTTP/"));
+                                    return make_ready_future<std::optional<bool>>(true);
                                 });
-                            }).then([&buffer]() {
-                                BOOST_CHECK(buffer.size() > 8);
-                                BOOST_CHECK_EQUAL(buffer.substr(0, 5), sstring("HTTP/"));
                             });
                         });
+                    }).finally([&os] {
+                        return os.close();
                     });
-                }).finally([&os] {
-                    return os.close();
                 });
             });
         });
-    });
+
+    }).discard_result();
 }
+
+static const auto google_name = "www.google.com";
 
 // broken out from below. to allow pre-lookup
 static future<socket_address> google_address() {
     static socket_address google;
 
     if (google.is_unspecified()) {
-        return net::dns::resolve_name("www.google.com", net::inet_address::family::INET).then([](net::inet_address addr) {
+        return net::dns::resolve_name(google_name, net::inet_address::family::INET).then([](net::inet_address addr) {
             google = socket_address(addr, 443);
             return google_address();
         });
@@ -109,7 +122,7 @@ static future<socket_address> google_address() {
 
 static future<> connect_to_ssl_google(::shared_ptr<tls::certificate_credentials> certs) {
     return google_address().then([certs](socket_address addr) {
-        return connect_to_ssl_addr(std::move(certs), addr, "www.google.com");
+        return connect_to_ssl_addr(std::move(certs), addr, google_name);
     });
 }
 


### PR DESCRIPTION
…rust_multiple (et al)

Fixes #1127

google servers have a (pretty short) timeout between connect and expected first
write. If we are delayed inbetween connect and write above (cert verification, scheduling
solar spots or just time sharing on AWS) we could get a short read here. Just retry.
If we get an actual error, it is either on protocol level (exception) or HTTP error.

This is not anything specific to TLS or anything, just particular web server config.