### PR TITLE
shared_mutex: return typed exceptional future in with_* error handlers

### DIFF
--- a/include/seastar/core/shared_mutex.hh
+++ b/include/seastar/core/shared_mutex.hh
@@ -193,7 +193,7 @@ with_shared(shared_mutex& sm, Func&& func) noexcept {
             });
         });
     } catch (...) {
-        return current_exception_as_future();
+        return futurize<std::invoke_result_t<Func>>::current_exception_as_future();
     }
 }
 
@@ -247,7 +247,7 @@ with_lock(shared_mutex& sm, Func&& func) noexcept {
             });
         });
     } catch (...) {
-        return current_exception_as_future();
+        return futurize<std::invoke_result_t<Func>>::current_exception_as_future();
     }
 }
 

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -22,6 +22,7 @@
 
 #include <chrono>
 
+#include <exception>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/do_with.hh>
@@ -31,6 +32,7 @@
 #include <seastar/core/shared_mutex.hh>
 #include <seastar/util/alloc_failure_injector.hh>
 #include <boost/range/irange.hpp>
+#include <stdexcept>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -301,4 +303,120 @@ SEASTAR_THREAD_TEST_CASE(test_shared_mutex_failed_lock) {
 
     seastar::memory::local_failure_injector().cancel();
 #endif // SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
+}
+
+struct expected_exception : public std::exception {
+    int value;
+    expected_exception(int v) noexcept : value(v) {}
+};
+
+struct moved_exception : public std::exception {
+    int count;
+    moved_exception(int c) noexcept : count(c) {}
+};
+
+struct throw_on_move {
+    int value;
+    int delay;
+    int count = 0;
+
+    throw_on_move(int v, int d = 0) noexcept : value(v), delay(d) {}
+    throw_on_move(const throw_on_move& o) = default;
+    throw_on_move(throw_on_move&& o)
+        : value(o.value)
+        , delay(o.delay)
+        , count(o.count + 1)
+    {
+        if (count >= delay) {
+            throw moved_exception(count);
+        }
+    }
+};
+
+SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_nothrow_move_func) {
+    shared_mutex sm;
+
+    auto expected = 42;
+    auto res = with_shared(sm, [expected] {
+        return expected;
+    }).get0();
+    BOOST_REQUIRE_EQUAL(res, expected);
+
+    try {
+        with_shared(sm, [expected] {
+            if (expected == 42) {
+                throw expected_exception(expected);
+            }
+            return expected;
+        }).get();
+        BOOST_FAIL("No exception was thrown");
+    } catch (const expected_exception& e) {
+        BOOST_REQUIRE_EQUAL(e.value, expected);
+    } catch (const std::exception& e) {
+        BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_throwing_move_func) {
+    shared_mutex sm;
+
+    int expected_value = 42;
+    bool done = false;
+    for (int move_delay = 0; !done; move_delay++) {
+        try {
+            auto res = with_shared(sm, [exp = throw_on_move(expected_value, move_delay)] {
+                auto expected = std::move(exp);
+                return expected.value;
+            }).get();
+            BOOST_REQUIRE_EQUAL(res, expected_value);
+            done = true;
+        } catch (const moved_exception& e) {
+        } catch (const std::exception& e) {
+            BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_nothrow_move_func) {
+    shared_mutex sm;
+
+    auto expected = 42;
+    auto res = with_lock(sm, [expected] {
+        return expected;
+    }).get0();
+    BOOST_REQUIRE_EQUAL(res, expected);
+
+    try {
+        with_lock(sm, [expected] {
+            if (expected == 42) {
+                throw expected_exception(expected);
+            }
+            return expected;
+        }).get();
+        BOOST_FAIL("No exception was thrown");
+    } catch (const expected_exception& e) {
+        BOOST_REQUIRE_EQUAL(e.value, expected);
+    } catch (const std::exception& e) {
+        BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_throwing_move_func) {
+    shared_mutex sm;
+
+    int expected_value = 42;
+    bool done = false;
+    for (int move_delay = 0; !done; move_delay++) {
+        try {
+            auto res = with_lock(sm, [exp = throw_on_move(expected_value, move_delay)] {
+                auto expected = std::move(exp);
+                return expected.value;
+            }).get();
+            BOOST_REQUIRE_EQUAL(res, expected_value);
+            done = true;
+        } catch (const moved_exception& e) {
+        } catch (const std::exception& e) {
+            BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
+        }
+    }
 }


### PR DESCRIPTION
Currently, exceptions in templates for functions that may
throw on move are handled in a generic way using
current_exception_as_future().

But if the passed functor returns a value, we need
to use current_exception_as_future<value_type> instead
so the error-free and error case returned future type
will match.

This change fixes that and adds unit test reproducers.

Fixes https://github.com/scylladb/seastar/issues/1295

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>