### PR TITLE
build: reuse compiler settings when cooking ingredients

### DIFF
--- a/cooking.sh
+++ b/cooking.sh
@@ -558,10 +558,21 @@ endfunction ()
 function (_cooking_determine_common_cmake_args output)
   string (REPLACE ";" ":::" prefix_path_with_colons "${CMAKE_PREFIX_PATH}")
 
-  set (${output}
+  if (CMAKE_CXX_FLAGS)
+    list (APPEND cmake_args -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS})
+  endif ()
+  if (CMAKE_C_FLAGS)
+    list (APPEND cmake_args -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  endif ()
+
+  list (APPEND cmake_args
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     -DCMAKE_PREFIX_PATH=${prefix_path_with_colons}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER})
+
+  set (${output} ${cmake_args}
     PARENT_SCOPE)
 endfunction ()
 


### PR DESCRIPTION
cooking_ingredient() is practically modeled after how ExternalProject is structured. like the latter, it construct a default set cmake options like CMAKE_BUILD_TYPE from the parent project. but CMAKE_C_COMPILER and CMAKE_CXX_COMPILER are not populated to the ingredients.

before this change, cooking.sh always leaves it to the ingredient to decide which compiler to use. most of the time, cc is used and under most circumstances, it is a wrapper of a symbolic link to gcc. if we want to test the build with another compiler or even another version of gcc which is not pointed by "gcc", we can only specify how Seastar is built.

But sometimes, we also want to check the combination of, for instance, clang + libc++. it'd be impossible before this change. as libc++ and libstdc++ are not ABI compatible, we have to rebuild all C++ dependencies to fix this.

after this change, both the C compiler and C++ compiler used in Seastar project are populated to the ingredient projects. this would allow us to perform the compilation test above.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>