### PR TITLE
future: Clear _state in promise::make_ready

### DIFF
--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -113,6 +113,16 @@ void promise_base::make_ready() noexcept {
         } else {
             ::seastar::schedule(std::exchange(_task, nullptr));
         }
+        // _state can point inside the task, future or promise. Since
+        // a task was created, we know that it was not pointing to the
+        // promise anymore. If a future still exists, _state points
+        // there and we don't need to do anything. If _future is null,
+        // we know that _state was pointing inside the task and we
+        // should clear it to avoid having a pointer to a destroyed
+        // object once task::run_and_dispose runs.
+        if (_future == nullptr) {
+            _state = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
        // _state can point inside the task, future or promise. Since
        // a task was created, we know that it was not pointing to the
        // promise anymore. If a future still exists, _state points
        // there and we don't need to do anything. If _future is null,
        // we know that _state was pointing inside the task and we
        // should clear it to avoid having a pointer to a destroyed
        // object once task::run_and_dispose runs.

Signed-off-by: Rafael Ávila de Espíndola <espindola@scylladb.com>
Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

This patch was originally sent to the mailing list.
Resubmitted here (unchanged) as a PR for CI purposes.