### PR TITLE
Add NOLINT for cert-err58-cpp

### DIFF
--- a/include/seastar/testing/test_case.hh
+++ b/include/seastar/testing/test_case.hh
@@ -32,5 +32,5 @@
         const char* get_name() const override { return #name; } \
         seastar::future<> run_test_case() const override; \
     }; \
-    static const name name ## _instance; \
+    static const name name ## _instance; /* NOLINT(cert-err58-cpp) */ \
     seastar::future<> name::run_test_case() const

--- a/include/seastar/testing/thread_test_case.hh
+++ b/include/seastar/testing/thread_test_case.hh
@@ -39,7 +39,7 @@
         } \
         void do_run_test_case() const; \
     }; \
-    static const name name ## _instance; \
+    static const name name ## _instance; /* NOLINT(cert-err58-cpp) */ \
     void name::do_run_test_case() const
 
 #define SEASTAR_THREAD_TEST_CASE(name) \


### PR DESCRIPTION
Disable clang-tidy check cert-err58-cpp in SEASTAR_TEST_CASE and related macros. This check complains about a possibly-throwing (i.e., not noexcept) constructor for global objects. We create such an object for each test case. Since the constructor can throw (in the unlikely event of a memory allocation failure) we simply disbale the warning for these global objects using NOLINT.

In any case, if these objects throw, the process will be terminated which is an appropriate action for a memory allocation failure at startup.