### PR TITLE
Add an allocation failure metric

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -234,16 +234,19 @@ class statistics {
     size_t _free_memory;
     uint64_t _reclaims;
     uint64_t _large_allocs;
+    uint64_t _failed_allocs;
 
     uint64_t _foreign_mallocs;
     uint64_t _foreign_frees;
     uint64_t _foreign_cross_frees;
 private:
     statistics(uint64_t mallocs, uint64_t frees, uint64_t cross_cpu_frees,
-            uint64_t total_memory, uint64_t free_memory, uint64_t reclaims, uint64_t large_allocs,
+            uint64_t total_memory, uint64_t free_memory, uint64_t reclaims,
+            uint64_t large_allocs, uint64_t failed_allocs,
             uint64_t foreign_mallocs, uint64_t foreign_frees, uint64_t foreign_cross_frees)
         : _mallocs(mallocs), _frees(frees), _cross_cpu_frees(cross_cpu_frees)
-        , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims), _large_allocs(large_allocs)
+        , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims)
+        , _large_allocs(large_allocs), _failed_allocs(failed_allocs)
         , _foreign_mallocs(foreign_mallocs), _foreign_frees(foreign_frees)
         , _foreign_cross_frees(foreign_cross_frees) {}
 public:
@@ -266,6 +269,9 @@ public:
     uint64_t reclaims() const { return _reclaims; }
     /// Number of allocations which violated the large allocation threshold
     uint64_t large_allocations() const { return _large_allocs; }
+    /// Number of allocations which failed, i.e., where the required memory could not be obtained
+    /// even after reclaim was attempted
+    uint64_t failed_allocations() const { return _failed_allocs; }
     /// Number of foreign allocations
     uint64_t foreign_mallocs() const { return _foreign_mallocs; }
     /// Number of foreign frees

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1676,9 +1676,10 @@ seastar::internal::log_buf::inserter_iterator do_dump_memory_diagnostics(seastar
     auto total_mem = get_cpu_mem().nr_pages * page_size;
     it = fmt::format_to(it, "Dumping seastar memory diagnostics\n");
 
-    it = fmt::format_to(it, "Used memory:  {}\n", to_hr_size(total_mem - free_mem));
-    it = fmt::format_to(it, "Free memory:  {}\n", to_hr_size(free_mem));
-    it = fmt::format_to(it, "Total memory: {}\n\n", to_hr_size(total_mem));
+    it = fmt::format_to(it, "Used memory:   {}\n", to_hr_size(total_mem - free_mem));
+    it = fmt::format_to(it, "Free memory:   {}\n", to_hr_size(free_mem));
+    it = fmt::format_to(it, "Total memory:  {}\n", to_hr_size(total_mem));
+    it = fmt::format_to(it, "Hard failures: {}\n\n", alloc_stats::get(alloc_stats::types::failed_allocs));
 
     if (additional_diagnostics_producer) {
         additional_diagnostics_producer([&it] (std::string_view v) mutable {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -220,7 +220,8 @@ static thread_local bool is_reactor_thread = false;
 
 namespace alloc_stats {
 
-enum class types { allocs, frees, cross_cpu_frees, reclaims, large_allocs, foreign_mallocs, foreign_frees, foreign_cross_frees, enum_size };
+enum class types { allocs, frees, cross_cpu_frees, reclaims, large_allocs, failed_allocs,
+    foreign_mallocs, foreign_frees, foreign_cross_frees, enum_size };
 
 using stats_array = std::array<uint64_t, static_cast<std::size_t>(types::enum_size)>;
 using stats_atomic_array = std::array<std::atomic_uint64_t, static_cast<std::size_t>(types::enum_size)>;
@@ -1561,7 +1562,8 @@ void configure(std::vector<resource::memory> m, bool mbind,
 statistics stats() {
     return statistics{alloc_stats::get(alloc_stats::types::allocs), alloc_stats::get(alloc_stats::types::frees), alloc_stats::get(alloc_stats::types::cross_cpu_frees),
         cpu_mem.nr_pages * page_size, cpu_mem.nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
-        alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees), alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
+        alloc_stats::get(alloc_stats::types::failed_allocs), alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees),
+        alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
 }
 
 size_t free_memory() {
@@ -1796,6 +1798,8 @@ void maybe_dump_memory_diagnostics(size_t size) {
 }
 
 void on_allocation_failure(size_t size) {
+    alloc_stats::increment(alloc_stats::types::failed_allocs);
+
     maybe_dump_memory_diagnostics(size);
 
     if (!abort_on_alloc_failure_suppressed
@@ -2267,7 +2271,7 @@ void configure(std::vector<resource::memory> m, bool mbind, std::optional<std::s
 }
 
 statistics stats() {
-    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0};
+    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0, 0};
 }
 
 size_t free_memory() {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2301,7 +2301,8 @@ void reactor::register_metrics() {
             sm::make_current_bytes("free_memory", [] { return memory::stats().free_memory(); }, sm::description("Free memory size in bytes")),
             sm::make_current_bytes("total_memory", [] { return memory::stats().total_memory(); }, sm::description("Total memory size in bytes")),
             sm::make_current_bytes("allocated_memory", [] { return memory::stats().allocated_memory(); }, sm::description("Allocated memory size in bytes")),
-            sm::make_counter("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations"))
+            sm::make_counter("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations")),
+            sm::make_counter("malloc_failed", [] { return memory::stats().failed_allocations(); }, sm::description("Total count of failed memory allocations"))
     });
 
     _metric_groups.add_group("reactor", {

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -25,6 +25,8 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/memory_diagnostics.hh>
 
+#include <memory>
+#include <new>
 #include <vector>
 #include <future>
 #include <iostream>
@@ -191,6 +193,39 @@ SEASTAR_TEST_CASE(test_realloc_nullptr) {
     BOOST_REQUIRE(p1 != nullptr);
     free(p0);
     free(p1);
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_bad_alloc_throws) {
+    // test that a large allocation throws bad_alloc
+    auto stats = seastar::memory::stats();
+
+    // this allocation cannot be satisfied (at least when the seastar
+    // allocator is used, which it is for this test)
+    size_t size = stats.total_memory() * 2;
+
+    [[gnu::unused]]
+    void * volatile sink;
+
+    // test that new throws
+    try {
+        sink = operator new(size);
+        BOOST_TEST_FAIL("operator new did not throw");
+    } catch (std::bad_alloc&) {
+    }
+
+    // test that huge malloc returns null
+    BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
+
+    // test that huge realloc on nullptr returns null
+    BOOST_REQUIRE_EQUAL(realloc(nullptr, size), nullptr);
+
+    // test that huge realloc on an existing ptr returns null
+    void *p = malloc(1);
+    BOOST_REQUIRE(p);
+    BOOST_REQUIRE_EQUAL(realloc(p, size), nullptr);
+    free(p);
 
     return make_ready_future<>();
 }

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -214,11 +214,7 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
 
     // test that new throws
     stats = seastar::memory::stats();
-    try {
-        sink = operator new(size);
-        BOOST_TEST_FAIL("operator new did not throw");
-    } catch (std::bad_alloc&) {
-    }
+    BOOST_REQUIRE_THROW(sink = operator new(size), std::bad_alloc);
     BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge malloc returns null


### PR DESCRIPTION
This metric counts the number of times an allocation request
could not be satisfied even after reclaim, and a nullptr/bad_alloc
was returned/thrown.

In our experience, one a seastar-using server starts throwing bad 
allocs, it is only a matter of time before the node crashes entirely,
so this metric going from 0 to 1 is a strong indicator of an unhealthy
node.

One possible cause of false negatives is if there are very large
allocations (e.g., `(size_t)-1`) which could never be satisfied, but
occur due to bugs. Depending on where they are occur these may
be harmless and are not an indication of memory exhaustion since
they would fail at any amount of available memory. Solution is to:
fix those places (they are easy to find if they trigger the large allocation
warning, so it is good to have that enabled, even with a very large
threshold).
that is enabled).