### PR TITLE
build: get the full path of c-ares

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -27,14 +27,15 @@ pkg_check_modules (c-ares IMPORTED_TARGET GLOBAL libcares)
 if (c-ares_FOUND)
   add_library (c-ares::cares INTERFACE IMPORTED)
   target_link_libraries (c-ares::cares INTERFACE PkgConfig::c-ares)
-  set(c-ares_LIBRARY ${c-ares_LIBRARIES})
   set(c-ares_INCLUDE_DIR ${c-ares_INCLUDE_DIRS})
 endif ()
 
-if (NOT c-cares_LIBRARY)
-  find_library (c-ares_LIBRARY
-    NAMES cares)
-endif ()
+# for the full path of libcares
+find_library (c-ares_LIBRARY
+   NAMES cares
+   HINTS
+     ${c-ares_LIBDIR}
+     ${c-ares_LIBRARY_DIRS})
 
 if (NOT c-ares_INCLUDE_DIR)
   find_path (c-ares_INCLUDE_DIR


### PR DESCRIPTION
otherwise the linker would not be able to find the library using ${c-ares_LIBRARY} reported by pkgconfig. the former is just "cares". so the command line would look like:

clang++ ... cares ...

and it fails to link like:

clang-15: error: no such file or directory: 'cares'

if a target links against ${c-ares_LIBRARY}, it would fail to link after 27c2d888e682ecb1d312fa123a88dd2f55745510. the offending change does not impact the target which links against c-ares::cares.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>