### PR TITLE
gate: add move ctor and move assignment operator for gate

### DIFF
--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -50,8 +50,16 @@ class gate {
 public:
     gate() = default;
     gate(const gate&) = delete;
-    gate(gate&&) = default;
-    gate& operator=(gate&&) = default;
+    gate(gate&& x) noexcept
+        : _count(std::exchange(x._count, 0)), _stopped(std::exchange(x._stopped, std::nullopt)) {}
+    gate& operator=(gate&& x) noexcept {
+        if (this != &x) {
+            assert(!_count && "gate reassigned with outstanding requests");
+            _count = std::exchange(x._count, 0);
+            _stopped = std::exchange(x._stopped, std::nullopt);
+        }
+        return *this;
+    }
     ~gate() {
         assert(!_count && "gate destroyed with outstanding requests");
     }


### PR DESCRIPTION
we have a use case where a std::vector<> is used for holding a number of domain specific "io channel" instances. the type of element in the vector is plain io channel, not a smart pointer, as all members variables in io channel have well defined move ctor and all of them are noexcept. each of io channel uses a seastar::gate to ensure that all the submitted requests are completed before the io channel is destroyed. but when we want to increase the number of io channels in the std::vector<>, there is a chance that the vector reallocates the elements in it. if the io channel has its move ctor defined as noexcept, the vector should be able to use it without calling the dtor to destroy the old elements and calling copy ctor to create the new ones.

but the problem is, the request count tracked by seastar::gate is left unchanged after its move ctor is called. so when the dtor of moved-away io channel is called, the dtor of its gate would have assertion failure, because of the "outstanding requests", despite that they are already moved into the newly allocated gate.

in this change, the move ctor and move assignment operator are added for gate, so that it can be moved without confusing its dtor.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>