### PR TITLE
Fix: error when compiling http_client_demo

### DIFF
--- a/demos/http_client_demo.cc
+++ b/demos/http_client_demo.cc
@@ -39,7 +39,7 @@ struct printer {
         if (buf.empty()) {
             return make_ready_future<consumption_result<char>>(stop_consuming(std::move(buf)));
         }
-        fmt::print("{}", buf);
+        fmt::print("{}", sstring(buf.get(), buf.size()));
         return make_ready_future<consumption_result<char>>(continue_consuming());
     }
 };
@@ -73,7 +73,7 @@ int main(int ac, char** av) {
             if (body != "") {
                 future<file> f = open_file_dma(body, open_flags::ro);
                 req.write_body("txt", [ f = std::move(f) ] (output_stream<char>&& out) mutable {
-                    return seastar::async([f = std::move(f), out = std::move(out)] mutable {
+                    return seastar::async([f = std::move(f), out = std::move(out)] () mutable {
                         auto in = make_file_input_stream(f.get0());
                         copy(in, out).get();
                         out.flush().get();

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -26,8 +26,8 @@ namespace seastar {
 
 namespace http {
 
-class request;
-class reply;
+struct request;
+struct reply;
 
 namespace experimental {
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -78,7 +78,7 @@ future<> connection::send_request_head(request& req) {
     }
 
     return _write_buf.write(req.request_line()).then([this, &req] {
-        return req.write_request_headers(_write_buf).then([this, &req] {
+        return req.write_request_headers(_write_buf).then([this] {
             return _write_buf.write("\r\n", 2);
         });
     });
@@ -88,7 +88,7 @@ future<reply> connection::recv_reply() {
     http_response_parser parser;
     return do_with(std::move(parser), [this] (auto& parser) {
         parser.init();
-        return _read_buf.consume(parser).then([this, &parser] {
+        return _read_buf.consume(parser).then([&parser] {
             if (parser.eof()) {
                 throw std::runtime_error("Invalid response");
             }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1020,7 +1020,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 fmt::print("Request with chunked body\n");
                 auto req = http::request::make("GET", "test", "/test");
                 req.write_body("txt", [] (auto&& out) -> future<> {
-                    return seastar::async([out = std::move(out)] mutable {
+                    return seastar::async([out = std::move(out)] () mutable {
                         out.write(sstring("req")).get();
                         out.write(sstring("1234\r\n7890")).get();
                         out.flush().get();


### PR DESCRIPTION
- **resolve error when compiling new http_client_demo**: 
  > error: use of deleted function ‘seastar::temporary_buffer<CharType>::temporary_buffer(const seastar::temporary_buffer<CharType>&) [with CharType = char]’ 

  Print a `sstring` instead of `temporary_buffer`.

- **silent warning**:  
  > ../../demos/http_client_demo.cc:76:84: warning: parameter declaration before lambda declaration specifiers only optional with ‘-std=c++2b’ or ‘-std=gnu++2b’

  Add parameter declaration before mutable.

- **resolve error of inconsistent definition, it occurs when compiling with clang**:

  > /home/circleci/project/include/seastar/http/request.hh:51:1: error: 'request' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]  
  > struct request {  
  > ^  
  > /home/circleci/project/include/seastar/http/client.hh:29:1: note: did you mean struct here?  
  > class request;