### PR TITLE
core, util, rpc: enable compile time format checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,10 @@ find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
 
+cmake_dependent_option (Seastar_LOGGER_COMPILE_TIME_FMT
+  "Enable the compile-time {fmt} check when formatting logging messages" ON
+  "fmt_VERSION VERSION_GREATER_EQUAL 8.0.0" OFF)
+
 #
 # Code generation helpers.
 #
@@ -937,6 +941,11 @@ endif ()
 if (Seastar_ALLOC_PAGE_SIZE)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_OVERRIDE_ALLOCATOR_PAGE_SIZE=${Seastar_ALLOC_PAGE_SIZE})
+endif ()
+
+if (Seastar_LOGGER_COMPILE_TIME_FMT)
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_LOGGER_COMPILE_TIME_FMT)
 endif ()
 
 target_compile_definitions (seastar

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -204,7 +204,11 @@ class logger {
 
     // _seastar_logger will always be used first if it's available
     template <typename... Args>
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
+    void log(log_level level, fmt::format_string<Args...> fmt, Args&&... args) const {
+#else
     void log(log_level level, const char* fmt, Args&&... args) const {
+#endif
         if (_seastar_logger) {
             _seastar_logger->log(level, fmt, std::forward<Args>(args)...);
         // If the log level is at least `info`, fall back to legacy logging without explicit level.

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
+#include <seastar/util/backtrace.hh>
 #include <seastar/util/concepts.hh>
 #include <seastar/util/log-impl.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -33,7 +34,9 @@
 #include <iosfwd>
 #include <atomic>
 #include <mutex>
+#include <type_traits>
 #include <boost/lexical_cast.hpp>
+#include <fmt/core.h>
 #include <fmt/format.h>
 #endif
 
@@ -120,6 +123,57 @@ public:
 
     /// \cond internal
     /// \brief used to hold the log format string and the caller's source_location.
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
+    template<typename... Args>
+    struct format_info {
+        /// implicitly construct format_info from a constant format string
+        /// \param fmt - {fmt} style format string
+        template<
+            typename S,
+            std::enable_if_t<std::is_convertible_v<const S&, std::string_view>, int> = 0>
+        FMT_CONSTEVAL inline format_info(const S& format,
+                           compat::source_location loc = compat::source_location::current()) noexcept
+            : format(format)
+            , loc(loc)
+        {}
+        /// construct format_info from an instance of \c format_string
+        ///
+        /// this constructor is used by other printers which print to logger
+        /// \param s a format_string
+        inline format_info(fmt::format_string<Args...> s,
+                           compat::source_location loc = compat::source_location::current()) noexcept
+            : format(s)
+            , loc(loc)
+        {}
+#if FMT_VERSION >= 100000
+        using runtime_format_string_t = fmt::runtime_format_string<char>;
+#else
+        using runtime_format_string_t = fmt::basic_runtime<char>;
+#endif
+        inline format_info(runtime_format_string_t s,
+                           compat::source_location loc = compat::source_location::current()) noexcept
+            : format(s)
+            , loc(loc)
+        {}
+        /// implicitly construct format_info with no format string.
+        FMT_CONSTEVAL format_info() noexcept
+            : format_info("")
+        {}
+        fmt::format_string<Args...> format;
+        compat::source_location loc;
+    };
+#ifdef __cpp_lib_type_identity
+    template <typename T>
+    using type_identity_t = typename std::type_identity<T>::type;
+#else
+    template <typename T> struct type_identity { using type = T; };
+    template <typename T> using type_identity_t = typename type_identity<T>::type;
+#endif
+    template <typename... Args>
+    using format_info_t = format_info<type_identity_t<Args>...>;
+#else  // SEASTAR_LOGGER_COMPILE_TIME_FMT
+    /// \cond internal
+    /// \brief used to hold the log format string and the caller's source_location.
     struct format_info {
         /// implicitly construct format_info from a const char* format string.
         /// \param fmt - {fmt} style format string
@@ -141,12 +195,19 @@ public:
         std::string_view format;
         compat::source_location loc;
     };
+    // to reduce the number of #ifdefs, let's be compatible with the templated
+    // format_info
+    template <typename...>
+    using format_info_t = format_info;
+#endif // SEASTAR_LOGGER_COMPILE_TIME_FMT
 
 private:
 
     // We can't use an std::function<> as it potentially allocates.
     void do_log(log_level level, log_writer& writer);
-    void failed_to_log(std::exception_ptr ex, format_info fmt) noexcept;
+    void failed_to_log(std::exception_ptr ex,
+                       fmt::string_view fmt,
+                       compat::source_location loc) noexcept;
 
     class silencer {
     public:
@@ -224,19 +285,19 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void log(log_level level, format_info fmt, Args&&... args) noexcept {
+    void log(log_level level, format_info_t<Args...> fmt, Args&&... args) noexcept {
         if (is_enabled(level)) {
             try {
                 lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
-#if FMT_VERSION >= 80000
-                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
-#else
+#if defined(SEASTAR_LOGGER_COMPILE_TIME_FMT) || FMT_VERSION < 80000
                     return fmt::format_to(it, fmt.format, std::forward<Args>(args)...);
+#else
+                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
 #endif
                 });
                 do_log(level, writer);
             } catch (...) {
-                failed_to_log(std::current_exception(), std::move(fmt));
+                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
             }
         }
     }
@@ -256,7 +317,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void log(log_level level, rate_limit& rl, format_info fmt, Args&&... args) noexcept {
+    void log(log_level level, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
         if (is_enabled(level) && rl.check()) {
             try {
                 lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
@@ -271,7 +332,7 @@ public:
                 });
                 do_log(level, writer);
             } catch (...) {
-                failed_to_log(std::current_exception(), std::move(fmt));
+                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
             }
         }
     }
@@ -286,12 +347,12 @@ public:
     /// avoid any allocations. The \arg writer will be passed a
     /// internal::log_buf::inserter_iterator that allows it to write into the log
     /// buffer directly, avoiding the use of any intermediary buffers.
-    void log(log_level level, log_writer& writer, format_info fmt = {}) noexcept {
+    void log(log_level level, log_writer& writer, format_info_t<> fmt = {}) noexcept {
         if (is_enabled(level)) {
             try {
                 do_log(level, writer);
             } catch (...) {
-                failed_to_log(std::current_exception(), std::move(fmt));
+                failed_to_log(std::current_exception(), "", fmt.loc);
             }
         }
     }
@@ -305,7 +366,7 @@ public:
     /// internal::log_buf::inserter_iterator that allows it to write into the log
     /// buffer directly, avoiding the use of any intermediary buffers.
     /// This is rate-limited version, see \ref rate_limit.
-    void log(log_level level, rate_limit& rl, log_writer& writer, format_info fmt = {}) noexcept {
+    void log(log_level level, rate_limit& rl, log_writer& writer, format_info_t<> fmt = {}) noexcept {
         if (is_enabled(level) && rl.check()) {
             try {
                 lambda_log_writer writer_wrapper([&] (internal::log_buf::inserter_iterator it) {
@@ -316,7 +377,7 @@ public:
                 });
                 do_log(level, writer_wrapper);
             } catch (...) {
-                failed_to_log(std::current_exception(), std::move(fmt));
+                failed_to_log(std::current_exception(), "", fmt.loc);
             }
         }
     }
@@ -330,7 +391,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void error(format_info fmt, Args&&... args) noexcept {
+    void error(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::error, std::move(fmt), std::forward<Args>(args)...);
     }
     /// Log with warning tag:
@@ -341,7 +402,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void warn(format_info fmt, Args&&... args) noexcept {
+    void warn(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::warn, std::move(fmt), std::forward<Args>(args)...);
     }
     /// Log with info tag:
@@ -352,7 +413,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void info(format_info fmt, Args&&... args) noexcept {
+    void info(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::info, std::move(fmt), std::forward<Args>(args)...);
     }
     /// Log with info tag on shard zero only:
@@ -363,7 +424,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void info0(format_info fmt, Args&&... args) noexcept {
+    void info0(format_info_t<Args...> fmt, Args&&... args) noexcept {
         if (is_shard_zero()) {
             log(log_level::info, std::move(fmt), std::forward<Args>(args)...);
         }
@@ -376,7 +437,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void debug(format_info fmt, Args&&... args) noexcept {
+    void debug(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::debug, std::move(fmt), std::forward<Args>(args)...);
     }
     /// Log with trace tag:
@@ -387,7 +448,7 @@ public:
     /// \param args - args to print string
     ///
     template <typename... Args>
-    void trace(format_info fmt, Args&&... args) noexcept {
+    void trace(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::trace, std::move(fmt), std::forward<Args>(args)...);
     }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -626,7 +626,11 @@ static bool sched_debug() {
 
 template <typename... Args>
 void
+#if SEASTAR_LOGGER_COMPILE_TIME_FMT
+sched_print(fmt::format_string<Args...> fmt, Args&&... args) {
+#else
 sched_print(const char* fmt, Args&&... args) {
+#endif
     if (sched_debug()) {
         sched_logger.trace(fmt, std::forward<Args>(args)...);
     }
@@ -3183,7 +3187,7 @@ int reactor::run() noexcept {
     try {
         return do_run();
     } catch (const std::exception& e) {
-        seastar_logger.error(e.what());
+        seastar_logger.error("{}", e.what());
         print_with_backtrace("exception running reactor main loop");
         _exit(1);
     }
@@ -4532,7 +4536,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
             engine().configure(reactor_opts);
             engine().do_run();
           } catch (const std::exception& e) {
-              seastar_logger.error(e.what());
+              seastar_logger.error("{}", e.what());
               _exit(1);
           }
         });
@@ -4543,7 +4547,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     try {
         allocate_reactor(0, backend_selector, reactor_cfg);
     } catch (const std::exception& e) {
-        seastar_logger.error(e.what());
+        seastar_logger.error("{}", e.what());
         _exit(1);
     }
 

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -376,13 +376,15 @@ logger::do_log(log_level level, log_writer& writer) {
     }
 }
 
-void logger::failed_to_log(std::exception_ptr ex, format_info fmt) noexcept
+void logger::failed_to_log(std::exception_ptr ex,
+                           fmt::string_view fmt,
+                           compat::source_location loc) noexcept
 {
     try {
-        lambda_log_writer writer([ex = std::move(ex), fmt = std::move(fmt)] (internal::log_buf::inserter_iterator it) {
-            it = fmt::format_to(it, "{}:{} @{}: failed to log message", fmt.loc.file_name(), fmt.loc.line(), fmt.loc.function_name());
-            if (!fmt.format.empty()) {
-                it = fmt::format_to(it, ": fmt='{}'", fmt.format);
+        lambda_log_writer writer([ex = std::move(ex), fmt, loc] (internal::log_buf::inserter_iterator it) {
+            it = fmt::format_to(it, "{}:{} @{}: failed to log message", loc.file_name(), loc.line(), loc.function_name());
+            if (fmt.size() > 0) {
+                it = fmt::format_to(it, ": fmt='{}'", fmt);
             }
             return fmt::format_to(it, ": {}", ex);
         });

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -184,7 +184,17 @@ BOOST_AUTO_TEST_CASE(format_error_test) {
     l.set_ostream(log_msg);
 
     const char* fmt = "bad format string: {}";
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
+    // {fmt} v8.0 and up comes with compile-time format string checking, so
+    // malformed format_string passed to `logger.error(format_string, args)`
+    // can be identified at compile time. but a runtime variable passed to
+    // `logger.error(msg)` cannot be considered as a format string anymore
+    // when compiled with {fmt} v8.0 and up. so we have to test with a runtime
+    // format string here
+    l.error(fmt::runtime(fmt));
+#else
     l.error(fmt);
+#endif
 
     BOOST_TEST_MESSAGE(log_msg.str());
     BOOST_REQUIRE_NE(log_msg.str().find(__builtin_FILE()), std::string::npos);


### PR DESCRIPTION
[util/log, rpc, core: use compile-time formatting with fmtlib >= 8.0](https://github.com/scylladb/seastar/pull/1196/commits/6020f4e64388cbb9aeb9e5dbc3d5aeb7e0036dbe)

fmtlib v8.0.0 comes with compile-time formatting and more importantly,
compile-time format string checking.
see https://github.com/fmtlib/fmt/releases/tag/8.0.0 .

in order to take advantage of this feature, and keep the backward
compatiblity with following use cases::

1. Seastar applications which still need to compile with {fmt} < 8.0.0
2. Seastar applications which compile with {fmt} > 8.0.0, but still
   want to use runtime format strings without constructing the format
   string with `fmt::runtime()` explicitly.

a new option named `Seastar_LOGGER_COMPILE_TIME_FMT` is introduced. this
option is enabled by default if {fmt} >= 8.0.0. but applications can
still opt out of this by disabling this option explicitly. please note,
we intend to deprecate the implicit runtime format string in a future
API level.

in this change:

* util/log: templatize `format_info` so that
  - it can carry a templated `format_string` member variable.
  - it can be instantiate by specifying its type in the function
    accepting it as a parameter.
* util/log: use fmt::format_string<> for passing format string
* util/log: use type_identity<> so that the template arguments of
  logger::log() are not deduced. in other words, with type_identify,
  we ensure that the types are passed to the format_info::format_info
  as they are, without trying to convert them to fit the needs. this
  matches the behavior of {fmt}. and reduces the mental load of
  programmers.
* util/log: disable failed_to_log() handling, as the compile-time
  check is able to take care of the formatting failure at compile-time.
* tests/unit: disable format_error_test when compiling with fmtlib >=
  8.0
* util/log: change `log(log_level level, format_info fmt, Args&&... args)`
  to `log(log_level level, Fmt fmt, Args&&... args)`, so it won't be
  matched by the compiler when it tries to look up a function like

  ```c++
  seastar_logger.log(lvl,
  "IO queue uses {:.2f}ms latency goal for device {}",
  goal.count() * 1000, cfg.devid);
  ```
  without the change, both `void log(log_level level,
  fmt::format_string<Args...> fmt, Args&&... args)` and the old
  `void log(log_level level, format_info fmt, Args&&... args)`
  would be candidates of this call, and hence they are ambigous.
  with this change, if Seastar is compiled with fmt v8 and up,
  only the new API would be matched.

when compiling with fmtlib v9.0.0, we'd have following compiling
failure if the format string is malformed, like

 logger.trace("{}: failed ({})", e.what());

and the error message would look like:
```
../src/seastar-application.cc:181:15:   in ‘constexpr’ expansion of ‘fmt::v9::basic_format_string<char, const seastar::basic_sstring<char, unsigned int, 15, true>&>("{}: reap_sqes({})")’
../third-party/fmt/include/fmt/core.h:3116:40:   in ‘constexpr’ expansion of ‘fmt::v9::detail::parse_format_string<true, char, fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, seastar::$
../third-party/fmt/include/fmt/core.h:2658:44:   in ‘constexpr’ expansion of ‘fmt::v9::detail::parse_replacement_field<char, fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, seastar::ba$
../third-party/fmt/include/fmt/core.h:2623:51:   in ‘constexpr’ expansion of ‘(& handler)->fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, seastar::basic_sstring<char, unsigned int, 15$
../third-party/fmt/include/fmt/core.h:2928:70:   in ‘constexpr’ expansion of ‘((fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, seastar::basic_sstring<char, unsigned int, 15, true> >*)$
../third-party/fmt/include/fmt/core.h:742:40: error: ‘constexpr void fmt::v9::basic_format_parse_context<Char, ErrorHandler>::on_error(const char*) [with Char = char; ErrorHandler = fmt::v9::detail::error_handler]$
  742 |     if (id >= num_args_) this->on_error("argument not found");
      |                          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
../third-party/fmt/include/fmt/core.h:713:22: note: ‘constexpr void fmt::v9::basic_format_parse_context<Char, ErrorHandler>::on_error(const char*) [with Char = char; ErrorHandler = fmt::v9::detail::error_handler]’$
  713 |   FMT_CONSTEXPR void on_error(const char* message) {
      |                      ^~~~~~~~
../third-party/fmt/include/fmt/core.h:714:27: error: call to non-‘constexpr’ function ‘void fmt::v9::detail::error_handler::on_error(const char*)’
  714 |     ErrorHandler::on_error(message);
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../third-party/fmt/include/fmt/core.h:633:21: note: ‘void fmt::v9::detail::error_handler::on_error(const char*)’ declared here
  633 |   FMT_NORETURN void on_error(const char* message) {
      |                     ^~~~~~~~
```
when compiling with fmtlib v8.0.0, we have similar error messages.

please note, the formatter or the log writer could throw when the
formatted string is huge and results in out of memory. in that case,
we still want to print out minimum information of the logging message,
for instance, the source_location where the log is printed. in
existing implementation, this information is stored along with the
format string in `format_info`. but in the new implementataion we
don't have `format_info` anymore, as it would have to be a compile-time
constant. as an alternative, the backtrace is printed.