### PR TITLE
reactor: advance the head pointer in batch

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1389,7 +1389,6 @@ private:
             auto cqe = *p;
             auto completion = reinterpret_cast<kernel_completion*>(cqe->user_data);
             completion->complete_with(cqe->res);
-            ::io_uring_cqe_seen(&_uring, cqe);
         }
     }
 
@@ -1398,6 +1397,7 @@ private:
         struct ::io_uring_cqe* buf[s_queue_len];
         auto n = ::io_uring_peek_batch_cqe(&_uring, buf, s_queue_len);
         do_process_ready_kernel_completions(buf, n);
+        ::io_uring_cq_advance(&_uring, n);
         return n != 0;
     }
 


### PR DESCRIPTION
before this change, we advance the head pointer of cq by 1 after process each cqe.

after this change, we advance the head pointer after done with all cqes.

because `io_uring_cqe_seen()` is implemented using `io_uring_cq_advance()` which in turn effectively calls `atomic::store(new_head, std::memory_order::release)`. so less calls of `io_uring_cqe_seen()` would incurs less write memory barriers put on in the execution path. so this change should help improve the performance a little bit.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>