### PR TITLE
smp: destroy_smp_service_group: verify smp_service_group id

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -102,12 +102,16 @@ struct smp_service_group_config {
 /// new smp_service_group_instead.
 class smp_service_group {
     unsigned _id;
+#ifdef SEASTAR_DEBUG
+    unsigned _version = 0;
+#endif
 private:
     explicit smp_service_group(unsigned id) noexcept : _id(id) {}
 
     friend unsigned internal::smp_service_group_id(smp_service_group ssg) noexcept;
     friend smp_service_group default_smp_service_group() noexcept;
     friend future<smp_service_group> create_smp_service_group(smp_service_group_config ssgc) noexcept;
+    friend future<> destroy_smp_service_group(smp_service_group) noexcept;
 };
 
 inline


### PR DESCRIPTION
Verify that the smp_service_group id to be destroyed
is valid, otherwise we end up with clearing a vector
in an arbitrary position in memory.

call on_internal_error_noexcept if the ssg id is invalid.

Also, added a unit test for that.

v2 of this patch was sent to the mailing list.

In v3 (430916ad4ba2394eed9ff85c151d544300d35f56):
- added "smp: add validate_smp_service_group"
