### PR TITLE
Make seastar_test constructor noexcept

### DIFF
--- a/include/seastar/testing/seastar_test.hh
+++ b/include/seastar/testing/seastar_test.hh
@@ -36,7 +36,7 @@ namespace testing {
 
 class seastar_test {
 public:
-    seastar_test();
+    seastar_test() noexcept;
     virtual ~seastar_test() {}
     virtual const char* get_test_file() = 0;
     virtual const char* get_name() = 0;

--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -66,7 +66,7 @@ const std::vector<seastar_test*>& known_tests() {
     return *tests;
 }
 
-seastar_test::seastar_test() {
+seastar_test::seastar_test() noexcept {
     if (!tests) {
         tests = new std::vector<seastar_test*>();
     }


### PR DESCRIPTION
This constructor cannot throw except in the case of memory exhaustion causing a bad_alloc to be thrown. Since it it used as a global static object clang-tidy would like the constructor to be noexcept, so let us make it so.

In case that an exception is thrown, the error message is the same for the case of (a) global objects whose constructor throws and (b) when a noexcept method does throw, so on the (very unlikely) case of a throw this has the same behavior.