### PR TITLE
lw_shared_ptr: Add nullptr_t comparing operators

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -739,6 +739,20 @@ operator==(std::nullptr_t, const shared_ptr<T>& y) {
     return nullptr == y.get();
 }
 
+template <typename T>
+inline
+bool
+operator==(const lw_shared_ptr<T>& x, std::nullptr_t) {
+    return x.get() == nullptr;
+}
+
+template <typename T>
+inline
+bool
+operator==(std::nullptr_t, const lw_shared_ptr<T>& y) {
+    return nullptr == y.get();
+}
+
 template <typename T, typename U>
 inline
 bool
@@ -757,6 +771,20 @@ template <typename T>
 inline
 bool
 operator!=(std::nullptr_t, const shared_ptr<T>& y) {
+    return nullptr != y.get();
+}
+
+template <typename T>
+inline
+bool
+operator!=(const lw_shared_ptr<T>& x, std::nullptr_t) {
+    return x.get() != nullptr;
+}
+
+template <typename T>
+inline
+bool
+operator!=(std::nullptr_t, const lw_shared_ptr<T>& y) {
     return nullptr != y.get();
 }
 

--- a/tests/unit/shared_ptr_test.cc
+++ b/tests/unit/shared_ptr_test.cc
@@ -202,3 +202,19 @@ BOOST_AUTO_TEST_CASE(test_const_release) {
     do_test_release<const A>();
     do_test_release<const A_esft>();
 }
+
+BOOST_AUTO_TEST_CASE(test_nullptr_compare) {
+    seastar::shared_ptr<int> ptr;
+    BOOST_REQUIRE(ptr == nullptr);
+    BOOST_REQUIRE(nullptr == ptr);
+    ptr = seastar::make_shared<int>(0);
+    BOOST_REQUIRE(ptr != nullptr);
+    BOOST_REQUIRE(nullptr != ptr);
+
+    seastar::lw_shared_ptr<int> lptr;
+    BOOST_REQUIRE(lptr == nullptr);
+    BOOST_REQUIRE(nullptr == lptr);
+    lptr = seastar::make_lw_shared<int>(0);
+    BOOST_REQUIRE(lptr != nullptr);
+    BOOST_REQUIRE(nullptr != lptr);
+}


### PR DESCRIPTION
Otherwise compiling lw_shared_ptr<T> == nullptr_t fails:

error: use of overloaded operator '==' is ambiguous (with operand types 'const seastar::lw_shared_ptr<int>' and 'const std::nullptr_t')
    return left == right;
           ~~~~ ^  ~~~~~
note: candidate function
    bool operator==(const lw_shared_ptr<const T>& x) const {
         ^
note: candidate function
    bool operator==(const lw_shared_ptr<std::remove_const_t<T>>& x) const {
         ^
Same for operator!=, c++17 doesn't generate it from == one. Compilation test included (and for shared_ptr too, it already works).

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>