### PR TITLE
reactor: trim returned buffer to received number of bytes

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1910,6 +1910,7 @@ public:
                     if (size_t(*r) == buffer.size()) {
                         fd.speculate_epoll(EPOLLIN);
                     }
+                    buffer.trim(*r);
                     return make_ready_future<temporary_buffer<char>>(std::move(buffer));
                 }
             } catch (...) {


### PR DESCRIPTION
before this change, the io_uring backend fails to trim the returned buffer to the number of bytes actually received. so reactor_backend_uring::recv_some() could return a buffer with trailing garbage bits.

after this change, reactor_backend_uring::recv_some() always trims the trailing bits off the returned buffer, so the returned buffer is the bytes read from wire without uninitialized bits at its end.

Fixes: #1258
Signed-off-by: Kefu Chai <tchaikov@gmail.com>