### PR TITLE
future: use invoke_result instead of nested requirements

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1120,9 +1120,7 @@ template <typename Func, typename Return, typename... T>
 concept ApplyReturns = InvokeReturns<Func, Return, T...>;
 
 template <typename Func, typename... T>
-concept InvokeReturnsAnyFuture = requires (Func f, T... args) {
-    requires is_future<decltype(f(std::forward<T>(args)...))>::value;
-};
+concept InvokeReturnsAnyFuture = Future<std::invoke_result_t<Func, T...>>;
 
 // Deprecated alias
 template <typename Func, typename... T>


### PR DESCRIPTION
instead of using nested requirement for specifying the constraints on the template parameters, use Future concept for better readability.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>