### PR TITLE
reactor: use separate calls in reactor and reactor_backend for read/write/sendmsg/recvmsg

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -511,7 +511,7 @@ public:
 
     future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local);
 
-    future<> write_all(pollable_fd_state& fd, const void* buffer, size_t size);
+    future<> send_all(pollable_fd_state& fd, const void* buffer, size_t size);
 
     future<file> open_file_dma(std::string_view name, open_flags flags, file_open_options options = {}) noexcept;
     future<file> open_directory(std::string_view name) noexcept;
@@ -632,7 +632,7 @@ private:
     void unregister_poller(pollfn* p);
     void replace_poller(pollfn* old, pollfn* neww);
     void register_metrics();
-    future<> write_all_part(pollable_fd_state& fd, const void* buffer, size_t size, size_t completed);
+    future<> send_all_part(pollable_fd_state& fd, const void* buffer, size_t size, size_t completed);
 
     future<> fdatasync(int fd) noexcept;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -451,7 +451,7 @@ private:
     do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 
     future<size_t>
-    do_write_some(pollable_fd_state& fd, const void* buffer, size_t size);
+    do_send(pollable_fd_state& fd, const void* buffer, size_t size);
     future<size_t>
     do_write_some(pollable_fd_state& fd, net::packet& p);
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -446,7 +446,7 @@ private:
     future<size_t>
     do_read_some(pollable_fd_state& fd, void* buffer, size_t size);
     future<size_t>
-    do_read_some(pollable_fd_state& fd, const std::vector<iovec>& iov);
+    do_recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov);
     future<temporary_buffer<char>>
     do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -453,7 +453,7 @@ private:
     future<size_t>
     do_send(pollable_fd_state& fd, const void* buffer, size_t size);
     future<size_t>
-    do_write_some(pollable_fd_state& fd, net::packet& p);
+    do_sendmsg(pollable_fd_state& fd, net::packet& p);
 
     future<temporary_buffer<char>>
     do_recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -444,7 +444,7 @@ private:
     future<> do_connect(pollable_fd_state& pfd, socket_address& sa);
 
     future<size_t>
-    do_read_some(pollable_fd_state& fd, void* buffer, size_t size);
+    do_read(pollable_fd_state& fd, void* buffer, size_t size);
     future<size_t>
     do_recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov);
     future<temporary_buffer<char>>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -360,13 +360,13 @@ reactor::do_sendmsg(pollable_fd_state& fd, net::packet& p) {
 }
 
 future<>
-reactor::write_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed) {
+reactor::send_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed) {
     if (completed == len) {
         return make_ready_future<>();
     } else {
         return _backend->send(fd, static_cast<const char*>(buffer) + completed, len - completed).then(
                 [&fd, buffer, len, completed, this] (size_t part) mutable {
-            return write_all_part(fd, buffer, len, completed + part);
+            return send_all_part(fd, buffer, len, completed + part);
         });
     }
 }
@@ -389,9 +389,9 @@ reactor::do_recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
 }
 
 future<>
-reactor::write_all(pollable_fd_state& fd, const void* buffer, size_t len) {
+reactor::send_all(pollable_fd_state& fd, const void* buffer, size_t len) {
     assert(len);
-    return write_all_part(fd, buffer, len, 0);
+    return send_all_part(fd, buffer, len, 0);
 }
 
 future<size_t> pollable_fd_state::read_some(char* buffer, size_t size) {
@@ -415,11 +415,11 @@ future<size_t> pollable_fd_state::write_some(net::packet& p) {
 }
 
 future<> pollable_fd_state::write_all(const char* buffer, size_t size) {
-    return engine().write_all(*this, buffer, size);
+    return engine().send_all(*this, buffer, size);
 }
 
 future<> pollable_fd_state::write_all(const uint8_t* buffer, size_t size) {
-    return engine().write_all(*this, buffer, size);
+    return engine().send_all(*this, buffer, size);
 }
 
 future<> pollable_fd_state::write_all(net::packet& p) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -270,11 +270,11 @@ future<> reactor::do_connect(pollable_fd_state& pfd, socket_address& sa) {
 }
 
 future<size_t>
-reactor::do_read_some(pollable_fd_state& fd, void* buffer, size_t len) {
+reactor::do_read(pollable_fd_state& fd, void* buffer, size_t len) {
     return readable(fd).then([this, &fd, buffer, len] () mutable {
         auto r = fd.fd.read(buffer, len);
         if (!r) {
-            return do_read_some(fd, buffer, len);
+            return do_read(fd, buffer, len);
         }
         if (size_t(*r) == len) {
             fd.speculate_epoll(EPOLLIN);
@@ -395,11 +395,11 @@ reactor::write_all(pollable_fd_state& fd, const void* buffer, size_t len) {
 }
 
 future<size_t> pollable_fd_state::read_some(char* buffer, size_t size) {
-    return engine()._backend->read_some(*this, buffer, size);
+    return engine()._backend->read(*this, buffer, size);
 }
 
 future<size_t> pollable_fd_state::read_some(uint8_t* buffer, size_t size) {
-    return engine()._backend->read_some(*this, buffer, size);
+    return engine()._backend->read(*this, buffer, size);
 }
 
 future<size_t> pollable_fd_state::read_some(const std::vector<iovec>& iov) {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -632,8 +632,8 @@ reactor_backend_aio::read_some(pollable_fd_state& fd, internal::buffer_allocator
 }
 
 future<size_t>
-reactor_backend_aio::write_some(pollable_fd_state& fd, const void* buffer, size_t len) {
-    return _r.do_write_some(fd, buffer, len);
+reactor_backend_aio::send(pollable_fd_state& fd, const void* buffer, size_t len) {
+    return _r.do_send(fd, buffer, len);
 }
 
 future<size_t>
@@ -1008,8 +1008,8 @@ reactor_backend_epoll::read_some(pollable_fd_state& fd, internal::buffer_allocat
 }
 
 future<size_t>
-reactor_backend_epoll::write_some(pollable_fd_state& fd, const void* buffer, size_t len) {
-    return _r.do_write_some(fd, buffer, len);
+reactor_backend_epoll::send(pollable_fd_state& fd, const void* buffer, size_t len) {
+    return _r.do_send(fd, buffer, len);
 }
 
 future<size_t>
@@ -1119,8 +1119,8 @@ reactor_backend_osv::read_some(pollable_fd_state& fd, internal::buffer_allocator
 }
 
 future<size_t>
-reactor_backend_osv::write_some(pollable_fd_state& fd, const void* buffer, size_t len) {
-    return engine().do_write_some(fd, buffer, len);
+reactor_backend_osv::send(pollable_fd_state& fd, const void* buffer, size_t len) {
+    return engine().do_send(fd, buffer, len);
 }
 
 future<size_t>
@@ -1797,7 +1797,7 @@ public:
         auto req = internal::io_request::make_sendmsg(fd.fd.get(), desc->msghdr(), MSG_NOSIGNAL);
         return submit_request(std::move(desc), std::move(req));
     }
-    virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override {
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override {
         if (fd.take_speculation(EPOLLOUT)) {
             try {
                 auto r = fd.fd.send(buffer, len, MSG_NOSIGNAL | MSG_DONTWAIT);

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -617,8 +617,8 @@ void reactor_backend_aio::shutdown(pollable_fd_state& fd, int how) {
 }
 
 future<size_t>
-reactor_backend_aio::read_some(pollable_fd_state& fd, void* buffer, size_t len) {
-    return _r.do_read_some(fd, buffer, len);
+reactor_backend_aio::read(pollable_fd_state& fd, void* buffer, size_t len) {
+    return _r.do_read(fd, buffer, len);
 }
 
 future<size_t>
@@ -993,8 +993,8 @@ void reactor_backend_epoll::shutdown(pollable_fd_state& fd, int how) {
 }
 
 future<size_t>
-reactor_backend_epoll::read_some(pollable_fd_state& fd, void* buffer, size_t len) {
-    return _r.do_read_some(fd, buffer, len);
+reactor_backend_epoll::read(pollable_fd_state& fd, void* buffer, size_t len) {
+    return _r.do_read(fd, buffer, len);
 }
 
 future<size_t>
@@ -1104,7 +1104,7 @@ reactor_backend_osv::recv(pollable_fd_state& fd, void* buffer, size_t len) {
 }
 
 future<size_t>
-reactor_backend_osv::read_some(pollable_fd_state& fd, void* buffer, size_t len) {
+reactor_backend_osv::read(pollable_fd_state& fd, void* buffer, size_t len) {
     return engine().do_read_some(fd, buffer, len);
 }
 
@@ -1598,7 +1598,7 @@ public:
     virtual void shutdown(pollable_fd_state& fd, int how) override {
         fd.fd.shutdown(how);
     }
-    virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override {
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override {
         if (fd.take_speculation(POLLIN)) {
             try {
                 auto r = fd.fd.read(buffer, len);

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -622,8 +622,8 @@ reactor_backend_aio::read_some(pollable_fd_state& fd, void* buffer, size_t len) 
 }
 
 future<size_t>
-reactor_backend_aio::read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) {
-    return _r.do_read_some(fd, iov);
+reactor_backend_aio::recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) {
+    return _r.do_recvmsg(fd, iov);
 }
 
 future<temporary_buffer<char>>
@@ -998,8 +998,8 @@ reactor_backend_epoll::read_some(pollable_fd_state& fd, void* buffer, size_t len
 }
 
 future<size_t>
-reactor_backend_epoll::read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) {
-    return _r.do_read_some(fd, iov);
+reactor_backend_epoll::recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) {
+    return _r.do_recvmsg(fd, iov);
 }
 
 future<temporary_buffer<char>>
@@ -1109,7 +1109,7 @@ reactor_backend_osv::read_some(pollable_fd_state& fd, void* buffer, size_t len) 
 }
 
 future<size_t>
-reactor_backend_osv::read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) {
+reactor_backend_osv::recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) {
     return engine().do_read_some(fd, iov);
 }
 
@@ -1638,7 +1638,7 @@ public:
         auto req = internal::io_request::make_read(fd.fd.get(), -1, buffer, len, false);
         return submit_request(std::move(desc), std::move(req));
     }
-    virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) override {
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override {
         if (fd.take_speculation(POLLIN)) {
             ::msghdr mh = {};
             mh.msg_iov = const_cast<iovec*>(iov.data());

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -637,8 +637,8 @@ reactor_backend_aio::send(pollable_fd_state& fd, const void* buffer, size_t len)
 }
 
 future<size_t>
-reactor_backend_aio::write_some(pollable_fd_state& fd, net::packet& p) {
-    return _r.do_write_some(fd, p);
+reactor_backend_aio::sendmsg(pollable_fd_state& fd, net::packet& p) {
+    return _r.do_sendmsg(fd, p);
 }
 
 future<temporary_buffer<char>>
@@ -1013,8 +1013,8 @@ reactor_backend_epoll::send(pollable_fd_state& fd, const void* buffer, size_t le
 }
 
 future<size_t>
-reactor_backend_epoll::write_some(pollable_fd_state& fd, net::packet& p) {
-    return _r.do_write_some(fd, p);
+reactor_backend_epoll::sendmsg(pollable_fd_state& fd, net::packet& p) {
+    return _r.do_sendmsg(fd, p);
 }
 
 future<temporary_buffer<char>>
@@ -1124,8 +1124,8 @@ reactor_backend_osv::send(pollable_fd_state& fd, const void* buffer, size_t len)
 }
 
 future<size_t>
-reactor_backend_osv::write_some(pollable_fd_state& fd, net::packet& p) {
-    return engine().do_write_some(fd, p);
+reactor_backend_osv::sendmsg(pollable_fd_state& fd, net::packet& p) {
+    return engine().do_sendmsg(fd, p);
 }
 
 void
@@ -1739,7 +1739,7 @@ public:
             return submit_request(std::move(desc), std::move(req));
         });
     }
-    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) final {
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) final {
         if (fd.take_speculation(EPOLLOUT)) {
             static_assert(offsetof(iovec, iov_base) == offsetof(net::fragment, base) &&
                 sizeof(iovec::iov_base) == sizeof(net::fragment::base) &&

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1128,6 +1128,11 @@ reactor_backend_osv::sendmsg(pollable_fd_state& fd, net::packet& p) {
     return engine().do_sendmsg(fd, p);
 }
 
+future<temporary_buffer<char>>
+reactor_backend_osv::recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
+    return engine().do_recv_some(fd, p);
+}
+
 void
 reactor_backend_osv::enable_timer(steady_clock_type::time_point when) {
     _poller.set_timer(when);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -199,7 +199,7 @@ public:
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;
     virtual void shutdown(pollable_fd_state& fd, int how) = 0;
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) = 0;
-    virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) = 0;
     virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) = 0;
@@ -265,7 +265,7 @@ public:
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;
@@ -314,7 +314,7 @@ public:
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;
@@ -359,7 +359,7 @@ public:
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(net::packet& p) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -202,7 +202,7 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) = 0;
-    virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) = 0;
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) = 0;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
 
     virtual bool do_blocking_io() const {
@@ -268,7 +268,7 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
-    virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override;
@@ -317,7 +317,7 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
-    virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override;
@@ -362,7 +362,7 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> write_some(net::packet& p) override;
-    virtual future<size_t> write_some(pollable_fd_state& fd, const void* buffer, size_t len) override;
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
 
     void enable_timer(steady_clock_type::time_point when);
     virtual pollable_fd_state_ptr

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -198,7 +198,7 @@ public:
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;
     virtual void shutdown(pollable_fd_state& fd, int how) = 0;
-    virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) = 0;
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) = 0;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) = 0;
@@ -264,7 +264,7 @@ public:
     accept(pollable_fd_state& listenfd) override;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
@@ -313,7 +313,7 @@ public:
     accept(pollable_fd_state& listenfd) override;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
@@ -358,7 +358,7 @@ public:
     accept(pollable_fd_state& listenfd) override;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
     virtual void shutdown(pollable_fd_state& fd, int how) override;
-    virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -201,7 +201,7 @@ public:
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) = 0;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
-    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) = 0;
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) = 0;
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) = 0;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
 
@@ -267,7 +267,7 @@ public:
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
-    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
@@ -316,7 +316,7 @@ public:
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
-    virtual future<size_t> write_some(pollable_fd_state& fd, net::packet& p) override;
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
@@ -361,7 +361,7 @@ public:
     virtual future<size_t> read_some(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
-    virtual future<size_t> write_some(net::packet& p) override;
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
 
     void enable_timer(steady_clock_type::time_point when);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -363,6 +363,7 @@ public:
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, net::packet& p) override;
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
+    virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
     void enable_timer(steady_clock_type::time_point when);
     virtual pollable_fd_state_ptr


### PR DESCRIPTION
for better readability