### PR TITLE
util/process: include used header

### DIFF
--- a/include/seastar/util/process.hh
+++ b/include/seastar/util/process.hh
@@ -33,6 +33,7 @@
 #include <vector>
 #include <fmt/format.h>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/posix.hh>
 #include <seastar/core/sstring.hh>
 
 namespace seastar::experimental {


### PR DESCRIPTION
file_desc is declared in core/posix.hh, so we need to include core/posix.hh explicitly in process.hh which references file_desc.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>