### PR TITLE
tests: Fix false-positive use-after-free detection

### DIFF
--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -230,9 +230,10 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
     stats = seastar::memory::stats();
     void *p = malloc(1);
     BOOST_REQUIRE(p);
-    BOOST_REQUIRE_EQUAL(realloc(p, size), nullptr);
+    void *p2 = realloc(p, size);
+    BOOST_REQUIRE_EQUAL(p2, nullptr);
     BOOST_CHECK_EQUAL(failed_allocs(), 1);
-    free(p);
+    free(p2 ?: p);
 
     return make_ready_future<>();
 }


### PR DESCRIPTION
g++ version 12.2.1 reports

/usr/lib64/ccache/g++ -DBOOST_TEST_DYN_LINK -DFMT_LOCALE -DFMT_SHARED -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_LZ4_COMPRESS_DEFAULT -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_URING -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_TESTING_MAIN -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -I/home/xemul/src/seastar/tests/unit -I/home/xemul/src/seastar/src -I/home/xemul/src/seastar/include -I/home/xemul/src/seastar/build/dev/gen/include -O1 -U_FORTIFY_SOURCE -Wno-maybe-uninitialized -DSEASTAR_SSTRING -Wno-error=unused-result -fstack-clash-protection -fvisibility=hidden -UNDEBUG -Wall -Werror -Wno-array-bounds -Wno-error=deprecated-declarations -gz -std=gnu++23 -MD -MT tests/unit/CMakeFiles/test_unit_alloc.dir/alloc_test.cc.o -MF tests/unit/CMakeFiles/test_unit_alloc.dir/alloc_test.cc.o.d -o tests/unit/CMakeFiles/test_unit_alloc.dir/alloc_test.cc.o -c /home/xemul/src/seastar/tests/unit/alloc_test.cc /home/xemul/src/seastar/tests/unit/alloc_test.cc: In member function ‘virtual seastar::future<> test_bad_alloc_throws::run_test_case() const’: /home/xemul/src/seastar/tests/unit/alloc_test.cc:235:9: error: pointer may be used after ‘void* realloc(void*, size_t)’ [-Werror=use-after-free]
  235 |     free(p);
      |     ~~~~^~~
In file included from /usr/include/boost/test/test_tools.hpp:45,
                 from /usr/include/boost/test/unit_test.hpp:18,
                 from /home/xemul/src/seastar/include/seastar/testing/seastar_test.hh:27,
                 from /home/xemul/src/seastar/include/seastar/testing/test_case.hh:27,
                 from /home/xemul/src/seastar/tests/unit/alloc_test.cc:22:
/home/xemul/src/seastar/tests/unit/alloc_test.cc:233:32: note: call to ‘void* realloc(void*, size_t)’ here
  233 |     BOOST_REQUIRE_EQUAL(realloc(p, size), nullptr);
      |                         ~~~~~~~^~~~~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>