### PR TITLE
reactor: use aio to implement reactor_backend_uring::read()

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1662,44 +1662,7 @@ public:
         fd.fd.shutdown(how);
     }
     virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override {
-        if (fd.take_speculation(POLLIN)) {
-            try {
-                auto r = fd.fd.read(buffer, len);
-                if (r) {
-                    if (size_t(*r) == len) {
-                        fd.speculate_epoll(EPOLLIN);
-                    }
-                    return make_ready_future<size_t>(*r);
-                }
-            } catch (...) {
-                return current_exception_as_future<size_t>();
-            }
-        }
-        class read_completion final : public io_completion {
-            pollable_fd_state& _fd;
-            const size_t _to_read;
-            promise<size_t> _result;
-        public:
-            read_completion(pollable_fd_state& fd, size_t to_read)
-                : _fd(fd), _to_read(to_read) {}
-            void complete(size_t bytes) noexcept final {
-                if (bytes == _to_read) {
-                    _fd.speculate_epoll(EPOLLIN);
-                }
-                _result.set_value(bytes);
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            future<size_t> get_future() {
-                return _result.get_future();
-            }
-        };
-        auto desc = std::make_unique<read_completion>(fd, len);
-        auto req = internal::io_request::make_read(fd.fd.get(), -1, buffer, len, false);
-        return submit_request(std::move(desc), std::move(req));
+        return _r.do_read(fd, buffer, len);
     }
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override {
         if (fd.take_speculation(POLLIN)) {


### PR DESCRIPTION
this change reverts https://github.com/tchaikov/seastar/commit/64480988a3dd531603e46010693f9a87baa9437c. per
our tests on linux 5.11.0, read op returns -EAGAIN even after
poll(EPOLLIN) with io_uring backend returns with an fd created using
`file_desc::inotify_init()`. this practically fails all tests in
fsnotifier_test.cc, and also some tests in tls_test.cc exercising
`reloadable_credentials`. as `reloadable_credentials` uses inotify
to watch the changes of the credential files.

but on newer kernel like linux 6.0, the io_uring backend works fine
with inotify. since inotify is not used in critical paths, we can
tolerate this hybrid implementation at this moment. and we can use
io_uring backend once the CircleCI is able to offer newer image with
newer linux kernel, and we need to bump up the required kernel
version for using some io_uring features.

Fixes #1386
Fixes #1387
Signed-off-by: Kefu Chai <tchaikov@gmail.com>