### PR TITLE
io_request: remove ctor overloads of io_request and s/io_request/const io_request/

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -404,15 +404,18 @@ std::vector<io_request::part> io_request::split(size_t max_length) {
 
 std::vector<io_request::part> io_request::split_buffer(size_t max_length) {
     std::vector<part> ret;
-    ret.reserve((_size.len + max_length - 1) / max_length);
+    // the layout of _read and _write should be identical, otherwise we need to
+    // have two different implementations for each of them
+    static_assert(std::is_same_v<decltype(_read), decltype(_write)>);
+    const auto& op = _read;
+    ret.reserve((op.size + max_length - 1) / max_length);
 
     size_t off = 0;
     do {
-        size_t len = std::min(_size.len - off, max_length);
-        io_request part(_op, _fd, _attr.pos + off, _ptr.addr + off, len, _nowait_works);
-        ret.push_back({ std::move(part), len, {} });
+        size_t len = std::min(op.size - off, max_length);
+        ret.push_back({ sub_req_buffer(off, len), len, {} });
         off += len;
-    } while (off < _size.len);
+    } while (off < op.size);
 
     return ret;
 }
@@ -420,10 +423,14 @@ std::vector<io_request::part> io_request::split_buffer(size_t max_length) {
 std::vector<io_request::part> io_request::split_iovec(size_t max_length) {
     std::vector<part> parts;
     std::vector<::iovec> vecs;
-    ::iovec* cur = iov();
+    // the layout of _readv and _writev should be identical, otherwise we need to
+    // have two different implementations for each of them
+    static_assert(std::is_same_v<decltype(_readv), decltype(_writev)>);
+    const auto& op = _readv;
+    ::iovec* cur = op.iovec;
     size_t pos = 0;
     size_t off = 0;
-    ::iovec* end = cur + iov_len();
+    ::iovec* end = cur + op.iov_len;
     size_t remaining = max_length;
 
     while (cur != end) {
@@ -445,7 +452,7 @@ std::vector<io_request::part> io_request::split_iovec(size_t max_length) {
             vecs.push_back(std::move(iov));
         }
 
-        io_request req(_op, _fd, _attr.pos + pos, vecs.data(), vecs.size(), _nowait_works);
+        auto req = sub_req_iovec(pos, vecs);
         parts.push_back({ std::move(req), max_length, std::move(vecs) });
         pos += max_length;
         remaining = max_length;
@@ -453,7 +460,7 @@ std::vector<io_request::part> io_request::split_iovec(size_t max_length) {
 
     if (vecs.size() > 0) {
         assert(remaining < max_length);
-        io_request req(_op, _fd, _attr.pos + pos, vecs.data(), vecs.size(), _nowait_works);
+        auto req = sub_req_iovec(pos, vecs);
         parts.push_back({ std::move(req), max_length - remaining, std::move(vecs) });
     }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -60,7 +60,7 @@ public:
     }
 };
 
-void prepare_iocb(io_request& req, io_completion* desc, iocb& iocb) {
+void prepare_iocb(const io_request& req, io_completion* desc, iocb& iocb) {
     switch (req.opcode()) {
     case io_request::operation::fdatasync:
         iocb = make_fdsync_iocb(req.as<io_request::operation::fdatasync>().fd);
@@ -178,7 +178,7 @@ aio_storage_context::submit_work() {
     bool did_work = false;
 
     _submission_queue.resize(0);
-    size_t to_submit = _r._io_sink.drain([this] (internal::io_request& req, io_completion* desc) -> bool {
+    size_t to_submit = _r._io_sink.drain([this] (const internal::io_request& req, io_completion* desc) -> bool {
         if (!_iocb_pool.has_capacity()) {
             return false;
         }
@@ -1351,7 +1351,7 @@ private:
         return ufd->get_completion_future(events);
     }
 
-    void submit_io_request(internal::io_request& req, io_completion* completion) {
+    void submit_io_request(const internal::io_request& req, io_completion* completion) {
         auto sqe = get_sqe();
         using o = internal::io_request::operation;
         switch (req.opcode()) {
@@ -1426,7 +1426,7 @@ private:
 
     // Returns true if any work was done
     bool queue_pending_file_io() {
-        return _r._io_sink.drain([&] (internal::io_request& req, io_completion* completion) -> bool {
+        return _r._io_sink.drain([&] (const internal::io_request& req, io_completion* completion) -> bool {
             submit_io_request(req, completion);
             return true;
         });

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -53,15 +53,17 @@ struct fake_file {
     }
 
     void execute_write_req(internal::io_request& rq, io_completion* desc) {
-        data[rq.pos()] = *(reinterpret_cast<int*>(rq.address()));
-        desc->complete_with(rq.size());
+        const auto& op = rq.as<internal::io_request::operation::write>();
+        data[op.pos] = *(reinterpret_cast<int*>(op.addr));
+        desc->complete_with(op.size);
     }
 
     void execute_writev_req(internal::io_request& rq, io_completion* desc) {
         size_t len = 0;
-        for (unsigned i = 0; i < rq.iov_len(); i++) {
-            data[rq.pos() + i] = *(reinterpret_cast<int*>(rq.iov()[i].iov_base));
-            len += rq.iov()[i].iov_len;
+        const auto& op = rq.as<internal::io_request::operation::writev>();
+        for (unsigned i = 0; i < op.iov_len; i++) {
+            data[op.pos + i] = *(reinterpret_cast<int*>(op.iovec[i].iov_base));
+            len += op.iovec[i].iov_len;
         }
         desc->complete_with(len);
     }
@@ -146,7 +148,8 @@ static void do_test_large_request_flow(part_flaw flaw) {
         tio.sink.drain([&file, i, flaw] (internal::io_request& rq, io_completion* desc) -> bool {
             if (i == 1) {
                 if (flaw == part_flaw::partial) {
-                    rq.iov()[0].iov_len /= 2;
+                    const auto& op = rq.as<internal::io_request::operation::writev>();
+                    op.iovec[0].iov_len /= 2;
                 }
                 if (flaw == part_flaw::error) {
                     desc->complete_with(-EIO);
@@ -316,13 +319,15 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
 SEASTAR_TEST_CASE(test_request_buffer_split) {
     auto ensure = [] (const std::vector<internal::io_request::part>& parts, const internal::io_request& req, int idx, uint64_t pos, size_t size, uintptr_t mem) {
         BOOST_REQUIRE(parts[idx].req.opcode() == req.opcode());
-        BOOST_REQUIRE_EQUAL(parts[idx].req.fd(), req.fd());
-        BOOST_REQUIRE_EQUAL(parts[idx].req.pos(), pos);
-        BOOST_REQUIRE_EQUAL(parts[idx].req.size(), size);
-        BOOST_REQUIRE_EQUAL(parts[idx].req.address(), reinterpret_cast<void*>(mem));
-        BOOST_REQUIRE_EQUAL(parts[idx].req.nowait_works(), req.nowait_works());
+        const auto& op = req.as<internal::io_request::operation::read>();
+        const auto& sub_op = parts[idx].req.as<internal::io_request::operation::read>();
+        BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
+        BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
+        BOOST_REQUIRE_EQUAL(sub_op.size, size);
+        BOOST_REQUIRE_EQUAL(sub_op.addr, reinterpret_cast<void*>(mem));
+        BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
         BOOST_REQUIRE_EQUAL(parts[idx].iovecs.size(), 0);
-        BOOST_REQUIRE_EQUAL(parts[idx].size, parts[idx].req.size());
+        BOOST_REQUIRE_EQUAL(parts[idx].size, sub_op.size);
     };
 
     // No split
@@ -360,9 +365,10 @@ static void show_request(const internal::io_request& req, void* buf_off, std::st
         return;
     }
 
-    seastar_logger.trace("{}{} iovecs on req:", pfx, req.iov_len());
-    for (unsigned i = 0; i < req.iov_len(); i++) {
-        seastar_logger.trace("{}  base={} len={}", pfx, reinterpret_cast<uintptr_t>(req.iov()[i].iov_base) - reinterpret_cast<uintptr_t>(buf_off), req.iov()[i].iov_len);
+    const auto& op = req.as<internal::io_request::operation::readv>();
+    seastar_logger.trace("{}{} iovecs on req:", pfx, op.iov_len);
+    for (unsigned i = 0; i < op.iov_len; i++) {
+        seastar_logger.trace("{}  base={} len={}", pfx, reinterpret_cast<uintptr_t>(op.iovec[i].iov_base) - reinterpret_cast<uintptr_t>(buf_off), op.iovec[i].iov_len);
     }
 }
 
@@ -418,15 +424,17 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
 
     auto ensure = [] (const std::vector<internal::io_request::part>& parts, const internal::io_request& req, int idx, uint64_t pos) {
         BOOST_REQUIRE(parts[idx].req.opcode() == req.opcode());
-        BOOST_REQUIRE_EQUAL(parts[idx].req.fd(), req.fd());
-        BOOST_REQUIRE_EQUAL(parts[idx].req.pos(), pos);
-        BOOST_REQUIRE_EQUAL(parts[idx].req.iov_len(), parts[idx].iovecs.size());
-        BOOST_REQUIRE_EQUAL(parts[idx].req.nowait_works(), req.nowait_works());
+        const auto& op = req.as<internal::io_request::operation::writev>();
+        const auto& sub_op = parts[idx].req.as<internal::io_request::operation::writev>();
+        BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
+        BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
+        BOOST_REQUIRE_EQUAL(sub_op.iov_len, parts[idx].iovecs.size());
+        BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
         BOOST_REQUIRE_EQUAL(parts[idx].size, internal::iovec_len(parts[idx].iovecs));
 
         for (unsigned iov = 0; iov < parts[idx].iovecs.size(); iov++) {
-            BOOST_REQUIRE_EQUAL(parts[idx].req.iov()[iov].iov_base, parts[idx].iovecs[iov].iov_base);
-            BOOST_REQUIRE_EQUAL(parts[idx].req.iov()[iov].iov_len, parts[idx].iovecs[iov].iov_len);
+            BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_base, parts[idx].iovecs[iov].iov_base);
+            BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_len, parts[idx].iovecs[iov].iov_len);
         }
     };
 


### PR DESCRIPTION
The existing io_request constructor overloads are error-prone. better off using a more explicit way to select the expected constructor. In this change:

* remove ctor overloads. and construct `io_request` instances using the `make_*` methods directly.
* use tagged union for holding different op types. so don't try to shoehorn things into fields.
* access the op members via the op returned by `as<op>()`
* add `sub_req_buffer()` and `sub_req_iovec()` helpers to construct io_request which represents a subrange of current io_request.
* s/io_request/const io_request/

Signed-off-by: Kefu Chai <tchaikov@gmail.com>