### PR TITLE
build: compile dpdk with -fpie (position independent executable)

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -254,7 +254,7 @@ endif()
 
 set (dpdk_args
   # gcc 10 defaults to -fno-common, which dpdk is not prepared for
-  "EXTRA_CFLAGS=-Wno-error -fcommon"
+  "EXTRA_CFLAGS=-Wno-error -fcommon -fpie"
   O=<BINARY_DIR>
   DESTDIR=<INSTALL_DIR>
   T=${dpdk_quadruple})


### PR DESCRIPTION
Clang 15 defaults to -fpie, but gcc 12 does not. When building Seastar with clang, cooking.sh still uses gcc for dpdk. The mismatch in pie option breaks the link.

Compile dpdk with -fpie to fix. Note an object compiled with -fpie will still link into a non-pie executable.

This fixes the build on Fedora 37.