### PR TITLE
Add compile_commands.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cmake/Cooking.cmake
 tags
 .idea/
 .vscode/
+compile_commands.json


### PR DESCRIPTION
This flie is required by clangd to understand the compile command for each source file. It needs to be at the root of the repository and it will be common to have this file there for anyone using a clangd LSP based integratoin.