### PR TITLE
condition_variable: add support for abort source

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -185,6 +185,12 @@ public:
     virtual std::exception_ptr get_default_exception() const noexcept {
         return make_exception_ptr(abort_requested_exception());
     }
+
+    /// Returns the exception_ptr abort was requested with
+    /// or nullptr if no abort was requested.
+    std::exception_ptr get_exception() const noexcept {
+        return _ex;
+    }
 };
 
 /// @}

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -110,6 +110,7 @@ private:
         using handle_type = SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<void>;
 
         condition_variable* _cv;
+        optimized_optional<abort_source::subscription> _sub;
         handle_type _when_ready;
         std::exception_ptr _ex;
         task* _waiting_task = nullptr;
@@ -118,8 +119,19 @@ private:
             : _cv(cv)
         {}
 
+        awaiter(condition_variable* cv, abort_source& as)
+            : _cv(cv)
+        {
+            _sub = as.subscribe([this] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+                set_exception(opt_ex.value_or(std::make_exception_ptr(abort_requested_exception())));
+            });
+            if (!_sub) {
+                _ex = as.get_exception();
+            }
+        }
+
         bool await_ready() const {
-            return _cv->check_and_consume_signal();
+            return _cv->check_and_consume_signal() || _ex;
         }
         template<typename T>
         void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<T> h) {
@@ -185,7 +197,7 @@ private:
         bool await_ready() const {
             if (!_func()) {
                 Base::await_ready(); // clear out any signal state
-                return false;
+                return bool(Base::_ex);
             }
             return true;
         }        
@@ -367,6 +379,18 @@ public:
     }
 
     /// Coroutine/co_await only waiter.
+    /// Waits until condition variable is signaled or abort was requested,
+    /// may wake up without condition been met
+    ///
+    /// \return a future that becomes ready when \ref signal() is called
+    ///         If abort was requested, return the \ref abort_source exception.
+    ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
+    ///         exception.
+    awaiter when(abort_source& as) noexcept {
+        return awaiter{this, as};
+    }
+
+    /// Coroutine/co_await only waiter.
     /// Waits until condition variable is signaled or timeout is reached
     ///
     /// \param timeout time point at which wait will exit with a timeout
@@ -403,7 +427,21 @@ public:
     template<typename Pred>
     SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
     auto when(Pred&& pred) noexcept {
-        return predicate_awaiter<Pred, awaiter>{std::forward<Pred>(pred), when()};
+        return predicate_awaiter<Pred, awaiter>{std::forward<Pred>(pred), this};
+    }
+
+    /// Coroutine/co_await only waiter.
+    /// Waits until condition variable is notified and pred() == true, otherwise
+    /// wait again.
+    ///
+    /// \param pred predicate that checks that awaited condition is true
+    ///
+    /// \return a future that becomes ready when \ref signal() is called
+    ///         If the condition variable was \ref broken(), may contain an exception.
+    template<typename Pred>
+    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    auto when(abort_source& as, Pred&& pred) noexcept {
+        return predicate_awaiter<Pred, awaiter>{std::forward<Pred>(pred), this, as};
     }
 
     /// Coroutine/co_await only waiter.
@@ -419,7 +457,7 @@ public:
     template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration, typename Pred>
     SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
     auto when(std::chrono::time_point<Clock, Duration> timeout, Pred&& pred) noexcept {
-        return predicate_awaiter<Pred, timeout_awaiter<Clock, Duration>>{std::forward<Pred>(pred), when(timeout)};
+        return predicate_awaiter<Pred, timeout_awaiter<Clock, Duration>>{std::forward<Pred>(pred), this, timeout};
     }
 
     /// Coroutine/co_await only waiter.

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -233,12 +233,12 @@ public:
         }
         struct timeout_waiter : public promise_waiter, public timer<Clock> {};
 
-        auto w = std::make_unique<timeout_waiter>();
+        auto w = new timeout_waiter;
         auto f = w->get_future();
 
-        w->set_callback(std::bind(&waiter::timeout, w.get()));
+        w->set_callback(std::bind(&waiter::timeout, w));
         w->arm(timeout);
-        add_waiter(*w.release());
+        add_waiter(*w);
         return f;
     }
 


### PR DESCRIPTION
Add an optional abort_source* parameter to wait functions so
individual waiters can be aborted using an abort source.

Add respective unit tests.
