### PR TITLE
build: check for fix of CWG2631

### DIFF
--- a/cmake/FindSourceLocation.cmake
+++ b/cmake/FindSourceLocation.cmake
@@ -21,17 +21,24 @@
 #
 
 include (CheckCXXSourceCompiles)
-include(CMakePushCheckState)
+include (CheckCXXSourceRuns)
+include (CMakePushCheckState)
 
-file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/Source_location_test.cc _source_location_test_code)
 cmake_push_check_state ()
+file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/Source_location_test.cc _source_location_test_code)
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
 check_cxx_source_compiles ("${_source_location_test_code}" CxxSourceLocation_SUPPORTED)
+
+file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/Source_location_default_argument.cc _source_location_test_code)
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
+# see also https://cplusplus.github.io/CWG/issues/2631.html
+check_cxx_source_runs ("${_source_location_test_code}" CxxSourceLocation_IMPLEMENTS_CWG2631)
 cmake_pop_check_state ()
 
 if (NOT (TARGET SourceLocation::source_location))
   add_library (SourceLocation::source_location INTERFACE IMPORTED)
-  if  (NOT CxxSourceLocation_SUPPORTED)
+  if  ((NOT CxxSourceLocation_SUPPORTED) OR
+       (NOT CxxSourceLocation_IMPLEMENTS_CWG2631))
     set_target_properties (SourceLocation::source_location
       PROPERTIES
         INTERFACE_COMPILE_DEFINITIONS SEASTAR_BROKEN_SOURCE_LOCATION)

--- a/cmake/code_tests/Source_location_default_argument.cc
+++ b/cmake/code_tests/Source_location_default_argument.cc
@@ -1,0 +1,10 @@
+#include<source_location>
+
+int test_source_location(int line,
+                         std::source_location loc = std::source_location::current()) {
+    return line == loc.line() ? 0 : 1;
+}
+
+int main() {
+    return test_source_location(__LINE__);
+}


### PR DESCRIPTION
CWG 2631 (https://cplusplus.github.io/CWG/issues/2631.html) reports an issue on how the default argument is evaluated. this problem is more obvious when it comes to how `std::source_location::current()` is evaluated as a default argument. but not all compilers have the same behavior, see https://godbolt.org/z/PK865KdG4.

notebaly, clang-15 evaluates the default argument at the callee site. so we need to check the capability of compiler and fall back to the one defined by util/source_location-compat.hh if the compiler suffers from CWG 2631.

in this change, FindSourceLocation.cmake is reused for checking the behavior of compiler by adding a new test which fails if the expected line number is different from the one returned by `std::source_location::current()`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>