### PR TITLE
build: bump up fmtlib, boost and cryptopp in cooking_recipe

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -280,8 +280,8 @@ cooking_ingredient (dpdk
 
 cooking_ingredient (fmt
   EXTERNAL_PROJECT_ARGS
-    URL https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz
-    URL_MD5 eaf6e3c1b2f4695b9a612cedf17b509d
+    URL https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
+    URL_MD5 21fac48cae8f3b4a5783ae06b443973a
   CMAKE_ARGS
     -DFMT_DOC=OFF
     -DFMT_TEST=OFF)

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -133,8 +133,8 @@ cooking_ingredient (zlib
 
 cooking_ingredient (Boost
   EXTERNAL_PROJECT_ARGS
-    URL https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2
-    URL_HASH SHA256=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
+    URL_HASH SHA256=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
     PATCH_COMMAND
       ./bootstrap.sh
       --prefix=<INSTALL_DIR>

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -236,12 +236,14 @@ cooking_ingredient (c-ares
     INSTALL_COMMAND ${make_command} install)
 
 cooking_ingredient (cryptopp
-  CMAKE_ARGS
-    -DCMAKE_INSTALL_LIBDIR=<INSTALL_DIR>/lib
-    -DBUILD_TESTING=OFF
   EXTERNAL_PROJECT_ARGS
-    URL https://github.com/weidai11/cryptopp/archive/CRYPTOPP_5_6_5.tar.gz
-    URL_MD5 88224d9c0322f63aa1fb5b8ae78170f0)
+    URL https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz
+    URL_MD5 69b11e59094c10d437f295f11e51c16a
+    CONFIGURE_COMMAND <DISABLE>
+    BUILD_COMMAND <DISABLE>
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>
+      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} ${make_command} install-lib PREFIX=<INSTALL_DIR>)
 
 
 # Use the "native" profile that DPDK defines in `dpdk/config`, but in `dpdk_configure.cmake` we override


### PR DESCRIPTION
- build: bump fmtlib to 9.1.0 in cooking_recipe
- build: bump boost to 1.81.0 in cooking_recipe
- build: bump cryptopp to 8.7.0 in cooking_recipe