### PR TITLE
build: build static library of cryptopp

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -242,7 +242,7 @@ cooking_ingredient (cryptopp
     BUILD_COMMAND <DISABLE>
     INSTALL_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>
-      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} ${make_command} install-lib PREFIX=<INSTALL_DIR>)
+      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} static install-lib PREFIX=<INSTALL_DIR>)
 
 
 # Use the "native" profile that DPDK defines in `dpdk/config`, but in `dpdk_configure.cmake` we override


### PR DESCRIPTION
before this change,

* only the headers and the executable for testing are installed.
* CMAKE_CXX_FLAGS are not used when building cryptopp

these have two sequences:

* the static library are not installed, so the cooked library cannot be picked up by find_package(..)
* if we want to pass, for instance, '-stdlib=libc++' as the CXXFLAGS, when building Seastar, it won't be used, and libstdc++ is used. this would cause link failure, as libstdc++ and libc++ are not ABI compatible.

after this change,

* the "static" target is built before "install-lib" is built.
* the CMAKE_CXX_FLAGS are used,as GNUmake uses CXXFLAGS variable implicitly when building targets.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>