### PR TITLE
build: s/c-ares::c-ares/c-ares::cares/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,7 +745,7 @@ target_link_libraries (seastar
     Boost::boost
     Boost::program_options
     Boost::thread
-    c-ares::c-ares
+    c-ares::cares
     cryptopp::cryptopp
     fmt::fmt
     lz4::lz4

--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -51,10 +51,10 @@ find_package_handle_standard_args (c-ares
 set (c-ares_LIBRARIES ${c-ares_LIBRARY})
 set (c-ares_INCLUDE_DIRS ${c-ares_INCLUDE_DIR})
 
-if (c-ares_FOUND AND NOT (TARGET c-ares::c-ares))
-  add_library (c-ares::c-ares UNKNOWN IMPORTED)
+if (c-ares_FOUND AND NOT (TARGET c-ares::cares))
+  add_library (c-ares::cares UNKNOWN IMPORTED)
 
-  set_target_properties (c-ares::c-ares
+  set_target_properties (c-ares::cares
     PROPERTIES
       IMPORTED_LOCATION ${c-ares_LIBRARY}
       INTERFACE_INCLUDE_DIRECTORIES ${c-ares_INCLUDE_DIRS})


### PR DESCRIPTION
to be aligned with the c-ares upstream, which provides
c-ares-config.cmake in c-ares v1.17 and up. this cmake config file
is also packaged by fedora and CentOS stream in c-ares-devel-1.17.1 and
up.

without this change, if a Seastar application uses a third-party library
whose building system is implemented using CMake. and this library
also links against c-ares like
```cmake
find_package(c-ares REQUIRED)
target_link_libraries(foobar
  c-ares::cares)
```
as it expects the library name used by upstream. if the Seastar
application includes Seastar using `add_subdirectory(seastar)`.
the third-party library would fail to link against c-ares. because
Seastar already provides a `Findc-ares.cmake` which predates when
c-ares provides its own cmake config files. But the library names
defined by Seastar's `Findc-ares.cmake` and the one expected by the
third-party library are different, namely, `c-ares::c-ares` versus
`c-ares::cares`.

so in this change, all `c-ares::c-ares` are changed to `c-ares::ares`
to be aligned with the upstream.

we cannot remove `cmake/Findc-ares.cmake` from seastar yet, as we need
to support c-ares before 1.17.1, and not all popular distros package the
cmake config files provided by c-ares. some distros, like Debian sid and
Ubuntu jammy, do not package the cmake config files, even they do
package libc-ares-dev 1.18.1 at the time of writing.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>