### PR TITLE
Add simple http client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,7 @@ add_library (seastar STATIC
   src/http/reply.cc
   src/http/routes.cc
   src/http/transformers.cc
+  src/http/url.cc
   src/json/formatter.cc
   src/json/json_elements.cc
   src/net/arp.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,7 @@ add_library (seastar STATIC
   include/seastar/http/routes.hh
   include/seastar/http/short_streams.hh
   include/seastar/http/transformers.hh
+  include/seastar/http/client.hh
   include/seastar/json/formatter.hh
   include/seastar/json/json_elements.hh
   include/seastar/net/api.hh
@@ -672,6 +673,8 @@ add_library (seastar STATIC
   src/http/routes.cc
   src/http/transformers.cc
   src/http/url.cc
+  src/http/client.cc
+  src/http/request.cc
   src/json/formatter.cc
   src/json/json_elements.cc
   src/net/arp.cc

--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -40,11 +40,11 @@ using namespace httpd;
 
 class handl : public httpd::handler_base {
 public:
-    virtual future<std::unique_ptr<reply> > handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+    virtual future<std::unique_ptr<http::reply> > handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
         rep->_content = "hello";
         rep->done("html");
-        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 };
 

--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -41,7 +41,7 @@ using namespace httpd;
 class handl : public httpd::handler_base {
 public:
     virtual future<std::unique_ptr<reply> > handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) {
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
         rep->_content = "hello";
         rep->done("html");
         return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
@@ -52,7 +52,7 @@ void set_routes(routes& r) {
     function_handler* h1 = new function_handler([](const_req req) {
         return "hello";
     });
-    function_handler* h2 = new function_handler([](std::unique_ptr<request> req) {
+    function_handler* h2 = new function_handler([](std::unique_ptr<http::request> req) {
         return make_ready_future<json::json_return_type>("json-future");
     });
     r.add(operation_type::GET, url("/"), h1);

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -119,3 +119,6 @@ seastar_add_demo (file
 
 seastar_add_demo (tutorial_examples
   SOURCES tutorial_examples.cc)
+
+seastar_add_demo (http_client
+  SOURCES http_client_demo.cc)

--- a/demos/http_client_demo.cc
+++ b/demos/http_client_demo.cc
@@ -1,0 +1,97 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 ScyllaDB Ltd.
+ */
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/http/client.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/dns.hh>
+
+using namespace seastar;
+namespace bpo = boost::program_options;
+
+struct printer {
+    future<consumption_result<char>> operator() (temporary_buffer<char> buf) {
+        if (buf.empty()) {
+            return make_ready_future<consumption_result<char>>(stop_consuming(std::move(buf)));
+        }
+        fmt::print("{}", buf);
+        return make_ready_future<consumption_result<char>>(continue_consuming());
+    }
+};
+
+int main(int ac, char** av) {
+    app_template app;
+    app.add_options()
+            ("host", bpo::value<std::string>(), "Host to connect")
+            ("path", bpo::value<std::string>(), "Path to query upon")
+            ("method", bpo::value<std::string>()->default_value("GET"), "Method to use")
+            ("file", bpo::value<std::string>(), "File to get body from (no body if missing)")
+    ;
+
+
+    return app.run(ac, av, [&] {
+        auto&& config = app.configuration();
+        auto host = config["host"].as<std::string>();
+        auto path = config["path"].as<std::string>();
+        auto method = config["method"].as<std::string>();
+        auto body = config.count("file") == 0 ? std::string("") : config["file"].as<std::string>();
+
+        return seastar::async([=] {
+            net::hostent e = net::dns::get_host_by_name(host, net::inet_address::family::INET).get0();
+            socket_address local = socket_address(::sockaddr_in{AF_INET, INADDR_ANY, {0}});
+            ipv4_addr addr(e.addr_list.front(), 80);
+            fmt::print("{} {}:80{}\n", method, e.addr_list.front(), path);
+            connected_socket s = connect(make_ipv4_address(addr), local, transport::TCP).get0();
+
+            http::experimental::connection conn(std::move(s));
+            auto req = http::request::make(method, host, path);
+            if (body != "") {
+                future<file> f = open_file_dma(body, open_flags::ro);
+                req.write_body("txt", [ f = std::move(f) ] (output_stream<char>&& out) mutable {
+                    return seastar::async([f = std::move(f), out = std::move(out)] mutable {
+                        auto in = make_file_input_stream(f.get0());
+                        copy(in, out).get();
+                        out.flush().get();
+                        out.close().get();
+                        in.close().get();
+                    });
+                });
+            }
+            http::reply rep = conn.make_request(std::move(req)).get0();
+
+            fmt::print("Reply status {}\n--------8<--------\n", rep._status);
+            auto in = conn.in(rep);
+            in.consume(printer{}).get();
+            in.close().get();
+
+            conn.close().get();
+        }).handle_exception([](auto ep) {
+            fmt::print("Error: {}", ep);
+        });
+    });
+}

--- a/include/seastar/http/api_docs.hh
+++ b/include/seastar/http/api_docs.hh
@@ -125,11 +125,11 @@ public:
         set_route(this);
     }
 
-    future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override {
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         rep->_content = json::formatter::to_json(_docs);
         rep->done("json");
-        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 
     void reg(const sstring& api, const sstring& description,
@@ -258,12 +258,12 @@ public:
         set_route(this);
     }
 
-    future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override {
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         rep->write_body("json", [this, req = std::move(req)] (output_stream<char>&& os) mutable {
             return _docs.write(std::move(os), std::move(req));
         });
-        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 
     virtual void reg(doc_entry&& f) {

--- a/include/seastar/http/api_docs.hh
+++ b/include/seastar/http/api_docs.hh
@@ -126,7 +126,7 @@ public:
     }
 
     future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) override {
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override {
         rep->_content = json::formatter::to_json(_docs);
         rep->done("json");
         return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
@@ -238,7 +238,7 @@ class api_docs_20 {
     std::vector<doc_entry> _definitions;
 
 public:
-    future<> write(output_stream<char>&&, std::unique_ptr<request> req);
+    future<> write(output_stream<char>&&, std::unique_ptr<http::request> req);
 
     void add_api(doc_entry&& f) {
         _apis.emplace_back(std::move(f));
@@ -259,7 +259,7 @@ public:
     }
 
     future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) override {
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override {
         rep->write_body("json", [this, req = std::move(req)] (output_stream<char>&& os) mutable {
             return _docs.write(std::move(os), std::move(req));
         });

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -31,6 +31,12 @@ class reply;
 
 namespace experimental {
 
+/**
+ * \brief Class connection represents an HTTP connection over a given transport
+ *
+ * Check the demos/http_client_demo.cc for usage example
+ */
+
 class connection {
     connected_socket _fd;
     input_stream<char> _read_buf;

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -1,0 +1,28 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 Scylladb, Ltd.
+ */
+
+namespace seastar {
+
+namespace http {
+
+} // http namespace
+
+} // seastar namespace

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -19,9 +19,75 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#include <seastar/net/api.hh>
+#include <seastar/core/iostream.hh>
+
 namespace seastar {
 
 namespace http {
+
+class request;
+class reply;
+
+namespace experimental {
+
+class connection {
+    connected_socket _fd;
+    input_stream<char> _read_buf;
+    output_stream<char> _write_buf;
+
+public:
+    /**
+     * \brief Create an http connection
+     *
+     * Construct the connection that will work over the provided \fd transport socket
+     *
+     */
+    connection(connected_socket&& fd);
+
+    /**
+     * \brief Send the request and wait for response
+     *
+     * Sends the provided request to the server, and returns a future that will resolve
+     * into the server response.
+     *
+     * If the request was configured with the set_expects_continue() and the server replied
+     * early with some error code, this early reply will be returned back.
+     *
+     * The returned reply only contains the status and headers. To get the reply body the
+     * caller should read it via the input_stream provided by the connection.in() method.
+     *
+     * \param rq -- request to be sent
+     *
+     */
+    future<reply> make_request(request rq);
+
+    /**
+     * \brief Get a reference on the connection input stream
+     *
+     * The stream can be used to get back the server response body. After the stream is
+     * finished, the reply can be additionally updated with trailing headers and chunk
+     * extentions
+     *
+     */
+    input_stream<char> in(reply& rep);
+
+    /**
+     * \brief Closes the connection
+     *
+     * Connection must be closed regardless of whether there was an exception making the
+     * request or not
+     */
+    future<> close();
+
+private:
+    future<> send_request_head(request& rq);
+    future<std::optional<reply>> maybe_wait_for_continue(request& req);
+    future<> write_body(request& rq);
+    future<reply> recv_reply();
+};
+
+} // experimental namespace
 
 } // http namespace
 

--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -76,6 +76,13 @@ enum operation_type {
  */
 operation_type str2type(const sstring& type);
 
+/**
+ * Translate the operation type to command string
+ * @param type the string GET or POST
+ * @return the command string "GET" or "POST"
+ */
+sstring type2str(operation_type type);
+
 }
 
 }

--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -23,8 +23,15 @@
 
 #include <unordered_map>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/iostream.hh>
 
 namespace seastar {
+
+namespace http {
+namespace internal {
+output_stream<char> make_http_chunked_output_stream(output_stream<char>& out);
+} // internal namespace
+} // http namespace
 
 namespace httpd {
 

--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -35,7 +35,7 @@ namespace httpd {
  */
 class base_exception : public std::exception {
 public:
-    base_exception(const std::string& msg, reply::status_type status)
+    base_exception(const std::string& msg, http::reply::status_type status)
             : _msg(msg), _status(status) {
     }
 
@@ -43,7 +43,7 @@ public:
         return _msg.c_str();
     }
 
-    reply::status_type status() const {
+    http::reply::status_type status() const {
         return _status;
     }
 
@@ -52,7 +52,7 @@ public:
     }
 private:
     std::string _msg;
-    reply::status_type _status;
+    http::reply::status_type _status;
 
 };
 
@@ -62,7 +62,7 @@ private:
 class redirect_exception : public base_exception {
 public:
     redirect_exception(const std::string& url)
-            : base_exception("", reply::status_type::moved_permanently), url(
+            : base_exception("", http::reply::status_type::moved_permanently), url(
                     url) {
     }
     std::string url;
@@ -74,7 +74,7 @@ public:
 class not_found_exception : public base_exception {
 public:
     not_found_exception(const std::string& msg = "Not found")
-            : base_exception(msg, reply::status_type::not_found) {
+            : base_exception(msg, http::reply::status_type::not_found) {
     }
 };
 
@@ -85,7 +85,7 @@ public:
 class bad_request_exception : public base_exception {
 public:
     bad_request_exception(const std::string& msg)
-            : base_exception(msg, reply::status_type::bad_request) {
+            : base_exception(msg, http::reply::status_type::bad_request) {
     }
 };
 
@@ -115,7 +115,7 @@ public:
 class server_error_exception : public base_exception {
 public:
     server_error_exception(const std::string& msg)
-            : base_exception(msg, reply::status_type::internal_server_error) {
+            : base_exception(msg, http::reply::status_type::internal_server_error) {
     }
 };
 
@@ -135,10 +135,10 @@ public:
     json_exception(std::exception_ptr e) {
 	std::ostringstream exception_description;
 	exception_description << e;
-	set(exception_description.str(), reply::status_type::internal_server_error);
+	set(exception_description.str(), http::reply::status_type::internal_server_error);
     }
 private:
-    void set(const std::string& msg, reply::status_type code) {
+    void set(const std::string& msg, http::reply::status_type code) {
         register_params();
         _msg = msg;
         _code = (int) code;

--- a/include/seastar/http/file_handler.hh
+++ b/include/seastar/http/file_handler.hh
@@ -85,7 +85,7 @@ public:
      * @param rep the reply
      * @return true on redirect
      */
-    bool redirect_if_needed(const http::request& req, reply& rep) const;
+    bool redirect_if_needed(const http::request& req, http::reply& rep) const;
 
     /**
      * A helper method that returns the file extension.
@@ -102,8 +102,8 @@ protected:
      * @param req the reuest
      * @param rep the reply
      */
-    future<std::unique_ptr<reply> > read(sstring file,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep);
+    future<std::unique_ptr<http::reply> > read(sstring file,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep);
     file_transformer* transformer;
 
     output_stream<char> get_stream(std::unique_ptr<http::request> req,
@@ -132,8 +132,8 @@ public:
     explicit directory_handler(const sstring& doc_root,
             file_transformer* transformer = nullptr);
 
-    future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override;
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override;
 
 private:
     sstring doc_root;
@@ -159,8 +159,8 @@ public:
                     force_path) {
     }
 
-    future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override;
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override;
 
 private:
     sstring file;

--- a/include/seastar/http/file_handler.hh
+++ b/include/seastar/http/file_handler.hh
@@ -47,7 +47,7 @@ public:
      * @param extension the file extension originating the content
      * returns a new output stream to be used when writing the file to the reply
      */
-    virtual output_stream<char> transform(std::unique_ptr<request> req,
+    virtual output_stream<char> transform(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s) = 0;
 
     virtual ~file_transformer() = default;
@@ -85,7 +85,7 @@ public:
      * @param rep the reply
      * @return true on redirect
      */
-    bool redirect_if_needed(const request& req, reply& rep) const;
+    bool redirect_if_needed(const http::request& req, reply& rep) const;
 
     /**
      * A helper method that returns the file extension.
@@ -103,10 +103,10 @@ protected:
      * @param rep the reply
      */
     future<std::unique_ptr<reply> > read(sstring file,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep);
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep);
     file_transformer* transformer;
 
-    output_stream<char> get_stream(std::unique_ptr<request> req,
+    output_stream<char> get_stream(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s);
 };
 
@@ -133,7 +133,7 @@ public:
             file_transformer* transformer = nullptr);
 
     future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) override;
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override;
 
 private:
     sstring doc_root;
@@ -160,7 +160,7 @@ public:
     }
 
     future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) override;
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override;
 
 private:
     sstring file;

--- a/include/seastar/http/function_handlers.hh
+++ b/include/seastar/http/function_handlers.hh
@@ -38,7 +38,7 @@ typedef std::function<sstring(const_req req)> request_function;
 /**
  * A handle function is a lambda expression that gets request and reply
  */
-typedef std::function<sstring(const_req req, reply&)> handle_function;
+typedef std::function<sstring(const_req req, http::reply&)> handle_function;
 
 /**
  * A json request function is a lambda expression that gets only the request
@@ -56,8 +56,8 @@ typedef std::function<
         future<json::json_return_type>(std::unique_ptr<http::request> req)> future_json_function;
 
 typedef std::function<
-        future<std::unique_ptr<reply>>(std::unique_ptr<http::request> req,
-                std::unique_ptr<reply> rep)> future_handler_function;
+        future<std::unique_ptr<http::reply>>(std::unique_ptr<http::request> req,
+                std::unique_ptr<http::reply> rep)> future_handler_function;
 /**
  * The function handler get a lambda expression in the constructor.
  * it will call that expression to get the result
@@ -69,9 +69,9 @@ public:
 
     function_handler(const handle_function & f_handle, const sstring& type)
             : _f_handle(
-                    [f_handle](std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+                    [f_handle](std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
                         rep->_content += f_handle(*req.get(), *rep.get());
-                        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                     }), _type(type) {
     }
 
@@ -81,24 +81,24 @@ public:
 
     function_handler(const request_function & _handle, const sstring& type)
             : _f_handle(
-                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
                         rep->_content += _handle(*req.get());
-                        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                     }), _type(type) {
     }
 
     function_handler(const json_request_function& _handle)
             : _f_handle(
-                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
                         json::json_return_type res = _handle(*req.get());
                         rep->_content += res._res;
-                        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                     }), _type("json") {
     }
 
     function_handler(const future_json_function& _handle)
             : _f_handle(
-                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+                    [_handle](std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
                         return _handle(std::move(req)).then([rep = std::move(rep)](json::json_return_type&& res) mutable {
                                 if (res._body_writer) {
                                     rep->write_body("json", std::move(res._body_writer));
@@ -106,19 +106,19 @@ public:
                                     rep->_content += res._res;
 
                                 }
-                                return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                                return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                         });
                     }), _type("json") {
     }
 
     function_handler(const function_handler&) = default;
 
-    future<std::unique_ptr<reply>> handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) override {
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         return _f_handle(std::move(req), std::move(rep)).then(
-                [this](std::unique_ptr<reply> rep) {
+                [this](std::unique_ptr<http::reply> rep) {
                     rep->done(_type);
-                    return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                    return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                 });
     }
 

--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -31,7 +31,7 @@ namespace seastar {
 
 namespace httpd {
 
-typedef const httpd::request& const_req;
+typedef const http::request& const_req;
 
 /**
  * handlers holds the logic for serving an incoming request.
@@ -49,7 +49,7 @@ public:
      * @param rep the reply
      */
     virtual future<std::unique_ptr<reply> > handle(const sstring& path,
-            std::unique_ptr<request> req, std::unique_ptr<reply> rep) = 0;
+            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) = 0;
 
     virtual ~handler_base() = default;
 

--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -48,8 +48,8 @@ public:
      * @param req the original request
      * @param rep the reply
      */
-    virtual future<std::unique_ptr<reply> > handle(const sstring& path,
-            std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) = 0;
+    virtual future<std::unique_ptr<http::reply> > handle(const sstring& path,
+            std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) = 0;
 
     virtual ~handler_base() = default;
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -100,18 +100,6 @@ public:
 
     future<> start_response();
 
-    static short hex_to_byte(char c);
-
-    /**
-     * Convert a hex encoded 2 bytes substring to char
-     */
-    static char hexstr_to_char(const std::string_view& in, size_t from);
-
-    /**
-     * URL_decode a substring and place it in the given out sstring
-     */
-    static bool url_decode(const std::string_view& in, sstring& out);
-
     /**
      * Add a single query parameter to the parameter list
      */

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -69,7 +69,7 @@ class connection : public boost::intrusive::list_base_hook<> {
     static constexpr size_t limit = 4096;
     using tmp_buf = temporary_buffer<char>;
     http_request_parser _parser;
-    std::unique_ptr<request> _req;
+    std::unique_ptr<http::request> _req;
     std::unique_ptr<reply> _resp;
     // null element marks eof
     queue<std::unique_ptr<reply>> _replies { 10 };
@@ -112,17 +112,17 @@ public:
     /**
      * Add a single query parameter to the parameter list
      */
-    static void add_param(request& req, const std::string_view& param);
+    static void add_param(http::request& req, const std::string_view& param);
 
     /**
      * Set the query parameters in the request objects.
      * query param appear after the question mark and are separated
      * by the ampersand sign
      */
-    static sstring set_query_param(request& req);
+    static sstring set_query_param(http::request& req);
 
-    future<bool> generate_reply(std::unique_ptr<request> req);
-    void generate_error_reply_and_close(std::unique_ptr<request> req, reply::status_type status, const sstring& msg);
+    future<bool> generate_reply(std::unique_ptr<http::request> req);
+    void generate_error_reply_and_close(std::unique_ptr<http::request> req, reply::status_type status, const sstring& msg);
 
     future<> write_body();
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -47,11 +47,14 @@
 
 namespace seastar {
 
+namespace http {
+struct reply;
+}
+
 namespace httpd {
 
 class http_server;
 class http_stats;
-struct reply;
 
 using namespace std::chrono_literals;
 
@@ -70,9 +73,9 @@ class connection : public boost::intrusive::list_base_hook<> {
     using tmp_buf = temporary_buffer<char>;
     http_request_parser _parser;
     std::unique_ptr<http::request> _req;
-    std::unique_ptr<reply> _resp;
+    std::unique_ptr<http::reply> _resp;
     // null element marks eof
-    queue<std::unique_ptr<reply>> _replies { 10 };
+    queue<std::unique_ptr<http::reply>> _replies { 10 };
     bool _done = false;
 public:
     [[deprecated("use connection(http_server&, connected_socket&&)")]]
@@ -93,7 +96,7 @@ public:
     future<> respond();
     future<> do_response_loop();
 
-    void set_headers(reply& resp);
+    void set_headers(http::reply& resp);
 
     future<> start_response();
 
@@ -122,7 +125,7 @@ public:
     static sstring set_query_param(http::request& req);
 
     future<bool> generate_reply(std::unique_ptr<http::request> req);
-    void generate_error_reply_and_close(std::unique_ptr<http::request> req, reply::status_type status, const sstring& msg);
+    void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg);
 
     future<> write_body();
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -96,7 +96,6 @@ public:
     void set_headers(reply& resp);
 
     future<> start_response();
-    future<> write_reply_headers(std::unordered_map<sstring, sstring>::iterator hi);
 
     static short hex_to_byte(char c);
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -100,18 +100,6 @@ public:
 
     future<> start_response();
 
-    /**
-     * Add a single query parameter to the parameter list
-     */
-    static void add_param(http::request& req, const std::string_view& param);
-
-    /**
-     * Set the query parameters in the request objects.
-     * query param appear after the question mark and are separated
-     * by the ampersand sign
-     */
-    static sstring set_query_param(http::request& req);
-
     future<bool> generate_reply(std::unique_ptr<http::request> req);
     void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg);
 

--- a/include/seastar/http/mime_types.hh
+++ b/include/seastar/http/mime_types.hh
@@ -14,7 +14,7 @@
 
 namespace seastar {
 
-namespace httpd {
+namespace http {
 
 namespace mime_types {
 
@@ -29,5 +29,14 @@ const char* extension_to_type(const sstring& extension);
 } // namespace mime_types
 
 } // namespace httpd
+
+namespace httpd {
+namespace mime_types {
+[[deprecated("Use http::mime_types::extension_to_type instead")]]
+inline const char* extension_to_type(const sstring& extension) {
+    return http::mime_types::extension_to_type(extension);
+}
+}
+}
 
 }

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -44,6 +44,10 @@ namespace httpd {
 class connection;
 class routes;
 
+}
+
+namespace http {
+
 /**
  * A reply to be sent to a client.
  */
@@ -190,14 +194,18 @@ struct reply {
     void write_body(const sstring& content_type, sstring content);
 
 private:
-    future<> write_reply_to_connection(connection& con);
-    future<> write_reply_headers(connection& connection);
+    future<> write_reply_to_connection(httpd::connection& con);
+    future<> write_reply_headers(httpd::connection& connection);
 
     noncopyable_function<future<>(output_stream<char>&&)> _body_writer;
-    friend class routes;
-    friend class connection;
+    friend class httpd::routes;
+    friend class httpd::connection;
 };
 
-} // namespace httpd
+} // namespace http
+
+namespace httpd {
+using reply [[deprecated("Use http::reply instead")]] = http::reply;
+}
 
 }

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -119,6 +119,19 @@ struct reply {
         return *this;
     }
 
+    /**
+     * Search for the first header of a given name
+     * @param name the header name
+     * @return a pointer to the header value, if it exists or empty string
+     */
+    sstring get_header(const sstring& name) const {
+        auto res = _headers.find(name);
+        if (res == _headers.end()) {
+            return "";
+        }
+        return res->second;
+    }
+
     reply& set_version(const sstring& version) {
         _version = version;
         return *this;

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -39,6 +39,8 @@
 
 namespace seastar {
 
+struct http_response;
+
 namespace httpd {
 
 class connection;
@@ -110,9 +112,14 @@ struct reply {
     sstring _content;
 
     sstring _response_line;
+    std::unordered_map<sstring, sstring> trailing_headers;
+    std::unordered_map<sstring, sstring> chunk_extensions;
+
     reply()
             : _status(status_type::ok) {
     }
+
+    explicit reply(http_response&&);
 
     reply& add_header(const sstring& h, const sstring& value) {
         _headers[h] = value;

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -215,6 +215,8 @@ private:
     friend class httpd::connection;
 };
 
+std::ostream& operator<<(std::ostream& os, reply::status_type st);
+
 } // namespace http
 
 namespace httpd {

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -160,7 +160,7 @@ struct reply {
      * that would have been used if it was a file: e.g. html, txt, json etc'
      */
     reply& set_content_type(const sstring& content_type = "html") {
-        set_mime_type(httpd::mime_types::extension_to_type(content_type));
+        set_mime_type(http::mime_types::extension_to_type(content_type));
         return *this;
     }
 

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -41,7 +41,6 @@
 namespace seastar {
 
 namespace httpd {
-class connection;
 
 /**
  * A request received from a client.
@@ -69,13 +68,10 @@ struct request {
     sstring _method;
     sstring _url;
     sstring _version;
-    int http_version_major;
-    int http_version_minor;
     ctclass content_type_class;
     size_t content_length = 0;
     std::unordered_map<sstring, sstring, case_insensitive_hash, case_insensitive_cmp> _headers;
     std::unordered_map<sstring, sstring> query_parameters;
-    connection* connection_ptr;
     parameters param;
     sstring content; // deprecated: use content_stream instead
     /*

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -40,7 +40,7 @@
 
 namespace seastar {
 
-namespace httpd {
+namespace http {
 
 /**
  * A request received from a client.
@@ -72,7 +72,7 @@ struct request {
     size_t content_length = 0;
     std::unordered_map<sstring, sstring, case_insensitive_hash, case_insensitive_cmp> _headers;
     std::unordered_map<sstring, sstring> query_parameters;
-    parameters param;
+    httpd::parameters param;
     sstring content; // deprecated: use content_stream instead
     /*
      * The handler should read the contents of this stream till reaching eof (i.e., the end of this request's content). Failing to do so
@@ -151,5 +151,9 @@ struct request {
 };
 
 } // namespace httpd
+
+namespace httpd {
+using request [[deprecated("Use http::request instead")]] = http::request;
+}
 
 }

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -148,6 +148,17 @@ struct request {
             return it == _headers.end() || !case_insensitive_cmp()(it->second, "close");
         }
     }
+
+    /**
+     * Set the query parameters in the request objects.
+     * Returns the URL path part, i.e. -- without the query paremters
+     * query param appear after the question mark and are separated
+     * by the ampersand sign
+     */
+    sstring parse_query_param();
+
+private:
+    void add_param(const std::string_view& param);
 };
 
 } // namespace httpd

--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -138,7 +138,7 @@ public:
      * @param req the http request
      * @param rep the http reply
      */
-    future<std::unique_ptr<reply> > handle(const sstring& path, std::unique_ptr<request> req, std::unique_ptr<reply> rep);
+    future<std::unique_ptr<reply> > handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<reply> rep);
 
     /**
      * Search and return an exact match
@@ -243,7 +243,7 @@ public:
  * @param params the parameters object
  * @param param the parameter to look for
  */
-void verify_param(const httpd::request& req, const sstring& param);
+void verify_param(const http::request& req, const sstring& param);
 
 /**
  * The handler_registration object facilitates registration and auto

--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -138,7 +138,7 @@ public:
      * @param req the http request
      * @param rep the http reply
      */
-    future<std::unique_ptr<reply> > handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<reply> rep);
+    future<std::unique_ptr<http::reply> > handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep);
 
     /**
      * Search and return an exact match
@@ -179,7 +179,7 @@ private:
     //default Handler -- for any HTTP Method and Path (/*)
     handler_base* _default_handler = nullptr;
 public:
-    using exception_handler_fun = std::function<std::unique_ptr<reply>(std::exception_ptr eptr)>;
+    using exception_handler_fun = std::function<std::unique_ptr<http::reply>(std::exception_ptr eptr)>;
     using exception_handler_id = size_t;
 private:
     std::map<exception_handler_id, exception_handler_fun> _exceptions;
@@ -204,7 +204,7 @@ public:
         _exceptions.erase(id);
     }
 
-    std::unique_ptr<reply> exception_reply(std::exception_ptr eptr);
+    std::unique_ptr<http::reply> exception_reply(std::exception_ptr eptr);
 
     routes();
 

--- a/include/seastar/http/transformers.hh
+++ b/include/seastar/http/transformers.hh
@@ -41,7 +41,7 @@ namespace httpd {
  */
 class content_replace : public file_transformer {
 public:
-    virtual output_stream<char> transform(std::unique_ptr<request> req,
+    virtual output_stream<char> transform(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s);
     /**
      * the constructor get the file extension the replace would work on.

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -28,6 +28,16 @@ namespace internal {
 
 bool url_decode(const std::string_view& in, sstring& out);
 
+/**
+ * Makes a percent-encoded string out of the given parameter
+ *
+ * Note, that it does NOT parse and encode a URL correctly handling
+ * all the delimeters in arguments. It's up to the caller to split
+ * the URL into path and arguments (both names and values) and use
+ * this helper to encode individual strings
+ */
+sstring url_encode(const std::string_view& in);
+
 } // internal namespace
 } // http namespace
 

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -1,0 +1,34 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 Scylladb, Ltd.
+ */
+
+#include <seastar/core/sstring.hh>
+
+namespace seastar {
+
+namespace http {
+namespace internal {
+
+bool url_decode(const std::string_view& in, sstring& out);
+
+} // internal namespace
+} // http namespace
+
+} // seastar namespace

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -664,7 +664,7 @@ class metrics_handler : public handler_base  {
      * It returns true if a metric should be included, or false otherwise.
      * The filters are created from the request query parameters.
      */
-    std::function<bool(const mi::labels_type&)> make_filter(const httpd::request& req) {
+    std::function<bool(const mi::labels_type&)> make_filter(const http::request& req) {
         std::unordered_map<sstring, std::regex> matcher;
         auto labels = mi::get_local_impl()->get_labels();
         for (auto&& qp : req.query_parameters) {
@@ -687,7 +687,7 @@ public:
     metrics_handler(config ctx) : _ctx(ctx) {}
 
     future<std::unique_ptr<httpd::reply>> handle(const sstring& path,
-        std::unique_ptr<httpd::request> req, std::unique_ptr<httpd::reply> rep) override {
+        std::unique_ptr<http::request> req, std::unique_ptr<httpd::reply> rep) override {
         sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
         bool show_help = req->get_query_param("__help__") != "false";

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -686,8 +686,8 @@ class metrics_handler : public handler_base  {
 public:
     metrics_handler(config ctx) : _ctx(ctx) {}
 
-    future<std::unique_ptr<httpd::reply>> handle(const sstring& path,
-        std::unique_ptr<http::request> req, std::unique_ptr<httpd::reply> rep) override {
+    future<std::unique_ptr<http::reply>> handle(const sstring& path,
+        std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
         bool show_help = req->get_query_param("__help__") != "false";
@@ -706,7 +706,7 @@ public:
                 });
             });
         });
-        return make_ready_future<std::unique_ptr<httpd::reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 };
 

--- a/src/http/api_docs.cc
+++ b/src/http/api_docs.cc
@@ -49,7 +49,7 @@ doc_entry get_file_reader(sstring file_name) {
     };
 }
 
-future<> api_docs_20::write(output_stream<char>&& os, std::unique_ptr<request> req) {
+future<> api_docs_20::write(output_stream<char>&& os, std::unique_ptr<http::request> req) {
     return do_with(output_stream<char>(_transform.transform(std::move(req), "", std::move(os))), [this] (output_stream<char>& os) {
         return do_for_each(_apis, [&os](doc_entry& api) {
             return api(os);

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -19,10 +19,118 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#include <seastar/core/loop.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/http/client.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/http/response_parser.hh>
+#include <seastar/http/internal/content_source.hh>
 
 namespace seastar {
 namespace http {
+namespace experimental {
 
+connection::connection(connected_socket&& fd)
+        : _fd(std::move(fd))
+        , _read_buf(_fd.input())
+        , _write_buf(_fd.output())
+{
+}
+
+future<> connection::write_body(request& req) {
+    if (req.body_writer) {
+        return req.body_writer(internal::make_http_chunked_output_stream(_write_buf)).then([this] {
+            return _write_buf.write("0\r\n\r\n");
+        });
+    } else if (!req.content.empty()) {
+        return _write_buf.write(req.content);
+    } else {
+        return make_ready_future<>();
+    }
+}
+
+future<std::optional<reply>> connection::maybe_wait_for_continue(request& req) {
+    if (req.get_header("Expect") == "") {
+        return make_ready_future<std::optional<reply>>(std::nullopt);
+    }
+
+    return _write_buf.flush().then([this] {
+        return recv_reply().then([] (reply rep) {
+            if (rep._status == reply::status_type::continue_) {
+                return make_ready_future<std::optional<reply>>(std::nullopt);
+            } else {
+                return make_ready_future<std::optional<reply>>(std::move(rep));
+            }
+        });
+    });
+}
+
+future<> connection::send_request_head(request& req) {
+    if (req._version.empty()) {
+        req._version = "1.1";
+    }
+    if (req.content_length != 0) {
+        if (!req.body_writer && req.content.empty()) {
+            throw std::runtime_error("Request body writer not set and content is empty");
+        }
+        req._headers["Content-Length"] = to_sstring(req.content_length);
+    }
+
+    return _write_buf.write(req.request_line()).then([this, &req] {
+        return req.write_request_headers(_write_buf).then([this, &req] {
+            return _write_buf.write("\r\n", 2);
+        });
+    });
+}
+
+future<reply> connection::recv_reply() {
+    http_response_parser parser;
+    return do_with(std::move(parser), [this] (auto& parser) {
+        parser.init();
+        return _read_buf.consume(parser).then([this, &parser] {
+            if (parser.eof()) {
+                throw std::runtime_error("Invalid response");
+            }
+
+            auto resp = parser.get_parsed_response();
+            return make_ready_future<reply>(std::move(*resp));
+        });
+    });
+}
+
+future<reply> connection::make_request(request req) {
+    return do_with(std::move(req), [this] (auto& req) {
+        return send_request_head(req).then([this, &req] {
+            return maybe_wait_for_continue(req).then([this, &req] (std::optional<reply> cont) {
+                if (cont.has_value()) {
+                    return make_ready_future<reply>(std::move(*cont));
+                }
+
+                return write_body(req).then([this] {
+                    return _write_buf.flush().then([this] {
+                        return recv_reply();
+                    });
+                });
+            });
+        });
+    });
+}
+
+input_stream<char> connection::in(reply& rep) {
+    if (http::request::case_insensitive_cmp()(rep.get_header("Transfer-Encoding"), "chunked")) {
+        return input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(_read_buf, rep.chunk_extensions, rep.trailing_headers)));
+    }
+
+    sstring length_header = rep.get_header("Content-Length");
+    auto content_length = strtol(length_header.c_str(), nullptr, 10);
+    return input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(_read_buf, content_length)));
+}
+
+future<> connection::close() {
+    return when_all(_read_buf.close(), _write_buf.close()).discard_result();
+}
+
+} // experimental namespace
 } // http namespace
 } // seastar namespace

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -1,0 +1,28 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 Scylladb, Ltd.
+ */
+
+#include <seastar/http/client.hh>
+
+namespace seastar {
+namespace http {
+
+} // http namespace
+} // seastar namespace

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/http/common.hh>
+#include <seastar/core/iostream-impl.hh>
 
 namespace seastar {
 
@@ -50,6 +51,55 @@ operation_type str2type(const sstring& type) {
     return GET;
 }
 
+}
+
+namespace http {
+namespace internal {
+
+class http_chunked_data_sink_impl : public data_sink_impl {
+    output_stream<char>& _out;
+
+    future<> write_size(size_t s) {
+        auto req = format("{:x}\r\n", s);
+        return _out.write(req);
+    }
+public:
+    http_chunked_data_sink_impl(output_stream<char>& out) : _out(out) {
+    }
+    virtual future<> put(net::packet data)  override { abort(); }
+    using data_sink_impl::put;
+    virtual future<> put(temporary_buffer<char> buf) override {
+        if (buf.size() == 0) {
+            // size 0 buffer should be ignored, some server
+            // may consider it an end of message
+            return make_ready_future<>();
+        }
+        auto size = buf.size();
+        return write_size(size).then([this, buf = std::move(buf)] () mutable {
+            return _out.write(buf.get(), buf.size());
+        }).then([this] () mutable {
+            return _out.write("\r\n", 2);
+        });
+    }
+    virtual future<> close() override {
+        return  make_ready_future<>();
+    }
+};
+
+class http_chunked_data_sink : public data_sink {
+public:
+    http_chunked_data_sink(output_stream<char>& out)
+        : data_sink(std::make_unique<http_chunked_data_sink_impl>(
+                out)) {}
+};
+
+output_stream<char> make_http_chunked_output_stream(output_stream<char>& out) {
+    output_stream_options opts;
+    opts.trim_to_size = true;
+    return output_stream<char>(http_chunked_data_sink(out), 32000, opts);
+}
+
+}
 }
 
 }

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -51,6 +51,31 @@ operation_type str2type(const sstring& type) {
     return GET;
 }
 
+sstring type2str(operation_type type) {
+    if (type == DELETE) {
+        return "DELETE";
+    }
+    if (type == POST) {
+        return "POST";
+    }
+    if (type == PUT) {
+        return "PUT";
+    }
+    if (type == HEAD) {
+        return "HEAD";
+    }
+    if (type == OPTIONS) {
+        return "OPTIONS";
+    }
+    if (type == TRACE) {
+        return "TRACE";
+    }
+    if (type == CONNECT) {
+        return "CONNECT";
+    }
+    return "GET";
+}
+
 }
 
 namespace http {

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -38,8 +38,8 @@ directory_handler::directory_handler(const sstring& doc_root,
         : file_interaction_handler(transformer), doc_root(doc_root) {
 }
 
-future<std::unique_ptr<reply>> directory_handler::handle(const sstring& path,
-        std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+future<std::unique_ptr<http::reply>> directory_handler::handle(const sstring& path,
+        std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
     sstring full_path = doc_root + req->param["path"];
     auto h = this;
     return engine().file_type(full_path).then(
@@ -47,14 +47,14 @@ future<std::unique_ptr<reply>> directory_handler::handle(const sstring& path,
                 if (val) {
                     if (val.value() == directory_entry_type::directory) {
                         if (h->redirect_if_needed(*req.get(), *rep.get())) {
-                            return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                            return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                         }
                         full_path += "/index.html";
                     }
                     return h->read(full_path, std::move(req), std::move(rep));
                 }
-                rep->set_status(reply::status_type::not_found).done();
-                return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+                rep->set_status(http::reply::status_type::not_found).done();
+                return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
 
             });
 }
@@ -83,9 +83,9 @@ output_stream<char> file_interaction_handler::get_stream(std::unique_ptr<http::r
     return std::move(s);
 }
 
-future<std::unique_ptr<reply>> file_interaction_handler::read(
+future<std::unique_ptr<http::reply>> file_interaction_handler::read(
         sstring file_name, std::unique_ptr<http::request> req,
-        std::unique_ptr<reply> rep) {
+        std::unique_ptr<http::reply> rep) {
     sstring extension = get_extension(file_name);
     rep->write_body(extension, [req = std::move(req), extension, file_name, this] (output_stream<char>&& s) mutable {
         return do_with(output_stream<char>(get_stream(std::move(req), extension, std::move(s))),
@@ -101,13 +101,13 @@ future<std::unique_ptr<reply>> file_interaction_handler::read(
             });
         });
     });
-    return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+    return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
 }
 
 bool file_interaction_handler::redirect_if_needed(const http::request& req,
-        reply& rep) const {
+        http::reply& rep) const {
     if (req._url.length() == 0 || req._url.back() != '/') {
-        rep.set_status(reply::status_type::moved_permanently);
+        rep.set_status(http::reply::status_type::moved_permanently);
         rep._headers["Location"] = req.get_url() + "/";
         rep.done();
         return true;
@@ -115,10 +115,10 @@ bool file_interaction_handler::redirect_if_needed(const http::request& req,
     return false;
 }
 
-future<std::unique_ptr<reply>> file_handler::handle(const sstring& path,
-        std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+future<std::unique_ptr<http::reply>> file_handler::handle(const sstring& path,
+        std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
     if (force_path && redirect_if_needed(*req.get(), *rep.get())) {
-        return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
     return read(file, std::move(req), std::move(rep));
 }

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -39,7 +39,7 @@ directory_handler::directory_handler(const sstring& doc_root,
 }
 
 future<std::unique_ptr<reply>> directory_handler::handle(const sstring& path,
-        std::unique_ptr<request> req, std::unique_ptr<reply> rep) {
+        std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
     sstring full_path = doc_root + req->param["path"];
     auto h = this;
     return engine().file_type(full_path).then(
@@ -75,7 +75,7 @@ sstring file_interaction_handler::get_extension(const sstring& file) {
     return extension;
 }
 
-output_stream<char> file_interaction_handler::get_stream(std::unique_ptr<request> req,
+output_stream<char> file_interaction_handler::get_stream(std::unique_ptr<http::request> req,
         const sstring& extension, output_stream<char>&& s) {
     if (transformer) {
         return transformer->transform(std::move(req), extension, std::move(s));
@@ -84,7 +84,7 @@ output_stream<char> file_interaction_handler::get_stream(std::unique_ptr<request
 }
 
 future<std::unique_ptr<reply>> file_interaction_handler::read(
-        sstring file_name, std::unique_ptr<request> req,
+        sstring file_name, std::unique_ptr<http::request> req,
         std::unique_ptr<reply> rep) {
     sstring extension = get_extension(file_name);
     rep->write_body(extension, [req = std::move(req), extension, file_name, this] (output_stream<char>&& s) mutable {
@@ -104,7 +104,7 @@ future<std::unique_ptr<reply>> file_interaction_handler::read(
     return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
 }
 
-bool file_interaction_handler::redirect_if_needed(const request& req,
+bool file_interaction_handler::redirect_if_needed(const http::request& req,
         reply& rep) const {
     if (req._url.length() == 0 || req._url.back() != '/') {
         rep.set_status(reply::status_type::moved_permanently);
@@ -116,7 +116,7 @@ bool file_interaction_handler::redirect_if_needed(const request& req,
 }
 
 future<std::unique_ptr<reply>> file_handler::handle(const sstring& path,
-        std::unique_ptr<request> req, std::unique_ptr<reply> rep) {
+        std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
     if (force_path && redirect_if_needed(*req.get(), *rep.get())) {
         return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
     }

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -325,23 +325,6 @@ void connection::shutdown() {
     _fd.shutdown_output();
 }
 
-future<> connection::write_reply_headers(
-        std::unordered_map<sstring, sstring>::iterator hi) {
-    if (hi == _resp->_headers.end()) {
-        return make_ready_future<>();
-    }
-    return _write_buf.write(hi->first.data(), hi->first.size()).then(
-            [this] {
-                return _write_buf.write(": ", 2);
-            }).then([hi, this] {
-        return _write_buf.write(hi->second.data(), hi->second.size());
-    }).then([this] {
-        return _write_buf.write("\r\n", 2);
-    }).then([hi, this] () mutable {
-        return write_reply_headers(++hi);
-    });
-}
-
 short connection::hex_to_byte(char c) {
     if (c >='a' && c <= 'z') {
         return c - 'a' + 10;

--- a/src/http/mime_types.cc
+++ b/src/http/mime_types.cc
@@ -12,7 +12,7 @@
 
 namespace seastar {
 
-namespace httpd {
+namespace http {
 namespace mime_types {
 
 struct mapping {
@@ -45,6 +45,6 @@ const char* extension_to_type(const sstring& extension)
 
 } // namespace mime_types
 
-} // httpd
+} // http
 
 }

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -32,6 +32,7 @@
 #include <seastar/core/print.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/common.hh>
+#include <seastar/http/response_parser.hh>
 #include <seastar/core/loop.hh>
 
 namespace seastar {
@@ -171,6 +172,13 @@ static const sstring& to_string(reply::status_type status) {
 
 std::ostream& operator<<(std::ostream& os, reply::status_type st) {
     return os << status_strings::to_string(st);
+}
+
+reply::reply(http_response&& resp)
+        : _status(static_cast<status_type>(resp._status_code))
+        , _headers(std::move(resp._headers))
+        , _version(std::move(resp._version))
+{
 }
 
 sstring reply::response_line() {

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -40,46 +40,46 @@ namespace http {
 
 namespace status_strings {
 
-const sstring continue_ = " 100 Continue\r\n";
-const sstring switching_protocols = " 101 Switching Protocols\r\n";
-const sstring ok = " 200 OK\r\n";
-const sstring created = " 201 Created\r\n";
-const sstring accepted = " 202 Accepted\r\n";
-const sstring nonauthoritative_information = " 203 Non-Authoritative Information\r\n";
-const sstring no_content = " 204 No Content\r\n";
-const sstring reset_content = " 205 Reset Content\r\n";
-const sstring multiple_choices = " 300 Multiple Choices\r\n";
-const sstring moved_permanently = " 301 Moved Permanently\r\n";
-const sstring moved_temporarily = " 302 Moved Temporarily\r\n";
-const sstring see_other = " 303 See Other\r\n";
-const sstring not_modified = " 304 Not Modified\r\n";
-const sstring use_proxy = " 305 Use Proxy\r\n";
-const sstring temporary_redirect = " 307 Temporary Redirect\r\n";
-const sstring bad_request = " 400 Bad Request\r\n";
-const sstring unauthorized = " 401 Unauthorized\r\n";
-const sstring payment_required = " 402 Payment Required\r\n";
-const sstring forbidden = " 403 Forbidden\r\n";
-const sstring not_found = " 404 Not Found\r\n";
-const sstring method_not_allowed = " 405 Method Not Allowed\r\n";
-const sstring not_acceptable = " 406 Not Acceptable\r\n";
-const sstring request_timeout = " 408 Request Timeout\r\n";
-const sstring conflict = " 409 Conflict\r\n";
-const sstring gone = " 410 Gone\r\n";
-const sstring length_required = " 411 Length Required\r\n";
-const sstring payload_too_large = " 413 Payload Too Large\r\n";
-const sstring uri_too_long = " 414 URI Too Long\r\n";
-const sstring unsupported_media_type = " 415 Unsupported Media Type\r\n";
-const sstring expectation_failed = " 417 Expectation Failed\r\n";
-const sstring unprocessable_entity = " 422 Unprocessable Entity\r\n";
-const sstring upgrade_required = " 426 Upgrade Required\r\n";
-const sstring too_many_requests = " 429 Too Many Requests\r\n";
-const sstring internal_server_error = " 500 Internal Server Error\r\n";
-const sstring not_implemented = " 501 Not Implemented\r\n";
-const sstring bad_gateway = " 502 Bad Gateway\r\n";
-const sstring service_unavailable = " 503 Service Unavailable\r\n";
-const sstring gateway_timeout = " 504 Gateway Timeout\r\n";
-const sstring http_version_not_supported = " 505 HTTP Version Not Supported\r\n";
-const sstring insufficient_storage = " 507 Insufficient Storage\r\n";
+const sstring continue_ = "100 Continue";
+const sstring switching_protocols = "101 Switching Protocols";
+const sstring ok = "200 OK";
+const sstring created = "201 Created";
+const sstring accepted = "202 Accepted";
+const sstring nonauthoritative_information = "203 Non-Authoritative Information";
+const sstring no_content = "204 No Content";
+const sstring reset_content = "205 Reset Content";
+const sstring multiple_choices = "300 Multiple Choices";
+const sstring moved_permanently = "301 Moved Permanently";
+const sstring moved_temporarily = "302 Moved Temporarily";
+const sstring see_other = "303 See Other";
+const sstring not_modified = "304 Not Modified";
+const sstring use_proxy = "305 Use Proxy";
+const sstring temporary_redirect = "307 Temporary Redirect";
+const sstring bad_request = "400 Bad Request";
+const sstring unauthorized = "401 Unauthorized";
+const sstring payment_required = "402 Payment Required";
+const sstring forbidden = "403 Forbidden";
+const sstring not_found = "404 Not Found";
+const sstring method_not_allowed = "405 Method Not Allowed";
+const sstring not_acceptable = "406 Not Acceptable";
+const sstring request_timeout = "408 Request Timeout";
+const sstring conflict = "409 Conflict";
+const sstring gone = "410 Gone";
+const sstring length_required = "411 Length Required";
+const sstring payload_too_large = "413 Payload Too Large";
+const sstring uri_too_long = "414 URI Too Long";
+const sstring unsupported_media_type = "415 Unsupported Media Type";
+const sstring expectation_failed = "417 Expectation Failed";
+const sstring unprocessable_entity = "422 Unprocessable Entity";
+const sstring upgrade_required = "426 Upgrade Required";
+const sstring too_many_requests = "429 Too Many Requests";
+const sstring internal_server_error = "500 Internal Server Error";
+const sstring not_implemented = "501 Not Implemented";
+const sstring bad_gateway = "502 Bad Gateway";
+const sstring service_unavailable = "503 Service Unavailable";
+const sstring gateway_timeout = "504 Gateway Timeout";
+const sstring http_version_not_supported = "505 HTTP Version Not Supported";
+const sstring insufficient_storage = "507 Insufficient Storage";
 
 static const sstring& to_string(reply::status_type status) {
     switch (status) {
@@ -169,8 +169,12 @@ static const sstring& to_string(reply::status_type status) {
 }
 } // namespace status_strings
 
+std::ostream& operator<<(std::ostream& os, reply::status_type st) {
+    return os << status_strings::to_string(st);
+}
+
 sstring reply::response_line() {
-    return "HTTP/" + _version + status_strings::to_string(_status);
+    return "HTTP/" + _version + " " + status_strings::to_string(_status) + "\r\n";
 }
 
 void reply::write_body(const sstring& content_type, noncopyable_function<future<>(output_stream<char>&&)>&& body_writer) {

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -35,7 +35,7 @@
 
 namespace seastar {
 
-namespace httpd {
+namespace http {
 
 namespace status_strings {
 
@@ -226,7 +226,7 @@ void reply::write_body(const sstring& content_type, sstring content) {
     done(content_type);
 }
 
-future<> reply::write_reply_to_connection(connection& con) {
+future<> reply::write_reply_to_connection(httpd::connection& con) {
     add_header("Transfer-Encoding", "chunked");
     return con.out().write(response_line()).then([this, &con] () mutable {
         return write_reply_headers(con);
@@ -238,7 +238,7 @@ future<> reply::write_reply_to_connection(connection& con) {
 
 }
 
-future<> reply::write_reply_headers(connection& con) {
+future<> reply::write_reply_headers(httpd::connection& con) {
     return do_for_each(_headers, [&con](auto& h) {
         return con.out().write(h.first + ": " + h.second + "\r\n");
     });

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -21,9 +21,35 @@
 
 #include <seastar/http/request.hh>
 #include <seastar/http/url.hh>
+#include <seastar/http/common.hh>
 
 namespace seastar {
 namespace http {
+
+sstring request::format_url() const {
+    sstring query = "";
+    sstring delim = "?";
+    for (const auto& p : query_parameters) {
+        query += delim + internal::url_encode(p.first);
+        if (!p.second.empty()) {
+            query += "=" + internal::url_encode(p.second);
+        }
+        delim = "&";
+    }
+    return _url + query;
+}
+
+sstring request::request_line() const {
+    assert(!_version.empty());
+    return _method + " " + format_url() + " HTTP/" + _version + "\r\n";
+}
+
+// FIXME -- generalize with reply::write_request_headers
+future<> request::write_request_headers(output_stream<char>& out) {
+    return do_for_each(_headers, [&out] (auto& h) {
+        return out.write(h.first + ": " + h.second + "\r\n");
+    });
+}
 
 void request::add_param(const std::string_view& param) {
     size_t split = param.find('=');
@@ -58,6 +84,34 @@ sstring request::parse_query_param() {
     }
     add_param(url.substr(curr));
     return _url.substr(0, pos);
+}
+
+void request::write_body(const sstring& content_type, sstring content) {
+    set_content_type(content_type);
+    content_length = content.size();
+    this->content = std::move(content);
+}
+
+void request::write_body(const sstring& content_type, noncopyable_function<future<>(output_stream<char>&&)>&& body_writer) {
+    set_content_type(content_type);
+    _headers["Transfer-Encoding"] = "chunked";
+    this->body_writer = std::move(body_writer);
+}
+
+void request::set_expects_continue() {
+    _headers["Expect"] = "100-continue";
+}
+
+request request::make(sstring method, sstring host, sstring path) {
+    request rq;
+    rq._method = std::move(method);
+    rq._url = std::move(path);
+    rq._headers["Host"] = std::move(host);
+    return rq;
+}
+
+request request::make(httpd::operation_type type, sstring host, sstring path) {
+    return make(httpd::type2str(type), std::move(host), std::move(path));
 }
 
 } // http namespace

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -1,0 +1,28 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 Scylladb, Ltd.
+ */
+
+#include <seastar/http/request.hh>
+
+namespace seastar {
+namespace http {
+
+} // http namespace
+} // seastar namespace

--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -137,14 +137,14 @@ public:
         eof,
         done,
     };
-    std::unique_ptr<httpd::request> _req;
+    std::unique_ptr<http::request> _req;
     sstring _field_name;
     sstring _value;
     state _state;
 public:
     void init() {
         init_base();
-        _req.reset(new httpd::request());
+        _req.reset(new http::request());
         _state = state::eof;
         %% write init;
     }

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -53,11 +53,38 @@ action store_value {
     _value = str();
 }
 
+action no_mark_store_value {
+    _value = get_str();
+    g.mark_start(nullptr);
+}
+
+action checkpoint {
+    // Needs a start to be marked beforehand.
+    // Used to mark the candidate end of value string. Can be moved furhter by repetitive use
+    // of this action.
+    // To store the string that ends on the last checkpoint (instead of the last processed character)
+    // use %no_mark_store_value instead of %store_value
+    g.mark_end(p);
+    g.mark_start(p);
+}
+
 action assign_field {
-    _rsp->_headers[_field_name] = std::move(_value);
+    if (_rsp->_headers.count(_field_name)) {
+        // RFC 7230, section 3.2.2.  Field Parsing:
+        // A recipient MAY combine multiple header fields with the same field name into one
+        // "field-name: field-value" pair, without changing the semantics of the message,
+        // by appending each subsequent field value to the combined field value in order, separated by a comma.
+        _rsp->_headers[_field_name] += sstring(",") + std::move(_value);
+    } else {
+        _rsp->_headers[_field_name] = std::move(_value);
+    }
 }
 
 action extend_field  {
+    // RFC 7230, section 3.2.4.  Field Order:
+    // A server that receives an obs-fold in a request message that is not
+    // within a message/http container MUST either reject the message [...]
+    // or replace each received obs-fold with one or more SP octets [...]
     _rsp->_headers[_field_name] += sstring(" ") + std::move(_value);
 }
 
@@ -83,14 +110,18 @@ sp_ht = sp | ht;
 
 http_version = 'HTTP/' (digit '.' digit) >mark %store_version;
 
+obs_text = 0x80..0xFF; # defined in RFC 7230, Section 3.2.6.
+field_vchars = (graph | obs_text)+ %checkpoint;
+field_content = (field_vchars sp_ht*)*;
+
 field = tchar+ >mark %store_field_name;
-value = any* >mark %store_value;
+value = field_content >mark %no_mark_store_value;
 status_code = (digit digit digit) >mark %store_status;
 start_line = http_version space status_code space (any - cr - lf)* crlf;
-header_1st = (field sp_ht* ':' value :> crlf) %assign_field;
-header_cont = (sp_ht+ value sp_ht* crlf) %extend_field;
+header_1st = (field ':' sp_ht* value crlf) %assign_field;
+header_cont = (sp_ht+ value crlf) %extend_field;
 header = header_1st header_cont*;
-main := start_line header* :> (crlf @done);
+main := start_line header* (crlf @done);
 
 }%%
 
@@ -129,7 +160,13 @@ public:
 #pragma clang diagnostic pop
 #endif
         if (!done) {
-            p = nullptr;
+            if (p == eof) {
+                _state = state::eof;
+            } else if (p != pe) {
+                _state = state::error;
+            } else {
+                p = nullptr;
+            }
         } else {
             _state = state::done;
         }
@@ -140,6 +177,9 @@ public:
     }
     bool eof() const {
         return _state == state::eof;
+    }
+    bool failed() const {
+        return _state == state::error;
     }
 };
 

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -31,7 +31,7 @@ namespace httpd {
 
 using namespace std;
 
-void verify_param(const request& req, const sstring& param) {
+void verify_param(const http::request& req, const sstring& param) {
     if (req.get_query_param(param) == "") {
         throw missing_param_exception(param);
     }
@@ -81,7 +81,7 @@ std::unique_ptr<reply> routes::exception_reply(std::exception_ptr eptr) {
     return rep;
 }
 
-future<std::unique_ptr<reply> > routes::handle(const sstring& path, std::unique_ptr<request> req, std::unique_ptr<reply> rep) {
+future<std::unique_ptr<reply> > routes::handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
     handler_base* handler = get_handler(str2type(req->_method),
             normalize_url(path), req->param);
     if (handler != nullptr) {

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -54,8 +54,8 @@ routes::~routes() {
 
 }
 
-std::unique_ptr<reply> routes::exception_reply(std::exception_ptr eptr) {
-    auto rep = std::make_unique<reply>();
+std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
+    auto rep = std::make_unique<http::reply>();
     try {
         // go over the register exception handler
         // if one of them handle the exception, return.
@@ -73,7 +73,7 @@ std::unique_ptr<reply> routes::exception_reply(std::exception_ptr eptr) {
     } catch (const base_exception& e) {
         rep->set_status(e.status(), json_exception(e).to_json());
     } catch (...) {
-        rep->set_status(reply::status_type::internal_server_error,
+        rep->set_status(http::reply::status_type::internal_server_error,
                 json_exception(std::current_exception()).to_json());
     }
 
@@ -81,7 +81,7 @@ std::unique_ptr<reply> routes::exception_reply(std::exception_ptr eptr) {
     return rep;
 }
 
-future<std::unique_ptr<reply> > routes::handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<reply> rep) {
+future<std::unique_ptr<http::reply> > routes::handle(const sstring& path, std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
     handler_base* handler = get_handler(str2type(req->_method),
             normalize_url(path), req->param);
     if (handler != nullptr) {
@@ -92,19 +92,19 @@ future<std::unique_ptr<reply> > routes::handle(const sstring& path, std::unique_
             auto r =  handler->handle(path, std::move(req), std::move(rep));
             return r.handle_exception(_general_handler);
         } catch (const redirect_exception& _e) {
-            rep.reset(new reply());
+            rep.reset(new http::reply());
             rep->add_header("Location", _e.url).set_status(_e.status()).done(
                     "json");
         } catch (...) {
             rep = exception_reply(std::current_exception());
         }
     } else {
-        rep.reset(new reply());
+        rep.reset(new http::reply());
         json_exception ex(not_found_exception("Not found"));
-        rep->set_status(reply::status_type::not_found, ex.to_json()).done(
+        rep->set_status(http::reply::status_type::not_found, ex.to_json()).done(
                 "json");
     }
-    return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
+    return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
 }
 
 sstring routes::normalize_url(const sstring& url) {

--- a/src/http/transformers.cc
+++ b/src/http/transformers.cc
@@ -198,7 +198,7 @@ public:
                 std::move(out), std::move(key_value))) {}
 };
 
-output_stream<char> content_replace::transform(std::unique_ptr<request> req,
+output_stream<char> content_replace::transform(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s) {
     sstring host = req->get_header("Host");
     if (host == "" || (this->extension != "" && extension != this->extension)) {

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -1,0 +1,73 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2022 Scylladb, Ltd.
+ */
+
+#include <seastar/http/url.hh>
+
+namespace seastar {
+namespace http {
+namespace internal {
+
+namespace {
+
+short hex_to_byte(char c) {
+    if (c >='a' && c <= 'z') {
+        return c - 'a' + 10;
+    } else if (c >='A' && c <= 'Z') {
+        return c - 'A' + 10;
+    }
+    return c - '0';
+}
+
+/**
+ * Convert a hex encoded 2 bytes substring to char
+ */
+char hexstr_to_char(const std::string_view& in, size_t from) {
+
+    return static_cast<char>(hex_to_byte(in[from]) * 16 + hex_to_byte(in[from + 1]));
+}
+
+}
+
+bool url_decode(const std::string_view& in, sstring& out) {
+    size_t pos = 0;
+    sstring buff(in.length(), 0);
+    for (size_t i = 0; i < in.length(); ++i) {
+        if (in[i] == '%') {
+            if (i + 3 <= in.size()) {
+                buff[pos++] = hexstr_to_char(in, i + 1);
+                i += 2;
+            } else {
+                return false;
+            }
+        } else if (in[i] == '+') {
+            buff[pos++] = ' ';
+        } else {
+            buff[pos++] = in[i];
+        }
+    }
+    buff.resize(pos);
+    out = buff;
+    return true;
+}
+
+} // internal namespace
+} // http namespace
+} // seastar namespace

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -140,7 +140,7 @@ future<> connection::read_http_upgrade_request() {
             _done = true;
             return make_ready_future<>();
         }
-        std::unique_ptr<httpd::request> req = _http_parser.get_parsed_request();
+        std::unique_ptr<http::request> req = _http_parser.get_parsed_request();
         if (_http_parser.failed()) {
             return make_exception_future<>(websocket::exception("Incorrect upgrade request"));
         }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1245,3 +1245,24 @@ SEASTAR_TEST_CASE(test_url_encode_decode) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_url_param_encode_decode) {
+    http::request to_send;
+    to_send._url = "/foo/bar";
+    to_send.query_parameters["a"] = "a+a*a";
+    to_send.query_parameters["b"] = "b/b\%b";
+
+    http::request to_recv;
+    to_recv._url = to_send.format_url();
+    sstring url = to_recv.parse_query_param();
+
+    BOOST_REQUIRE_EQUAL(url, to_send._url);
+    BOOST_REQUIRE_EQUAL(to_recv.query_parameters.size(), to_send.query_parameters.size());
+    for (const auto& p : to_send.query_parameters) {
+        auto it = to_recv.query_parameters.find(p.first);
+        BOOST_REQUIRE(it != to_recv.query_parameters.end());
+        BOOST_REQUIRE_EQUAL(it->second, p.second);
+    }
+
+    return make_ready_future<>();
+}

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -192,11 +192,11 @@ SEASTAR_TEST_CASE(test_formatter)
 SEASTAR_TEST_CASE(test_decode_url) {
     http::request req;
     req._url = "/a?q=%23%24%23";
-    sstring url = http_server::connection::set_query_param(req);
+    sstring url = req.parse_query_param();
     BOOST_REQUIRE_EQUAL(url, "/a");
     BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "#$#");
     req._url = "/a?a=%23%24%23&b=%22%26%22";
-    http_server::connection::set_query_param(req);
+    req.parse_query_param();
     BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "#$#");
     BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "\"&\"");
     return make_ready_future<>();


### PR DESCRIPTION
There's http server implementation in seastar, but client code is usually done by sending raw string into connected_socket's stream and reading raw string back from another socket stream. This set provides basement for more convenient http client API. The proposed API summary is in the patch titled "http: Basic connection implementation"

fixes: #761