### PR TITLE
core/polymorphic_temporary_buffer: include <seastar/core/memory.hh>

### DIFF
--- a/include/seastar/core/polymorphic_temporary_buffer.hh
+++ b/include/seastar/core/polymorphic_temporary_buffer.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <seastar/core/memory.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/std-compat.hh>
 


### PR DESCRIPTION
this header file references `memory::malloc_allocator`, which is in turn declared by `seastar/core/memory.hh`. since a header file is supposed to be self-contained, let's include `seastar/core/memory.hh` .

Signed-off-by: Kefu Chai <tchaikov@gmail.com>