### PR TITLE
build: Fix chevrons imbalance in liburing_libs

### DIFF
--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -29,7 +29,7 @@ fmt_libs=$<TARGET_LINKER_FILE:fmt::fmt>
 lksctp_tools_cflags=-I$<JOIN:@lksctp-tools_INCLUDE_DIRS@, -I>
 lksctp_tools_libs=$<JOIN:@lksctp-tools_LIBRARIES@, >
 liburing_cflags=$<$<BOOL:@Seastar_IO_URING@>:-I$<JOIN:$<TARGET_PROPERTY:URING::uring,INTERFACE_INCLUDE_DIRECTORIES>, -I>>
-liburing_libs=$<$<BOOL:@Seastar_IO_URING@>:$<JOIN:@URING_LIBARIES@, >
+liburing_libs=$<$<BOOL:@Seastar_IO_URING@>:$<JOIN:@URING_LIBARIES@, >>
 numactl_cflags=-I$<JOIN:@numactl_INCLUDE_DIRS@, -I>
 numactl_libs=$<JOIN:@numactl_LIBRARIES@, >
 


### PR DESCRIPTION
Commit be3fc0ee (build: use URING_LIBRARIES for liburing_libs in .pc file) broke the brackets harmony in one of the variables. This comes unnoticed when building seastar, but breaks scylla in a weird manner:

./build/dev/gen/api/api-doc/endpoint_snitch_info.json.hh:14:10: fatal error: 'seastar/core/sstring.hh' file not found

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>