### PR TITLE
defer: mark deferred_* with [[nodiscard]]

### DIFF
--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -48,7 +48,7 @@ concept closeable = requires (Object o) {
 /// needs to wait on the \c obj close() future.
 template <typename Object>
 SEASTAR_CONCEPT( requires closeable<Object> )
-class deferred_close {
+class [[nodiscard("unassigned deferred_close")]] deferred_close {
     std::reference_wrapper<Object> _obj;
     bool _closed = false;
 
@@ -122,7 +122,7 @@ concept stoppable = requires (Object o) {
 /// needs to wait on the \c obj stop() future.
 template <typename Object>
 SEASTAR_CONCEPT( requires stoppable<Object> )
-class deferred_stop {
+class [[nodiscard("unassigned deferred_stop")]] deferred_stop {
     std::reference_wrapper<Object> _obj;
     bool _stopped = false;
 

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -43,7 +43,7 @@ namespace seastar {
 
 template <typename Func>
 SEASTAR_CONCEPT( requires deferrable_action<Func> )
-class deferred_action {
+class [[nodiscard("unassigned deferred_action")]] deferred_action {
     Func _func;
     bool _cancelled = false;
 public:


### PR DESCRIPTION
in hope to catch issues where developer forgets to assign, for
instance, deferred_action to a variable, and the action is not
deferred.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>