### PR TITLE
build: specify CMake policy CMP0135 to new

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ project (Seastar
   VERSION 1.0
   LANGUAGES CXX)
 
+if (POLICY CMP0135)
+  cmake_policy (SET CMP0135 NEW)
+endif ()
+
 # generic boolean values passed as string, potentially from configure.py
 set (True_STRING_VALUES "ON" "yes" "Yes" "YES" "true" "True" "TRUE")
 set (False_STRING_VALUES "OFF" "no" "No" "NO" "false" "False" "FALSE")


### PR DESCRIPTION
this new option was introduced in CMake 3.24. and CMake 3.24 complains like:

  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.

if `cmake_policy(SET CMP0135 NEW)` is not specified explicitly, or `DOWNLOAD_EXTRACT_TIMESTAMP` is not specified when calling `ExternalProject_add()`.

if we enable this option when calling `ExternalProject_add()` unconditionally, we'd have warning like:

CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:1176 (message):
  value 'DOWNLOAD_EXTRACT_TIMESTAMP' with no previous keyword in
  ExternalProject_Add

when running older CMake. so let's just enable this policy if it exists.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>