### PR TITLE
httpd: add a ctor without addr parameter

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -75,8 +75,10 @@ class connection : public boost::intrusive::list_base_hook<> {
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
 public:
+    [[deprecated("use connection(http_server&, connected_socket&&)")]]
     connection(http_server& server, connected_socket&& fd,
-            socket_address addr)
+            socket_address) : connection(server, std::move(fd)) {}
+    connection(http_server& server, connected_socket&& fd)
             : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
                     _fd.output()) {
         on_new_connection();


### PR DESCRIPTION
`addr` parameter is not used, and compiler complains at seeing
unused parameter.

in this change

* the `addr` parameter of `seastar::httpd::connection::connection()`
  is removed. this silences the compiler warning.
* a new ctor for `httpd::connection` is added. so we can encourage
  new application can start using the ctor without the unused parameter.
* a [[deprecated]] attribute is added to the ctor with the `addr`
  parameter. so developers which compiles Seastar applications using
  the old ctor can be switch to the new one.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>