### PR TITLE
reactor, file: support zns-append command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,12 @@ if (DEFINED Seastar_IO_URING)
     ON)
 endif ()
 
+if (DEFINED Seastar_NVME)
+  option (Seastar_NVME
+    "Enable nvme support."
+    ON)
+endif ()
+
 set (Seastar_JENKINS
   ""
   CACHE
@@ -937,6 +943,13 @@ if (Seastar_IO_URING)
     PRIVATE URING::uring)
 endif ()
 
+set_option_if_package_is_found(Seastar_NVME LibNvme)
+if (Seastar_NVME)
+  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_NVME)
+  target_link_libraries (seastar
+    PRIVATE NVME::nvme)
+endif ()
+
 if (Seastar_LD_FLAGS)
   # In newer versions of CMake, there is `target_link_options`.
   target_link_libraries (seastar
@@ -1260,6 +1273,7 @@ if (Seastar_INSTALL)
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findyaml-cpp.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SeastarDependencies.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibUring.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibNvme.cmake
     DESTINATION ${install_cmakedir})
 
   install (

--- a/cmake/FindLibNvme.cmake
+++ b/cmake/FindLibNvme.cmake
@@ -1,0 +1,72 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright 2022 Jinyong Ha (jyha200@gmail.com), Heewon Shin (shw096@snu.ac.kr)
+#
+
+find_package (PkgConfig REQUIRED)
+
+pkg_search_module (NVME libnvme)
+INCLUDE(CheckIncludeFile)
+
+find_library (NVME_LIBRARY
+  NAMES nvme
+  HINTS
+    ${NVME_PC_LIBDIR}
+    ${NVME_PC_LIBRARY_DIRS})
+
+find_path (NVME_INCLUDE_DIR
+  NAMES libnvme.h
+  HINTS
+    ${NVME_PC_INCLUDE_DIR}
+    ${NVME_PC_INCLUDE_DIRS})
+
+if (NVME_INCLUDE_DIR)
+  include (CheckStructHasMember)
+  include (CMakePushCheckState)
+  cmake_push_check_state (RESET)
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${NVME_INCLUDE_DIR})
+  set (HAVE_LIBNVME TRUE)
+endif ()
+
+mark_as_advanced (
+  NVME_LIBRARY
+  NVME_INCLUDE_DIR
+  HAVE_LIBNVME)
+
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (LibNvme
+  REQUIRED_VARS
+    NVME_LIBRARY
+    NVME_INCLUDE_DIR
+  VERSION_VAR NVME_PC_VERSION)
+
+set (NVME_LIBRARIES ${NVME_LIBRARY})
+set (NVME_INCLUDE_DIRS ${NVME_INCLUDE_DIR})
+
+if (NVME_FOUND AND NOT (TARGET NVME::nvme))
+  add_library (NVME::nvme UNKNOWN IMPORTED)
+
+  set_target_properties (NVME::nvme
+    PROPERTIES
+      IMPORTED_LOCATION ${NVME_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${NVME_INCLUDE_DIRS})
+endif ()

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -92,6 +92,7 @@ macro (seastar_find_dependencies)
     Concepts
     GnuTLS
     LibUring
+    LibNvme
     LinuxMembarrier
     Sanitizers
     SourceLocation

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -117,5 +117,8 @@ seastar_add_demo (sharded_parameter
 seastar_add_demo (file
   SOURCES file_demo.cc)
 
+seastar_add_demo (passthru_append
+  SOURCES passthru_append_demo.cc)
+
 seastar_add_demo (tutorial_examples
   SOURCES tutorial_examples.cc)

--- a/demos/passthru_append_demo.cc
+++ b/demos/passthru_append_demo.cc
@@ -1,0 +1,66 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2022 Jinyong Ha (jyha200@gmail.com), Heewon Shin (shw096@snu.ac.kr)
+ */
+#include <seastar/core/app-template.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/seastar.hh>
+#include <iostream>
+
+using namespace seastar;
+namespace bpo = boost::program_options;
+
+static const size_t IO_SIZE = 4096;
+static const size_t ALIGNMENT_SIZE = 4096;
+
+int main(int ac, char** av) {
+    app_template app;
+    app.add_options()
+        ("dev", bpo::value<std::string>(), "e.g. --dev /dev/nvme0n1")
+        ;
+
+    return app.run_deprecated(ac, av, [&app] {
+        auto&& config = app.configuration();
+        auto filepath = config["dev"].as<std::string>();
+
+        return open_file_dma(filepath, open_flags::rw | open_flags::create).then([] (file f) {
+            auto wbuf = allocate_aligned_buffer<unsigned char>(IO_SIZE, ALIGNMENT_SIZE);
+            size_t address = 0;
+            std::fill(wbuf.get(), wbuf.get() + IO_SIZE, (uint8_t)0xa);
+            auto wb = wbuf.get();
+            auto result = f.dma_append(address * IO_SIZE, wb, IO_SIZE).then([f, address, wbuf = std::move(wbuf)] (io_result ret) mutable {
+                auto appended_address = ret.res2;
+                assert(ret.res1 == IO_SIZE);
+                assert(ret.res2 != -1);
+                auto rbuf = allocate_aligned_buffer<unsigned char>(IO_SIZE, ALIGNMENT_SIZE);
+                auto rb = rbuf.get();
+                (void)f.dma_read(appended_address, rb, IO_SIZE).then([f, rbuf = std::move(rbuf), wbuf = std::move(wbuf)] (size_t ret) mutable{
+                    assert(ret == IO_SIZE);
+                    assert(std::equal(rbuf.get(), rbuf.get() + IO_SIZE, wbuf.get()));
+                    return f.close().then([](){
+                        std::cout << "done" << std::endl;
+                        engine().exit(0);
+                    });
+                });
+            });
+        });
+    });
+}
+

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/align.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/file-types.hh>
+#include <seastar/core/io_result.hh>
 #include <seastar/util/std-compat.hh>
 #include <system_error>
 #include <sys/statvfs.h>

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/io_request.hh>
+#include <seastar/core/io_result.hh>
 #include <seastar/util/spinlock.hh>
 
 struct io_queue_for_tests;
@@ -121,7 +122,7 @@ public:
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
     future<size_t> queue_request(const io_priority_class& pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
-    future<size_t> queue_one_request(const io_priority_class& pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
+    future<io_result> queue_one_request(const io_priority_class& pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
     void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -120,6 +120,8 @@ public:
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
     future<size_t> submit_io_write(const io_priority_class& priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
+    future<io_result> submit_io_append(const io_priority_class& priority_class,
+            size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
     future<size_t> queue_request(const io_priority_class& pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
     future<io_result> queue_one_request(const io_priority_class& pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;

--- a/include/seastar/core/io_result.hh
+++ b/include/seastar/core/io_result.hh
@@ -1,0 +1,31 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2022 Jinyong Ha (jyha200@gmail.com), Heewon Shin (shw096@snu.ac.kr)
+ */
+
+#pragma once
+
+namespace seastar {
+
+struct io_result {
+  size_t res1; // written or read bytes (same as legacy write or read command)
+  ssize_t res2; // assigned block address from ZNS SSD (only for append command, otherwise -1) 
+};
+
+}

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -171,10 +171,11 @@ class disk_config_params;
 
 class io_completion : public kernel_completion {
 public:
-    virtual void complete_with(ssize_t res) final override;
+    virtual void complete_with(ssize_t res) override;
 
     virtual void complete(size_t res) noexcept = 0;
     virtual void set_exception(std::exception_ptr eptr) noexcept = 0;
+    virtual void set_additional_result(size_t result_) { };
 };
 
 class reactor {
@@ -687,7 +688,7 @@ private:
 
     future<struct stat> fstat(int fd) noexcept;
     future<struct statfs> fstatfs(int fd) noexcept;
-    friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags) noexcept;
+    friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags, std::string name) noexcept;
 public:
     future<> readable(pollable_fd_state& fd);
     future<> writeable(pollable_fd_state& fd);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -531,6 +531,8 @@ public:
     future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
     future<int> inotify_add_watch(int fd, std::string_view path, uint32_t flags);
+
+    bool support_append();
     
     int run() noexcept;
     void exit(int ret);

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -57,6 +57,7 @@ debian_packages=(
     doxygen
     openssl
     pkg-config
+    libnvme
 )
 
 # seastar doesn't directly depend on these packages. They are
@@ -77,6 +78,7 @@ redhat_packages=(
     lksctp-tools-devel
     lz4-devel
     liburing-devel
+    libnvme-devel
     gcc
     make
     python3

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -30,6 +30,8 @@ lksctp_tools_cflags=-I$<JOIN:@lksctp-tools_INCLUDE_DIRS@, -I>
 lksctp_tools_libs=$<JOIN:@lksctp-tools_LIBRARIES@, >
 liburing_cflags=$<$<BOOL:@Seastar_IO_URING@>:-I$<JOIN:$<TARGET_PROPERTY:URING::uring,INTERFACE_INCLUDE_DIRECTORIES>, -I>>
 liburing_libs=$<$<BOOL:@Seastar_IO_URING@>:$<TARGET_LINKER_FILE:URING::uring>>
+libnvme_cflags=$<$<BOOL:@Seastar_NVME@>:-I$<JOIN:$<TARGET_PROPERTY:NVME::nvme,INTERFACE_INCLUDE_DIRECTORIES>, -I>>
+libnvme_libs=$<$<BOOL:@Seastar_NVME@>:$<TARGET_LINKER_FILE:NVME::nvme>>
 numactl_cflags=-I$<JOIN:@numactl_INCLUDE_DIRS@, -I>
 numactl_libs=$<JOIN:@numactl_LIBRARIES@, >
 
@@ -40,6 +42,6 @@ seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<
 Requires: liblz4 >= 1.7.3
 Requires.private: gnutls >= 3.2.26, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
-Cflags: ${boost_cflags} ${c_ares_cflags} ${cryptopp_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${numactl_cflags} ${seastar_cflags}
+Cflags: ${boost_cflags} ${c_ares_cflags} ${cryptopp_cflags} ${fmt_cflags} ${liburing_cflags} ${libnvme_cflags} ${lksctp_tools_cflags} ${numactl_cflags} ${seastar_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${boost_thread_libs} ${c_ares_libs} ${cryptopp_libs} ${fmt_libs}
-Libs.private: ${dl_libs} ${rt_libs} ${boost_thread_libs} ${lksctp_tools_libs} ${liburing_libs} ${numactl_libs} ${stdatomic_libs}
+Libs.private: ${dl_libs} ${rt_libs} ${boost_thread_libs} ${lksctp_tools_libs} ${liburing_libs} ${libnvme_libs} ${numactl_libs} ${stdatomic_libs}

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -33,6 +33,7 @@
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min
+#include <libnvme.h>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/report_exception.hh>
@@ -419,6 +420,12 @@ posix_file_impl::do_write_dma(uint64_t pos, const void* buffer, size_t len, cons
     return _io_queue.submit_io_write(io_priority_class, len, std::move(req), intent);
 }
 
+future<io_result>
+posix_file_impl::do_append_dma(uint64_t pos, const void* buffer, size_t len, const io_priority_class& io_priority_class, io_intent* intent, int ng_device_fd, uint32_t nsid, size_t block_size) noexcept {
+    auto req = internal::io_request::make_append(ng_device_fd, pos, buffer, len, _nowait_works, nsid, block_size);
+    return _io_queue.submit_io_append(io_priority_class, len, std::move(req), intent);
+}
+
 future<size_t>
 posix_file_impl::do_write_dma(uint64_t pos, std::vector<iovec> iov, const io_priority_class& io_priority_class, io_intent* intent) noexcept {
     auto len = internal::sanitize_iovecs(iov, _disk_write_dma_alignment);
@@ -579,8 +586,8 @@ static bool blockdev_nowait_works(dev_t device_id) {
     return blockdev_gen_nowait_works;
 }
 
-blockdev_file_impl::blockdev_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, size_t block_size)
-        : posix_file_impl(fd, f, options, device_id, blockdev_nowait_works(device_id)) {
+blockdev_file_impl::blockdev_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, size_t block_size, int ng_device_fd, uint32_t nsid)
+        : posix_file_impl(fd, f, options, device_id, blockdev_nowait_works(device_id)), ng_device_fd(ng_device_fd), nsid(nsid), block_size(block_size) {
     // FIXME -- configure file_impl::_..._dma_alignment's from block_size
 }
 
@@ -626,9 +633,29 @@ blockdev_file_impl::read_dma(uint64_t pos, std::vector<iovec> iov, const io_prio
     return posix_file_impl::do_read_dma(pos, std::move(iov), pc, intent);
 }
 
+future<io_result>
+blockdev_file_impl::append_dma(uint64_t pos, const void* buffer, size_t len, const io_priority_class& pc, io_intent* intent) noexcept {
+    // append is available on ng device only
+    if (ng_device_fd != -1) {
+        return posix_file_impl::do_append_dma(pos, buffer, len, pc, intent, ng_device_fd, nsid, block_size);
+    } else {
+        return posix_file_impl::do_write_dma(pos, buffer, len, pc, intent).then([pos] (auto result) {
+            return make_ready_future<io_result>(io_result(result, pos));
+        });
+    }
+}
+
 future<temporary_buffer<uint8_t>>
 blockdev_file_impl::dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc, io_intent* intent) noexcept {
     return posix_file_impl::do_dma_read_bulk(offset, range_size, pc, intent);
+}
+
+future<>
+blockdev_file_impl::close() noexcept {
+  if (ng_device_fd != -1) {
+    ::close(ng_device_fd);
+  }
+  return posix_file_impl::close();
 }
 
 append_challenged_posix_file_impl::append_challenged_posix_file_impl(int fd, open_flags f, file_open_options options, const fs_info& fsi, dev_t device_id)
@@ -992,18 +1019,54 @@ xfs_concurrency_from_kernel_version() {
     return 0;
 }
 
+static const std::string NVME_STR = "nvme";
+static const std::string NG_STR = "ng";
+
+bool
+is_nvme_device(std::string name) {
+  size_t pos = name.find(NVME_STR);
+  if (pos != std::string::npos) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+int
+open_ng_device_fd(std::string nvme_file_path) {
+  std::string ng_file_path = nvme_file_path;
+  size_t pos = ng_file_path.find(NVME_STR);
+  assert(pos != std::string::npos);
+  ng_file_path.replace(pos, NVME_STR.size(), NG_STR);
+  return ::open(ng_file_path.c_str(), O_RDWR);
+}
+
 future<shared_ptr<file_impl>>
-make_file_impl(int fd, file_open_options options, int flags) noexcept {
-    return engine().fstat(fd).then([fd, options = std::move(options), flags] (struct stat st) mutable {
+make_file_impl(int fd, file_open_options options, int flags, std::string name) noexcept {
+    return engine().fstat(fd).then([fd, options = std::move(options), flags, name = std::move(name)] (struct stat st) mutable {
         auto st_dev = st.st_dev;
 
         if (S_ISBLK(st.st_mode)) {
-            size_t block_size;
+            size_t block_size = 0;
             auto ret = ::ioctl(fd, BLKBSZGET, &block_size);
             if (ret == -1) {
                 return make_exception_future<shared_ptr<file_impl>>(
                         std::system_error(errno, std::system_category(), "ioctl(BLKBSZGET) failed"));
             }
+
+            uint32_t nsid = -1;
+            int ng_device_fd = -1;
+#ifdef SEASTAR_HAVE_NVME
+            if (is_nvme_device(name)) {
+                if (engine().support_append()) {
+                    nvme_get_nsid(fd, &nsid);
+                    ng_device_fd = open_ng_device_fd(name);
+                    if (ng_device_fd != -1) {
+                        return make_ready_future<shared_ptr<file_impl>>(make_shared<blockdev_file_impl>(fd, open_flags(flags), options, st.st_rdev, block_size, ng_device_fd ,nsid));
+                    }
+                }
+            }
+#endif
             return make_ready_future<shared_ptr<file_impl>>(make_shared<blockdev_file_impl>(fd, open_flags(flags), options, st.st_rdev, block_size));
         } else {
             if (S_ISDIR(st.st_mode)) {
@@ -1218,6 +1281,15 @@ future<size_t> file::dma_write(uint64_t pos, std::vector<iovec> iov, const io_pr
     return _file_impl->write_dma(pos, std::move(iov), pc, intent);
   } catch (...) {
     return current_exception_as_future<size_t>();
+  }
+}
+
+future<io_result>
+file::dma_append_impl(uint64_t pos, const uint8_t* buffer, size_t len, const io_priority_class& pc, io_intent* intent) noexcept {
+  try {
+    return _file_impl->append_dma(pos, buffer, len, pc, intent);
+  } catch (...) {
+    return current_exception_as_future<io_result>();
   }
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -208,8 +208,9 @@ class io_desc_read_write final : public io_completion {
     const stream_id _stream;
     const io_direction_and_length _dnl;
     const fair_queue_ticket _fq_ticket;
-    promise<size_t> _pr;
+    promise<io_result> _pr;
     iovec_keeper _iovs;
+    size_t _assigned_lba = -1; // For append command, assigned block address from ZNS SSD is written here.
 
 public:
     io_desc_read_write(io_queue& ioq, io_queue::priority_class_data& pc, stream_id stream, io_direction_and_length dnl, fair_queue_ticket ticket, iovec_keeper iovs)
@@ -237,8 +238,12 @@ public:
         auto now = io_queue::clock_type::now();
         _pclass.on_complete(std::chrono::duration_cast<std::chrono::duration<double>>(now - _ts));
         _ioq.complete_request(*this);
-        _pr.set_value(res);
+        _pr.set_value(io_result(res, _assigned_lba));
         delete this;
+    }
+
+    virtual void set_additional_result(size_t result_) {
+        _assigned_lba = result_;
     }
 
     void cancel() noexcept {
@@ -254,7 +259,7 @@ public:
         _ts = now;
     }
 
-    future<size_t> get_future() {
+    future<io_result> get_future() {
         return _pr.get_future();
     }
 
@@ -305,7 +310,7 @@ public:
         _intent.enqueue(cq);
     }
 
-    future<size_t> get_future() noexcept { return _desc->get_future(); }
+    future<io_result> get_future() noexcept { return _desc->get_future(); }
     fair_queue_entry& queue_entry() noexcept { return _fq_entry; }
     stream_id stream() const noexcept { return _stream; }
 
@@ -833,7 +838,7 @@ io_queue::request_limits io_queue::get_request_limits() const noexcept {
     return l;
 }
 
-future<size_t> io_queue::queue_one_request(const io_priority_class& pc, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+future<io_result> io_queue::queue_one_request(const io_priority_class& pc, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
     return futurize_invoke([&pc, dnl = std::move(dnl), req = std::move(req), this, intent, iovs = std::move(iovs)] () mutable {
         // First time will hit here, and then we create the class. It is important
         // that we create the shared pointer in the same shard it will be used at later.
@@ -857,15 +862,18 @@ future<size_t> io_queue::queue_request(const io_priority_class& pc, io_direction
     size_t max_length = _group->_max_request_length[dnl.rw_idx()];
 
     if (__builtin_expect(dnl.length() <= max_length, true)) {
-        return queue_one_request(pc, dnl, std::move(req), intent, std::move(iovs));
+        return queue_one_request(pc, dnl, std::move(req), intent, std::move(iovs)).then(
+          [] (auto io_result) {
+            return make_ready_future<size_t>(io_result.res1);
+          });
     }
 
     std::vector<internal::io_request::part> parts;
-    lw_shared_ptr<std::vector<future<size_t>>> p;
+    lw_shared_ptr<std::vector<future<io_result>>> p;
 
     try {
         parts = req.split(max_length);
-        p = make_lw_shared<std::vector<future<size_t>>>();
+        p = make_lw_shared<std::vector<future<io_result>>>();
         p->reserve(parts.size());
         find_or_create_class(pc).on_split(dnl);
         engine()._io_stats.aio_outsizes++;
@@ -888,7 +896,7 @@ future<size_t> io_queue::queue_request(const io_priority_class& pc, io_direction
         for (auto&& res : results) {
             if (!res.failed()) {
                 if (prev_ok) {
-                    size_t sz = res.get0();
+                    size_t sz = res.get0().res1;
                     total += sz;
                     prev_ok &= (sz == max_length);
                 }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -927,6 +927,13 @@ future<size_t> io_queue::submit_io_read(const io_priority_class& pc, size_t len,
     return queue_request(pc, io_direction_and_length(io_direction_read, len), std::move(req), intent, std::move(iovs));
 }
 
+future<io_result> io_queue::submit_io_append(const io_priority_class& pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+    auto& r = engine();
+    ++r._io_stats.aio_writes;
+    r._io_stats.aio_write_bytes += len;
+    return queue_one_request(pc, io_direction_and_length(io_direction_write, len), std::move(req), intent, std::move(iovs));
+}
+
 future<size_t> io_queue::submit_io_write(const io_priority_class& pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
     auto& r = engine();
     ++r._io_stats.aio_writes;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1619,6 +1619,8 @@ sstring io_request::opname() const {
         return "poll remove";
     case io_request::operation::cancel:
         return "cancel";
+    case io_request::operation::append:
+        return "append";
     }
     std::abort();
 }
@@ -1748,7 +1750,7 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
             return wrap_syscall<int>(fd);
         }).then([&options, name = std::move(name), &open_flags] (syscall_result<int> sr) {
             sr.throw_fs_exception_if_error("open failed", name);
-            return make_file_impl(sr.result, options, open_flags);
+            return make_file_impl(sr.result, options, open_flags, name);
         }).then([] (shared_ptr<file_impl> impl) {
             return make_ready_future<file>(std::move(impl));
         });

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1861,6 +1861,11 @@ reactor::file_type(std::string_view name, follow_symlink follow) noexcept {
     });
 }
 
+bool reactor::support_append(){
+    return _backend->support_append();
+}
+
+
 future<std::optional<directory_entry_type>>
 file_type(std::string_view name, follow_symlink follow) noexcept {
     return engine().file_type(name, follow);

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -675,6 +675,11 @@ reactor_backend_aio::make_pollable_fd_state(file_desc fd, pollable_fd::speculati
     return pollable_fd_state_ptr(new aio_pollable_fd_state(std::move(fd), std::move(speculate)));
 }
 
+bool
+reactor_backend_aio::support_append() {
+    return false;
+}
+
 reactor_backend_epoll::reactor_backend_epoll(reactor& r)
         : _r(r)
         , _steady_clock_timer_reactor_thread(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC))
@@ -1032,6 +1037,11 @@ reactor_backend_epoll::make_pollable_fd_state(file_desc fd, pollable_fd::specula
     return pollable_fd_state_ptr(new epoll_pollable_fd_state(std::move(fd), std::move(speculate)));
 }
 
+bool
+reactor_backend_epoll::support_append() {
+    return false;
+}
+
 void reactor_backend_epoll::reset_preemption_monitor() {
     _r._preemption_monitor.head.store(0, std::memory_order_relaxed);
 }
@@ -1127,6 +1137,12 @@ reactor_backend_osv::make_pollable_fd_state(file_desc fd, pollable_fd::speculati
     std::cerr << "reactor_backend_osv does not support file descriptors - make_pollable_fd_state() shouldn't have been called!\n";
     abort();
 }
+
+bool
+reactor_backend_osv::support_append() {
+    return false;
+}
+
 #endif
 
 #ifdef SEASTAR_HAVE_URING
@@ -1674,6 +1690,9 @@ public:
     }
     virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override {
         return pollable_fd_state_ptr(new uring_pollable_fd_state(std::move(fd), std::move(speculate)));
+    }
+    virtual bool support_append() override {
+        return true;
     }
 };
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -34,6 +34,15 @@
 
 #ifdef SEASTAR_HAVE_URING
 #include <liburing.h>
+#ifdef SEASTAR_HAVE_NVME
+#include <linux/nvme_ioctl.h>
+#include <linux/io_uring.h>
+
+#ifndef IORING_OP_URING_CMD
+#define IORING_OP_URING_CMD (40)
+#endif
+#define USE_PASSTHRU
+#endif
 #endif
 
 #ifdef HAVE_OSV
@@ -1254,7 +1263,13 @@ class reactor_backend_uring final : public reactor_backend {
             }
             auto sqe = be.get_sqe();
             ::io_uring_prep_poll_add(sqe, fd().get(), POLLIN);
+#ifdef USE_PASSTHRU
+            auto arg = new passthru_arg;
+            arg->completion = this;
+            ::io_uring_sqe_set_data(sqe, arg);
+#else
             ::io_uring_sqe_set_data(sqe, static_cast<kernel_completion*>(this));
+#endif
             _armed = true;
             be._has_pending_submissions = true;
         }
@@ -1316,10 +1331,139 @@ private:
         auto sqe = get_sqe();
         ::io_uring_prep_poll_add(sqe, fd.fd.get(), events);
         auto ufd = static_cast<uring_pollable_fd_state*>(&fd);
+#ifdef USE_PASSTHRU
+        auto arg = new passthru_arg;
+        arg->completion = ufd->get_desc(events);
+        ::io_uring_sqe_set_data(sqe, arg);
+#else
         ::io_uring_sqe_set_data(sqe, static_cast<kernel_completion*>(ufd->get_desc(events)));
+#endif
         _has_pending_submissions = true;
         return ufd->get_completion_future(events);
     }
+
+#ifdef USE_PASSTHRU
+    struct block_uring_cmd {
+        __u32   ioctl_cmd;
+        __u32   unused1;
+        __u64   unused2[4];
+    };
+
+    struct nvme_user_io_t {
+        uint32_t cdw00_09[10];
+        uint64_t slba;
+        uint32_t nlb  : 16;
+        uint32_t rsvd :  4;
+        uint32_t dtype  :  4;
+        uint32_t rsvd2  :  2;
+        uint32_t prinfo :  4;
+        uint32_t fua  :  1;
+        uint32_t lr :  1;
+        uint32_t cdw13_15[3];
+    };
+
+    struct nvme_io_command {
+        union {
+#ifdef NVME_IOCTL_IO64_CMD
+            nvme_passthru_cmd64 common;
+#else
+            nvme_passthru_cmd common;
+#endif
+            nvme_user_io_t rw;
+            uint32_t raw[16];
+        };
+
+        enum class opcode {
+            FLUSH = 0x0,
+            WRITE = 0x1,
+            READ = 0x2,
+            APPEND = 0x7D,
+        };
+    };
+    struct passthru_arg;
+    class passthru_completion final : public kernel_completion {
+        public:
+            io_completion* orig_completion = nullptr;
+            passthru_arg* arg = nullptr;
+            size_t block_size = -1;
+
+            void complete_with(ssize_t res) override {
+                if (res >= 0) {
+                    complete(res);
+                    return;
+                }
+                ++engine()._io_stats.aio_errors;
+                try {
+                    throw_kernel_error(res);
+                } catch (...) {
+                    set_exception(std::current_exception());
+                }
+            }
+
+            void complete(size_t res) noexcept {
+                if (res == 0) {
+                    orig_completion->set_additional_result(arg->cmd.common.result * block_size);
+                    orig_completion->complete_with(arg->cmd.common.data_len);
+                } else {
+                    // TODO pass proper error code
+                    orig_completion->complete_with(-1);
+                }
+                delete this;
+            }
+
+            void set_exception(std::exception_ptr eptr) noexcept {
+                orig_completion->set_exception(eptr);
+            }
+
+            ~passthru_completion() {}
+    };
+
+    struct passthru_arg {
+        nvme_io_command cmd;
+        kernel_completion* completion;
+    };
+
+    void prep_passthru_append(struct io_uring_sqe *sqe, int fd, void *buf, unsigned nbytes, off_t offset, uint32_t nsid, size_t block_size, io_completion* io_completion) {
+        // create append nvme command
+        auto arg = new passthru_arg;
+        auto& cmd = arg->cmd;
+        memset(&cmd, 0x0, sizeof(nvme_io_command));
+        cmd.common.opcode = static_cast<uint8_t>(nvme_io_command::opcode::APPEND);
+        cmd.common.nsid = nsid;
+        cmd.common.addr = reinterpret_cast<uint64_t>(buf);
+        cmd.common.data_len = nbytes;
+        cmd.rw.slba = offset / block_size;
+        cmd.rw.nlb = nbytes / block_size - 1;
+
+        // create sqe for passthru command
+        sqe->opcode = IORING_OP_URING_CMD;
+        sqe->addr = 4;
+        sqe->len = cmd.common.data_len;
+        sqe->off = reinterpret_cast<uint64_t>(&(cmd));
+        sqe->flags = 0;
+        sqe->fd = fd;
+        sqe->ioprio = 0;
+        sqe->user_data = reinterpret_cast<uint64_t>(arg);
+        sqe->rw_flags = 0;
+        sqe->__pad2[0] = 0;
+        sqe->__pad2[1] = 0;
+        sqe->__pad2[2] = 0;
+
+        struct block_uring_cmd  *blk_cmd =
+            reinterpret_cast<block_uring_cmd *>(&sqe->len);
+
+#ifdef NVME_IOCTL_IO64_CMD
+        blk_cmd->ioctl_cmd = NVME_IOCTL_IO64_CMD;
+#else
+        blk_cmd->ioctl_cmd = NVME_IOCTL_IO_CMD;
+#endif
+        auto completion = new passthru_completion;
+        completion->block_size = block_size;
+        completion->arg = arg;
+        arg->completion = completion;
+        completion->orig_completion = io_completion;
+    }
+#endif
 
     void submit_io_request(internal::io_request& req, io_completion* completion) {
         auto sqe = get_sqe();
@@ -1340,6 +1484,11 @@ private:
             case o::fdatasync:
                 ::io_uring_prep_fsync(sqe, req.fd(), IORING_FSYNC_DATASYNC);
                 break;
+#ifdef USE_PASSTHRU
+            case o::append:
+                prep_passthru_append(sqe, req.fd(), req.address(), req.size(), req.pos(), req.nsid(), req.block_size(), completion);
+                break;
+#endif
             case o::recv:
             case o::recvmsg:
             case o::send:
@@ -1355,7 +1504,16 @@ private:
                 seastar_logger.error("Invalid operation for iocb: {}", req.opname());
                 abort();
         }
+
+#ifdef USE_PASSTHRU
+        if (req.opcode() != o::append) {
+            auto arg = new passthru_arg;
+            arg->completion = completion;
+            ::io_uring_sqe_set_data(sqe, arg);
+        }
+#else
         ::io_uring_sqe_set_data(sqe, completion);
+#endif
 
         _has_pending_submissions = true;
     }
@@ -1374,8 +1532,14 @@ private:
     void do_process_ready_kernel_completions(::io_uring_cqe** buf, size_t nr) {
         for (auto p = buf; p != buf + nr; ++p) {
             auto cqe = *p;
-            auto completion = reinterpret_cast<kernel_completion*>(cqe->user_data);
+#ifdef USE_PASSTHRU
+            passthru_arg* arg = reinterpret_cast<passthru_arg*>(cqe->user_data);
+            arg->completion->complete_with(cqe->res);
+            delete arg;
+#else
+            auto completion = reinterpret_cast<passthru_arg*>(cqe->user_data);
             completion->complete_with(cqe->res);
+#endif
             ::io_uring_cqe_seen(&_uring, cqe);
         }
     }

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -212,6 +212,7 @@ public:
     virtual void start_handling_signal() = 0;
 
     virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) = 0;
+    virtual bool support_append() = 0;
 };
 
 // reactor backend using file-descriptor & epoll, suitable for running on
@@ -275,6 +276,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    virtual bool support_append() override;
 };
 
 class reactor_backend_aio : public reactor_backend {
@@ -323,6 +326,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    virtual bool support_append() override;
 };
 
 #ifdef HAVE_OSV
@@ -360,6 +365,8 @@ public:
     void enable_timer(steady_clock_type::time_point when);
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    virtual bool support_append() override;
 };
 #endif /* HAVE_OSV */
 


### PR DESCRIPTION
passthru is the functionality that enables users to submit an NVMe command manually constructed by themselves. passthru is also available via IOCTL, but it is now proper to be used as performance usage because of IOCTL's overhead.

ZNS is new type of NVMe SSD that only supports sequential write within a zone. Therefore NVMe commands, which is executed in out-of-order manner, requires stricted address sequencing overhead.

ZNS append command is new type of NVMe command that targets to relax the overhead of deciding the block address to place user data. With ZNS append command, user only submit command to a zone and ZNS SSD decides the exact block address of user data by its own placement policy. The assigned block address is returned to user via the completion of NVMe protocol. However append command is not provided as a user level library like aio_write(). The only way to use append command is submit it via manually constructed NVMe command.

io_uring library provides passthru with low overhead. Therefore it is proper to be used to submitting IO commands like append or write. We aim to use this passthru functionality to utilize append command on user level.

By utilizing append command on user level, user can mitigate synchronization overhead for sequencing address rather than using legacy write command.

Therefore, we implemented passthru functionality via io uring library and append command on file-related classes, and also added simple example application that write data via append command and then read data and verify it. 