### PR TITLE
dns: dns_resolver: sock_entry: move-construct tcp/udp entries in place

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -921,10 +921,10 @@ private:
             e.typ = type::none;
             switch (typ) {
             case type::tcp:
-                tcp = std::move(e.tcp);
+                new (&tcp) tcp_entry(std::move(e.tcp));
                 break;
             case type::udp:
-                udp = std::move(e.udp);
+                new (&udp) udp_entry(std::move(e.udp));
                 break;
             default:
                 break;


### PR DESCRIPTION
They are uninitialized so they might contain junk.
We can't just move-assign them since it may try to delete
a junk ptr.

Fixes #1197

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>