### PR TITLE
util/closeable: add move ctor for deferred_stop

### DIFF
--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -61,6 +61,19 @@ public:
     /// Construct an object that will auto-close \c obj when destroyed.
     /// \tparam obj the object to auto-close.
     deferred_close(Object& obj) noexcept : _obj(obj) {}
+    /// Moves the \c deferred_close into a new one, and
+    /// the old one is canceled.
+    deferred_close(deferred_close&& x) noexcept : _obj(x._obj), _closed(std::exchange(x._closed, true)) {}
+    deferred_close(const deferred_close&) = delete;
+    /// Move-assign another \ref deferred_close.
+    /// The current \ref deferred_close is closed before being assigned.
+    /// And the other one's state is transferred to the current one.
+    deferred_close& operator=(deferred_close&& x) noexcept {
+        do_close();
+        _obj = x._obj;
+        _closed = std::exchange(x._closed, true);
+        return *this;
+    }
     /// Destruct the deferred_close object and auto-close \c obj.
     ~deferred_close() {
         do_close();
@@ -122,6 +135,19 @@ public:
     /// Construct an object that will auto-stop \c obj when destroyed.
     /// \tparam obj the object to auto-stop.
     deferred_stop(Object& obj) noexcept : _obj(obj) {}
+    /// Moves the \c deferred_stop into a new one, and
+    /// the old one is canceled.
+    deferred_stop(deferred_stop&& x) noexcept : _obj(x._obj), _stopped(std::exchange(x._stopped, true)) {}
+    deferred_stop(const deferred_stop&) = delete;
+    /// Move-assign another \ref deferred_stop.
+    /// The current \ref deferred_stop is stopped before being assigned.
+    /// And the other one's state is transferred to the current one.
+    deferred_stop& operator=(deferred_stop&& x) noexcept {
+        do_stop();
+        _obj = x._obj;
+        _stopped = std::exchange(x._stopped, true);
+        return *this;
+    }
     /// Destruct the deferred_stop object and auto-stop \c obj.
     ~deferred_stop() {
         do_stop();


### PR DESCRIPTION
before this change, if we move from a deferred_stop, when the original
instance is destructed, the obj referenced by it is always stopped if
the deferred_stop is not canceled. and the new instance of deferred_stop
also stops the referenced object when it is destroyed. but developer
would expect the obj is stopped only once, and should be stopped by the
new deferred_stop instance. this behavior is surprising when developer
intentially capture the deferred_stop instance by move and store it in
a local variable.

in this change,

* a move ctor is added for deferred_stop, so that the original
  instance is always canceled.
* a test is added accordingly.

please note, as a side effect, the default copy ctor is deleted. this is
expected. as deferred_stop should not be copiable. this might break
existing code. this is expected also. so developers can have a chance to
fix it using the move-ctor instead.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>