### PR TITLE
http: request_parser: fix grammar ambiguity in field_content

### DIFF
--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -137,4 +137,16 @@ public:
     }
 };
 
+inline void trim_trailing_spaces_and_tabs(sstring& str) {
+    auto data = str.data();
+    size_t i;
+    for (i = str.size(); i > 0; --i) {
+        auto c = data[i-1];
+        if (!(c == ' ' || c == '\t')) {
+            break;
+        }
+    }
+    str.resize(i);
+}
+
 }

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -53,19 +53,10 @@ action store_value {
     _value = str();
 }
 
-action no_mark_store_value {
-    _value = get_str();
+action trim_trailing_whitespace_and_store_value {
+    _value = str();
+    trim_trailing_spaces_and_tabs(_value);
     g.mark_start(nullptr);
-}
-
-action checkpoint {
-    // Needs a start to be marked beforehand.
-    // Used to mark the candidate end of value string. Can be moved furhter by repetitive use
-    // of this action.
-    // To store the string that ends on the last checkpoint (instead of the last processed character)
-    // use %no_mark_store_value instead of %store_value
-    g.mark_end(p);
-    g.mark_start(p);
 }
 
 action assign_field {
@@ -111,15 +102,19 @@ sp_ht = sp | ht;
 http_version = 'HTTP/' (digit '.' digit) >mark %store_version;
 
 obs_text = 0x80..0xFF; # defined in RFC 7230, Section 3.2.6.
-field_vchars = (graph | obs_text)+ %checkpoint;
-field_content = (field_vchars sp_ht*)*;
+field_vchar = (graph | obs_text);
+# RFC 9110, Section 5.5 allows single ' '/'\t' separators between
+# field_vchar words. We are less strict and allow any number of spaces
+# between words.
+# Trailing spaces are trimmed in postprocessing.
+field_content = (field_vchar | sp_ht)*;
 
 field = tchar+ >mark %store_field_name;
-value = field_content >mark %no_mark_store_value;
+value = field_content >mark %trim_trailing_whitespace_and_store_value;
 status_code = (digit digit digit) >mark %store_status;
 start_line = http_version space status_code space (any - cr - lf)* crlf;
-header_1st = (field ':' sp_ht* value crlf) %assign_field;
-header_cont = (sp_ht+ value crlf) %extend_field;
+header_1st = (field ':' sp_ht* <: value crlf) %assign_field;
+header_cont = (sp_ht+ <: value crlf) %extend_field;
 header = header_1st header_cont*;
 main := start_line header* (crlf @done);
 


### PR DESCRIPTION
`field_vchars` is intended to catch all graphical characters until the next space. But due to an ambiguity in the grammar, after each `(graph | obs_text)`, instead of following to the next character, the parser can instead choose to exit `field_vchars`, move to `sp_ht*`, consume 0 times sp_ht, and loop back to `field_vchars`. And in fact, this is what happens.

As a result, `checkpoint` is called after every character in a field value. This does not change the correctness of parsing, but is a serious performance problem, because it invokes the expensive `sstring::operator+` for each parsed character.
See https://github.com/scylladb/scylladb/pull/12445 for a discussion.

To break the ambiguity, we use ragel's state transition priority features.