### PR TITLE
addr2line: extend asan regex

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -99,7 +99,7 @@ class BacktraceResolver(object):
             self.oneline_re = re.compile(f"^((?:.*(?:(?:at|backtrace):?|:))?(?:\s+))?({token}(?:\s+{token})*)(?:\).*|\s*)$", flags=re.IGNORECASE)
             self.address_re = re.compile(full_addr_match, flags=re.IGNORECASE)
             self.syslog_re = re.compile(f"^(?:#\d+\s+)(?P<addr>{addr})(?:.*\s+)\({ignore_addr_match}\)\s*$", flags=re.IGNORECASE)
-            self.asan_re = re.compile(f"^(?:.*\s+)\({full_addr_match}\)\s*$", flags=re.IGNORECASE)
+            self.asan_re = re.compile(f"^(?:.*\s+)\({full_addr_match}\)(\s+\(BuildId: [0-9a-fA-F]+\))?$", flags=re.IGNORECASE)
             self.asan_ignore_re = re.compile(f"^=.*$", flags=re.IGNORECASE)
             self.generic_re = re.compile(f"^(?:.*\s+){full_addr_match}\s*$", flags=re.IGNORECASE)
             self.separator_re = re.compile('^\W*-+\W*$')

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -173,6 +173,9 @@ if args.test:
         ('#0 0x14d24642  (/jenkins/workspace/scylla-enterprise/dtest-debug/scylla/.ccm/scylla-repository/1a5173bd45d01697d98ba2a7645f5d86afb2d0be/scylla/libexec/scylla+0x14d24642)',
                 {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None,
                  'addresses': [{'path': '/jenkins/workspace/scylla-enterprise/dtest-debug/scylla/.ccm/scylla-repository/1a5173bd45d01697d98ba2a7645f5d86afb2d0be/scylla/libexec/scylla', 'addr': '0x14d24642'}]}),
+        ('    #1 0xd8d910f  (/home/myhome/.dtest/dtest-84j9064d/test/node1/bin/scylla+0xd8d910f) (BuildId: 05a1d3d58d2b07e526decdad717e71a4590be2e0)',
+                {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None,
+                 'addresses': [{'path': '/home/myhome/.dtest/dtest-84j9064d/test/node1/bin/scylla', 'addr': '0xd8d910f'}]}),
 
         ('Apr 28 11:42:58 ip-172-31-2-154.ec2.internal scylla[10612]: Reactor stalled for 260 ms on shard 20.', None),
         ('Apr 28 11:42:58 ip-172-31-2-154.ec2.internal scylla[10612]: Backtrace:', None),


### PR DESCRIPTION
Since clang 14
(llvm/llvm-project@edd2b99a57c127dc3d99fe7550d69a113de53eb0), the BuildID information is printed on each line.

Let the respective regular expression
match that too and add a test case for it.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>