### PR TITLE
build: drop unused target_include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -729,8 +729,7 @@ target_include_directories (seastar
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${Seastar_GEN_BINARY_DIR}/include>
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${Seastar_GEN_BINARY_DIR}/src)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set (Seastar_PRIVATE_CXX_FLAGS
   -fvisibility=hidden


### PR DESCRIPTION
we use seastar_generate_ragel() to generate the header files using ragel. and ragel outputs the generated header files under `${Seastar_GEN_BINARY_DIR}/include`. so we never write any source or header files into `${Seastar_GEN_BINARY_DIR}/src`.

in this change, the unused include directory is removed.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>