### PR TITLE
http: delay input stream close until responses sent

### DIFF
--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -159,8 +159,6 @@ future<> connection::read() {
         }
         f.ignore_ready_future();
         return _replies.push_eventually( {});
-    }).finally([this] {
-        return _read_buf.close();
     });
 }
 
@@ -296,6 +294,10 @@ future<> connection::process() {
             hlogger.debug("Response exception encountered: {}", std::current_exception());
         }
         return make_ready_future<>();
+    }).finally([this]{
+        return _read_buf.close().handle_exception([](std::exception_ptr e) {
+            hlogger.debug("Close exception encountered: {}", e);
+        });
     });
 }
 void connection::shutdown() {


### PR DESCRIPTION
This is a workaround for issue https://github.com/scylladb/seastar/issues/906 when using TLS connections to an httpd service.

Previously, https:// servers would fail to send a response whenever a client sent a "Connection: Close" HTTP/1.1 response.

This was hidden mostly by the case-sensitive parse of "Close", where typical clients send "close".  Commit c14f9315 fized the parsing to be case insensitive, which makes the underlying issue manifest. Previously we were mostly ignoring `Connection` headers.