### PR TITLE
[RFC] net: close objects before they are destroyed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,14 +64,14 @@ option (Seastar_SSTRING
   ON)
 
 set (Seastar_API_LEVEL
-  "6"
+  "7"
   CACHE
   STRING
-  "Seastar compatibility API level (2=server_socket::accept() returns accept_result, 3=make_file_output_stream(), make_file_data_sink() returns future<...>, 4=when_all_succeed returns future<std::tuple<>>, 5=future<T>::get() returns T&&), 6=future is not variadic")
+  "Seastar compatibility API level (2=server_socket::accept() returns accept_result, 3=make_file_output_stream(), make_file_data_sink() returns future<...>, 4=when_all_succeed returns future<std::tuple<>>, 5=future<T>::get() returns T&&), 6=future is not variadic, 7=net classes require close")
 
 set_property (CACHE Seastar_API_LEVEL
   PROPERTY
-  STRINGS 2 3 4 5 6)
+  STRINGS 2 3 4 5 6 7)
 
 set (Seastar_SCHEDULING_GROUPS_COUNT
   "16"

--- a/configure.py
+++ b/configure.py
@@ -64,8 +64,8 @@ arg_parser.add_argument('--ldflags', action = 'store', dest = 'user_ldflags', de
                         help = 'Extra flags for the linker')
 arg_parser.add_argument('--optflags', action = 'store', dest = 'user_optflags', default = '',
                         help = 'Extra optimization flags for the release mode')
-arg_parser.add_argument('--api-level', action='store', dest='api_level', default='6',
-                        help='Compatibility API level (6=latest)')
+arg_parser.add_argument('--api-level', action='store', dest='api_level', default='7',
+                        help='Compatibility API level (7=latest)')
 arg_parser.add_argument('--compiler', action = 'store', dest = 'cxx', default = 'g++',
                         help = 'C++ compiler path')
 arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc',

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1985,7 +1985,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = SEASTAR_API_LEVEL=6
+PREDEFINED             = SEASTAR_API_LEVEL=7
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -26,6 +26,12 @@
 #define SEASTAR_API_LEVEL 3
 #endif
 
+#if SEASTAR_API_LEVEL == 7
+#define SEASTAR_INCLUDE_API_V7 inline
+#else
+#define SEASTAR_INCLUDE_API_V7
+#endif
+
 #if SEASTAR_API_LEVEL == 6
 #define SEASTAR_INCLUDE_API_V6 inline
 #else
@@ -77,6 +83,11 @@ namespace seastar {
     SEASTAR_INCLUDE_API_V6 namespace api_v6 {
         inline namespace and_newer {
             using namespace api_v5::and_newer;
+        }
+    }
+    SEASTAR_INCLUDE_API_V7 namespace api_v7 {
+        inline namespace and_newer {
+            using namespace api_v6::and_newer;
         }
     }
 }

--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -54,4 +54,11 @@ bool set_abort_on_internal_error(bool do_abort) noexcept;
 /// in noexcept contexts like destructors or noexcept functions.
 void on_internal_error_noexcept(logger& logger, std::string_view reason) noexcept;
 
+/// Report an internal error and abort unconditionally
+///
+/// The error will be logged to \logger and the program will be aborted,
+/// regardless of the abort_on_internal_error setting.
+/// This overload can be used to replace assert().
+void on_fatal_internal_error(logger& logger, std::string_view reason) noexcept;
+
 }

--- a/include/seastar/core/shared_ptr_debug_helper.hh
+++ b/include/seastar/core/shared_ptr_debug_helper.hh
@@ -25,8 +25,13 @@
 
 #include <thread>
 #include <cassert>
+#include <fmt/format.h>
+
+#include <seastar/core/on_internal_error.hh>
 
 namespace seastar {
+
+extern logger seastar_logger;
 
 // A counter that is only comfortable being incremented on the cpu
 // it was created on.  Useful for verifying that a shared_ptr
@@ -60,7 +65,9 @@ public:
     }
 private:
     void check() const {
-        assert(_cpu == std::this_thread::get_id());
+        if (__builtin_expect(_cpu != std::this_thread::get_id(), false)) {
+            on_fatal_internal_error(seastar_logger, "shared_ptr accessed on non-owner cpu");
+        }
     }
 };
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -83,6 +83,7 @@ class connection : public list_base_hook {
     bool _done = false;
 public:
     connection(http_server& server, connected_socket&& fd);
+    connection(connection&& c) noexcept;
     ~connection();
     void on_new_connection();
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -132,6 +132,8 @@ public:
     future<> write_body();
 
     output_stream<char>& out();
+
+    future<> close() noexcept;
 };
 
 class http_server_tester;

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -82,11 +82,7 @@ class connection : public list_base_hook {
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
 public:
-    connection(http_server& server, connected_socket&& fd)
-            : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
-                    _fd.output()) {
-        on_new_connection();
-    }
+    connection(http_server& server, connected_socket&& fd);
     ~connection();
     void on_new_connection();
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -82,9 +82,12 @@ class connection : public list_base_hook {
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
 public:
-    connection(http_server& server, connected_socket&& fd);
+    connection(http_server& server, connected_socket&& fd, input_stream<char>&& read_buf, output_stream<char>&& write_buf) noexcept;
     connection(connection&& c) noexcept;
     ~connection();
+
+    static future<std::unique_ptr<connection>> make_connection(http_server& server, connected_socket&& fd) noexcept;
+
     void on_new_connection();
 
     future<> process();

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -82,8 +82,7 @@ class connection : public list_base_hook {
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
 public:
-    connection(http_server& server, connected_socket&& fd,
-            socket_address addr)
+    connection(http_server& server, connected_socket&& fd)
             : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
                     _fd.output()) {
         on_new_connection();

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -61,7 +61,14 @@ public:
     http_stats(http_server& server, const sstring& name);
 };
 
-class connection : public boost::intrusive::list_base_hook<> {
+using list_base_hook = boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
+
+using connections_list_type = boost::intrusive::list<
+        connection,
+        boost::intrusive::base_hook<list_base_hook>,
+        boost::intrusive::constant_time_size<false>>;
+
+class connection : public list_base_hook {
     http_server& _server;
     connected_socket _fd;
     input_stream<char> _read_buf;
@@ -202,7 +209,7 @@ public:
     static sstring http_date();
 private:
     future<> do_accept_one(int which);
-    boost::intrusive::list<connection> _connections;
+    connections_list_type _connections;
     friend class seastar::httpd::connection;
     friend class http_server_tester;
 };

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -243,6 +243,10 @@ public:
     explicit operator bool() const noexcept {
         return static_cast<bool>(_csi);
     }
+    /// Wait on any async activity.
+    ///
+    /// Must be called before destroying the \c connected_socket.
+    future<> close() noexcept;
 };
 /// @}
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -143,6 +143,10 @@ class network_interface_impl;
 
 class connected_socket;
 
+namespace rpc {
+class client;
+}
+
 /// \endcond
 
 /// The seastar socket.
@@ -182,6 +186,7 @@ private:
     const net::socket_impl* impl() const noexcept;
 
     friend class connected_socket;
+    friend class rpc::client;
 };
 
 /// Configuration for buffered connected_socket input operations
@@ -297,6 +302,7 @@ protected:
     void set_socket(socket&& s) noexcept;
 
     friend class network_stack;
+    friend class rpc::client;
 };
 /// @}
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -139,6 +139,47 @@ class network_interface_impl;
 /// \addtogroup networking-module
 /// @{
 
+/// \cond internal
+
+class connected_socket;
+
+/// \endcond
+
+/// The seastar socket.
+///
+/// A \c socket that allows a connection to be established between
+/// two endpoints.
+class socket {
+    std::unique_ptr<net::socket_impl> _si;
+public:
+    socket() noexcept = default;
+    ~socket();
+
+    /// \cond internal
+    explicit socket(std::unique_ptr<net::socket_impl> si) noexcept;
+    /// \endcond
+    /// Moves a \c seastar::socket object.
+    socket(socket&&) noexcept;
+    /// Move-assigns a \c seastar::socket object.
+    socket& operator=(socket&&) noexcept;
+
+    /// Attempts to establish the connection.
+    ///
+    /// \return a \ref connected_socket representing the connection.
+    future<connected_socket> connect(socket_address sa, socket_address local = {}, transport proto = transport::TCP);
+
+    /// Sets SO_REUSEADDR option (enable reuseaddr option on a socket)
+    void set_reuseaddr(bool reuseaddr);
+    /// Gets O_REUSEADDR option
+    /// \return whether the reuseaddr option is enabled or not
+    bool get_reuseaddr() const;
+    /// Stops any in-flight connection attempt.
+    ///
+    /// Cancels the connection attempt if it's still in progress, and
+    /// terminates the connection if it has already been established.
+    void shutdown();
+};
+
 /// Configuration for buffered connected_socket input operations
 ///
 /// This structure allows tuning of buffered input operations done via
@@ -248,46 +289,6 @@ public:
     /// Must be called before destroying the \c connected_socket.
     future<> close() noexcept;
 };
-/// @}
-
-/// \addtogroup networking-module
-/// @{
-
-/// The seastar socket.
-///
-/// A \c socket that allows a connection to be established between
-/// two endpoints.
-class socket {
-    std::unique_ptr<net::socket_impl> _si;
-public:
-    socket() noexcept = default;
-    ~socket();
-
-    /// \cond internal
-    explicit socket(std::unique_ptr<net::socket_impl> si) noexcept;
-    /// \endcond
-    /// Moves a \c seastar::socket object.
-    socket(socket&&) noexcept;
-    /// Move-assigns a \c seastar::socket object.
-    socket& operator=(socket&&) noexcept;
-
-    /// Attempts to establish the connection.
-    ///
-    /// \return a \ref connected_socket representing the connection.
-    future<connected_socket> connect(socket_address sa, socket_address local = {}, transport proto = transport::TCP);
-
-    /// Sets SO_REUSEADDR option (enable reuseaddr option on a socket)
-    void set_reuseaddr(bool reuseaddr);
-    /// Gets O_REUSEADDR option
-    /// \return whether the reuseaddr option is enabled or not
-    bool get_reuseaddr() const;
-    /// Stops any in-flight connection attempt.
-    ///
-    /// Cancels the connection attempt if it's still in progress, and
-    /// terminates the connection if it has already been established.
-    void shutdown();
-};
-
 /// @}
 
 /// \addtogroup networking-module

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -182,6 +182,10 @@ public:
     /// Cancels the connection attempt if it's still in progress, and
     /// terminates the connection if it has already been established.
     void shutdown();
+    /// Wait on any async activity.
+    ///
+    /// Must be called before destroying the \c socket.
+    future<> close() noexcept;
 private:
     const net::socket_impl* impl() const noexcept;
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -178,6 +178,10 @@ public:
     /// Cancels the connection attempt if it's still in progress, and
     /// terminates the connection if it has already been established.
     void shutdown();
+private:
+    const net::socket_impl* impl() const noexcept;
+
+    friend class connected_socket;
 };
 
 /// Configuration for buffered connected_socket input operations
@@ -212,6 +216,7 @@ struct session_dn {
 class connected_socket {
     friend class net::get_impl;
     std::unique_ptr<net::connected_socket_impl> _csi;
+    socket _socket;  // For auto-closing the socket_impl passed down from the network_stack
 public:
     /// Constructs a \c connected_socket not corresponding to a connection
     connected_socket() noexcept;
@@ -288,6 +293,10 @@ public:
     ///
     /// Must be called before destroying the \c connected_socket.
     future<> close() noexcept;
+protected:
+    void set_socket(socket&& s) noexcept;
+
+    friend class network_stack;
 };
 /// @}
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -358,6 +358,10 @@ public:
     explicit operator bool() const noexcept {
         return static_cast<bool>(_ssi);
     }
+
+    /// Close the server_socket
+    /// Waits on all asynchronous fibers to complete.
+    future<> close() noexcept;
 };
 
 /// @}

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -152,6 +152,7 @@ public:
     socket_address local_address() const override {
         return _sa;
     }
+    virtual future<> close() noexcept override { return make_ready_future<>(); }
     static void move_connected_socket(int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::pmr::polymorphic_allocator<char>* allocator);
 
     template <typename T>
@@ -173,6 +174,7 @@ public:
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     virtual socket_address local_address() const override;
+    virtual future<> close() noexcept override { return make_ready_future<>(); }
 };
 
 class posix_reuseport_server_socket_impl : public server_socket_impl {
@@ -186,6 +188,7 @@ public:
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     virtual socket_address local_address() const override;
+    virtual future<> close() noexcept override { return make_ready_future<>(); }
 };
 
 class posix_network_stack : public network_stack {

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -61,6 +61,11 @@ public:
     virtual void set_reuseaddr(bool reuseaddr) = 0;
     virtual bool get_reuseaddr() const = 0;
     virtual void shutdown() = 0;
+#if SEASTAR_API_LEVEL >= 7
+    virtual future<> close() noexcept = 0;
+#else
+    virtual future<> close() noexcept { return make_ready_future<>(); }
+#endif
 };
 
 

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -65,6 +65,11 @@ public:
     virtual future<accept_result> accept() = 0;
     virtual void abort_accept() = 0;
     virtual socket_address local_address() const = 0;
+#if SEASTAR_API_LEVEL >= 7
+    virtual future<> close() noexcept = 0;
+#else
+    virtual future<> close() noexcept { return make_ready_future<>(); }
+#endif
 };
 
 class udp_channel_impl {

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -47,6 +47,11 @@ public:
     virtual void set_sockopt(int level, int optname, const void* data, size_t len) = 0;
     virtual int get_sockopt(int level, int optname, void* data, size_t len) const = 0;
     virtual socket_address local_address() const noexcept = 0;
+#if SEASTAR_API_LEVEL >= 7
+    virtual future<> close() noexcept = 0;
+#else
+    virtual future<> close() noexcept { return make_ready_future<>(); }
+#endif
 };
 
 class socket_impl {

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -612,6 +612,7 @@ public:
     server(protocol_base* proto, server_options opts, const socket_address& addr, resource_limits memory_limit = resource_limits());
     server(protocol_base* proto, server_socket, resource_limits memory_limit = resource_limits(), server_options opts = server_options{});
     server(protocol_base* proto, server_options opts, server_socket, resource_limits memory_limit = resource_limits());
+    ~server();
     void accept();
     future<> stop();
     template<typename Func>

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -523,7 +523,7 @@ public:
             c->_parent = this->weak_from_this();
             c->_is_stream = true;
             return c->await_connection().then([c, this] {
-                auto s = make_lw_shared(make_foreign(static_pointer_cast<rpc::connection>(c)));
+                auto s = make_lw_shared(xshard_connection_ptr(static_pointer_cast<rpc::connection>(c)));
                 this->register_stream(c->get_connection_id(), s);
                 return sink<Out...>(make_shared<sink_impl<Serializer, Out...>>(std::move(s)));
             }).handle_exception([c] (std::exception_ptr eptr) {

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -502,8 +502,8 @@ public:
     void wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel);
     void wait_timed_out(id_type id);
     future<> stop() noexcept;
-    void abort_all_streams();
-    void deregister_this_stream();
+    future<> abort_all_streams();
+    future<> deregister_this_stream();
     socket_address peer_address() const override {
         return _server_addr;
     }
@@ -542,6 +542,10 @@ public:
     template<typename Serializer, typename... Out>
     future<sink<Out...>> make_stream_sink() {
         return make_stream_sink<Serializer, Out...>(make_socket());
+    }
+    template<typename Serializer, typename... Out>
+    future<sink<Out...>> close() noexcept {
+        return rpc::connection::stop();
     }
 };
 

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -241,7 +241,7 @@ protected:
     bool _error = false;
     bool _connected = false;
     std::optional<shared_promise<>> _negotiated = shared_promise<>();
-    promise<> _stopped;
+    promise<> _done;
     stats _stats;
     const logger& _logger;
     // The owner of the pointer below is an instance of rpc::protocol<typename Serializer> class.

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -241,7 +241,7 @@ protected:
     bool _error = false;
     bool _connected = false;
     std::optional<shared_promise<>> _negotiated = shared_promise<>();
-    promise<> _done;
+    shared_promise<> _done;
     stats _stats;
     const logger& _logger;
     // The owner of the pointer below is an instance of rpc::protocol<typename Serializer> class.

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -293,6 +293,8 @@ protected:
     // the future holds if sink is already closed
     // if it is not ready it means the sink is been closed
     future<bool> _sink_closed_future = make_ready_future<bool>(false);
+    bool _stopping = false;
+    shared_promise<> _stop_done;
 
     size_t outgoing_queue_length() const noexcept {
         return _outgoing_queue_size;
@@ -457,6 +459,8 @@ private:
     socket_address _server_addr, _local_addr;
     client_options _options;
     weak_ptr<client> _parent; // for stream clients
+    bool _stopping = false;
+    shared_promise<> _stop_done;
 
 private:
     future<> negotiate_protocol(input_stream<char>& in);

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -265,7 +265,7 @@ constexpr connection_id invalid_connection_id = connection_id::make_invalid_id()
 
 std::ostream& operator<<(std::ostream&, const connection_id&);
 
-using xshard_connection_ptr = lw_shared_ptr<foreign_ptr<shared_ptr<connection>>>;
+using xshard_connection_ptr = foreign_ptr<shared_ptr<connection>>;
 constexpr size_t max_queued_stream_buffers = 50;
 constexpr size_t max_stream_buffers_memory = 100 * 1024;
 
@@ -278,10 +278,10 @@ class sink {
 public:
     class impl {
     protected:
-        xshard_connection_ptr _con;
+        lw_shared_ptr<xshard_connection_ptr> _con;
         semaphore _sem;
         std::exception_ptr _ex;
-        impl(xshard_connection_ptr con) : _con(std::move(con)), _sem(max_stream_buffers_memory) {}
+        impl(lw_shared_ptr<xshard_connection_ptr> con) : _con(std::move(con)), _sem(max_stream_buffers_memory) {}
     public:
         virtual ~impl() {};
         virtual future<> operator()(const Out&... args) = 0;
@@ -317,9 +317,9 @@ class source {
 public:
     class impl {
     protected:
-        xshard_connection_ptr _con;
+        lw_shared_ptr<xshard_connection_ptr> _con;
         circular_buffer<foreign_ptr<std::unique_ptr<rcv_buf>>> _bufs;
-        impl(xshard_connection_ptr con) : _con(std::move(con)) {
+        impl(lw_shared_ptr<xshard_connection_ptr> con) : _con(std::move(con)) {
             _bufs.reserve(max_queued_stream_buffers);
         }
     public:

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -250,6 +250,7 @@ class connection : public list_base_hook {
     sstring _subprotocol;
     handler_t _handler;
     bool _shutdown = false;
+    gate _gate;
 public:
     connection(server& server, connected_socket&& fd,
             input_stream<char>&& read_buf, output_stream<char>&& write_buf,

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -254,20 +254,7 @@ public:
      * \param server owning \ref server
      * \param fd established socket used for communication
      */
-    connection(server& server, connected_socket&& fd)
-        : _server(server)
-        , _fd(std::move(fd))
-        , _read_buf(_fd.input())
-        , _write_buf(_fd.output())
-        , _input_buffer{PIPE_SIZE}
-        , _output_buffer{PIPE_SIZE}
-    {
-        _input = input_stream<char>{data_source{
-                std::make_unique<connection_source_impl>(&_input_buffer)}};
-        _output = output_stream<char>{data_sink{
-                std::make_unique<connection_sink_impl>(&_output_buffer)}};
-        on_new_connection();
-    }
+    connection(server& server, connected_socket&& fd);
     connection(connection&&) = default;
     ~connection();
 

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -305,6 +305,7 @@ class server {
     future<> _accept_fut = make_ready_future<>();
     bool _stopped = false;
 public:
+    ~server();
     /*!
      * \brief listen for a WebSocket connection on given address
      * \param addr address to listen on

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -249,6 +249,7 @@ class connection : public list_base_hook {
 
     sstring _subprotocol;
     handler_t _handler;
+    bool _shutdown = false;
 public:
     connection(server& server, connected_socket&& fd,
             input_stream<char>&& read_buf, output_stream<char>&& write_buf,

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -58,3 +58,8 @@ void seastar::on_internal_error_noexcept(logger& logger, std::string_view msg) n
         abort();
     }
 }
+
+void seastar::on_fatal_internal_error(logger& logger, std::string_view msg) noexcept {
+    set_abort_on_internal_error(true);
+    on_internal_error_noexcept(logger, msg);
+}

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -137,6 +137,15 @@ future<> connection::start_response() {
     });
 }
 
+connection::connection(http_server& server, connected_socket&& fd)
+        : _server(server)
+        , _fd(std::move(fd))
+        , _read_buf(_fd.input())
+        , _write_buf(_fd.output())
+{
+    on_new_connection();
+}
+
 connection::~connection() {
     --_server._current_connections;
     this->unlink();

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -503,7 +503,7 @@ future<> http_server::do_accepts(int which) {
 
 future<> http_server::do_accept_one(int which) {
     return _listeners[which].accept().then([this] (accept_result ar) mutable {
-        auto conn = std::make_unique<connection>(*this, std::move(ar.connection), std::move(ar.remote_address));
+        auto conn = std::make_unique<connection>(*this, std::move(ar.connection));
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().handle_exception([conn = std::move(conn)] (std::exception_ptr ex) {
                 hlogger.error("request error: {}", ex);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -146,6 +146,14 @@ connection::connection(http_server& server, connected_socket&& fd)
     on_new_connection();
 }
 
+connection::connection(connection&& c) noexcept
+        : _server(c._server)
+        , _fd(std::move(c._fd))
+        , _read_buf(std::move(c._read_buf))
+        , _write_buf(std::move(c._write_buf))
+{
+}
+
 connection::~connection() {
     --_server._current_connections;
     this->unlink();

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -139,7 +139,7 @@ future<> connection::start_response() {
 
 connection::~connection() {
     --_server._current_connections;
-    _server._connections.erase(_server._connections.iterator_to(*this));
+    this->unlink();
 }
 
 bool connection::url_decode(const std::string_view& in, sstring& out) {

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -921,10 +921,10 @@ private:
             e.typ = type::none;
             switch (typ) {
             case type::tcp:
-                tcp = std::move(e.tcp);
+                new (&tcp) tcp_entry(std::move(e.tcp));
                 break;
             case type::udp:
-                udp = std::move(e.udp);
+                new (&udp) udp_entry(std::move(e.udp));
                 break;
             default:
                 break;

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -518,10 +518,14 @@ private:
         ++e.pending;
     }
     void release(ares_socket_t fd) {
-        auto& e = _sockets.at(fd);
+        auto it = _sockets.find(fd);
+        if (it == _sockets.end()) {
+            throw std::out_of_range(format("socket fd {} not found", fd));
+        }
+        auto& e = it->second;
         dns_log.trace("Release socket {} -> {}", fd, e.pending -  1);
         if (--e.pending < 0) {
-            _sockets.erase(fd);
+            _sockets.erase(it);
             dns_log.trace("Released socket {}", fd);
         }
         _gate.leave();

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -145,6 +145,11 @@ public:
             _conn->shutdown_connect();
         }
     }
+
+    virtual future<> close() noexcept override {
+        // FIXME: close _conn
+        return make_ready_future<>();
+    }
 };
 
 template <typename Protocol>

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -105,6 +105,7 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const override;
     void set_sockopt(int level, int optname, const void* data, size_t len) override;
     socket_address local_address() const noexcept override;
+    virtual future<> close() noexcept override;
 };
 
 template <typename Protocol>
@@ -269,6 +270,12 @@ int native_connected_socket_impl<Protocol>::get_sockopt(int level, int optname, 
 template<typename Protocol>
 socket_address native_connected_socket_impl<Protocol>::local_address() const noexcept {
     return {_conn->local_ip(), _conn->local_port()};
+}
+
+template<typename Protocol>
+future<> native_connected_socket_impl<Protocol>::close() noexcept {
+    // FIMME: close Protocol::connection
+    return make_ready_future<>();
 }
 
 }

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -48,6 +48,7 @@ public:
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     virtual socket_address local_address() const override;
+    virtual future<> close() noexcept override { return make_ready_future<>(); }
 };
 
 template <typename Protocol>

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -474,6 +474,13 @@ public:
             }
         }
     }
+
+    virtual future<> close() noexcept override {
+        if (_fd) {
+            _fd.close();
+        }
+        return make_ready_future<>();
+    }
 };
 
 future<accept_result>

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -266,6 +266,7 @@ public:
     socket_address local_address() const noexcept override {
         return _ops->local_address(_fd.get_file_desc());
     }
+    virtual future<> close() noexcept override { return make_ready_future<>(); }
 
     friend class posix_server_socket_impl;
     friend class posix_ap_server_socket_impl;

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -170,12 +170,14 @@ socket_address connected_socket::local_address() const noexcept {
 }
 
 void connected_socket::shutdown_output() {
+    _socket.shutdown();
     if (_csi) {
         _csi->shutdown_output();
     }
 }
 
 void connected_socket::shutdown_input() {
+    _socket.shutdown();
     if (_csi) {
         _csi->shutdown_input();
     }
@@ -190,6 +192,7 @@ future<> connected_socket::close() noexcept {
 }
 
 void connected_socket::set_socket(socket&& s) noexcept {
+    seastar_logger.debug("connected_socket {} set_socket {}, at {}", fmt::ptr(this), fmt::ptr(&s), current_backtrace());
     _socket = std::move(s);
 }
 
@@ -223,7 +226,9 @@ bool socket::get_reuseaddr() const {
 }
 
 void socket::shutdown() {
+  if (_si) {
     _si->shutdown();
+  }
 }
 
 const net::socket_impl* socket::impl() const noexcept {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1474,14 +1474,8 @@ public:
             // running in background. try to bye-handshake us nicely, but after 10s we forcefully close.
             (void)with_timeout(timer<>::clock::now() + std::chrono::seconds(10), shutdown()).finally([this] {
                 _eof = true;
-                try {
                     (void)_in.close().handle_exception([](std::exception_ptr) {}); // should wake any waiters
-                } catch (...) {
-                }
-                try {
                     (void)_out.close().handle_exception([](std::exception_ptr) {});
-                } catch (...) {
-                }
                 // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
                 // handshake aqcuire, because in worst case, we get here while a reader is attempting
                 // re-handshake.

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1693,6 +1693,9 @@ public:
     socket_address local_address() const override {
         return _sock.local_address();
     }
+    future<> close() noexcept override {
+        return _sock.close();
+    }
 private:
 
     shared_ptr<server_credentials> _creds;

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1825,6 +1825,9 @@ public:
     virtual void shutdown() override {
         _socket.shutdown();
     }
+    virtual future<> close() noexcept override {
+        return _socket.close();
+    }
 };
 
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1502,19 +1502,19 @@ public:
             // FIXME: this should be an internal error
             return;
         }
-        // FIXME: return future<>, indentation
-            auto me = shared_from_this();
-            shutdown();
-            (void)wait_for_shutdown().finally([this] {
-                // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
-                // handshake aqcuire, because in worst case, we get here while a reader is attempting
-                // re-handshake.
-                return with_semaphore(_in_sem, 1, [this] {
-                    return with_semaphore(_out_sem, 1, [] {});
-                });
-            }).then_wrapped([me = std::move(me)](future<> f) { // must keep object alive until here.
-                f.ignore_ready_future();
+        // FIXME: return future<>
+        auto me = shared_from_this();
+        shutdown();
+        (void)wait_for_shutdown().finally([this] {
+            // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
+            // handshake aqcuire, because in worst case, we get here while a reader is attempting
+            // re-handshake.
+            return with_semaphore(_in_sem, 1, [this] {
+                return with_semaphore(_out_sem, 1, [] {});
             });
+        }).then_wrapped([me = std::move(me)](future<> f) { // must keep object alive until here.
+            f.ignore_ready_future();
+        });
     }
     // helper for sink
     future<> flush() noexcept {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1163,7 +1163,8 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
           parallel_for_each(_conns | boost::adaptors::map_values, [] (shared_ptr<connection> conn) {
               return conn->stop();
           }),
-          _reply_gate.close()
+          _reply_gate.close(),
+          _ss.close()
       ).discard_result();
   }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -326,7 +326,7 @@ namespace rpc {
       } catch (...) {
           log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
       }
-      return _done.get_future();
+      return _done.get_shared_future();
   }
 
   template<typename Connection>
@@ -698,7 +698,7 @@ namespace rpc {
       } catch(...) {
           log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
       }
-      return _done.get_future();
+      return _done.get_shared_future();
   }
 
   void client::abort_all_streams() {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -584,11 +584,11 @@ namespace rpc {
       });
   }
 
-  void connection::register_stream(connection_id id, xshard_connection_ptr c) {
+  void connection::register_stream(connection_id id, lw_shared_ptr<xshard_connection_ptr> c) {
       _streams.emplace(id, std::move(c));
   }
 
-  xshard_connection_ptr connection::get_stream(connection_id id) const {
+  lw_shared_ptr<xshard_connection_ptr> connection::get_stream(connection_id id) const {
       auto it = _streams.find(id);
       if (it == _streams.end()) {
           throw std::logic_error(format("rpc stream id {} not found", id).c_str());

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -372,11 +372,7 @@ future<> connection::read_one() {
 future<> connection::read_loop() {
     return read_http_upgrade_request().then([this] {
         return when_all_succeed(
-            _handler(_input, _output).handle_exception([this] (std::exception_ptr e) mutable {
-                return _read_buf.close().then([e = std::move(e)] () mutable {
-                    return make_exception_future<>(std::move(e));
-                });
-            }),
+            _handler(_input, _output),
             do_until([this] {return _done;}, [this] {return read_one();})
         ).discard_result();
     }).finally([this] {

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -20,6 +20,7 @@
  */
 
 #include "seastar/core/future.hh"
+#include "seastar/util/backtrace.hh"
 #include <exception>
 #include <seastar/websocket/server.hh>
 #include <seastar/util/log.hh>
@@ -437,9 +438,11 @@ future<> connection::response_loop() {
 }
 
 void connection::shutdown() {
-    wlogger.debug("Shutting down");
+  if (!std::exchange(_shutdown, true)) {
+    wlogger.debug("Shutting down {}, at {}", fmt::ptr(this), current_backtrace());
     _fd.shutdown_input();
     _fd.shutdown_output();
+  }
 }
 
 future<> connection::close() {

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -11,6 +11,7 @@ using namespace net;
 SEASTAR_THREAD_TEST_CASE(test_connection_attempt_is_shutdown) {
     ipv4_addr server_addr("172.16.0.1");
     auto unconn = make_socket();
+    auto close_unc = deferred_close(unconn);
     auto f = unconn.connect(make_ipv4_address(server_addr));
     unconn.shutdown();
     BOOST_REQUIRE_THROW(f.get(), std::exception);
@@ -26,6 +27,7 @@ SEASTAR_THREAD_TEST_CASE(test_unconnected_socket_shutsdown_established_connectio
     auto close_listener = deferred_close(listener);
     auto f = listener.accept();
     auto unconn = make_socket();
+    auto close_unc = deferred_close(unconn);
     auto conn = unconn.connect(sa).get();
     auto close_conn = deferred_close(conn);
     unconn.shutdown();

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -22,13 +22,12 @@ SEASTAR_THREAD_TEST_CASE(test_unconnected_socket_shutsdown_established_connectio
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
     auto listener = engine().net().listen(sa, listen_options());
-    // FIXME: indentation
-        auto f = listener.accept();
-        auto unconn = make_socket();
-        auto conn = unconn.connect(sa).get();
-            unconn.shutdown();
-            auto out = conn.output(1);
-            BOOST_REQUIRE_THROW(out.write("ping").get(), std::exception);
+    auto f = listener.accept();
+    auto unconn = make_socket();
+    auto conn = unconn.connect(sa).get();
+    unconn.shutdown();
+    auto out = conn.output(1);
+    BOOST_REQUIRE_THROW(out.write("ping").get(), std::exception);
     f.get();
 }
 
@@ -37,16 +36,15 @@ SEASTAR_THREAD_TEST_CASE(test_accept_after_abort) {
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
     auto listener = engine().net().listen(sa, listen_options());
-    // FIXME: indentation
-        using ftype = future<accept_result>;
-        promise<ftype> p;
-        future<ftype> done = p.get_future();
-        auto f = listener.accept().then_wrapped([&listener, p = std::move(p)] (auto f) mutable {
-            f.ignore_ready_future();
-            p.set_value(listener.accept());
-        });
-        listener.abort_accept();
-        ftype done_fut = done.get();
-        BOOST_REQUIRE_THROW(done_fut.get(), std::exception);
+    using ftype = future<accept_result>;
+    promise<ftype> p;
+    future<ftype> done = p.get_future();
+    auto f = listener.accept().then_wrapped([&listener, p = std::move(p)] (auto f) mutable {
+        f.ignore_ready_future();
+        p.set_value(listener.accept());
+    });
+    listener.abort_accept();
+    ftype done_fut = done.get();
+    BOOST_REQUIRE_THROW(done_fut.get(), std::exception);
     f.get();
 }

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -3,6 +3,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/net/ip.hh>
+#include <seastar/util/closeable.hh>
 
 using namespace seastar;
 using namespace net;
@@ -22,6 +23,7 @@ SEASTAR_THREAD_TEST_CASE(test_unconnected_socket_shutsdown_established_connectio
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
     auto listener = engine().net().listen(sa, listen_options());
+    auto close_listener = deferred_close(listener);
     auto f = listener.accept();
     auto unconn = make_socket();
     auto conn = unconn.connect(sa).get();
@@ -36,6 +38,7 @@ SEASTAR_THREAD_TEST_CASE(test_accept_after_abort) {
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
     auto listener = engine().net().listen(sa, listen_options());
+    auto close_listener = deferred_close(listener);
     using ftype = future<accept_result>;
     promise<ftype> p;
     future<ftype> done = p.get_future();

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -1,59 +1,43 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/net/ip.hh>
 
 using namespace seastar;
 using namespace net;
 
-SEASTAR_TEST_CASE(test_connection_attempt_is_shutdown) {
+SEASTAR_THREAD_TEST_CASE(test_connection_attempt_is_shutdown) {
     ipv4_addr server_addr("172.16.0.1");
     auto unconn = make_socket();
-    auto f = unconn
-        .connect(make_ipv4_address(server_addr))
-        .then_wrapped([] (auto&& f) {
-            try {
-                f.get();
-                BOOST_REQUIRE(false);
-            } catch (...) {}
-        });
+    auto f = unconn.connect(make_ipv4_address(server_addr));
     unconn.shutdown();
-    return f.finally([unconn = std::move(unconn)] {});
+    BOOST_REQUIRE_THROW(f.get(), std::exception);
 }
 
-SEASTAR_TEST_CASE(test_unconnected_socket_shutsdown_established_connection) {
+SEASTAR_THREAD_TEST_CASE(test_unconnected_socket_shutsdown_established_connection) {
     // Use a random port to reduce chance of conflict.
     // TODO: retry a few times on failure.
     std::default_random_engine& rnd = testing::local_random_engine;
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
-    return do_with(engine().net().listen(sa, listen_options()), [sa] (auto& listener) {
+    auto listener = engine().net().listen(sa, listen_options());
+    // FIXME: indentation
         auto f = listener.accept();
         auto unconn = make_socket();
-        auto connf = unconn.connect(sa);
-        return connf.then([unconn = std::move(unconn)] (auto&& conn) mutable {
+        auto conn = unconn.connect(sa).get();
             unconn.shutdown();
-            return do_with(std::move(conn), [] (auto& conn) {
-                return do_with(conn.output(1), [] (auto& out) {
-                    return out.write("ping").then_wrapped([] (auto&& f) {
-                        try {
-                            f.get();
-                            BOOST_REQUIRE(false);
-                        } catch (...) {}
-                    });
-                });
-            });
-        }).finally([f = std::move(f)] () mutable {
-            return std::move(f);
-        });
-    });
+            auto out = conn.output(1);
+            BOOST_REQUIRE_THROW(out.write("ping").get(), std::exception);
+    f.get();
 }
 
-SEASTAR_TEST_CASE(test_accept_after_abort) {
+SEASTAR_THREAD_TEST_CASE(test_accept_after_abort) {
     std::default_random_engine& rnd = testing::local_random_engine;
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
-    return do_with(seastar::server_socket(engine().net().listen(sa, listen_options())), [] (auto& listener) {
+    auto listener = engine().net().listen(sa, listen_options());
+    // FIXME: indentation
         using ftype = future<accept_result>;
         promise<ftype> p;
         future<ftype> done = p.get_future();
@@ -62,13 +46,7 @@ SEASTAR_TEST_CASE(test_accept_after_abort) {
             p.set_value(listener.accept());
         });
         listener.abort_accept();
-        return done.then([] (ftype f) {
-          return f.then_wrapped([] (ftype f) {
-            BOOST_REQUIRE(f.failed());
-            if (f.available()) {
-                f.ignore_ready_future();
-            }
-          });
-        });
-    });
+        ftype done_fut = done.get();
+        BOOST_REQUIRE_THROW(done_fut.get(), std::exception);
+    f.get();
 }

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -27,10 +27,12 @@ SEASTAR_THREAD_TEST_CASE(test_unconnected_socket_shutsdown_established_connectio
     auto f = listener.accept();
     auto unconn = make_socket();
     auto conn = unconn.connect(sa).get();
+    auto close_conn = deferred_close(conn);
     unconn.shutdown();
     auto out = conn.output(1);
     BOOST_REQUIRE_THROW(out.write("ping").get(), std::exception);
-    f.get();
+    auto ar = f.get();
+    ar.connection.close().get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_accept_after_abort) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -718,9 +718,9 @@ struct extra_big_object : public json::json_base {
 SEASTAR_TEST_CASE(json_stream) {
     std::vector<extra_big_object> vec;
     size_t num_objects = 1000;
-    size_t total_size = num_objects * 1000001 + 1;
+    size_t total_size = num_objects * 100001 + 1;
     for (size_t i = 0; i < num_objects; i++) {
-        vec.emplace_back(1000000);
+        vec.emplace_back(100000);
     }
     return test_client_server::run_test(json::stream_object(vec), [total_size](size_t s, http_consumer& h) {
         BOOST_REQUIRE_EQUAL(h._size, total_size);

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -83,7 +83,9 @@ SEASTAR_TEST_CASE(tcp_packet_test) {
         BOOST_REQUIRE(la.addr().is_ipv6());
 
         auto cc = connect(la).get0();
+        auto close_cc = deferred_close(cc);
         auto lc = std::move(sc.accept().get0().connection);
+        auto close_lc = deferred_close(lc);
 
         auto strm = cc.output();
         strm.write("los lobos").get();

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/closeable.hh>
 
 using namespace seastar;
 
@@ -76,6 +77,7 @@ SEASTAR_TEST_CASE(tcp_packet_test) {
 
     return async([] {
         auto sc = server_socket(engine().net().listen(ipv6_addr{"::1"}, {}));
+        auto close_sc = deferred_close(sc);
         auto la = sc.local_address();
 
         BOOST_REQUIRE(la.addr().is_ipv6());

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -302,8 +302,8 @@ public:
             return _factory.make_new_server_connection(std::move(b1), b2).then([b2] {
                 return make_foreign(b2);
             });
-        }).then([this] (foreign_ptr<lw_shared_ptr<loopback_buffer>> b2) {
-            return _factory.make_new_client_connection(_b1, std::move(b2));
+        }).then([this, b1 = _b1] (foreign_ptr<lw_shared_ptr<loopback_buffer>> b2) mutable {
+            return _factory.make_new_client_connection(std::move(b1), std::move(b2));
         });
     }
     virtual void set_reuseaddr(bool reuseaddr) override {}

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -214,6 +214,10 @@ public:
         // CMH dummy
         return {};
     }
+    virtual future<> close() noexcept override {
+        // FIXME: close _pending sockets
+        return make_ready_future<>();
+    }
 };
 
 

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -314,10 +314,15 @@ public:
             _connect_abort->set_exception(std::make_exception_ptr(std::system_error(ECONNABORTED, std::system_category())));
             _connect_abort = std::nullopt;
         } else {
+          if (_b1) {
             _b1->shutdown();
+            _b1 = {};
+          }
+          if (_b2) {
             (void)smp::submit_to(_b2.get_owner_shard(), [b2 = std::move(_b2)] {
                 b2->shutdown();
             });
+          }
         }
     }
 };

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -508,6 +508,7 @@ future<stream_test_result> stream_test_func(rpc_test_env<>& env, bool stop_clien
             }).finally([sink] {});
 
             auto source_loop = seastar::async([source, &r] () mutable {
+                auto close_source = deferred_close(source);
                 while (!r.server_source_closed) {
                     auto data = source().get0();
                     if (data) {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -154,6 +154,9 @@ public:
     virtual void shutdown() override {
         _socket.shutdown();
     }
+    virtual future<> close() noexcept override {
+        return _socket.close();
+    }
 };
 
 struct rpc_test_config {

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -58,7 +58,6 @@ private:
     const socket_address server_addr;
 
     const std::optional<string> client_path;
-    server_socket server;
     const int rounds;
     int rounds_left;
     server_socket* lstn_sock;
@@ -119,6 +118,8 @@ future<> ud_server_client::init_server() {
             }
         }).finally([this]{
             return th.join();
+        }).finally([&lstn]{
+            return lstn.close();
         });
     });
 }

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -51,11 +51,11 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
                     });
                 });
             });
-        websocket::connection conn(dummy, acceptor.get0().connection);
-        future<> serve = conn.process();
+        auto conn = websocket::connection::make_connection(dummy, acceptor.get0().connection).get0();
+        future<> serve = conn->process();
         auto close = defer([&conn, &input, &output, &serve, &dummy] () noexcept {
-            conn.shutdown();
-            conn.close().get();
+            conn->shutdown();
+            conn->close().get();
             input.close().get();
             output.close().get();
             serve.get();
@@ -119,12 +119,12 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
                 });
             });
         });
-        websocket::connection conn(ws, acceptor.get0().connection);
-        future<> serve = conn.process();
+        auto conn = websocket::connection::make_connection(ws, acceptor.get0().connection).get0();
+        future<> serve = conn->process();
 
         auto close = defer([&conn, &input, &output, &serve, &ws] () noexcept {
-            conn.shutdown();
-            conn.close().get();
+            conn->shutdown();
+            conn->close().get();
             input.close().get();
             output.close().get();
             serve.get();

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -51,12 +51,13 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
             });
         websocket::connection conn(dummy, acceptor.get0().connection);
         future<> serve = conn.process();
-        auto close = defer([&conn, &input, &output, &serve] () noexcept {
+        auto close = defer([&conn, &input, &output, &serve, &dummy] () noexcept {
             conn.shutdown();
             conn.close().get();
             input.close().get();
             output.close().get();
             serve.get();
+            dummy.stop().get();
          });
 
         // Send the handshake
@@ -117,12 +118,13 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
         websocket::connection conn(ws, acceptor.get0().connection);
         future<> serve = conn.process();
 
-        auto close = defer([&conn, &input, &output, &serve] () noexcept {
+        auto close = defer([&conn, &input, &output, &serve, &ws] () noexcept {
             conn.shutdown();
             conn.close().get();
             input.close().get();
             output.close().get();
             serve.get();
+            ws.stop().get();
          });
 
         // handshake

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -54,7 +54,6 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
         auto conn = websocket::connection::make_connection(dummy, acceptor.get0().connection).get0();
         future<> serve = conn->process();
         auto close = defer([&conn, &input, &output, &serve, &dummy] () noexcept {
-            conn->shutdown();
             conn->close().get();
             input.close().get();
             output.close().get();
@@ -123,7 +122,6 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
         future<> serve = conn->process();
 
         auto close = defer([&conn, &input, &output, &serve, &ws] () noexcept {
-            conn->shutdown();
             conn->close().get();
             input.close().get();
             output.close().get();

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -6,7 +6,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/http/response_parser.hh>
-#include <seastar/util/defer.hh>
+#include <seastar/util/closeable.hh>
 #include "loopback_socket.hh"
 
 using namespace seastar;
@@ -25,7 +25,9 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
         loopback_connection_factory factory;
         loopback_socket_impl lsi(factory);
 
-        auto acceptor = factory.get_server_socket().accept();
+        auto ss = factory.get_server_socket();
+        auto close_ss = deferred_close(ss);
+        auto acceptor = ss.accept();
         auto connector = lsi.connect(socket_address(), socket_address());
         connected_socket sock = connector.get0();
         auto input = sock.input();
@@ -90,7 +92,9 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
         loopback_connection_factory factory;
         loopback_socket_impl lsi(factory);
 
-        auto acceptor = factory.get_server_socket().accept();
+        auto ss = factory.get_server_socket();
+        auto close_ss = deferred_close(ss);
+        auto acceptor = ss.accept();
         auto connector = lsi.connect(socket_address(), socket_address());
         connected_socket sock = connector.get0();
         auto input = sock.input();

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -32,6 +32,11 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
         connected_socket sock = connector.get0();
         auto input = sock.input();
         auto output = sock.output();
+        auto close_sock = defer([&] () noexcept {
+            output.close().get();
+            input.close().get();
+            sock.close().get();
+        });
 
         websocket::server dummy;
         dummy.register_handler("echo", [] (input_stream<char>& in,
@@ -98,6 +103,11 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
         connected_socket sock = connector.get0();
         auto input = sock.input();
         auto output = sock.output();
+        auto close_sock = defer([&] () noexcept {
+            output.close().get();
+            input.close().get();
+            sock.close().get();
+        });
 
         // Setup server
         websocket::server ws;


### PR DESCRIPTION
The series adds a close method to class across the board in the network stack
allowing the user to orderly wait on any background work left behind
after shutdown, thus preventing use-after-free, like the one seen in #1190
(and several others, currently noted by FIXME comments peppered around in the code).

The change is introduced as part of a new api_level, 7,
where the calls methods are added unconditionally and are voluntary to call at api_level 6,
while at api_level 7 or newer they are mandatory to be called and closed condition is verified at the respective destructors.

At this stage the series includes:
- server_socket, server_socket_impl
- connected_socket, connected_socket_impl
- WIP: net: socket, socket_impl: add close method
  - here I've hit a brick wall in the rpc streams labyrinth and any change I try either misses stopping or hangs when rpc::connection::stop appear to be deadlocked on itself.
- TODO: add close to tcp::connection
  - to wait on the future that should be returned from tcb::close() via `tcp::connection::close_write` to `tcp::connection::shutdown`