### PR TITLE
shared_ptr_debug_helper: turn assert into on_internal_error_abort

### DIFF
--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -54,4 +54,11 @@ bool set_abort_on_internal_error(bool do_abort) noexcept;
 /// in noexcept contexts like destructors or noexcept functions.
 void on_internal_error_noexcept(logger& logger, std::string_view reason) noexcept;
 
+/// Report an internal error and abort unconditionally
+///
+/// The error will be logged to \logger and the program will be aborted,
+/// regardless of the abort_on_internal_error setting.
+/// This overload can be used to replace assert().
+[[noreturn]] void on_fatal_internal_error(logger& logger, std::string_view reason) noexcept;
+
 }

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -33,9 +33,13 @@ bool seastar::set_abort_on_internal_error(bool do_abort) noexcept {
     return abort_on_internal_error.exchange(do_abort);
 }
 
+static void log_error_and_backtrace(logger& logger, std::string_view msg) noexcept {
+    logger.error("{}, at: {}", msg, current_backtrace());
+}
+
 void seastar::on_internal_error(logger& logger, std::string_view msg) {
     if (abort_on_internal_error.load()) {
-        logger.error("{}, at: {}", msg, current_backtrace());
+        log_error_and_backtrace(logger, msg);
         abort();
     } else {
         logger.error(msg);
@@ -53,13 +57,13 @@ void seastar::on_internal_error(logger& logger, std::exception_ptr ex) {
 }
 
 void seastar::on_internal_error_noexcept(logger& logger, std::string_view msg) noexcept {
-    logger.error("{}, at: {}", msg, current_backtrace());
+    log_error_and_backtrace(logger, msg);
     if (abort_on_internal_error.load()) {
         abort();
     }
 }
 
 void seastar::on_fatal_internal_error(logger& logger, std::string_view msg) noexcept {
-    logger.error("{}, at: {}", msg, current_backtrace());
+    log_error_and_backtrace(logger, msg);
     abort();
 }

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -58,3 +58,8 @@ void seastar::on_internal_error_noexcept(logger& logger, std::string_view msg) n
         abort();
     }
 }
+
+void seastar::on_fatal_internal_error(logger& logger, std::string_view msg) noexcept {
+    logger.error("{}, at: {}", msg, current_backtrace());
+    abort();
+}


### PR DESCRIPTION
Add `on_internal_error_abort` that prints the internal error log message and aborts unconditionally.

It allows the caller to log more information than what would have been printed just from the failed assert.

In addition, use it in the `shared_ptr_debug_helper` to replace the assert call, that is not useful in debug runs since the address sanitizer obfuscates the assert backtrace.

Fixes #1095