### PR TITLE
reactor_config: update stale doc comments

### DIFF
--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -59,7 +59,7 @@ struct reactor_options : public program_options::option_group {
     program_options::value<bool> poll_aio;
     /// \brief Max time (ms) between polls.
     ///
-    /// Default: 500.
+    /// Default: 0.5.
     program_options::value<double> task_quota_ms;
     /// \brief Max time (ms) IO operations must take.
     ///
@@ -74,7 +74,7 @@ struct reactor_options : public program_options::option_group {
     /// \brief Threshold in milliseconds over which the reactor is considered
     /// blocked if no progress is made.
     ///
-    /// Default: 200.
+    /// Default: 25.
     program_options::value<unsigned> blocked_reactor_notify_ms;
     /// \brief Maximum number of backtraces reported by stall detector per minute.
     ///


### PR DESCRIPTION
The default value of blocked-reactor-notify-ms was reduced from 200 ms to 25 ms in https://github.com/scylladb/seastar/commit/0464eae943071a2b9eefe71db4640b5a409529f7.
The default value of task-quota-ms was reduced from 500 ms to 0.5 ms in https://github.com/scylladb/seastar/commit/cf0b43c52de0cd3c678879ea238dfe5edefb6a9a.
But the relevant doc comments weren't adjusted accordingly. Fix that.