### PR TITLE
util, core: add spawn_process() helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,7 @@ add_library (seastar STATIC
   include/seastar/util/noncopyable_function.hh
   include/seastar/util/optimized_optional.hh
   include/seastar/util/print_safe.hh
+  include/seastar/util/process.hh
   include/seastar/util/program-options.hh
   include/seastar/util/read_first_line.hh
   include/seastar/util/reference_wrapper.hh
@@ -703,6 +704,7 @@ add_library (seastar STATIC
   src/util/exceptions.cc
   src/util/file.cc
   src/util/log.cc
+  src/util/process.cc
   src/util/program-options.cc
   src/util/read_first_line.cc
   src/util/tmp_file.cc

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -532,7 +532,13 @@ public:
     future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
     future<int> inotify_add_watch(int fd, std::string_view path, uint32_t flags);
-    
+
+    future<std::tuple<pid_t, int, int, int>>
+    spawn(std::string_view pathname,
+          std::vector<sstring> argv,
+          std::vector<sstring> env = {});
+    future<int> waitpid(pid_t pid);
+
     int run() noexcept;
     void exit(int ret);
     future<> when_started() { return _start_promise.get_future(); }

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -77,6 +77,12 @@ class udp_channel;
 
 }
 
+namespace experimental {
+// process.hh
+class process;
+struct spawn_parameters;
+}
+
 // Networking API
 
 /// \defgroup networking-module Networking
@@ -384,4 +390,35 @@ future<uint64_t> fs_avail(std::string_view name) noexcept;
 future<uint64_t> fs_free(std::string_view name) noexcept;
 /// @}
 
+namespace experimental {
+/// \defgroup subprocess-module Subprocess Management
+///
+/// Seastar provides a simple subprocess management API to
+/// spawn and interact with a subprocess.
+///
+/// \addtogroup subprocess-module
+/// @{
+
+/// Spawn a subprocess
+///
+/// \param pathname the path to the executable
+/// \param params parameters for spawning the subprocess
+///
+/// \return a process representing the spawned subprocess
+/// \note
+/// the subprocess is spawned with \c posix_spawn() system call, so the
+/// pathname should be relative or absolute path of the executable.
+future<process> spawn_process(const std::filesystem::path& pathname,
+                              spawn_parameters params);
+/// Spawn a subprocess
+///
+/// \param pathname the path to the executable
+///
+/// \return a process representing the spawned subprocess
+/// \note
+/// the this overload does not specify a \c params parameters for spawning the
+/// subprocess. Instead, it uses the pathname for the \c argv[0] in the params.
+future<process> spawn_process(const std::filesystem::path& pathname);
+/// @}
+}
 }

--- a/include/seastar/util/process.hh
+++ b/include/seastar/util/process.hh
@@ -1,0 +1,100 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2022 Kefu Chai ( tchaikov@gmail.com )
+ */
+
+#pragma once
+
+#include <sys/types.h>
+#include <algorithm>
+#include <filesystem>
+#include <initializer_list>
+#include <iterator>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <fmt/format.h>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/sstring.hh>
+
+namespace seastar::experimental {
+
+/// The optional parameters for spawning a subprocess
+///
+/// \note see \c execve(2) for more details on \c argv and \c env.
+struct spawn_parameters {
+    /// The arguments passed to the program
+    std::vector<sstring> argv;
+    /// The environment variables for the program
+    std::vector<sstring> env;
+};
+
+/// Interact with a spawned subprocess
+///
+/// \note the spawned subprocess should always be \c wait()'ed. Otherwise,
+/// the Seastar application spawning the subprocess will leave us with
+/// one ore more zombie subprocesses after it exists.
+class process {
+    struct create_tag {};
+    /// Spawn a subprocess using \c posix_spawn(3)
+    ///
+    /// \param pathname the full path to the executable
+    /// \param params parameters for spawning the subprocess
+    ///
+    /// \returns a \c process instance representing the spawned subprocess
+    static future<process> spawn(const std::filesystem::path& pathname,
+                                 spawn_parameters params);
+    /// Spawn a subprocess using \c posix_spawn(3)
+    ///
+    /// \param pathname the full path to the executable
+    ///
+    /// \returns a \c process instance representing the spawned subprocess
+    static future<process> spawn(const std::filesystem::path& pathname);
+public:
+    process(create_tag, pid_t pid, int stdin, int stdout, int stderr);
+    /// Return an writable stream which provides input from the child process
+    output_stream<char> stdin();
+    /// Return an writable stream which provides stdout output from the child process
+    input_stream<char> stdout();
+    /// Return an writable stream which provides stderr output from the child process
+    input_stream<char> stderr();
+    struct wait_exited {
+        int exit_code;
+    };
+    struct wait_signaled {
+        int terminating_signal;
+    };
+    using wait_status = std::variant<wait_exited, wait_signaled>;
+    /// Wait until the child process exits or terminates
+    ///
+    /// \returns the exit status
+    future<wait_status> wait();
+private:
+    const pid_t _pid;
+    const int _stdin;
+    const int _stdout;
+    const int _stderr;
+
+    friend future<process> spawn_process(const std::filesystem::path&,
+                                         spawn_parameters);
+    friend future<process> spawn_process(const std::filesystem::path&);
+};
+}

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -22,17 +22,20 @@
 #define __user /* empty */  // for xfs includes, below
 
 #include <cinttypes>
+#include <spawn.h>
 #include <sys/syscall.h>
 #include <sys/vfs.h>
 #include <sys/statfs.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/inotify.h>
+#include <sys/wait.h>
 #include <fmt/ranges.h>
 #include <seastar/core/task.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/memory.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/net/packet.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/net/posix-stack.hh>
@@ -41,7 +44,9 @@
 #include <seastar/core/print.hh>
 #include "core/scollectd-impl.hh"
 #include <seastar/util/conversions.hh>
+#include <seastar/util/process.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/make_task.hh>
@@ -1883,6 +1888,185 @@ reactor::inotify_add_watch(int fd, std::string_view path, uint32_t flags) {
             ret.throw_if_error();
             return make_ready_future<int>(ret.result);
         });
+    });
+}
+
+future<std::tuple<pid_t, int, int, int>>
+reactor::spawn(std::string_view pathname,
+               std::vector<sstring> argv,
+               std::vector<sstring> env) {
+    return do_with(pid_t{},
+                   std::array<int, 2>{-1, -1},
+                   std::array<int, 2>{-1, -1},
+                   std::array<int, 2>{-1, -1},
+                   sstring(pathname),
+                   posix_spawn_file_actions_t{},
+                   posix_spawnattr_t{},
+                   std::move(argv),
+                   std::move(env),
+                   [this](auto& child_pid, auto& cin_pipe, auto& cout_pipe, auto& cerr_pipe, auto& pathname, auto& actions, auto& attr, auto& argv, auto& env) {
+        auto create_cin_pipe = _thread_pool->submit<syscall_result<int>>([&cin_pipe] {
+            return wrap_syscall<int>(::pipe2(cin_pipe.data(), O_NONBLOCK));
+        });
+        auto create_cout_pipe = _thread_pool->submit<syscall_result<int>>([&cout_pipe] {
+            return wrap_syscall<int>(::pipe2(cout_pipe.data(), O_NONBLOCK));
+        });
+        auto create_cerr_pipe = _thread_pool->submit<syscall_result<int>>([&cerr_pipe] {
+            return wrap_syscall<int>(::pipe2(cerr_pipe.data(), O_NONBLOCK));
+        });
+        static constexpr int pipefd_read_end = 0;
+        static constexpr int pipefd_write_end = 1;
+        return when_all_succeed(std::move(create_cin_pipe),
+                                std::move(create_cout_pipe),
+                                std::move(create_cerr_pipe)).then_unpack([] (syscall_result<int> cin_ret,
+                                                                             syscall_result<int> cout_ret,
+                                                                             syscall_result<int> cerr_ret) {
+            for (auto& ret : {cin_ret, cout_ret, cerr_ret}) {
+                ret.throw_if_error();
+            }
+        }).then([&child_pid, &cin_pipe, &cout_pipe, &cerr_pipe, &pathname, &actions, &attr, &argv, &env, this] {
+            // the args and envs parameters passed to posix_spawn() should be array of pointers, and
+            // last one should be a null pointer.
+            std::vector<const char*> argvp;
+            std::transform(argv.cbegin(), argv.cend(), std::back_inserter(argvp),
+                           [](auto& s) { return s.c_str(); });
+            argvp.push_back(nullptr);
+
+            std::vector<const char*> envp;
+            std::transform(env.cbegin(), env.cend(), std::back_inserter(envp),
+                           [](auto& s) { return s.c_str(); });
+            envp.push_back(nullptr);
+
+            int r = 0;
+            r = ::posix_spawn_file_actions_init(&actions);
+            throw_pthread_error(r);
+            // the child process does not write to stdin
+            r = ::posix_spawn_file_actions_addclose(&actions, cin_pipe[pipefd_write_end]);
+            throw_pthread_error(r);
+            // the child process does not read from stdout
+            r = ::posix_spawn_file_actions_addclose(&actions, cout_pipe[pipefd_read_end]);
+            throw_pthread_error(r);
+            // the child process does not read from stderr
+            r = ::posix_spawn_file_actions_addclose(&actions, cerr_pipe[pipefd_read_end]);
+            throw_pthread_error(r);
+            // redirect stdin, stdout and stderr to cin_pipe, cout_pipe and cerr_pipe respectively
+            r = ::posix_spawn_file_actions_adddup2(&actions, cin_pipe[pipefd_read_end], STDIN_FILENO);
+            throw_pthread_error(r);
+            r = ::posix_spawn_file_actions_adddup2(&actions, cout_pipe[pipefd_write_end], STDOUT_FILENO);
+            throw_pthread_error(r);
+            r = ::posix_spawn_file_actions_adddup2(&actions, cerr_pipe[pipefd_write_end], STDERR_FILENO);
+            throw_pthread_error(r);
+            // after dup2() the interesting ends of pipes, close them
+            r = ::posix_spawn_file_actions_addclose(&actions, cin_pipe[pipefd_read_end]);
+            throw_pthread_error(r);
+            r = ::posix_spawn_file_actions_addclose(&actions, cout_pipe[pipefd_write_end]);
+            throw_pthread_error(r);
+            r = ::posix_spawn_file_actions_addclose(&actions, cerr_pipe[pipefd_write_end]);
+            throw_pthread_error(r);
+
+            r = ::posix_spawnattr_init(&attr);
+            throw_pthread_error(r);
+            // make sure the following signals are not ignored by the child process
+            sigset_t default_signals;
+            sigemptyset(&default_signals);
+            sigaddset(&default_signals, SIGINT);
+            sigaddset(&default_signals, SIGTERM);
+            r = ::posix_spawnattr_setsigdefault(&attr, &default_signals);
+            throw_pthread_error(r);
+            // make sure no signals are marked in the child process
+            sigset_t mask_signals;
+            sigemptyset(&mask_signals);
+            r = ::posix_spawnattr_setsigmask(&attr, &mask_signals);
+            throw_pthread_error(r);
+            r = ::posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK);
+            throw_pthread_error(r);
+
+            return _thread_pool->submit<syscall_result<int>>([&child_pid, &pathname, &actions, &attr,
+                                                              argv = std::move(argvp),
+                                                              env =  std::move(envp)] {
+                return wrap_syscall<int>(::posix_spawn(&child_pid, pathname.c_str(), &actions, &attr,
+                                                       const_cast<char* const *>(argv.data()),
+                                                       const_cast<char* const *>(env.data())));
+            });
+        }).finally([&actions, &attr] {
+            posix_spawn_file_actions_destroy(&actions);
+            posix_spawnattr_destroy(&attr);
+        }).then([&child_pid, &cin_pipe, &cout_pipe, &cerr_pipe] (syscall_result<int> ret) {
+            throw_pthread_error(ret.result);
+            // after spawning the child, parent does not need to access these fds anymore.
+            // the child process does.
+            ::close(cin_pipe[pipefd_read_end]);
+            ::close(cout_pipe[pipefd_write_end]);
+            ::close(cerr_pipe[pipefd_write_end]);
+            return make_ready_future<std::tuple<pid_t, int, int, int>>(child_pid,
+                                                                       cin_pipe[pipefd_write_end],
+                                                                       cout_pipe[pipefd_read_end],
+                                                                       cerr_pipe[pipefd_read_end]);
+        }).handle_exception([&cin_pipe, &cout_pipe, &cerr_pipe] (std::exception_ptr e) {
+            for (auto pipe : {cin_pipe, cout_pipe, cerr_pipe}) {
+               if (pipe[0] >= 0) {
+                    ::close(pipe[pipefd_read_end]);
+                    ::close(pipe[pipefd_write_end]);
+                }
+            }
+            return make_exception_future<std::tuple<pid_t, int, int, int>>(std::move(e));
+        });
+    });
+}
+
+static auto next_waitpid_timeout(std::chrono::milliseconds this_timeout) {
+    static const std::chrono::milliseconds step_timeout(20);
+    static const std::chrono::milliseconds max_timeout(1000);
+    if (this_timeout >= max_timeout) {
+        return max_timeout;
+    }
+    return this_timeout + step_timeout;
+}
+
+future<int> reactor::waitpid(pid_t pid) {
+    return _thread_pool->submit<syscall_result<int>>([pid] {
+        return wrap_syscall<int>(syscall(SYS_pidfd_open, pid, O_NONBLOCK));
+    }).then([pid, this] (syscall_result<int> pidfd) {
+        if (pidfd.result == -1) {
+            // pidfd_open() was introduced in linux 5.3, so the pidfd.error could be ENOSYS on
+            // older kernels. But it could be other error like EMFILE or ENFILE. anyway, we
+            // should always waitpid().
+            return do_with(int{}, std::chrono::milliseconds(0), [pid, this](int& wstatus,
+                                                                            std::chrono::milliseconds& wait_timeout) {
+                return repeat_until_value([this,
+                                           pid,
+                                           &wstatus,
+                                           &wait_timeout] {
+                    return _thread_pool->submit<syscall_result<pid_t>>([pid, &wstatus] {
+                        return wrap_syscall<pid_t>(::waitpid(pid, &wstatus, WNOHANG));
+                    }).then([&wstatus, &wait_timeout] (syscall_result<pid_t> ret) mutable {
+                        if (ret.result == 0) {
+                            wait_timeout = next_waitpid_timeout(wait_timeout);
+                            return ::seastar::sleep(wait_timeout).then([] {
+                                return make_ready_future<std::optional<int>>();
+                            });
+                        } else if (ret.result > 0) {
+                            return make_ready_future<std::optional<int>>(wstatus);
+                        } else {
+                            ret.throw_if_error();
+                            return make_ready_future<std::optional<int>>(-1);
+                        }
+                    });
+                });
+            });
+        } else {
+            return do_with(pollable_fd(file_desc::from_fd(pidfd.result)), int{}, [pid, this](auto& pidfd, int& wstatus) {
+                return pidfd.readable().then([pid, &wstatus, this] {
+                    return _thread_pool->submit<syscall_result<pid_t>>([pid, &wstatus] {
+                        return wrap_syscall<pid_t>(::waitpid(pid, &wstatus, WNOHANG));
+                    });
+                }).then([&wstatus] (syscall_result<pid_t> ret) {
+                    ret.throw_if_error();
+                    assert(ret.result > 0);
+                    return make_ready_future<int>(wstatus);
+                });
+            });
+        }
     });
 }
 
@@ -4296,6 +4480,17 @@ void reactor::add_high_priority_task(task* t) noexcept {
 
 void set_idle_cpu_handler(idle_cpu_handler&& handler) {
     engine().set_idle_cpu_handler(std::move(handler));
+}
+
+namespace experimental {
+future<process> spawn_process(const std::filesystem::path& pathname,
+                              spawn_parameters params) {
+    return process::spawn(pathname, std::move(params));
+}
+
+future<process> spawn_process(const std::filesystem::path& pathname) {
+    return process::spawn(pathname);
+}
 }
 
 static

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -665,3 +665,6 @@ seastar_add_test (closeable
 
 seastar_add_test (pipe
   SOURCES pipe_test.cc)
+
+seastar_add_test (spawn
+  SOURCES spawn_test.cc)

--- a/tests/unit/spawn_test.cc
+++ b/tests/unit/spawn_test.cc
@@ -1,0 +1,109 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2022 Kefu Chai ( tchaikov@gmail.com )
+ */
+#include <seastar/core/reactor.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/util/process.hh>
+
+using namespace seastar;
+using namespace seastar::experimental;
+
+SEASTAR_TEST_CASE(test_spawn_success) {
+    return spawn_process("/usr/bin/true").then([] (auto process) {
+        return process.wait();
+    }).then([] (auto wstatus) {
+        auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
+        BOOST_REQUIRE(exit_status != nullptr);
+        BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
+    });
+}
+
+SEASTAR_TEST_CASE(test_spawn_failure) {
+    return spawn_process("/usr/bin/false").then([] (auto process) {
+        return process.wait();
+    }).then([] (auto wstatus) {
+        auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
+        BOOST_REQUIRE(exit_status != nullptr);
+        BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_FAILURE);
+    });
+}
+
+SEASTAR_TEST_CASE(test_spawn_program_does_not_exist) {
+    return spawn_process("non/existent/path").then_wrapped([] (future<process> fut) {
+        BOOST_REQUIRE(fut.failed());
+        BOOST_CHECK_EXCEPTION(std::rethrow_exception(fut.get_exception()),
+                              std::system_error,
+                              [](const auto& e) {
+                                  return e.code().value() == ENOENT;
+                              });
+    });
+}
+
+SEASTAR_TEST_CASE(test_spawn_echo) {
+    const char* echo_cmd = "/usr/bin/echo";
+    return spawn_process(echo_cmd, {.argv = {echo_cmd, "-n", "hello", "world"}}).then([] (auto process) {
+        auto stdout = process.stdout();
+        return do_with(std::move(process), std::move(stdout), bool(true), [](auto& p, auto& stdout, auto& matched) {
+            using consumption_result_type = typename input_stream<char>::consumption_result_type;
+            using stop_consuming_type = typename consumption_result_type::stop_consuming_type;
+            using tmp_buf = stop_consuming_type::tmp_buf;
+            struct consumer {
+                consumer(std::string_view expected, bool& matched)
+                    : _expected(expected), _matched(matched) {}
+                future<consumption_result_type> operator()(tmp_buf buf) {
+                    _matched = std::equal(buf.begin(), buf.end(), _expected.begin());
+                    if (!_matched) {
+                        return make_ready_future<consumption_result_type>(stop_consuming_type({}));
+                    }
+                    _expected.remove_prefix(buf.size());
+                    return make_ready_future<consumption_result_type>(continue_consuming{});
+                }
+                std::string_view _expected;
+                bool& _matched;
+            };
+            return stdout.consume(consumer("hello world", matched)).then([&matched] {
+                BOOST_CHECK(matched);
+            }).finally([&p] {
+                return p.wait().discard_result();
+            });
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(test_spawn_input) {
+    static const sstring text = "hello world\n";
+    return spawn_process("/usr/bin/cat").then([] (auto process) {
+        auto stdin = process.stdin();
+        auto stdout = process.stdout();
+        return do_with(std::move(process), std::move(stdin), std::move(stdout), [](auto& p, auto& stdin, auto& stdout) {
+            return stdin.write(text).then([&stdin] {
+                return stdin.flush();
+            }).then([&stdout] {
+                return stdout.read_exactly(text.size());
+            }).then([] (temporary_buffer<char> echo) {
+                BOOST_CHECK(echo == echo.copy_of(text));
+            }).finally([&p] {
+                return p.wait().discard_result();
+            });
+        });
+    });
+}


### PR DESCRIPTION
So we can spawn a subprocess with Seastar.

In our use case, Seastar is used to implement a distributed service.
Before the daemon boots and joins the cluster, it calls an external
script to determine the host's location in the network topology and
failure domain settings, and attaches these information in its RPC
request for joining the cluster sent to the cluster management nodes.
The script can be customized by user so he/she can define their own
deployment policy, as long as the script is an executable and outputs
in the format that can be parsed by the daemon calling the script.

This is a convenient way allowing user to customize the daemon's
behavior without introducing yet another RPC service or a plugin
system.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>