### PR TITLE
http: Carry integer content_length on reply

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -110,6 +110,7 @@ struct reply {
      * The content to be sent in the reply.
      */
     sstring _content;
+    size_t content_length = 0; // valid when received via client connection
 
     sstring _response_line;
     std::unordered_map<sstring, sstring> trailing_headers;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -122,9 +122,7 @@ input_stream<char> connection::in(reply& rep) {
         return input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(_read_buf, rep.chunk_extensions, rep.trailing_headers)));
     }
 
-    sstring length_header = rep.get_header("Content-Length");
-    auto content_length = strtol(length_header.c_str(), nullptr, 10);
-    return input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(_read_buf, content_length)));
+    return input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(_read_buf, rep.content_length)));
 }
 
 future<> connection::close() {

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -179,6 +179,8 @@ reply::reply(http_response&& resp)
         , _headers(std::move(resp._headers))
         , _version(std::move(resp._version))
 {
+    sstring length_header = get_header("Content-Length");
+    content_length = strtol(length_header.c_str(), nullptr, 10);
 }
 
 sstring reply::response_line() {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -992,7 +992,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 auto resp = conn.make_request(std::move(req)).get0();
                 BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                 if (!chunked_reply) {
-                    BOOST_REQUIRE_EQUAL(resp._headers["Content-Length"], "0");
+                    BOOST_REQUIRE_EQUAL(resp.content_length, 0);
                 } else {
                     // If response is chunked it will contain the single termination
                     // zero-sized chunk that still needs to be read out
@@ -1009,7 +1009,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 auto resp = conn.make_request(std::move(req)).get0();
                 BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                 if (!chunked_reply) {
-                    BOOST_REQUIRE_EQUAL(resp._headers["Content-Length"], "20");
+                    BOOST_REQUIRE_EQUAL(resp.content_length, 20);
                 }
                 auto in = conn.in(resp);
                 sstring body = util::read_entire_stream_contiguous(in).get0();
@@ -1030,7 +1030,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 auto resp = conn.make_request(std::move(req)).get0();
                 BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                 if (!chunked_reply) {
-                    BOOST_REQUIRE_EQUAL(resp._headers["Content-Length"], "13");
+                    BOOST_REQUIRE_EQUAL(resp.content_length, 13);
                 }
                 auto in = conn.in(resp);
                 sstring body = util::read_entire_stream_contiguous(in).get0();
@@ -1045,7 +1045,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 auto resp = conn.make_request(std::move(req)).get0();
                 BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                 if (!chunked_reply) {
-                    BOOST_REQUIRE_EQUAL(resp._headers["Content-Length"], "6");
+                    BOOST_REQUIRE_EQUAL(resp.content_length, 6);
                 }
                 auto in = conn.in(resp);
                 sstring body = util::read_entire_stream_contiguous(in).get0();


### PR DESCRIPTION
When receiving and parsing a reply from server it's good to have the content length as integer, not as header string.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>