### PR TITLE
Remove deprecated --max-io-requests

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -96,7 +96,6 @@ public:
 
     struct config {
         dev_t devid;
-        unsigned capacity = std::numeric_limits<unsigned>::max();
         unsigned long req_count_rate = std::numeric_limits<int>::max();
         unsigned long blocks_count_rate = std::numeric_limits<int>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;
@@ -127,8 +126,6 @@ public:
     void complete_cancelled_request(queued_io_request& req) noexcept;
     void complete_request(io_desc_read_write& desc) noexcept;
 
-
-    [[deprecated("modern I/O queues should use a property file")]] size_t capacity() const;
 
     [[deprecated("I/O queue users should not track individual requests, but resources (weight, size) passing through the queue")]]
     size_t queued_requests() const {
@@ -191,10 +188,6 @@ private:
 
 inline const io_queue::config& io_queue::get_config() const noexcept {
     return _group->_config;
-}
-
-inline size_t io_queue::capacity() const {
-    return get_config().capacity;
 }
 
 inline sstring io_queue::mountpoint() const {

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -67,10 +67,6 @@ struct smp_options : public program_options::option_group {
     /// Defaults to the number of NUMA nodes
     /// \note Unused when seastar is compiled without \p HWLOC support.
     program_options::value<unsigned> num_io_groups;
-    /// \brief Maximum amount of concurrent requests to be sent to the disk.
-    ///
-    /// Defaults to 128 times the number of IO queues
-    program_options::value<unsigned> max_io_requests;
     /// Path to a YAML file describing the characteristics of the I/O Subsystem.
     program_options::value<std::string> io_properties_file;
     /// A YAML string describing the characteristics of the I/O Subsystem.

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3760,29 +3760,29 @@ public:
 
         cfg.devid = devid;
 
-            if (p.read_bytes_rate != std::numeric_limits<uint64_t>::max()) {
-                cfg.blocks_count_rate = (io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_bytes_rate, nr_groups)) >> io_queue::block_size_shift;
-                cfg.disk_blocks_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_bytes_rate) / p.write_bytes_rate;
-            }
-            if (p.read_req_rate != std::numeric_limits<uint64_t>::max()) {
-                cfg.req_count_rate = io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_req_rate, nr_groups);
-                cfg.disk_req_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_req_rate) / p.write_req_rate;
-            }
-            if (p.read_saturation_length != std::numeric_limits<uint64_t>::max()) {
-                cfg.disk_read_saturation_length = p.read_saturation_length;
-            }
-            if (p.write_saturation_length != std::numeric_limits<uint64_t>::max()) {
-                cfg.disk_write_saturation_length = p.write_saturation_length;
-            }
-            cfg.mountpoint = p.mountpoint;
-            cfg.duplex = p.duplex;
-            cfg.rate_factor = p.rate_factor;
-            cfg.rate_limit_duration = latency_goal();
-            // Block count limit should not be less than the minimal IO size on the device
-            // On the other hand, even this is not good enough -- in the worst case the
-            // scheduler will self-tune to allow for the single 64k request, while it would
-            // be better to sacrifice some IO latency, but allow for larger concurrency
-            cfg.block_count_limit_min = (64 << 10) >> io_queue::block_size_shift;
+        if (p.read_bytes_rate != std::numeric_limits<uint64_t>::max()) {
+            cfg.blocks_count_rate = (io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_bytes_rate, nr_groups)) >> io_queue::block_size_shift;
+            cfg.disk_blocks_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_bytes_rate) / p.write_bytes_rate;
+        }
+        if (p.read_req_rate != std::numeric_limits<uint64_t>::max()) {
+            cfg.req_count_rate = io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_req_rate, nr_groups);
+            cfg.disk_req_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_req_rate) / p.write_req_rate;
+        }
+        if (p.read_saturation_length != std::numeric_limits<uint64_t>::max()) {
+            cfg.disk_read_saturation_length = p.read_saturation_length;
+        }
+        if (p.write_saturation_length != std::numeric_limits<uint64_t>::max()) {
+            cfg.disk_write_saturation_length = p.write_saturation_length;
+        }
+        cfg.mountpoint = p.mountpoint;
+        cfg.duplex = p.duplex;
+        cfg.rate_factor = p.rate_factor;
+        cfg.rate_limit_duration = latency_goal();
+        // Block count limit should not be less than the minimal IO size on the device
+        // On the other hand, even this is not good enough -- in the worst case the
+        // scheduler will self-tune to allow for the single 64k request, while it would
+        // be better to sacrifice some IO latency, but allow for larger concurrency
+        cfg.block_count_limit_min = (64 << 10) >> io_queue::block_size_shift;
 
         return cfg;
     }


### PR DESCRIPTION
The concept of limiting only the number of requests was replaced more than two years ago, the CLI option was deprecated 1+ year ago. It should be safe to eliminate it altogether now