### PR TITLE
Revert "build: use pkg_search_module(.. IMPORTED_TARGET ..) in Findc-…

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -22,24 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_check_modules (c-ares IMPORTED_TARGET GLOBAL libcares)
+pkg_check_modules (c-ares_PC libcares)
 
-if (c-ares_FOUND)
-  add_library (c-ares::cares INTERFACE IMPORTED)
-  target_link_libraries (c-ares::cares INTERFACE PkgConfig::c-ares)
-  set(c-ares_LIBRARY ${c-ares_LIBRARIES})
-  set(c-ares_INCLUDE_DIR ${c-ares_INCLUDE_DIRS})
-endif ()
+find_library (c-ares_LIBRARY
+  NAMES cares
+  HINTS
+    ${c-ares_PC_LIBDIR}
+    ${c-ares_PC_LIBRARY_DIRS})
 
-if (NOT c-cares_LIBRARY)
-  find_library (c-ares_LIBRARY
-    NAMES cares)
-endif ()
-
-if (NOT c-ares_INCLUDE_DIR)
-  find_path (c-ares_INCLUDE_DIR
-    NAMES ares_dns.h)
-endif ()
+find_path (c-ares_INCLUDE_DIR
+  NAMES ares_dns.h
+  HINTS
+    ${c-ares_PC_INCLUDEDIR}
+    ${c-ares_PC_INCLUDE_DIRS})
 
 mark_as_advanced (
   c-ares_LIBRARY
@@ -53,15 +48,14 @@ find_package_handle_standard_args (c-ares
     c-ares_INCLUDE_DIR
   VERSION_VAR c-ares_PC_VERSION)
 
-if (c-ares_FOUND)
-  set (c-ares_LIBRARIES ${c-ares_LIBRARY})
-  set (c-ares_INCLUDE_DIRS ${c-ares_INCLUDE_DIR})
-  if (NOT (TARGET c-ares::cares))
-    add_library (c-ares::cares UNKNOWN IMPORTED)
+set (c-ares_LIBRARIES ${c-ares_LIBRARY})
+set (c-ares_INCLUDE_DIRS ${c-ares_INCLUDE_DIR})
 
-    set_target_properties (c-ares::cares
-      PROPERTIES
-        IMPORTED_LOCATION ${c-ares_LIBRARY}
-        INTERFACE_INCLUDE_DIRECTORIES ${c-ares_INCLUDE_DIRS})
-  endif ()
+if (c-ares_FOUND AND NOT (TARGET c-ares::cares))
+  add_library (c-ares::cares UNKNOWN IMPORTED)
+
+  set_target_properties (c-ares::cares
+    PROPERTIES
+      IMPORTED_LOCATION ${c-ares_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${c-ares_INCLUDE_DIRS})
 endif ()


### PR DESCRIPTION
…ares"

This reverts commit 27c2d888 (build: use pkg_search_module(.. IMPORTED_TARGET ..) in Findc-ares) as it breaks scylla build.

The fix results in

    seastar_libs_dev = ... /usr/lib64/libcares.so ...
    (the c-ares_LIBRARY variable)

gets converted into

    seastar_libs_dev = ... cares ...
    (the c-ares_LIBRARIES variable)

and it upsets clang linking targets:

    clang++ ... cares ...
    clang-15: error: no such file or directory: 'cares'
    clang-15: error: no such file or directory: 'cares'

The c-ares is public package. Other converted packages are private and got into seastar_libs_dev with -l option.