### PR TITLE
tls_test: use a dedicated https server for testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,11 @@ option (Seastar_TESTING
   "Enable testing targets."
   ${Seastar_MASTER_PROJECT})
 
+include (CMakeDependentOption)
+cmake_dependent_option (Seastar_ENABLE_TESTS_ACCESSING_INTERNET
+  "Enable tests accessing internet." ON
+  "Seastar_TESTING" OFF)
+
 option (Seastar_COMPRESS_DEBUG
   "Compress debug info."
   ON)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -119,7 +119,9 @@ function (seastar_add_test name)
       PRIVATE ${libraries})
 
     target_compile_definitions (${executable_target}
-      PRIVATE SEASTAR_TESTING_MAIN)
+      PRIVATE
+        SEASTAR_TESTING_MAIN
+        SEASTAR_TESTING_WITH_NETWORKING=$<BOOL:${Seastar_ENABLE_TESTS_ACCESSING_INTERNET}>)
 
     if ((Seastar_STACK_GUARDS STREQUAL "ON") OR
         ((Seastar_STACK_GUARDS STREQUAL "DEFAULT") AND

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -544,6 +544,7 @@ function(seastar_gen_mtls_certs)
   find_program(OPENSSL openssl)
 
   set(SUBJECT "/C=GB/ST=London/L=London/O=Redpanda Data/OU=Core/CN=redpanda.com")
+  set(EXTENSION "subjectAltName = IP:127.0.0.1")
   set(CLIENT1_SUBJECT "/C=GB/ST=London/L=London/O=Redpanda Data/OU=Core/CN=client1.org")
   set(CLIENT2_SUBJECT "/C=GB/ST=London/L=London/O=Redpanda Data/OU=Core/CN=client2.org")
 
@@ -552,7 +553,7 @@ function(seastar_gen_mtls_certs)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   add_custom_command(OUTPUT mtls_ca.crt
-    COMMAND ${OPENSSL} req -new -x509 -sha256 -key mtls_ca.key -out mtls_ca.crt -subj ${SUBJECT}
+    COMMAND ${OPENSSL} req -new -x509 -sha256 -key mtls_ca.key -out mtls_ca.crt -subj ${SUBJECT} -addext ${EXTENSION}
     DEPENDS mtls_ca.key
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
@@ -634,8 +635,16 @@ add_custom_target(tls_files
   DEPENDS ${out_tls_certificate_files}
 )
 
+add_custom_command (
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/https-server.py
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/https-server.py
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/https-server.py ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target (https_server
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/https-server.py)
+
 seastar_add_test (tls
-  DEPENDS tls_files testcrt othercrt mtls_certs
+  DEPENDS tls_files testcrt othercrt mtls_certs https_server
   SOURCES tls_test.cc
   LIBRARIES Boost::filesystem
   WORKING_DIRECTORY ${Seastar_BINARY_DIR})

--- a/tests/unit/https-server.py
+++ b/tests/unit/https-server.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2023 Kefu Chai ( tchaikov@gmail.com )
+#
+
+
+import argparse
+import socket
+import ssl
+from http.server import HTTPServer as _HTTPServer
+from http.server import SimpleHTTPRequestHandler
+
+
+class HTTPSServer(_HTTPServer):
+    def __init__(self, addr, port, context):
+        super().__init__((addr, port), SimpleHTTPRequestHandler)
+        self.context = context
+
+    def get_request(self):
+        sock, addr = self.socket.accept()
+        ssl_conn = self.context.wrap_socket(sock, server_side=True)
+        return ssl_conn, addr
+
+    def get_listen_port(self):
+        if self.socket.family == socket.AF_INET:
+            addr, port = self.socket.getsockname()
+            return port
+        elif self.socket.family == socket.AF_INET6:
+            address, port, flowinfo, scope_id = self.socket.getsockname()
+            return port
+        else:
+            raise Exception(f"unknown family: {self.socket.family}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="httpd for testing TLS")
+    parser.add_argument('--server', action='store',
+                        help='server address in <host>:<port> format',
+                        default='localhost:11311')
+    parser.add_argument('--cert', action='store',
+                        help='path to the certificate')
+    parser.add_argument('--key', action='store',
+                        help='path to the private key')
+    args = parser.parse_args()
+    host, port = args.server.split(':')
+
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(certfile=args.cert, keyfile=args.key)
+    with HTTPSServer(host, int(port), context) as server:
+        # print out the listening port when ready to serve
+        print(server.get_listen_port(), flush=True)
+        server.serve_forever()

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -104,6 +104,8 @@ static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> c
     }).discard_result();
 }
 
+#if SEASTAR_TESTING_WITH_NETWORKING
+
 static const auto google_name = "www.google.com";
 
 // broken out from below. to allow pre-lookup
@@ -197,6 +199,7 @@ SEASTAR_TEST_CASE(test_x509_client_with_priority_strings_fail) {
         return make_ready_future<>();
     });
 }
+#endif // SEASTAR_TESTING_WITH_NETWORKING
 
 SEASTAR_TEST_CASE(test_failed_connect) {
     tls::credentials_builder b;

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -33,6 +33,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/process.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/inet_address.hh>
@@ -159,7 +160,7 @@ SEASTAR_TEST_CASE(test_x509_client_with_builder_system_trust_multiple) {
     });
 }
 
-SEASTAR_TEST_CASE(test_x509_client_with_priority_strings) {
+SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
     static std::vector<sstring> prios( {
         "NORMAL:+ARCFOUR-128", // means normal ciphers plus ARCFOUR-128.
         "SECURE128:-VERS-SSL3.0:+COMP-DEFLATE", // means that only secure ciphers are enabled, SSL3.0 is disabled, and libz compression enabled.
@@ -179,7 +180,7 @@ SEASTAR_TEST_CASE(test_x509_client_with_priority_strings) {
     });
 }
 
-SEASTAR_TEST_CASE(test_x509_client_with_priority_strings_fail) {
+SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings_fail) {
     static std::vector<sstring> prios( { "NONE",
         "NONE:+CURVE-SECP256R1"
     });
@@ -200,6 +201,146 @@ SEASTAR_TEST_CASE(test_x509_client_with_priority_strings_fail) {
     });
 }
 #endif // SEASTAR_TESTING_WITH_NETWORKING
+
+class https_server {
+    const sstring _cert;
+    const std::string _addr = "127.0.0.1";
+    experimental::process _process;
+    uint16_t _port;
+
+    static experimental::process spawn(const std::string& addr, const sstring& key, const sstring& cert) {
+        auto httpd = boost::dll::program_location().parent_path() / "https-server.py";
+        const std::vector<sstring> argv{
+          "httpd",
+          "--server", fmt::format("{}:{}", addr, 0),
+          "--key", key,
+          "--cert", cert,
+        };
+        return experimental::spawn_process(httpd.string(), {.argv = argv}).get0();
+    }
+
+    // https-server.py picks an available port and listens on it. when it is
+    // ready to serve, it prints out the listening port. without hardwiring to
+    // a fixed port, we are able to run multiple tests in parallel.
+    static uint16_t read_port(experimental::process& process) {
+        using consumption_result_type = typename input_stream<char>::consumption_result_type;
+        using stop_consuming_type = typename consumption_result_type::stop_consuming_type;
+        using tmp_buf = stop_consuming_type::tmp_buf;
+        struct consumer {
+            future<consumption_result_type> operator()(tmp_buf buf) {
+                if (auto newline = std::find(buf.begin(), buf.end(), '\n'); newline != buf.end()) {
+                    size_t consumed = newline - buf.begin();
+                    line += std::string_view(buf.get(), consumed);
+                    buf.trim_front(consumed);
+                    return make_ready_future<consumption_result_type>(stop_consuming_type(std::move(buf)));
+                } else {
+                    line += std::string_view(buf.get(), buf.size());
+                    return make_ready_future<consumption_result_type>(stop_consuming_type({}));
+                }
+            }
+            std::string line;
+        };
+        auto reader = ::make_shared<consumer>();
+        process.stdout().consume(*reader).get();
+        return std::stoul(reader->line);
+    }
+
+public:
+    https_server(const std::string& ca = "mtls_ca")
+        : _cert(certfile(fmt::format("{}.crt", ca)))
+        , _process(spawn(_addr, certfile(fmt::format("{}.key", ca)), _cert))
+        , _port(read_port(_process))
+    {}
+    ~https_server() {
+        _process.terminate();
+        _process.wait().discard_result().get();
+    }
+    const sstring& cert() const {
+        return _cert;
+    }
+    socket_address addr() const {
+        return ipv4_addr(_addr, _port);
+    }
+    sstring name() const {
+        // should be identical to the one passed as the "-addext" option when
+        // generating the cert.
+        return "127.0.0.1";
+    }
+};
+
+#if !SEASTAR_TESTING_WITH_NETWORKING
+
+SEASTAR_THREAD_TEST_CASE(test_simple_x509_client) {
+    auto certs = ::make_shared<tls::certificate_credentials>();
+    https_server server;
+    certs->set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    connect_to_ssl_addr(certs, server.addr(), server.name()).get();
+}
+
+#endif // !SEASTAR_TESTING_WITH_NETWORKING
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_with_builder) {
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    connect_to_ssl_addr(b.build_certificate_credentials(), server.addr()).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_with_builder_multiple) {
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    auto creds = b.build_certificate_credentials();
+    auto addr = server.addr();
+    parallel_for_each(boost::irange(0, 20), [creds, addr](auto i) {
+        return connect_to_ssl_addr(creds, addr);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings) {
+    static std::vector<sstring> prios( {
+        "NORMAL:+ARCFOUR-128", // means normal ciphers plus ARCFOUR-128.
+        "SECURE128:-VERS-SSL3.0:+COMP-DEFLATE", // means that only secure ciphers are enabled, SSL3.0 is disabled, and libz compression enabled.
+        "SECURE256:+SECURE128",
+        "NORMAL:%COMPAT",
+        "NORMAL:-MD5",
+        "NONE:+VERS-TLS-ALL:+MAC-ALL:+RSA:+AES-256-GCM:+SIGN-ALL:+COMP-NULL:+GROUP-EC-ALL",
+        "NORMAL:+ARCFOUR-128",
+        "SECURE128:-VERS-TLS1.0:+COMP-DEFLATE",
+        "SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.2"
+    });
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    auto addr = server.addr();
+    do_for_each(prios, [&b, addr](const sstring& prio) {
+        b.set_priority_string(prio);
+        return connect_to_ssl_addr(b.build_certificate_credentials(), addr);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings_fail) {
+    static std::vector<sstring> prios( { "NONE",
+        "NONE:+CURVE-SECP256R1"
+    });
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    auto addr = server.addr();
+    do_for_each(prios, [&b, addr](const sstring& prio) {
+        b.set_priority_string(prio);
+        try {
+            return connect_to_ssl_addr(b.build_certificate_credentials(), addr).then([] {
+                BOOST_FAIL("Expected exception");
+            }).handle_exception([](auto ep) {
+                // ok.
+            });
+        } catch (...) {
+            // also ok
+        }
+        return make_ready_future<>();
+    }).get();
+}
 
 SEASTAR_TEST_CASE(test_failed_connect) {
     tls::credentials_builder b;


### PR DESCRIPTION
the goal of this change set is to drop the dependency on an external server for performing unit tests. ideally, the unit tests are supposed to be self-contained. the behavior of external resources is unpredictable.

- drop a test relying on CA certs provided by system.
- instead of using google.com as an HTTPS server for testing, use a dedicated HTTPS server implemented using python