### PR TITLE
build: install liburing.pc using stow

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -294,7 +294,7 @@ cooking_ingredient (liburing
     BUILD_COMMAND <DISABLE>
     BUILD_BYPRODUCTS "<SOURCE_DIR>/src/liburing.a"
     BUILD_IN_SOURCE ON
-    INSTALL_COMMAND ${make_command} -C src -s install)
+    INSTALL_COMMAND ${make_command} -s install)
 
 cooking_ingredient (lz4
   EXTERNAL_PROJECT_ARGS


### PR DESCRIPTION
before this change, liburing.pc is not installed if we configure the building system using `./configure ... --cooking liburing` and expect that CMake will find liburing. but in fact, CMake will reject the found liburing and continue without liburing enabled, as the found liburing package is missing version string.

after this change, we install liburing in its top source directory, so liburing.pc is also installed in addition to its header files and compiled library.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>