### PR TITLE
reactor: drop stale comment

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4175,7 +4175,6 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     inited->wait();
 
     engine().configure(reactor_opts);
-    // The raw `new` is necessary because of the private constructor of `lowres_clock_impl`.
 }
 
 bool smp::poll_queues() {


### PR DESCRIPTION
the per-shard `_lowres_clock_impl` member variable was dropped in 5809978cf345b7ac4a7c584e2ab6478bae03b448. the comment added in f057084a647b6d088f7a352eca62fe4cce68b733 does not apply anymore. so let's just drop it.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>