### PR TITLE
program_options: allow configure switch-stytle option programmatically

### DIFF
--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -459,14 +459,22 @@ public:
 /// Contains no value, can be set or not.
 template <>
 class value<std::monostate> : public basic_value {
-    bool _set = false;
+    std::optional<bool> _set;
 
 private:
     virtual void do_describe(options_descriptor& descriptor) const override {
         descriptor.visit_value();
     }
     virtual void do_mutate(options_mutator& mutator) override {
-        _set = mutator.visit_value();
+        bool is_set = mutator.visit_value();
+        if (_set.has_value()) {
+            // override the value only if it is not preset
+            if (is_set) {
+                _set = true;
+            }
+        } else {
+            _set = is_set;
+        }
     }
 
 public:
@@ -483,7 +491,7 @@ public:
         : basic_value(group, false, std::move(name), {})
     { }
     /// Is the option set?
-    operator bool () const { return _set; }
+    operator bool () const { return _set ? _set.value() : false; }
     void set_value() { _set = true; }
     void unset_value() { _set = false; }
 };


### PR DESCRIPTION
before this change, a `program_options::value<>` cannot be configured programmatically. if we configure a switch option and then mutate an `program_options::option_group` with this option, the switch option is always reset if the mutator does not contain that option even we set that option with a default value beforehand.

after this change, `program_options::value<>` tracks its value with an `optional<bool>` like the other specialization `program_options::value<T>`. so its value is overriden only if it is not preset. this allows us to configure switch-style options programmatically. so its behavior is more consistent with other `program_options::value<T>`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>