### PR TITLE
build: pass cflags and ldflags to cooking.sh

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -225,7 +225,12 @@ def configure_mode(mode):
         for ingredient in ingredients_to_cook:
             inclusion_arguments.extend(['-i', ingredient])
 
-        ARGS = seastar_cmake.COOKING_BASIC_ARGS + inclusion_arguments + ['-d', BUILD_PATH, '--']
+        ARGS = seastar_cmake.COOKING_BASIC_ARGS + inclusion_arguments
+        if args.user_cflags:
+            ARGS += ['-s', f'CXXFLAGS={args.user_cflags}']
+        if args.user_ldflags:
+            ARGS += ['-s', f'LDFLAGS={args.user_ldflags}']
+        ARGS += ['-d', BUILD_PATH, '--']
         dir = seastar_cmake.ROOT_PATH
     else:
         # When building without cooked dependencies, we can invoke cmake directly. We can't call

--- a/cooking.sh
+++ b/cooking.sh
@@ -162,8 +162,10 @@ EOF
 }
 
 parse_assignment() {
-    IFS='=' read -ra parts <<< "${1}"
-    export "${parts[0]}"="${parts[1]}"
+    local var
+    local value
+    IFS='=' read -r var value <<< "${1}"
+    export "${var}"="${value}"
 }
 
 yell_include_exclude_mutually_exclusive() {

--- a/cooking.sh
+++ b/cooking.sh
@@ -560,10 +560,21 @@ endfunction ()
 function (_cooking_determine_common_cmake_args output)
   string (REPLACE ";" ":::" prefix_path_with_colons "${CMAKE_PREFIX_PATH}")
 
-  set (${output}
+  if (CMAKE_CXX_FLAGS)
+    list(APPEND cmake_args -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS})
+  endif ()
+  if (CMAKE_C_FLAGS)
+    list(APPEND cmake_args -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  endif ()
+
+  list (APPEND cmake_args
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     -DCMAKE_PREFIX_PATH=${prefix_path_with_colons}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER})
+
+  set (${output} ${cmake_args}
     PARENT_SCOPE)
 endfunction ()
 


### PR DESCRIPTION
- build: pass cflags and ldflags from `configure.py` to cooking.sh
- build: cooking.sh: parse -s `foo=bar=baz` as foo=`bar=bz`
- build: reuse compiler settings when cooking ingredients

so cooking.sh can 

1. properly parse the environmental variables set by `configure.py`, 
2. expose them as environmental variables, and 
3. populate them when invoking cmake, and then, cmake can update builtin variables like CMAKE_CXX_FLAGS with the configured environmental variables.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>