### PR TITLE
reactor: support more network ops in io_uring backend

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1134,12 +1134,16 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
             IORING_FEAT_SUBMIT_STABLE
             | IORING_FEAT_NODROP;
     auto required_ops = {
-            IORING_OP_POLL_ADD,
-            IORING_OP_READ,
-            IORING_OP_WRITE,
+            IORING_OP_POLL_ADD, // linux 5.1
             IORING_OP_READV,
             IORING_OP_WRITEV,
             IORING_OP_FSYNC,
+            IORING_OP_SENDMSG,  // linux 5.3
+            IORING_OP_RECVMSG,
+            IORING_OP_READ,     // linux 5.6
+            IORING_OP_WRITE,
+            IORING_OP_SEND,
+            IORING_OP_RECV,
             };
     auto maybe_throw = [&] (auto exception) {
         if (throw_on_error) {
@@ -1176,7 +1180,6 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
             return std::nullopt;
         }
     }
-
     free_ring.cancel();
 
     return ring;
@@ -1313,11 +1316,8 @@ private:
         }
         return sqe;
     }
+
     future<> poll(pollable_fd_state& fd, int events) {
-        if (events & fd.events_known) {
-            fd.events_known &= ~events;
-            return make_ready_future<>();
-        }
         auto sqe = get_sqe();
         ::io_uring_prep_poll_add(sqe, fd.fd.get(), events);
         auto ufd = static_cast<uring_pollable_fd_state*>(&fd);
@@ -1346,9 +1346,17 @@ private:
                 ::io_uring_prep_fsync(sqe, req.fd(), IORING_FSYNC_DATASYNC);
                 break;
             case o::recv:
+                ::io_uring_prep_recv(sqe, req.fd(), req.address(), req.size(), req.flags());
+                break;
             case o::recvmsg:
+                ::io_uring_prep_recvmsg(sqe, req.fd(), req.msghdr(), req.flags());
+                break;
             case o::send:
+                ::io_uring_prep_send(sqe, req.fd(), req.address(), req.size(), req.flags());
+                break;
             case o::sendmsg:
+                ::io_uring_prep_sendmsg(sqe, req.fd(), req.msghdr(), req.flags());
+                break;
             case o::accept:
             case o::connect:
             case o::poll_add:
@@ -1401,8 +1409,15 @@ private:
         }
         return did_work | std::exchange(_did_work_while_getting_sqe, false);
     }
+protected:
+    template<typename Completion>
+    auto submit_request(std::unique_ptr<Completion> desc, io_request&& req) noexcept {
+        auto fut = desc->get_future();
+        _r._io_sink.submit(desc.release(), std::move(req));
+        return fut;
+    }
 public:
-    explicit reactor_backend_uring(reactor& r) 
+    explicit reactor_backend_uring(reactor& r)
             : _r(r)
             , _uring(try_create_uring(s_queue_len, true).value())
             , _hrtimer_timerfd(make_timerfd())
@@ -1478,51 +1493,111 @@ public:
         fd.fd.shutdown(how);
     }
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override {
-        return readable(fd).then([this, &fd, buffer, len] () mutable {
-            auto r = fd.fd.read(buffer, len);
-            if (!r) {
-                return read_some(fd, buffer, len);
-            }
-            if (size_t(*r) == len) {
-                fd.speculate_epoll(EPOLLIN);
-            }
-            return make_ready_future<size_t>(*r);
-        });
+        return _r.do_read_some(fd, buffer, len);
     }
     virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) override {
-        return readable(fd).then([this, &fd, iov = iov] () mutable {
+        if (fd.take_speculation(POLLIN)) {
             ::msghdr mh = {};
-            mh.msg_iov = &iov[0];
+            mh.msg_iov = const_cast<iovec*>(iov.data());
             mh.msg_iovlen = iov.size();
-            auto r = fd.fd.recvmsg(&mh, 0);
-            if (!r) {
-                return read_some(fd, iov);
+            try {
+                auto r = fd.fd.recvmsg(&mh, 0);
+                if (r) {
+                    if (size_t(*r) == internal::iovec_len(iov)) {
+                        fd.speculate_epoll(EPOLLIN);
+                    }
+                    return make_ready_future<size_t>(*r);
+                }
+            } catch (...) {
+                return current_exception_as_future<size_t>();
             }
-            if (size_t(*r) == internal::iovec_len(iov)) {
-                fd.speculate_epoll(EPOLLIN);
+        }
+        class read_completion final : public io_completion {
+            pollable_fd_state& _fd;
+            std::vector<iovec> _iov;
+            ::msghdr _mh = {};
+            promise<size_t> _result;
+        public:
+            read_completion(pollable_fd_state& fd, const std::vector<iovec>& iov)
+                : _fd(fd), _iov(iov) {
+                _mh.msg_iov = const_cast<iovec*>(_iov.data());
+                _mh.msg_iovlen = _iov.size();
             }
-            return make_ready_future<size_t>(*r);
-        });
+            void complete(size_t bytes) noexcept final {
+                if (bytes == internal::iovec_len(_iov)) {
+                    _fd.speculate_epoll(EPOLLIN);
+                }
+                _result.set_value(bytes);
+                delete this;
+            }
+            void set_exception(std::exception_ptr eptr) noexcept final {
+                _result.set_exception(eptr);
+                delete this;
+            }
+            ::msghdr* msghdr() {
+                return &_mh;
+            }
+            future<size_t> get_future() {
+                return _result.get_future();
+            }
+        };
+        auto desc = std::make_unique<read_completion>(fd, iov);
+        auto req = internal::io_request::make_recvmsg(fd.fd.get(), desc->msghdr(), 0);
+        return submit_request(std::move(desc), std::move(req));
     }
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override {
-        return readable(fd).then([this, &fd, ba] {
+        if (fd.take_speculation(POLLIN)) {
             auto buffer = ba->allocate_buffer();
-            auto r = fd.fd.read(buffer.get_write(), buffer.size());
-            if (!r) {
-                // Speculation failure, try again with real polling this time
-                // Note we release the buffer and will reallocate it when poll
-                // completes.
-                return read_some(fd, ba);
+            try {
+                auto r = fd.fd.read(buffer.get_write(), buffer.size());
+                if (r) {
+                    if (size_t(*r) == buffer.size()) {
+                        fd.speculate_epoll(EPOLLIN);
+                    }
+                    buffer.trim(*r);
+                    return make_ready_future<temporary_buffer<char>>(std::move(buffer));
+                }
+            } catch (...) {
+                return current_exception_as_future<temporary_buffer<char>>();
             }
-            if (size_t(*r) == buffer.size()) {
-                fd.speculate_epoll(EPOLLIN);
-            }
-            buffer.trim(*r);
-            return make_ready_future<temporary_buffer<char>>(std::move(buffer));
+        }
+        return readable(fd).then([this, &fd, ba] {
+            class read_completion final : public io_completion {
+                pollable_fd_state& _fd;
+                temporary_buffer<char> _buffer;
+                promise<temporary_buffer<char>> _result;
+            public:
+                read_completion(pollable_fd_state& fd, temporary_buffer<char> buffer)
+                    : _fd(fd), _buffer(std::move(buffer)) {}
+                void complete(size_t bytes) noexcept final {
+                    if (bytes == _buffer.size()) {
+                        _fd.speculate_epoll(EPOLLIN);
+                    }
+                    _buffer.trim(bytes);
+                    _result.set_value(std::move(_buffer));
+                    delete this;
+                }
+                void set_exception(std::exception_ptr eptr) noexcept final {
+                    _result.set_exception(eptr);
+                    delete this;
+                }
+                future<temporary_buffer<char>> get_future() {
+                    return _result.get_future();
+                }
+                char* get_write() {
+                    return _buffer.get_write();
+                }
+                size_t get_size() {
+                    return _buffer.size();
+                }
+            };
+            auto desc = std::make_unique<read_completion>(fd, ba->allocate_buffer());
+            auto req = internal::io_request::make_read(fd.fd.get(), -1, desc->get_write(), desc->get_size(), false);
+            return submit_request(std::move(desc), std::move(req));
         });
     }
-    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override {
-        return writeable(fd).then([this, &fd, &p] () mutable {
+    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) final {
+        if (fd.take_speculation(EPOLLOUT)) {
             static_assert(offsetof(iovec, iov_base) == offsetof(net::fragment, base) &&
                 sizeof(iovec::iov_base) == sizeof(net::fragment::base) &&
                 offsetof(iovec, iov_len) == offsetof(net::fragment, size) &&
@@ -1531,31 +1606,93 @@ public:
                 sizeof(iovec) == sizeof(net::fragment)
                 , "net::fragment and iovec should be equivalent");
 
-            iovec* iov = reinterpret_cast<iovec*>(p.fragment_array());
-            msghdr mh = {};
-            mh.msg_iov = iov;
+            ::msghdr mh = {};
+            mh.msg_iov = reinterpret_cast<iovec*>(p.fragment_array());
             mh.msg_iovlen = std::min<size_t>(p.nr_frags(), IOV_MAX);
-            auto r = fd.fd.sendmsg(&mh, MSG_NOSIGNAL);
-            if (!r) {
-                return write_some(fd, p);
+            try {
+                auto r = fd.fd.sendmsg(&mh, MSG_NOSIGNAL);
+                if (r) {
+                    if (size_t(*r) == p.len()) {
+                        fd.speculate_epoll(EPOLLOUT);
+                    }
+                    return make_ready_future<size_t>(*r);
+                }
+            } catch (...) {
+                return current_exception_as_future<size_t>();
             }
-            if (size_t(*r) == p.len()) {
-                fd.speculate_epoll(EPOLLOUT);
+        }
+        class write_completion final : public io_completion {
+            pollable_fd_state& _fd;
+            ::msghdr _mh = {};
+            const size_t _to_write;
+            promise<size_t> _result;
+        public:
+            write_completion(pollable_fd_state& fd, net::packet& p)
+                : _fd(fd), _to_write(p.len()) {
+                _mh.msg_iov = reinterpret_cast<iovec*>(p.fragment_array());
+                _mh.msg_iovlen = std::min<size_t>(p.nr_frags(), IOV_MAX);
             }
-            return make_ready_future<size_t>(*r);
-        });
+            void complete(size_t bytes) noexcept final {
+                if (bytes == _to_write) {
+                    _fd.speculate_epoll(EPOLLOUT);
+                }
+                _result.set_value(bytes);
+                delete this;
+            }
+            void set_exception(std::exception_ptr eptr) noexcept final {
+                _result.set_exception(eptr);
+                delete this;
+            }
+            ::msghdr* msghdr() {
+                return &_mh;
+            }
+            future<size_t> get_future() {
+                return _result.get_future();
+            }
+        };
+        auto desc = std::make_unique<write_completion>(fd, p);
+        auto req = internal::io_request::make_sendmsg(fd.fd.get(), desc->msghdr(), MSG_NOSIGNAL);
+        return submit_request(std::move(desc), std::move(req));
     }
     virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override {
-        return writeable(fd).then([this, &fd, buffer, len] () mutable {
-            auto r = fd.fd.send(buffer, len, MSG_NOSIGNAL);
-            if (!r) {
-                return write_some(fd, buffer, len);
+        if (fd.take_speculation(EPOLLOUT)) {
+            try {
+                auto r = fd.fd.send(buffer, len, MSG_NOSIGNAL);
+                if (r) {
+                    if (size_t(*r) == len) {
+                        fd.speculate_epoll(EPOLLOUT);
+                    }
+                    return make_ready_future<size_t>(*r);
+                }
+            } catch (...) {
+                return current_exception_as_future<size_t>();
             }
-            if (size_t(*r) == len) {
-                fd.speculate_epoll(EPOLLOUT);
+        }
+        class write_completion final : public io_completion {
+            pollable_fd_state& _fd;
+            const size_t _to_write;
+            promise<size_t> _result;
+        public:
+            write_completion(pollable_fd_state& fd, size_t to_write)
+                : _fd(fd), _to_write(to_write) {}
+            void complete(size_t bytes) noexcept final {
+                if (bytes == _to_write) {
+                    _fd.speculate_epoll(EPOLLOUT);
+                }
+                _result.set_value(bytes);
+                delete this;
             }
-            return make_ready_future<size_t>(*r);
-        });
+            void set_exception(std::exception_ptr eptr) noexcept final {
+                _result.set_exception(eptr);
+                delete this;
+            }
+            future<size_t> get_future() {
+                return _result.get_future();
+            }
+        };
+        auto desc = std::make_unique<write_completion>(fd, len);
+        auto req = internal::io_request::make_send(fd.fd.get(), buffer, len, MSG_NOSIGNAL);
+        return submit_request(std::move(desc), std::move(req));
     }
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override {
         _r._signals.action(signo, siginfo, ignore);


### PR DESCRIPTION
* reorder `required_ops` in `try_create_uring` in the exact order of
  `io_uring_op` in linux/include/uapi/linux/io_uring.h. the
  `io_uring_op` enum is defined in the chronological order when the
  ops are added. and add comments to note the exact linux version
  in which the corresponding ops where added.
* move speculation from `reactor_backend_uring::poll()`, so we can
  be more explicit when calling `readable()` or `writeable()`. So,
  if `take_speculation()` is called, we want to have speculation
  explicitly. If `poll()` is called, the outcome should be a
  readable or writeable fd.
* document the `take_speculation()` and `speculate_epoll()` methods
* rewrite `reactor_backend_uring::read_some()` and
  `reactor_backend_uring::write_some()` with io_uring ops. please
  note, quote from the commit message of linux source commit d7718a9d

  > io_uring tries any request in a non-blocking manner, if it can,
  > and then retries from a worker thread if we get -EAGAIN.

  so, io_uring never returns EAGAIN, and after linux v5.7, it
  even polls for the events before performing I/O if -EAGAIN is
  returned. so we don't have to poll for the event or open the
  file / socket without `SOCK_NONBLOCK` or `O_NONBLOCK` in order
  to prevent io_uring from returning -EAGAIN.

tested on a 8-core x86 machine with `httpd --smp 1` (release build)
and `wrk -c 128 -t 4`. the aio backend showed:
```
Running 10s test @ http://localhost:10000/
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.49ms  109.56us   3.81ms   87.41%
    Req/Sec    21.51k   783.10    28.03k    87.84%
  862627 requests in 10.10s, 112.71MB read
Requests/sec:  85407.13
Transfer/sec:     11.16MB
```
while the io_uring backend gave us:
```
Running 10s test @ http://localhost:10000/
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.35ms  400.14us  37.64ms   98.36%
    Req/Sec    23.94k     2.36k   26.30k    70.25%
  952788 requests in 10.00s, 124.48MB read
Requests/sec:  95266.43
Transfer/sec:     12.45MB
```

Signed-off-by: Kefu Chai <tchaikov@gmail.com>