### PR TITLE
Use const test objects

### DIFF
--- a/include/seastar/testing/seastar_test.hh
+++ b/include/seastar/testing/seastar_test.hh
@@ -38,10 +38,10 @@ class seastar_test {
 public:
     seastar_test();
     virtual ~seastar_test() {}
-    virtual const char* get_test_file() = 0;
-    virtual const char* get_name() = 0;
-    virtual int get_expected_failures() { return 0; }
-    virtual future<> run_test_case() = 0;
+    virtual const char* get_test_file() const = 0;
+    virtual const char* get_name() const = 0;
+    virtual int get_expected_failures() const { return 0; }
+    virtual future<> run_test_case() const = 0;
     void run();
 };
 

--- a/include/seastar/testing/test_case.hh
+++ b/include/seastar/testing/test_case.hh
@@ -28,9 +28,9 @@
 
 #define SEASTAR_TEST_CASE(name) \
     struct name : public seastar::testing::seastar_test { \
-        const char* get_test_file() override { return __FILE__; } \
-        const char* get_name() override { return #name; } \
-        seastar::future<> run_test_case() override; \
+        const char* get_test_file() const override { return __FILE__; } \
+        const char* get_name() const override { return #name; } \
+        seastar::future<> run_test_case() const override; \
     }; \
-    static name name ## _instance; \
-    seastar::future<> name::run_test_case()
+    static const name name ## _instance; \
+    seastar::future<> name::run_test_case() const

--- a/include/seastar/testing/thread_test_case.hh
+++ b/include/seastar/testing/thread_test_case.hh
@@ -29,18 +29,18 @@
 
 #define SEASTAR_THREAD_TEST_CASE_EXPECTED_FAILURES(name, failures) \
     struct name : public seastar::testing::seastar_test { \
-        const char* get_test_file() override { return __FILE__; } \
-        const char* get_name() override { return #name; } \
-        int get_expected_failures() override { return failures; } \
-        seastar::future<> run_test_case() override { \
+        const char* get_test_file() const override { return __FILE__; } \
+        const char* get_name() const override { return #name; } \
+        int get_expected_failures() const override { return failures; } \
+        seastar::future<> run_test_case() const override { \
             return seastar::async([this] { \
                 do_run_test_case(); \
             }); \
         } \
-        void do_run_test_case(); \
+        void do_run_test_case() const; \
     }; \
-    static name name ## _instance; \
-    void name::do_run_test_case()
+    static const name name ## _instance; \
+    void name::do_run_test_case() const
 
 #define SEASTAR_THREAD_TEST_CASE(name) \
     SEASTAR_THREAD_TEST_CASE_EXPECTED_FAILURES(name, 0)

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -172,10 +172,10 @@ SEASTAR_TEST_CASE(test_thread_custom_stack_size) {
 // detect_stack_use_after_return=1 from the environment.
 #if defined(SEASTAR_THREAD_STACK_GUARDS) && defined(__x86_64__) && !defined(SEASTAR_ASAN_ENABLED)
 struct test_thread_custom_stack_size_failure : public seastar::testing::seastar_test {
-    const char* get_test_file() override { return __FILE__; }
-    const char* get_name() override { return "test_thread_custom_stack_size_failure"; }
-    int get_expected_failures() override { return 0; } \
-    seastar::future<> run_test_case() override;
+    const char* get_test_file() const override { return __FILE__; }
+    const char* get_name() const override { return "test_thread_custom_stack_size_failure"; }
+    int get_expected_failures() const override { return 0; } \
+    seastar::future<> run_test_case() const override;
 };
 
 static test_thread_custom_stack_size_failure test_thread_custom_stack_size_failure_instance;
@@ -213,7 +213,7 @@ static void bypass_stack_guard(int sig, siginfo_t* si, void* ctx) {
 
 // This test will fail with a regular stack size, because we only probe
 // around 10KiB of data, and the stack guard resides after 128'th KiB.
-seastar::future<> test_thread_custom_stack_size_failure::run_test_case() {
+seastar::future<> test_thread_custom_stack_size_failure::run_test_case() const {
     if (RUNNING_ON_VALGRIND) {
         return make_ready_future<>();
     }


### PR DESCRIPTION
The global (namespace scope) objects created by SEASTAR_TEST_CASE and related macros are stateless objects: their only purpose is to hold a vtable for overridden methods from seastar_test.

This means the base class methods and the object itself can be const.

This allows it to be allocated in .rodata (very minor benefit) and silences (valid?) clang-tidy warnings about non-const global objects.