### PR TITLE
iostream: remove unused function

### DIFF
--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -365,7 +365,6 @@ class output_stream final {
 
 private:
     size_t available() const noexcept { return _end - _begin; }
-    size_t possibly_available() const noexcept { return _size - _begin; }
     future<> split_and_put(temporary_buffer<CharType> buf) noexcept;
     future<> put(temporary_buffer<CharType> buf) noexcept;
     void poll_flush() noexcept;


### PR DESCRIPTION
`output_stream::possibly_available()` is not used since long ago. let's just ditch it.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>