### PR TITLE
reactor: s/resize(0)/clear()/

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -177,7 +177,7 @@ bool
 aio_storage_context::submit_work() {
     bool did_work = false;
 
-    _submission_queue.resize(0);
+    _submission_queue.clear();
     size_t to_submit = _r._io_sink.drain([this] (const internal::io_request& req, io_completion* desc) -> bool {
         if (!_iocb_pool.has_capacity()) {
             return false;


### PR DESCRIPTION
from functionality perspective, resize(0) is identical to clear(). but static_vector::resize(0) could use more CPU cycles than the latter. for instance, it compares the new size with the old size to determine if it should value-initialize the new elements if any. while clear() just nukes all the elements and set the new size to 0. it should be faster than resize(0). and more importantly, it has better readability.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>