### PR TITLE
http: Add 206 Partial Content response code

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -66,6 +66,7 @@ struct reply {
         nonauthoritative_information = 203, //!< nonauthoritative_information
         no_content = 204, //!< no_content
         reset_content = 205, //!< reset_content
+        partial_content = 206, //! partial_content
         multiple_choices = 300, //!< multiple_choices
         moved_permanently = 301, //!< moved_permanently
         moved_temporarily = 302, //!< moved_temporarily

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -49,6 +49,7 @@ const sstring accepted = "202 Accepted";
 const sstring nonauthoritative_information = "203 Non-Authoritative Information";
 const sstring no_content = "204 No Content";
 const sstring reset_content = "205 Reset Content";
+const sstring partial_content = "206 Partial Content";
 const sstring multiple_choices = "300 Multiple Choices";
 const sstring moved_permanently = "301 Moved Permanently";
 const sstring moved_temporarily = "302 Moved Temporarily";
@@ -100,6 +101,8 @@ static const sstring& to_string(reply::status_type status) {
         return no_content;
     case reply::status_type::reset_content:
         return reset_content;
+    case reply::status_type::partial_content:
+        return partial_content;
     case reply::status_type::multiple_choices:
         return multiple_choices;
     case reply::status_type::moved_permanently:


### PR DESCRIPTION
S3 GET with Range header results in 206 status code. This one is absent in seastar enum class, but it's good to have it.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>