### PR TITLE
Update tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1731,7 +1731,7 @@ public:
     my_service(const std::string& str) : _str(str) { }
     seastar::future<> run() {
         std::cerr << "running on " << seastar::engine().cpu_id() <<
-            ", _str = " << _str << \n";
+            ", _str = " << _str << "\n";
         return seastar::make_ready_future<>();
     }
     seastar::future<> stop() {


### PR DESCRIPTION
Add missing double quotation mark in the example of "Sharded services" section.