### PR TITLE
[TCP] Fix tcp hanging while getting refused on connect

### DIFF
--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -1163,6 +1163,7 @@ void tcp<InetTraits>::tcb::input_handle_syn_sent_state(tcp_hdr* th, packet p) {
         // reset", drop the segment, enter CLOSED state, delete TCB, and
         // return.  Otherwise (no ACK) drop the segment and return.
         if (acceptable) {
+            _connect_done.set_exception(tcp_refused_error());
             return do_reset();
         } else {
             return;


### PR DESCRIPTION
While trying to connect to another server address, if the server response an [RST,ACK] segment, the connect() function still being hang and failed just on timed out. due to no connection were closed and _connection_done has not be setted.
According to RFC 9293, Receiving RST:
If the receiver was in any other state except SYN-RECEIVED or LISTEN, it aborts the connection and advises the user and goes to the CLOSED state.