### PR TITLE
Mark file alignments as const

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -113,10 +113,10 @@ class file_impl {
     friend class file;
 protected:
     static file_impl* get_file_impl(file& f);
-    unsigned _memory_dma_alignment = 4096;
-    unsigned _disk_read_dma_alignment = 4096;
-    unsigned _disk_write_dma_alignment = 4096;
-    unsigned _disk_overwrite_dma_alignment = 4096;
+    const unsigned _memory_dma_alignment = 4096;
+    const unsigned _disk_read_dma_alignment = 4096;
+    const unsigned _disk_write_dma_alignment = 4096;
+    const unsigned _disk_overwrite_dma_alignment = 4096;
     unsigned _read_max_length = 1u << 30;
     unsigned _write_max_length = 1u << 30;
 

--- a/include/seastar/core/layered_file.hh
+++ b/include/seastar/core/layered_file.hh
@@ -43,11 +43,9 @@ public:
     /// Constructs a layered file. This sets up the underlying_file() method
     /// and initializes alignment constants to be the same as the underlying file.
     explicit layered_file_impl(file underlying_file) noexcept
-            : _underlying_file(std::move(underlying_file)) {
-        _memory_dma_alignment = _underlying_file.memory_dma_alignment();
-        _disk_read_dma_alignment = _underlying_file.disk_read_dma_alignment();
-        _disk_write_dma_alignment = _underlying_file.disk_write_dma_alignment();
-        _disk_overwrite_dma_alignment = _underlying_file.disk_overwrite_dma_alignment();
+            : file_impl(underlying_file.get_alignment_info())
+            , _underlying_file(std::move(underlying_file))
+    {
     }
 
     /// The underlying file which can be used to back I/O methods.

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -76,7 +76,7 @@ class posix_file_impl : public file_impl {
 protected:
     int _fd;
 
-    posix_file_impl(int fd, open_flags, file_open_options options, dev_t device_id, bool nowait_works);
+    posix_file_impl(int fd, open_flags, file_open_options options, dev_t device_id, bool nowait_works, internal::alignment_info ai = {});
     posix_file_impl(int fd, open_flags, file_open_options options, dev_t device_id, const internal::fs_info& fsi);
     posix_file_impl(int fd, open_flags, std::atomic<unsigned>* refcount, dev_t device_id,
             uint32_t memory_dma_alignment,
@@ -128,7 +128,6 @@ public:
         return _open_flags;
     }
 private:
-    void configure_dma_alignment(const internal::fs_info& fsi);
     void configure_io_lengths() noexcept;
 
     /**


### PR DESCRIPTION
There are four of them currently, they are set when file is constructed and never change then, but are not marked as const. The main (and the only) obstacle is that the values are initialized in inheritants' constructors bodies. So the main change in this set is moving the initialization into file_impl's initializer lists