### PR TITLE
sockets: Wait on socket peer closing the connection

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -110,6 +110,7 @@ public:
     future<size_t> sendmsg(struct msghdr *msg);
     future<size_t> recvmsg(struct msghdr *msg);
     future<size_t> sendto(socket_address addr, const void* buf, size_t len);
+    future<> poll_rdhup();
 
 protected:
     explicit pollable_fd_state(file_desc fd, speculation speculate = speculation())
@@ -188,6 +189,9 @@ public:
     void close() { _s.reset(); }
     explicit operator bool() const noexcept {
         return bool(_s);
+    }
+    future<> poll_rdhup() {
+        return _s->poll_rdhup();
     }
 protected:
     int get_fd() const { return _s->fd.get(); }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -674,6 +674,7 @@ public:
     future<> readable(pollable_fd_state& fd);
     future<> writeable(pollable_fd_state& fd);
     future<> readable_or_writeable(pollable_fd_state& fd);
+    future<> poll_rdhup(pollable_fd_state& fd);
     void enable_timer(steady_clock_type::time_point when) noexcept;
     /// Sets the "Strict DMA" flag.
     ///

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -243,6 +243,19 @@ public:
     explicit operator bool() const noexcept {
         return static_cast<bool>(_csi);
     }
+    /// Waits for the peer of this socket to disconnect
+    ///
+    /// \return future that resolves when the peer closes connection or shuts it down
+    /// for writing or when local socket is called \ref shutdown_input().
+    ///
+    /// Note, that when the returned future is resolved for whatever reason socket
+    /// may still be readable from, so the caller may want to wait for both events
+    /// -- this one and EOF from read.
+    ///
+    /// Calling it several times per socket is not allowed (undefined behavior)
+    ///
+    /// \see poll(2) about POLLRDHUP for more details
+    future<> wait_input_shutdown();
 };
 /// @}
 

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -47,6 +47,7 @@ public:
     virtual void set_sockopt(int level, int optname, const void* data, size_t len) = 0;
     virtual int get_sockopt(int level, int optname, void* data, size_t len) const = 0;
     virtual socket_address local_address() const noexcept = 0;
+    virtual future<> wait_input_shutdown() = 0;
 };
 
 class socket_impl {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -443,6 +443,10 @@ future<> pollable_fd_state::writeable() {
     return engine().writeable(*this);
 }
 
+future<> pollable_fd_state::poll_rdhup() {
+    return engine().poll_rdhup(*this);
+}
+
 future<> pollable_fd_state::readable_or_writeable() {
     return engine().readable_or_writeable(*this);
 }
@@ -1038,6 +1042,10 @@ future<> reactor::writeable(pollable_fd_state& fd) {
 
 future<> reactor::readable_or_writeable(pollable_fd_state& fd) {
     return _backend->readable_or_writeable(fd);
+}
+
+future<> reactor::poll_rdhup(pollable_fd_state& fd) {
+    return _backend->poll_rdhup(fd);
 }
 
 void reactor::set_strict_dma(bool value) {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -192,6 +192,7 @@ public:
     virtual future<> readable(pollable_fd_state& fd) = 0;
     virtual future<> writeable(pollable_fd_state& fd) = 0;
     virtual future<> readable_or_writeable(pollable_fd_state& fd) = 0;
+    virtual future<> poll_rdhup(pollable_fd_state& fd) = 0;
     virtual void forget(pollable_fd_state& fd) noexcept = 0;
 
     virtual future<std::tuple<pollable_fd, socket_address>>
@@ -258,6 +259,7 @@ public:
     virtual future<> readable(pollable_fd_state& fd) override;
     virtual future<> writeable(pollable_fd_state& fd) override;
     virtual future<> readable_or_writeable(pollable_fd_state& fd) override;
+    virtual future<> poll_rdhup(pollable_fd_state& fd) override;
     virtual void forget(pollable_fd_state& fd) noexcept override;
 
     virtual future<std::tuple<pollable_fd, socket_address>>
@@ -307,6 +309,7 @@ public:
     virtual future<> readable(pollable_fd_state& fd) override;
     virtual future<> writeable(pollable_fd_state& fd) override;
     virtual future<> readable_or_writeable(pollable_fd_state& fd) override;
+    virtual future<> poll_rdhup(pollable_fd_state& fd) override;
     virtual void forget(pollable_fd_state& fd) noexcept override;
 
     virtual future<std::tuple<pollable_fd, socket_address>>

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -104,6 +104,7 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const override;
     void set_sockopt(int level, int optname, const void* data, size_t len) override;
     socket_address local_address() const noexcept override;
+    virtual future<> wait_input_shutdown() override;
 };
 
 template <typename Protocol>
@@ -268,6 +269,11 @@ int native_connected_socket_impl<Protocol>::get_sockopt(int level, int optname, 
 template<typename Protocol>
 socket_address native_connected_socket_impl<Protocol>::local_address() const noexcept {
     return {_conn->local_ip(), _conn->local_port()};
+}
+
+template <typename Protocol>
+future<> native_connected_socket_impl<Protocol>::wait_input_shutdown() {
+    return _conn->wait_input_shutdown();
 }
 
 }

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -266,6 +266,9 @@ public:
     socket_address local_address() const noexcept override {
         return _ops->local_address(_fd.get_file_desc());
     }
+    future<> wait_input_shutdown() override {
+        return _fd.poll_rdhup();
+    }
 
     friend class posix_server_socket_impl;
     friend class posix_ap_server_socket_impl;

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -145,6 +145,10 @@ void connected_socket::shutdown_input() {
     _csi->shutdown_input();
 }
 
+future<> connected_socket::wait_input_shutdown() {
+    return _csi->wait_input_shutdown();
+}
+
 data_source
 net::connected_socket_impl::source(connected_socket_input_stream_config csisc) {
     // Default implementation falls back to non-parameterized data_source

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1637,6 +1637,9 @@ public:
     future<std::optional<session_dn>> get_distinguished_name() {
         return _session->get_distinguished_name();
     }
+    future<> wait_input_shutdown() override {
+        return _session->socket().wait_input_shutdown();
+    }
 };
 
 

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -193,6 +193,10 @@ public:
         // dummy
         return {};
     }
+    future<> wait_input_shutdown() override {
+        abort(); // No tests use this
+        return make_ready_future<>();
+    }
 };
 
 class loopback_server_socket_impl : public net::server_socket_impl {


### PR DESCRIPTION
This patch adds the connected_socket::wait_closed() call that returns a future that resolves when the connection is terminated by the peer or when the local socket is shutdown for reading. This event can be waited on even if a client doesn't read from (or write to) its end while server SUDDENLY closes it.

This can be useful for keep-alive HTTP sockets. When a client session is created and a request is served, client may want to cache the connected socket without sending new requrests right at once, but still needs to know if the server recycles the connection on his side.

Implementation depends on the socket type (and reactor backend)

- Posix socket

There's a useful polling event in the Linux called POLLRDHUP which is reported when socket is shutdown(SHUT_RD) or peer of the connection closes or shutdown(SHUT_RW). Two last options cause FIN to be sent to the client, respectively kernel sets it upon FIN receiving.

Said that, implementation is in extending the pollable_fd_state with the poll_rdhup() method that asks the backend to poll for it. AIO and URing backends just submit the respective iocb into the kernel, epoll backend needs a bit more care because it mixes events in one mask and needs to "parse" it when event comes.

- Native stack

The implementation mimics Linux kernel -- the connection promise is resolved when it's being read-aborted or when the connection receives FIN packet.

- TLS

This just forwards the call to the underlying socket.

Test included

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>