### PR TITLE
lw_shared_ptr, allow migration between cpu

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -360,6 +360,15 @@ public:
         }
     }
 
+#ifdef SEASTAR_DEBUG_SHARED_PTR
+    void migrate_to_this_cpu() {
+        _p->_count.migrate_to_this_cpu();
+    }
+#else
+    void migrate_to_this_cpu() {
+    }
+#endif
+
     operator lw_shared_ptr<const T>() const noexcept {
         return lw_shared_ptr<const T>(_p);
     }

--- a/include/seastar/core/shared_ptr_debug_helper.hh
+++ b/include/seastar/core/shared_ptr_debug_helper.hh
@@ -62,6 +62,9 @@ public:
         check();
         return _counter--;
     }
+    void migrate_to_this_cpu() {
+        _cpu = std::this_thread::get_id();
+    }
 private:
     void check() const {
         if (__builtin_expect(_cpu != std::this_thread::get_id(), false)) {


### PR DESCRIPTION
At the time lw_shared_ptr doesn't allow passing instances between shards. However, sometimes it can be useful to move its 'ownership' from one cpu to another to avoid copying.

A relevant example is [append_entries RPC in RAFT](https://github.com/scylladb/scylladb/pull/12374). If there are nodes in the cluster with different --smp values, this RPC can start processing on some random non-zero shard but since raft_group0 lives on zero shard, we need smp::submit_to. In [the append_entries PR](https://github.com/scylladb/scylladb/pull/12374) the problem is solved by copying the log_entries vector to the target shard, but this entails quite a significant overhead. If we just update the cpu in `debug_shared_ptr_counter_type`, the only remaining overhead will be cross-shard free. However, if I understand [the code](https://github.com/scylladb/seastar/blob/master/src/core/memory.cc#L906) correctly, cross-shard free overhead is just `compare_exchange_weak` to push the pointer to the target cpu free list, which should be cheaper than the entire copy.

This patch is RFC, the specific API is up for discussion and quite possible should be entirely different. Perhaps the overhead from cross-shard free is more significant than aforementioned `compare_exchange_weak`, then giving up copies would be less appealing. That said, however, there are quite a few places in the existing code (`gossiper`, `raft_group_registry`, `raft_group0`) where non-trivial data structures (e.g. `unordered_map`) are passed between shards, which already entails cross-shard free.

One more point - in the raft_append_entries example we need the ownership transfer semantics, not something like borrow (move the pointer to the target shard for processing and then return it back), since the transferred log_entries will live inside raft fsm for some time after the `append_entries` call ends.
