### PR TITLE
circleci: use versioned container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain "$@"' > run; chmod +x run
+      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2022-06-14 "$@"' > run; chmod +x run
       - run:
           command: |
             ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >>


### PR DESCRIPTION
This allows us to update the toolchain on master, while keeping an older toolchain for release branches.