### PR TITLE
file: Dont violate API layering

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1240,7 +1240,7 @@ future<size_t> file::dma_read(uint64_t pos, std::vector<iovec> iov, const io_pri
 
 future<temporary_buffer<uint8_t>>
 file::dma_read_exactly_impl(uint64_t pos, size_t len, const io_priority_class& pc, io_intent* intent) noexcept {
-    return dma_read<uint8_t>(pos, len, pc, intent).then([len](auto buf) {
+    return dma_read_impl(pos, len, pc, intent).then([len](auto buf) {
         if (buf.size() < len) {
             throw eof_error();
         }
@@ -1251,7 +1251,7 @@ file::dma_read_exactly_impl(uint64_t pos, size_t len, const io_priority_class& p
 
 future<temporary_buffer<uint8_t>>
 file::dma_read_impl(uint64_t pos, size_t len, const io_priority_class& pc, io_intent* intent) noexcept {
-    return dma_read_bulk<uint8_t>(pos, len, pc, intent).then([len](temporary_buffer<uint8_t> buf) {
+    return dma_read_bulk_impl(pos, len, pc, intent).then([len](temporary_buffer<uint8_t> buf) {
         if (len < buf.size()) {
             buf.trim(len);
         }


### PR DESCRIPTION
There are 3 layers "around" the file API:

- public calls
- ..._impl private calls
- file_impl pointer

Few calls from the ..._impl one call back the public calls because this is what they really wnat to do. This violates the layering (theory) and makes deprecation of public io_priority_class harder (practice). The fix is in making ..._impl calls call the other ..._impl calls.

tests: unit(dev), scylla.unit(dev)

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>