### PR TITLE
httpd: optimize header field assignment

### DIFF
--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -76,14 +76,13 @@ action checkpoint {
 }
 
 action assign_field {
-    if (_req->_headers.count(_field_name)) {
+    auto [iter, inserted] = _req->_headers.try_emplace(_field_name, std::move(_value));
+    if (!inserted) {
         // RFC 7230, section 3.2.2.  Field Parsing:
         // A recipient MAY combine multiple header fields with the same field name into one
         // "field-name: field-value" pair, without changing the semantics of the message,
         // by appending each subsequent field value to the combined field value in order, separated by a comma.
-        _req->_headers[_field_name] += sstring(",") + std::move(_value);
-    } else {
-        _req->_headers[_field_name] = std::move(_value);
+        iter->second += sstring(",") + std::move(_value);
     }
 }
 

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -69,14 +69,13 @@ action checkpoint {
 }
 
 action assign_field {
-    if (_rsp->_headers.count(_field_name)) {
+    auto [iter, inserted] = _rsp->_headers.try_emplace(_field_name, std::move(_value));
+    if (!inserted) {
         // RFC 7230, section 3.2.2.  Field Parsing:
         // A recipient MAY combine multiple header fields with the same field name into one
         // "field-name: field-value" pair, without changing the semantics of the message,
         // by appending each subsequent field value to the combined field value in order, separated by a comma.
-        _rsp->_headers[_field_name] += sstring(",") + std::move(_value);
-    } else {
-        _rsp->_headers[_field_name] = std::move(_value);
+        iter->second += sstring(",") + std::move(_value);
     }
 }
 


### PR DESCRIPTION
We lookup the field name twice, even in the simple case: once to check if it already exists, and the second time to insert it.

Optimize by using try_emplace to merge the check and insertion into a single lookup.