### PR TITLE
reactor: pass a plain pointer to io_uring_wait_cqes()

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1436,9 +1436,9 @@ public:
         if (did_work) {
             return;
         }
-        struct ::io_uring_cqe* buf[s_queue_len];
+        struct ::io_uring_cqe* cqe = nullptr;
         sigset_t sigs = *active_sigmask; // io_uring_wait_cqes() wants non-const
-        auto r = ::io_uring_wait_cqes(&_uring, buf, 1, nullptr, &sigs);
+        auto r = ::io_uring_wait_cqes(&_uring, &cqe, 1, nullptr, &sigs);
         if (__builtin_expect(r < 0, false)) {
             switch (-r) {
             case EINTR:


### PR DESCRIPTION
there is no need to have an array of `io_uring_cqe*` on the stack. as the output parameter of `sqe` will simply point to the start address of the shared ringbuffer of sq if the `io_uring_wait_cqes()` completes. we could use it to construct a `std::span<io_uring_cqe>` though.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>