### PR TITLE
test: temporarily disable warning for tests triggering warnings

### DIFF
--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -220,10 +220,13 @@ void report_failed_future(future_state_base::any&& state) noexcept {
 
 void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func) {
     auto before = engine()._abandoned_failed_futures;
+    auto old_level = seastar_logger.level();
+    seastar_logger.set_level(log_level::error);
     func();
     auto after = engine()._abandoned_failed_futures;
     assert(after - before == count);
     engine()._abandoned_failed_futures = before;
+    seastar_logger.set_level(old_level);
 }
 
 namespace {


### PR DESCRIPTION
without this change, we could find warning messages while performing tests which intentioally trigger warnings. this is misleading.

after this change, the logging level is temporarily increased so that the warnings messages are not printed when performing those tests.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>