### PR TITLE
noncopyable_function: Add concept for (Func func) constructor

### DIFF
--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <seastar/util/used_size.hh>
-
+#include <seastar/util/concepts.hh>
 #include <utility>
 #include <type_traits>
 #include <functional>
@@ -175,6 +175,7 @@ private:
 public:
     noncopyable_function() noexcept : _vtable(&_s_empty_vtable) {}
     template <typename Func>
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<Ret, Func, Args...> )
     noncopyable_function(Func func) {
         static_assert(!Noexcept || noexcept(std::declval<Func>()(std::declval<Args>()...)));
         vtable_for<Func>::initialize(std::move(func), this);


### PR DESCRIPTION
In its current form it looks as if it could construct n.c.f. from pretty much anything, but in reality it's more strict.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>