### PR TITLE
sstring: define formatter

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -805,3 +805,10 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
     return os;
 }
 }
+
+#if FMT_VERSION >= 90000
+
+template <typename char_type, typename Size, Size max_size, bool NulTerminate>
+struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>> : fmt::ostream_formatter {};
+
+#endif


### PR DESCRIPTION
Formatting a basic_sstring compiles now, via decaying the sstring into an std::string_view. However, it crashes. From my debugging it looks like the temporary std::string_view is captured by reference, which is then dangling. This happens only on aarch64, likely due to different optimization choices by the compiler.

Fix by defining a formatter.