### PR TITLE
Add Prometheus filtering capabilities by label

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -324,6 +324,7 @@ class impl {
     config _config;
     bool _dirty = true;
     shared_ptr<metric_metadata> _metadata;
+    std::set<sstring> _labels;
     std::vector<std::vector<metric_function>> _current_metrics;
 public:
     value_map& get_value_map() {
@@ -354,6 +355,10 @@ public:
 
     void dirty() {
         _dirty = true;
+    }
+
+    const std::set<sstring>& get_labels() const noexcept {
+        return _labels;
     }
 };
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -359,6 +359,9 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
             throw std::runtime_error("registering metrics " + name + " registered with different type.");
         }
         metric[id.labels()] = rm;
+        for (auto&& i : id.labels()) {
+            _labels.insert(i.first);
+        }
     } else {
         _value_map[name].info().type = type.base_type;
         _value_map[name].info().d = d;

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -660,9 +660,9 @@ public:
 
     future<std::unique_ptr<httpd::reply>> handle(const sstring& path,
         std::unique_ptr<httpd::request> req, std::unique_ptr<httpd::reply> rep) override {
-        sstring metric_family_name = req->get_query_param("name");
-        bool show_help = req->get_query_param("help") != "false";
+        sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
+        bool show_help = req->get_query_param("__help__") != "false";
 
         rep->write_body("txt", [this, metric_family_name, prefix, show_help] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -33,6 +33,7 @@
 #include <boost/range/combine.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/core/loop.hh>
+#include <regex>
 
 namespace seastar {
 
@@ -578,8 +579,8 @@ std::string get_value_as_string(std::stringstream& s, const mi::metric_value& va
     return value_str;
 }
 
-future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m, bool show_help) {
-    return seastar::async([&ctx, &out, &m, show_help] () mutable {
+future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m, bool show_help, std::function<bool(const mi::labels_type&)> filter) {
+    return seastar::async([&ctx, &out, &m, show_help, filter] () mutable {
         bool found = false;
         std::stringstream s;
         for (metric_family& metric_family : m) {
@@ -587,10 +588,10 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
             found = false;
             metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels);
             bool should_aggregate = !metric_family.metadata().aggregate_labels.empty();
-            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help](auto value, auto value_info) mutable {
+            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help, &filter](auto value, auto value_info) mutable {
                 s.clear();
                 s.str("");
-                if (value_info.should_skip_when_empty && value.is_empty()) {
+                if ((value_info.should_skip_when_empty && value.is_empty()) || !filter(value_info.id.labels())) {
                     return;
                 }
                 if (!found) {
@@ -634,6 +635,7 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
 class metrics_handler : public handler_base  {
     sstring _prefix;
     config _ctx;
+    static std::function<bool(const mi::labels_type&)> _true_function;
 
     /*!
      * \brief tries to trim an asterisk from the end of the string
@@ -655,6 +657,32 @@ class metrics_handler : public handler_base  {
         }
         return false;
     }
+    /*!
+     * \brief Return a filter function, based on the request
+     *
+     * A filter function filter what metrics should be included.
+     * It returns true if a metric should be included, or false otherwise.
+     * The filters are created from the request query parameters.
+     */
+    std::function<bool(const mi::labels_type&)> make_filter(const httpd::request& req) {
+        std::unordered_map<sstring, std::regex> matcher;
+        auto labels = mi::get_local_impl()->get_labels();
+        for (auto&& qp : req.query_parameters) {
+            if (labels.find(qp.first) != labels.end()) {
+                matcher.emplace(qp.first, std::regex(qp.second.c_str()));
+            }
+        }
+        return (matcher.empty()) ? _true_function : [matcher](const mi::labels_type& labels) {
+            for (auto&& m : matcher) {
+                auto l = labels.find(m.first);
+                if (!std::regex_match((l == labels.end())? "" : l->second.c_str(), m.second)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
 public:
     metrics_handler(config ctx) : _ctx(ctx) {}
 
@@ -663,14 +691,15 @@ public:
         sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
         bool show_help = req->get_query_param("__help__") != "false";
+        std::function<bool(const mi::labels_type&)> filter = make_filter(*req);
 
-        rep->write_body("txt", [this, metric_family_name, prefix, show_help] (output_stream<char>&& s) {
+        rep->write_body("txt", [this, metric_family_name, prefix, show_help, filter] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),
-                    [this, prefix, &metric_family_name, show_help] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
-                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name, show_help]() mutable {
+                    [this, prefix, &metric_family_name, show_help, filter] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
+                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name, show_help, filter]() mutable {
                     return do_with(get_range(families, metric_family_name, prefix),
-                            [&s, this, show_help](metric_family_range& m) {
-                        return write_text_representation(s, _ctx, m, show_help);
+                            [&s, this, show_help, filter](metric_family_range& m) {
+                        return write_text_representation(s, _ctx, m, show_help, filter);
                     });
                 }).finally([&s] () mutable {
                     return s.close();
@@ -681,7 +710,9 @@ public:
     }
 };
 
-
+std::function<bool(const mi::labels_type&)> metrics_handler::_true_function = [](const mi::labels_type&) {
+    return true;
+};
 
 future<> add_prometheus_routes(http_server& server, config ctx) {
     server._routes.put(GET, "/metrics", new metrics_handler(ctx));


### PR DESCRIPTION
This series adds the ability to filter Prometheus metrics by labels.

A user can specify any label that is used by the metrics layer and use a regular expression to define the expected value.

Use case example:
To get all metrics with scheduling_group_name equals `atexit` or `main`:
    
http://localhost:9180/metrics?scheduling_group_name=atexit|main
    
get all metrics without a `ks` label:
http://localhost:9180/metrics?ks=^$

Based on this functionality, systems with lots of metrics will be able to mark an essential subset of those metrics for reporting and query for detailed metrics on demand.

