### PR TITLE
Ragel chunk parser: compilation err, unused var

### DIFF
--- a/src/http/chunk_parsers.rl
+++ b/src/http/chunk_parsers.rl
@@ -104,7 +104,7 @@ public:
     }
     char* parse(char* p, char* pe, char* eof) {
         sstring_builder::guard g(_builder, p, pe);
-        auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
+        [[maybe_unused]] auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
         bool done = false;
         if (p != pe) {
             _state = state::error;
@@ -235,7 +235,7 @@ public:
     }
     char* parse(char* p, char* pe, char* eof) {
         sstring_builder::guard g(_builder, p, pe);
-        auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
+        [[maybe_unused]] auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
         bool done = false;
         if (p != pe) {
             _state = state::error;


### PR DESCRIPTION
```cmake
cmake_minimum_required(VERSION 3.24)
project(seastar_demo)

set(CMAKE_CXX_STANDARD 23)

include(FetchContent)
FetchContent_Declare(seastar
        # Personal fork, have merged a bunch of recent PR's to get features faster
        GIT_REPOSITORY https://github.com/GavinRay97/seastar
        GIT_TAG master)
FetchContent_MakeAvailable(seastar)

add_executable(seastar_demo main.cpp)
target_link_libraries(seastar_demo
        PRIVATE
        seastar)
```

```cpp
[43/86] Building CXX object _deps/seastar-build/CMakeFiles/seastar.dir/src/http/httpd.cc.o
FAILED: _deps/seastar-build/CMakeFiles/seastar.dir/src/http/httpd.cc.o
/usr/bin/clang++ -DFMT_SHARED -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_LZ4_COMPRESS_DEFAULT -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_URING -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -I/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/include -I/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-build/gen/include -I/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/src -I/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-build/gen/src -g -fcolor-diagnostics -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -fvisibility=hidden -UNDEBUG -Wall -Werror -Wno-array-bounds -Wno-error=deprecated-declarations -gz -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -std=gnu++2b -MD -MT _deps/seastar-build/CMakeFiles/seastar.dir/src/http/httpd.cc.o -MF _deps/seastar-build/CMakeFiles/seastar.dir/src/http/httpd.cc.o.d -o _deps/seastar-build/CMakeFiles/seastar.dir/src/http/httpd.cc.o -c /home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/src/http/httpd.cc
In file included from /home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/src/http/httpd.cc:39:
In file included from /home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/include/seastar/http/internal/content_source.hh:24:
/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/src/http/chunk_parsers.rl:55:9: error: unused variable 'str' [-Werror,-Wunused-variable]
                        auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
                             ^
/home/user/projects/seastar-demo/cmake-build-debug/_deps/seastar-src/src/http/chunk_parsers.rl:115:9: error: unused variable 'str' [-Werror,-Wunused-variable]
                        auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
                             ^
2 errors generated.
[54/86] Building CXX object _deps/seastar-build/CMakeFiles/seastar.dir/src/core/reactor.cc.o
```