### PR TITLE
reactor: drop unused member function declaration

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -361,7 +361,6 @@ private:
 private:
     static std::chrono::nanoseconds calculate_poll_time();
     static void block_notifier(int);
-    size_t handle_aio_error(internal::linux_abi::iocb* iocb, int ec);
     bool flush_pending_aio();
     steady_clock_type::time_point next_pending_aio() const noexcept;
     bool reap_kernel_completions();


### PR DESCRIPTION
reactor::handle_aio_error() was dropped back in 12138b32ed387311cb01074e84e72fb9fecbe520

Signed-off-by: Kefu Chai <tchaikov@gmail.com>