### PR TITLE
http: Convert http::request::content from sstring to temporary_buffer…

### DIFF
--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -76,7 +76,8 @@ struct request {
     std::unordered_map<sstring, sstring, case_insensitive_hash, case_insensitive_cmp> _headers;
     std::unordered_map<sstring, sstring> query_parameters;
     httpd::parameters param;
-    sstring content; // server-side deprecated: use content_stream instead
+    temporary_buffer<char> content; // server-side deprecated: use content_stream instead
+
     /*
      * The handler should read the contents of this stream till reaching eof (i.e., the end of this request's content). Failing to do so
      * will force the server to close this connection, and the client will not be able to reuse this connection for the next request.
@@ -194,6 +195,17 @@ struct request {
      * with any additional information that is needed to send the message.
      */
     void write_body(const sstring& content_type, sstring content);
+
+    /**
+     * \brief Write a buffer as the body
+     *
+     * \param content_type - is used to choose the content type of the body. Use the file extension
+     *  you would have used for such a content, (i.e. "txt", "html", "json", etc')
+     * \param content - the message content.
+     * This would set the the content, conent length and content type of the message along
+     * with any additional information that is needed to send the message.
+     */
+    void write_body(const sstring& content_type, temporary_buffer<char> content);
 
     /**
      * \brief Use an output stream to write the message body

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -44,7 +44,7 @@ future<> connection::write_body(request& req) {
             return _write_buf.write("0\r\n\r\n");
         });
     } else if (!req.content.empty()) {
-        return _write_buf.write(req.content);
+        return _write_buf.write(req.content.get(), req.content.size());
     } else {
         return make_ready_future<>();
     }

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -182,7 +182,7 @@ set_request_content(std::unique_ptr<http::request> req, input_stream<char>* cont
     } else {
         // Read the entire content into the request content string
         return util::read_entire_stream_contiguous(*content_stream).then([req = std::move(req)] (sstring content) mutable {
-            req->content = std::move(content);
+            req->content = std::move(content).release();
             return make_ready_future<std::unique_ptr<http::request>>(std::move(req));
         });
     }

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -89,6 +89,12 @@ sstring request::parse_query_param() {
 void request::write_body(const sstring& content_type, sstring content) {
     set_content_type(content_type);
     content_length = content.size();
+    this->content = std::move(content).release();
+}
+
+void request::write_body(const sstring& content_type, temporary_buffer<char> content) {
+    set_content_type(content_type);
+    content_length = content.size();
     this->content = std::move(content);
 }
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -932,7 +932,10 @@ struct echo_string_handler : public echo_handler {
     echo_string_handler(bool chunked_reply = false) : echo_handler(chunked_reply) {}
     future<std::unique_ptr<http::reply>> handle(const sstring& path,
             std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
-        return this->do_handle(req, rep, req->content);
+        return do_with(std::move(req), std::move(rep), sstring(), [this] (std::unique_ptr<http::request>& req, std::unique_ptr<http::reply>& rep, sstring& req_content) {
+            req_content = to_sstring(std::move(req->content));
+            return this->do_handle(req, rep, req_content);
+        });
     }
 };
 


### PR DESCRIPTION
…<char>

S3 upload doesn't support chunked-encoded bodies, instead it requires "classical" enccoding with content-length header. However, the http::request is not ready for this. In order to write body the caller has two options:

- provide body-writer callback. In this case the request will be sent with chunked encoding
- provide ready to use sstring. In this case client will send the content-length header and the raw body

None is suitable for s3 client. Using body writer callback just won't work, using sstring body is quite ugnly, because strictly speaking it's not going to be string at all.

Good news is that string body is deprecated for server-side and was recently re-used by experimental client, so it should not be dangerous to convert content from sstring to temporary buffer.

For convenience, writing body as sstring is still supported, just the string is converted to buffer.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>