### PR TITLE
Make http requests with content-length header and generated body

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -30,6 +30,9 @@ namespace seastar {
 namespace http {
 namespace internal {
 output_stream<char> make_http_chunked_output_stream(output_stream<char>& out);
+// The len parameter defines the maximum number of bytes to be written. After the
+// stream is closed, the len is updated with the actual number of bytes written.
+output_stream<char> make_http_content_length_output_stream(output_stream<char>& out, size_t& len);
 } // internal namespace
 } // http namespace
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -40,6 +40,16 @@ connection::connection(connected_socket&& fd)
 
 future<> connection::write_body(request& req) {
     if (req.body_writer) {
+        if (req.content_length != 0) {
+            auto orig_content_length = req.content_length;
+            return req.body_writer(internal::make_http_content_length_output_stream(_write_buf, req.content_length)).then([&req, orig_content_length] {
+                if (req.content_length == orig_content_length) {
+                    return make_ready_future<>();
+                } else {
+                    return make_exception_future<>(std::runtime_error(format("partial request body write, need {} sent {}", orig_content_length, req.content_length)));
+                }
+            });
+        }
         return req.body_writer(internal::make_http_chunked_output_stream(_write_buf)).then([this] {
             return _write_buf.write("0\r\n\r\n");
         });

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -81,6 +81,8 @@ sstring type2str(operation_type type) {
 namespace http {
 namespace internal {
 
+static constexpr size_t default_body_sink_buffer_size = 32000;
+
 class http_chunked_data_sink_impl : public data_sink_impl {
     output_stream<char>& _out;
 
@@ -121,7 +123,7 @@ public:
 output_stream<char> make_http_chunked_output_stream(output_stream<char>& out) {
     output_stream_options opts;
     opts.trim_to_size = true;
-    return output_stream<char>(http_chunked_data_sink(out), 32000, opts);
+    return output_stream<char>(http_chunked_data_sink(out), default_body_sink_buffer_size, opts);
 }
 
 }

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -83,6 +83,14 @@ namespace internal {
 
 static constexpr size_t default_body_sink_buffer_size = 32000;
 
+// Data sinks below are running "on top" of socket output stream and provide
+// reliable and handy way of generating request bodies according to selected
+// encoding type and content-length.
+//
+// Respectively, both .close() methods should not close the underlying stream,
+// because the socket in question may continue being in use for keep-alive
+// connections, and closing it would just break the keep-alive-ness
+
 class http_chunked_data_sink_impl : public data_sink_impl {
     output_stream<char>& _out;
 

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -134,6 +134,53 @@ output_stream<char> make_http_chunked_output_stream(output_stream<char>& out) {
     return output_stream<char>(http_chunked_data_sink(out), default_body_sink_buffer_size, opts);
 }
 
+class http_content_length_data_sink_impl : public data_sink_impl {
+    output_stream<char>& _out;
+    const size_t _limit;
+    size_t& _bytes_written;
+
+public:
+    http_content_length_data_sink_impl(output_stream<char>& out, size_t& len)
+            : _out(out)
+            , _limit(std::exchange(len, 0))
+            , _bytes_written(len)
+    {
+    }
+    virtual future<> put(net::packet data)  override { abort(); }
+    using data_sink_impl::put;
+    virtual future<> put(temporary_buffer<char> buf) override {
+        if (buf.size() == 0 || _bytes_written == _limit) {
+            return make_ready_future<>();
+        }
+
+        auto size = buf.size();
+        if (_bytes_written + size > _limit) {
+            return make_exception_future<>(std::runtime_error(format("body conent length overflow: want {} limit {}", _bytes_written + buf.size(), _limit)));
+        }
+
+        return _out.write(buf.get(), size).then([this, size] {
+            _bytes_written += size;
+        });
+    }
+    virtual future<> close() override {
+        return make_ready_future<>();
+    }
+};
+
+class http_content_length_data_sink : public data_sink {
+public:
+    http_content_length_data_sink(output_stream<char>& out, size_t& len)
+        : data_sink(std::make_unique<http_content_length_data_sink_impl>(out, len))
+    {
+    }
+};
+
+output_stream<char> make_http_content_length_output_stream(output_stream<char>& out, size_t& len) {
+    output_stream_options opts;
+    opts.trim_to_size = true;
+    return output_stream<char>(http_content_length_data_sink(out, len), default_body_sink_buffer_size, opts);
+}
+
 }
 }
 

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -98,6 +98,12 @@ void request::write_body(const sstring& content_type, noncopyable_function<futur
     this->body_writer = std::move(body_writer);
 }
 
+void request::write_body(const sstring& content_type, size_t len, noncopyable_function<future<>(output_stream<char>&&)>&& body_writer) {
+    set_content_type(content_type);
+    content_length = len;
+    this->body_writer = std::move(body_writer);
+}
+
 void request::set_expects_continue() {
     _headers["Expect"] = "100-continue";
 }


### PR DESCRIPTION
There are currently two options how to generate http request with body.

The first is to provide a body string, so that the client would set content-length header and send string plain-encoded.
The second is to provide a function, that would write the data into the output stream and the client would encode it with http chunks behind the scenes.

For S3 client we need 3rd option -- to generate the body in plain-encoding, _not_ from the contiguous string, but with the content-length header set. This set adds this ability with the write_body(length, body_writer_fn) method.