### PR TITLE
Use an integral type for uniform_int_distribution

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -530,7 +530,7 @@ private:
                             return max_concurrent_for_each(pos.begin(), pos.end(), 64, [this, bufsize] (auto pos) mutable {
                                 auto bufptr = allocate_aligned_buffer<char>(bufsize, 4096);
                                 auto buf = bufptr.get();
-                                std::uniform_int_distribution<char> fill('@', '~');
+                                std::uniform_int_distribution<int> fill('@', '~');
                                 memset(buf, fill(random_generator), bufsize);
                                 pos = pos * bufsize;
                                 return _file.dma_write(pos, buf, bufsize).finally([this, bufptr = std::move(bufptr), pos] {

--- a/demos/file_demo.cc
+++ b/demos/file_demo.cc
@@ -67,7 +67,7 @@ future<> demo_with_file() {
     fmt::print("Demonstrating with_file():\n");
     return tmp_dir::do_with_thread([] (tmp_dir& t) {
         auto rnd = std::mt19937(std::random_device()());
-        auto dist = std::uniform_int_distribution<char>(0, std::numeric_limits<char>::max());
+        auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
         auto wbuf = temporary_buffer<char>::aligned(aligned_size, aligned_size);
         sstring meta_filename = (t.get_path() / "meta_file").native();
         sstring data_filename = (t.get_path() / "data_file").native();
@@ -109,7 +109,7 @@ future<> demo_with_file_close_on_failure() {
     fmt::print("\nDemonstrating with_file_close_on_failure():\n");
     return tmp_dir::do_with_thread([] (tmp_dir& t) {
         auto rnd = std::mt19937(std::random_device()());
-        auto dist = std::uniform_int_distribution<char>(0, std::numeric_limits<char>::max());
+        auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
         auto wbuf = temporary_buffer<char>::aligned(aligned_size, aligned_size);
         sstring meta_filename = (t.get_path() / "meta_file").native();
         sstring data_filename = (t.get_path() / "data_file").native();
@@ -175,7 +175,7 @@ future<> demo_with_io_intent() {
         auto f = open_file_dma(filename, open_flags::rw | open_flags::create).get0();
 
         auto rnd = std::mt19937(std::random_device()());
-        auto dist = std::uniform_int_distribution<char>(0, std::numeric_limits<char>::max());
+        auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
 
         auto wbuf = temporary_buffer<char>::aligned(aligned_size, aligned_size);
         fmt::print("  writing random data into {}\n", filename);

--- a/tests/perf/rpc_perf.cc
+++ b/tests/perf/rpc_perf.cc
@@ -80,7 +80,7 @@ public:
         , _small_buffer_zeroes(seastar::temporary_buffer<char>(small_buffer_size))
     {
         auto& eng = testing::local_random_engine;
-        auto dist = std::uniform_int_distribution<char>();
+        auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
 
         std::generate_n(_small_buffer_random.get_write(), small_buffer_size, [&] { return dist(eng); });
         for (auto i = 0u; i < large_buffer_size / seastar::rpc::snd_buf::chunk_size; i++) {

--- a/tests/unit/allocator_test.cc
+++ b/tests/unit/allocator_test.cc
@@ -170,7 +170,7 @@ int main(int ac, char** av) {
     std::default_random_engine random_engine(seed);
     std::exponential_distribution<> distr(0.2);
     std::uniform_int_distribution<> type(0, 1);
-    std::uniform_int_distribution<char> poison(-128, 127);
+    std::uniform_int_distribution<int> poison(-128, 127);
     std::uniform_real_distribution<> which(0, 1);
     std::vector<allocation> allocations;
     auto iteration = [&] {

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -284,7 +284,7 @@ SEASTAR_TEST_CASE(test_consume_unaligned_file_large) {
 SEASTAR_TEST_CASE(test_input_stream_esp_around_eof) {
     return tmp_dir::do_with_thread([] (tmp_dir& t) {
         auto flen = uint64_t(5341);
-        auto rdist = std::uniform_int_distribution<char>();
+        auto rdist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
         auto reng = testing::local_random_engine;
         auto data = boost::copy_range<std::vector<uint8_t>>(
                 boost::irange<uint64_t>(0, flen)

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -966,7 +966,7 @@ void test_compressor(std::function<std::unique_ptr<seastar::rpc::compressor>()> 
     };
 
     auto& eng = testing::local_random_engine;
-    auto dist = std::uniform_int_distribution<char>();
+    auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());
 
     auto snd = snd_buf(1);
     *snd.front().get_write() = 'a';


### PR DESCRIPTION
`char` is not a supported type, and in particular is rejected by libc++-15. Change it to int and explicitly set the bounds where necessary.

This is a re-submission of https://github.com/scylladb/seastar/pull/1317 to see if this fixes the Circle CI issue.

cc @BenPope 