### PR TITLE
shared_ptr: add specializations for fmt::ptr()

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -879,6 +879,20 @@ struct hash<seastar::shared_ptr<T>> : private hash<T*> {
 
 }
 
+namespace fmt {
+
+template<typename T>
+const void* ptr(const seastar::lw_shared_ptr<T>& p) {
+    return p.get();
+}
+
+template<typename T>
+const void* ptr(const seastar::shared_ptr<T>& p) {
+    return p.get();
+}
+
+}
+
 namespace seastar {
 
 template<typename T>


### PR DESCRIPTION
so we are able to format, for instance, seastar::shared_ptr<T>, with

seastar::shared_ptr<int> p;
auto s = fmt::format("{}", fmt::ptr(p));

Signed-off-by: Kefu Chai <tchaikov@gmail.com>