### PR TITLE
reactor: make io_uring the default backend if available

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -294,7 +294,7 @@ cooking_ingredient (liburing
     BUILD_COMMAND <DISABLE>
     BUILD_BYPRODUCTS "<SOURCE_DIR>/src/liburing.a"
     BUILD_IN_SOURCE ON
-    INSTALL_COMMAND ${make_command} -C src -s install)
+    INSTALL_COMMAND ${make_command} -s install)
 
 cooking_ingredient (lz4
   EXTERNAL_PROJECT_ARGS

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1979,15 +1979,15 @@ reactor_backend_selector reactor_backend_selector::default_backend() {
 
 std::vector<reactor_backend_selector> reactor_backend_selector::available() {
     std::vector<reactor_backend_selector> ret;
-    if (has_enough_aio_nr() && detect_aio_poll()) {
-        ret.push_back(reactor_backend_selector("linux-aio"));
-    }
-    ret.push_back(reactor_backend_selector("epoll"));
 #ifdef SEASTAR_HAVE_URING
     if (detect_io_uring()) {
         ret.push_back(reactor_backend_selector("io_uring"));
     }
 #endif
+    if (has_enough_aio_nr() && detect_aio_poll()) {
+        ret.push_back(reactor_backend_selector("linux-aio"));
+    }
+    ret.push_back(reactor_backend_selector("epoll"));
     return ret;
 }
 


### PR DESCRIPTION
now that io_uring's performance is on par with that of linux-aio, and its throughput is always better than linux-aio, let's make it the default reactor backend. please note, io_uring is disabled by default on RHEL/RockyLinux 9 at the time of writing.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>