### PR TITLE
build: use correct version when finding liburing

### DIFF
--- a/cmake/FindLibUring.cmake
+++ b/cmake/FindLibUring.cmake
@@ -22,7 +22,7 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (URING liburing)
+pkg_search_module (URING_PC liburing)
 
 find_library (URING_LIBRARY
   NAMES uring
@@ -64,7 +64,7 @@ find_package_handle_standard_args (LibUring
 set (URING_LIBRARIES ${URING_LIBRARY})
 set (URING_INCLUDE_DIRS ${URING_INCLUDE_DIR})
 
-if (URING_FOUND AND NOT (TARGET URING::uring))
+if (LibUring_FOUND AND NOT (TARGET URING::uring))
   add_library (URING::uring UNKNOWN IMPORTED)
 
   set_target_properties (URING::uring


### PR DESCRIPTION
* use URING_PC as the prefix passed to pkg_search_module()
* use LibUring_FOUND when checking if LibUring is found. as this is the
  "FOUND_VAR" used by `find_package_handle_standard_args()`, and hence
  should be used as the authentic indicator.

without this change, if `pkg_search_module(URING liburing)` finds a
liburing with lower version than specified version, it is still accepted
as long as `pkg_search_module()` is able to find any liburing.pc. as
`URING_FOUND` is used as the indicator of the existence of the qualified
liburing library.

after this change, the `URING_PC` is used instead of `URING`. so
`find_package(LibUring...)` can do its job and find liburing if its
.pc file is found and its version is greater than 2.0. and
`LibUring_FOUND` is used so we don't accept liburing with unexpected
version anymore.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>