### PR TITLE
tests/unit/coroutine: Include <ranges>

### DIFF
--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -21,6 +21,7 @@
 
 #include <exception>
 #include <numeric>
+#include <ranges>
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future-util.hh>


### PR DESCRIPTION
libc++-15 seems to be a little tidier with its headers than libstdc++.

Signed-off-by: Ben Pope <ben@redpanda.com>