### PR TITLE
Outline reactor::add_task() and sanitize reactor::shuffle() methods

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -550,9 +550,6 @@ public:
         _at_destroy_tasks->_q.push_back(make_task(default_scheduling_group(), std::forward<Func>(func)));
     }
 
-#ifdef SEASTAR_SHUFFLE_TASK_QUEUE
-    void shuffle(task*&, task_queue&);
-#endif
     task* current_task() const { return _current_task; }
 
     void add_task(task* t) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -555,31 +555,8 @@ public:
 #endif
     task* current_task() const { return _current_task; }
 
-    void add_task(task* t) noexcept {
-        auto sg = t->group();
-        auto* q = _task_queues[sg._id].get();
-        bool was_empty = q->_q.empty();
-        q->_q.push_back(std::move(t));
-#ifdef SEASTAR_SHUFFLE_TASK_QUEUE
-        shuffle(q->_q.back(), *q);
-#endif
-        if (was_empty) {
-            activate(*q);
-        }
-    }
-    void add_urgent_task(task* t) noexcept {
-        memory::scoped_critical_alloc_section _;
-        auto sg = t->group();
-        auto* q = _task_queues[sg._id].get();
-        bool was_empty = q->_q.empty();
-        q->_q.push_front(std::move(t));
-#ifdef SEASTAR_SHUFFLE_TASK_QUEUE
-        shuffle(q->_q.front(), *q);
-#endif
-        if (was_empty) {
-            activate(*q);
-        }
-    }
+    void add_task(task* t) noexcept;
+    void add_urgent_task(task* t) noexcept;
 
     /// Set a handler that will be called when there is no task to execute on cpu.
     /// Handler should do a low priority work.


### PR DESCRIPTION
The former is not used outside of reactor.cc, the latter carries along the ifdef/endif decorations. Localizing both in .cc makes reactor.hh itself and reactor API a bit simpler