### PR TITLE
metrics.cc: Do not merge empty histogram

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -376,6 +376,9 @@ const bool metric_disabled = false;
 
 
 histogram& histogram::operator+=(const histogram& c) {
+    if (c.sample_count == 0) {
+        return *this;
+    }
     for (size_t i = 0; i < c.buckets.size(); i++) {
         if (buckets.size() <= i) {
             buckets.push_back(c.buckets[i]);


### PR DESCRIPTION
It is common to have empty histograms. This patch adds an optimization when merging an empty histogram to another histogram to return early.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>