### PR TITLE
http: Add connection::skip_body() sugar

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -79,6 +79,16 @@ public:
     input_stream<char> in(reply& rep);
 
     /**
+     * \brief Skips the reply body (if any)
+     *
+     * Can be called if the caller doesn't need the body contents of the reply (i.e. --
+     * only needs status and/or headers).
+     *
+     * Mutually exclusive with the \ref in(reply& rep) one.
+     */
+    future<> skip_body(reply& rep);
+
+    /**
      * \brief Closes the connection
      *
      * Connection must be closed regardless of whether there was an exception making the

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -26,6 +26,7 @@
 #include <seastar/http/reply.hh>
 #include <seastar/http/response_parser.hh>
 #include <seastar/http/internal/content_source.hh>
+#include <seastar/util/short_streams.hh>
 
 namespace seastar {
 namespace http {
@@ -123,6 +124,12 @@ input_stream<char> connection::in(reply& rep) {
     }
 
     return input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(_read_buf, rep.content_length)));
+}
+
+future<> connection::skip_body(reply& rep) {
+    return do_with(in(rep), [] (auto& in) {
+        return util::skip_entire_stream(in);
+    });
 }
 
 future<> connection::close() {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1003,6 +1003,17 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
             }
 
             {
+                fmt::print("Skip reply body test\n");
+                auto req = http::request::make("GET", "test", "/test");
+                req.write_body("txt", sstring("12345"));
+                auto resp = conn.make_request(std::move(req)).get0();
+                BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
+                conn.skip_body(resp).get();
+                // in fact, this case is to make sure that _next_ cases won't collect
+                // garbage from the client connection
+            }
+
+            {
                 fmt::print("Request with body test\n");
                 auto req = http::request::make("GET", "test", "/test");
                 req.write_body("txt", sstring("12345 78901\t34521345"));


### PR DESCRIPTION
Sometimes the request maker isn't interested in reply body, but only needs status and/or headers from it. Example -- S3 multipart upload completion request. The reply would contain parts summary which the caller may not need to check. However, leaving the body unread is not good if the connection is keep-alive and re-used for next request. In this case the left body will be read back as if it was the next reply itself which's wrong.

The added function drains the input stream clearing it for the next request.

Non-keep-alive requests can just close the socket.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>