### PR TITLE
memory: allow user to select allocator to be used at runtime

### DIFF
--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -27,6 +27,16 @@
 
 namespace seastar {
 
+enum class memory_allocator {
+    /// Seastar's own allocator, optimized for its shard-per core design.
+    /// Strongly recommended for most seastar apps.
+    seastar,
+    /// The standard allocator from libc.
+    /// Useful when writing seastar-based tool apps that want to
+    /// minimize their footprint on the system they run on.
+    standard,
+};
+
 /// Configuration for the multicore aspect of seastar.
 struct smp_options : public program_options::option_group {
     /// Number of threads (default: one per CPU).
@@ -79,6 +89,17 @@ struct smp_options : public program_options::option_group {
     /// \note Unused when seastar is compiled without \p HWLOC support.
     program_options::value<bool> allow_cpus_in_remote_numa_nodes;
 
+    /// Memory allocator to use.
+    ///
+    /// The following options only have effect if the \ref memory_allocator::seastar is used:
+    /// * \ref smp_options::memory
+    /// * \ref smp_options::reserve_memory
+    /// * \ref smp_options::hugepages
+    /// * \ref smp_options::mbind
+    /// * \ref reactor_options::heapprof
+    /// * \ref reactor_options::abort_on_seastar_bad_alloc
+    /// * \ref reactor_options::dump_memory_diagnostics_on_alloc_failure_kind
+    seastar::memory_allocator memory_allocator = memory_allocator::seastar;
 public:
     smp_options(program_options::option_group* parent_group);
 };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3995,7 +3995,9 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     if (thread_affinity) {
         smp::pin(allocations[0].cpu_id);
     }
-    memory::configure(allocations[0].mem, mbind, hugepages_path);
+    if (smp_opts.memory_allocator == memory_allocator::seastar) {
+        memory::configure(allocations[0].mem, mbind, hugepages_path);
+    }
 
     if (reactor_opts.abort_on_seastar_bad_alloc) {
         memory::enable_abort_on_allocation_failure();
@@ -4093,7 +4095,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     auto smp_tmain = smp::_tmain;
     for (i = 1; i < smp::count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4102,7 +4104,9 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
             if (thread_affinity) {
                 smp::pin(allocation.cpu_id);
             }
-            memory::configure(allocation.mem, mbind, hugepages_path);
+            if (smp_opts.memory_allocator == memory_allocator::seastar) {
+                memory::configure(allocation.mem, mbind, hugepages_path);
+            }
             if (heapprof_enabled) {
                 memory::set_heap_profiling_enabled(heapprof_enabled);
             }


### PR DESCRIPTION
This option is targeted at small utility/tool applications, which don't want to use the seastar allocator, as they don't want to commit to a fixed amount of memory to be used. Any amount they might commit to would be both too small and too large at the same time: we want to let them consume as much as they need and only as much instead. This option is not exposed on the command line, it can only be set from code. This is intentional: the application code has to be well prepared for the choice of allocator, this is not something a user can select at whim on the command line, this is a decision that only developers can make (with care).