### PR TITLE
reactor: destroy_scheduling_group: make sure scheduling_group is valid

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -431,7 +431,7 @@ private:
     void allocate_scheduling_group_specific_data(scheduling_group sg, scheduling_group_key key);
     future<> init_scheduling_group(scheduling_group sg, sstring name, float shares);
     future<> init_new_scheduling_group_key(scheduling_group_key key, scheduling_group_key_config cfg);
-    future<> destroy_scheduling_group(scheduling_group sg);
+    future<> destroy_scheduling_group(scheduling_group sg) noexcept;
     uint64_t tasks_processed() const;
     uint64_t min_vruntime() const;
     void request_preemption();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4444,7 +4444,10 @@ reactor::init_new_scheduling_group_key(scheduling_group_key key, scheduling_grou
 }
 
 future<>
-reactor::destroy_scheduling_group(scheduling_group sg) {
+reactor::destroy_scheduling_group(scheduling_group sg) noexcept {
+    if (sg._id >= max_scheduling_groups()) {
+        on_fatal_internal_error(seastar_logger, format("Invalid scheduling_group {}", sg._id));
+    }
     return with_scheduling_group(sg, [this, sg] () {
         auto& sg_data = _scheduling_group_specific_data;
         auto& this_sg = sg_data.per_scheduling_group_data[sg._id];


### PR DESCRIPTION
When called with an invalid sg (e.g. a previously destroyed one) with_scheduling_group segfaults when dereferencing _task_queues[sg._id] which is nullified by destroy_scheduling_group.

To prevent that, verify first the the sg is valid, and abort after calling on_internal_error_noexcept otherwise. return an exceptional future in debug mode to enable a unit test.

While at it, also mark the method noexcept.

Added a debug unit tests to verify the returned exception when re-destorying a scheduling_group or when destroying an invalid scheduling_group.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

This PR is companion to https://github.com/scylladb/seastar/pull/1229

v1 was sent to the mailing list.

In v2 (978d46eeb4e4d29173d35be27299a967a2349441):
- call on_internal_error_noexcept and abort in non-debug modes while throwing std::invalid_argument in debug mode for unit testing purposes (if not aborting on_internal_error).
- added unit test for invalid sg case