### PR TITLE
tests: connect_test: use 127.0.0.1 for connect refused test

### DIFF
--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -7,7 +7,7 @@ using namespace seastar;
 using namespace net;
 
 SEASTAR_TEST_CASE(test_connection_attempt_is_shutdown) {
-    ipv4_addr server_addr("172.16.0.1");
+    ipv4_addr server_addr("127.0.0.1");
     auto unconn = make_socket();
     auto f = unconn
         .connect(make_ipv4_address(server_addr))


### PR DESCRIPTION
before this change, 172.16.0.1:0 is used as a peer which is shutdown, this works fine when using aio as the backend. but unfortunately, when it comes to io_uring, if the fd in question is opened in blocking mode. the connect call is blocked forever. this behavior can be verified using liburing/test/connect.c after manually changing the IP address in this test from "127.0.0.1" to "172.16.0.1". if the fd is opened in non-blocking mode. 0 is returned in the cqe. hence the test of tests/unit/connect_test fails.

after this change, "172.16.0.1" is changed to "127.0.0.1", since 0 is not a valid TCP port for connection. we always have ECONNREFUSED.

this should help io_uring backend pass the tests/unit/connect_test test.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>