### PR TITLE
build: use BUILD_IN_SOURCE instead chdir <SOURCE_DIR>

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -265,10 +265,11 @@ cooking_ingredient (cryptopp
     URL https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz
     URL_MD5 69b11e59094c10d437f295f11e51c16a
     CONFIGURE_COMMAND <DISABLE>
-    BUILD_COMMAND <DISABLE>
+    BUILD_IN_SOURCE ON
+    BUILD_COMMAND
+      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} static
     INSTALL_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>
-      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} static install-lib PREFIX=<INSTALL_DIR>)
+      ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} install-lib PREFIX=<INSTALL_DIR>)
 
 
 # Use the "native" profile that DPDK defines in `dpdk/config`, but in `dpdk_configure.cmake` we override


### PR DESCRIPTION
also, build the "static" target in the BUILD_COMMAND instead in INSTALL_COMMAND of cryptopp, for better readability, and more importantly, to ensure that "static" target is built *before* "install-lib", so that "install-lib" can find the built static library.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>