### PR TITLE
test: use absolute include path

### DIFF
--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -25,7 +25,7 @@
 #include <seastar/util/later.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
-#include <../../src/core/stall_detector.hh>
+#include <seastar/core/stall_detector.hh>
 #include <atomic>
 #include <chrono>
 


### PR DESCRIPTION
It caused a problem when trying to build tests with bazel.

EDIT: I can see the tests fail so I guess there is a reason for this file not being exported for the test to include. I will just use a patch for my case.