### PR TITLE
De-futurize IO class update calls

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -146,7 +146,7 @@ public:
     sstring mountpoint() const;
     dev_t dev_id() const noexcept;
 
-    future<> update_shares_for_class(io_priority_class pc, size_t new_shares);
+    void update_shares_for_class(io_priority_class pc, size_t new_shares);
     future<> update_bandwidth_for_class(io_priority_class pc, uint64_t new_bandwidth);
     void rename_priority_class(io_priority_class pc, sstring new_name);
     void throttle_priority_class(const priority_class_data& pc) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -494,7 +494,7 @@ public:
     [[deprecated("Use io_priority_class.rename")]]
     static future<> rename_priority_class(io_priority_class pc, sstring new_name) noexcept;
     /// @private
-    future<> rename_queues(io_priority_class pc, sstring new_name) noexcept;
+    void rename_queues(io_priority_class pc, sstring new_name);
 
     void configure(const reactor_options& opts);
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -487,7 +487,7 @@ public:
     [[deprecated("Use io_priority_class.update_shares")]]
     future<> update_shares_for_class(io_priority_class pc, uint32_t shares);
     /// @private
-    future<> update_shares_for_queues(io_priority_class pc, uint32_t shares);
+    void update_shares_for_queues(io_priority_class pc, uint32_t shares);
     /// @private
     future<> update_bandwidth_for_queues(io_priority_class pc, uint64_t bandwidth);
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -966,11 +966,11 @@ io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {
 
 void
 io_queue::update_shares_for_class(const io_priority_class pc, size_t new_shares) {
-        auto& pclass = find_or_create_class(pc);
-        pclass.update_shares(new_shares);
-        for (auto&& s : _streams) {
-            s.update_shares_for_class(pclass.fq_class(), new_shares);
-        }
+    auto& pclass = find_or_create_class(pc);
+    pclass.update_shares(new_shares);
+    for (auto&& s : _streams) {
+        s.update_shares_for_class(pclass.fq_class(), new_shares);
+    }
 }
 
 future<> io_queue::update_bandwidth_for_class(const io_priority_class pc, uint64_t new_bandwidth) {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -671,7 +671,7 @@ future<> io_priority_class::rename(sstring new_name) noexcept {
         }
 
         return smp::invoke_on_all([this, new_name = std::move(new_name)] {
-            return engine().rename_queues(*this, new_name);
+            engine().rename_queues(*this, new_name);
         });
     });
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -230,9 +230,9 @@ future<> reactor::update_bandwidth_for_queues(io_priority_class pc, uint64_t ban
 }
 
 void reactor::rename_queues(io_priority_class pc, sstring new_name) {
-        for (auto&& queue : _io_queues) {
-            queue.second->rename_priority_class(pc, new_name);
-        }
+    for (auto&& queue : _io_queues) {
+        queue.second->rename_priority_class(pc, new_name);
+    }
 }
 
 future<std::tuple<pollable_fd, socket_address>>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -215,10 +215,10 @@ reactor::rename_priority_class(io_priority_class pc, sstring new_name) noexcept 
     return pc.rename(std::move(new_name));
 }
 
-future<> reactor::update_shares_for_queues(io_priority_class pc, uint32_t shares) {
-    return parallel_for_each(_io_queues, [pc, shares] (auto& queue) {
-        return queue.second->update_shares_for_class(pc, shares);
-    });
+void reactor::update_shares_for_queues(io_priority_class pc, uint32_t shares) {
+    for (auto&& q : _io_queues) {
+        q.second->update_shares_for_class(pc, shares);
+    }
 }
 
 future<> reactor::update_bandwidth_for_queues(io_priority_class pc, uint64_t bandwidth) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -229,12 +229,10 @@ future<> reactor::update_bandwidth_for_queues(io_priority_class pc, uint64_t ban
     });
 }
 
-future<> reactor::rename_queues(io_priority_class pc, sstring new_name) noexcept {
-    return futurize_invoke([this, pc, new_name = std::move(new_name)] {
+void reactor::rename_queues(io_priority_class pc, sstring new_name) {
         for (auto&& queue : _io_queues) {
             queue.second->rename_priority_class(pc, new_name);
         }
-    });
 }
 
 future<std::tuple<pollable_fd, socket_address>>


### PR DESCRIPTION
When updating shares for IO class or renaming it, it involves updating shares and names on the IO queues. Both calls are futurized, but there's no real need in it at the IO-queue level. Turning these updating methods to be void makes them compatible with scheduling groups shares update and rename which, in turn, makes it simpler to merge them eventually

refs: #1069