### PR TITLE
core/circular_buffer: refactor loop in circular_buffer::erase()

### DIFF
--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -494,18 +494,15 @@ circular_buffer<T, Alloc>::erase(iterator first, iterator last) noexcept {
     // This also guarantees that iterators will be stable when removing from either front or back.
     if (std::distance(begin(), first) < std::distance(last, end())) {
         auto new_start = std::move_backward(begin(), first, last);
-        auto i = begin();
-        while (i < new_start) {
-            std::allocator_traits<Alloc>::destroy(_impl, &*i++);
+        for (auto i = begin(); i < new_start; ++i) {
+            std::allocator_traits<Alloc>::destroy(_impl, &*i);
         }
         _impl.begin = new_start.idx;
         return last;
     } else {
         auto new_end = std::move(last, end(), first);
-        auto i = new_end;
-        auto e = end();
-        while (i < e) {
-            std::allocator_traits<Alloc>::destroy(_impl, &*i++);
+        for (auto i = new_end, e = end(); i < e; ++i) {
+            std::allocator_traits<Alloc>::destroy(_impl, &*i);
         }
         _impl.end = new_end.idx;
         return first;


### PR DESCRIPTION
* replace `while()` with `for()` for better readability
* use prefix increment operator of iterator for better performance

Signed-off-by: Kefu Chai <tchaikov@gmail.com>