### PR TITLE
docker: bump up to clang {14,15} and gcc {11,12}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2022-06-14 "$@"' > run; chmod +x run
+      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2022-11-29 "$@"' > run; chmod +x run
       - run:
           command: |
             ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >>
@@ -32,6 +32,6 @@ workflows:
       - build_and_test:
           matrix:
             parameters:
-              compiler: ["clang++-12", "g++-11"]
+              compiler: ["clang++-15", "g++-12"]
               standard: ["20", "17"]
               mode: ["dev", "debug", "release"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,18 +1,16 @@
-FROM ubuntu:jammy
+FROM ubuntu:kinetic
 RUN apt -y update \
     && apt -y install build-essential \
-    && apt -y install gcc-11 g++-11 gcc-10 g++-10 gcc-9 g++-9 pandoc \
+    && apt -y install gcc-12 g++-12 gcc-11 g++-11 pandoc \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 \
-    && apt -y install clang-12 clang-11 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 12 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 12 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 11 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 11
+    && apt -y install clang-15 clang-14 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 15 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 15 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 14 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 14
 COPY install-dependencies.sh /tmp/
 RUN bash /tmp/install-dependencies.sh
 CMD /bin/bash


### PR DESCRIPTION
since we only support the latest two major releases of compilers. at the moment of writing, Clang just released v15, and the latest major release of GCC is v12.

so we should install them respectively.

because ubuntu jammy does not ship clang-15. we need to bump up the base image from ubuntu:jammy to ubuntu:kinetic despite that kinetic is not an LTS release. we should use ubuntu 24.04 once it's out.

[avi: squash related circleci change, regenerate toolchain,
      and use versioned image tag instead of :latest]