### PR TITLE
coroutine: correct syntax error in doxygen comment

### DIFF
--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -30,13 +30,13 @@
 
 namespace seastar::coroutine {
 
-/// Invoke a function on all elements in a range in paralell and wait for all futures to complete in a coroutine.
+/// Invoke a function on all elements in a range in parallel and wait for all futures to complete in a coroutine.
 ///
 /// `parallel_for_each` can be used to launch a function concurrently
 /// on all elements in a given range and wait for all of them to complete.
 /// Waiting is performend by `co_await` and returns a future.
 ///
-/// If one or more of the function invocations resolves to an exception
+/// If one or more of the function invocations resolve to an exception
 /// then the one of the exceptions is re-thrown.
 /// All of the futures are waited for, even in the case of exceptions.
 ///


### PR DESCRIPTION
* s/in paralell/in parallel/
* in general, "one or more of the function invocations" should be considered as a plurial, and hence should be followed with a plural verb.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>