### PR TITLE
sstring: specialize uninitialize_string() and use resize_and_overwrite if available

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -604,8 +604,11 @@ string_type uninitialized_string(size_t size) {
         return string_type(typename string_type::initialized_later(), size);
     } else {
         string_type ret;
-        // FIXME: use __resize_default_init if available
+#ifdef __cpp_lib_string_resize_and_overwrite
+        ret.resize_and_overwrite(size, [](string_type::value_type*, string_type::size_type n) { return n; });
+#else
         ret.resize(size);
+#endif
         return ret;
     }
 }

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -592,18 +592,22 @@ public:
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 constexpr Size basic_sstring<char_type, Size, max_size, NulTerminate>::npos;
 
-template <typename string_type = sstring>
-string_type uninitialized_string(size_t size) {
-    string_type ret;
-    // FIXME: use __resize_default_init if available
-    ret.resize(size);
-    return ret;
+namespace internal {
+template <class T> struct is_sstring : std::false_type {};
+template <typename char_type, typename Size, Size max_size, bool NulTerminate>
+struct is_sstring<basic_sstring<char_type, Size, max_size, NulTerminate>> : std::true_type {};
 }
 
-template <typename char_type, typename Size, Size max_size, bool NulTerminate>
-basic_sstring<char_type, Size, max_size, NulTerminate> uninitialized_string(size_t size) {
-    using sstring_type = basic_sstring<char_type, Size, max_size, NulTerminate>;
-    return sstring_type(sstring_type::initialized_later(), size);
+template <typename string_type = sstring>
+string_type uninitialized_string(size_t size) {
+    if constexpr (internal::is_sstring<string_type>::value) {
+        return string_type(typename string_type::initialized_later(), size);
+    } else {
+        string_type ret;
+        // FIXME: use __resize_default_init if available
+        ret.resize(size);
+        return ret;
+    }
 }
 
 template <typename char_type, typename size_type, size_type Max, size_type N, bool NulTerminate>

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -214,3 +214,27 @@ BOOST_AUTO_TEST_CASE(test_nul_termination) {
         BOOST_REQUIRE(!strncmp(s1.c_str(), s2.c_str(), std::min(s1.size(), s2.size())));
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_resize_and_overwrite) {
+    static constexpr size_t new_size = 42;
+    static constexpr char pattern = 's';
+    {
+        // the size of new content is identical to the specified count
+        sstring s;
+        s.resize_and_overwrite(new_size, [](char* buf, size_t n) {
+            memset(buf, pattern, n);
+            return n;
+        });
+        BOOST_CHECK_EQUAL(s, sstring(new_size, pattern));
+    }
+    {
+        // the size of new content is smaller than the specified count
+        static constexpr size_t smaller_size = new_size / 2;
+        sstring s;
+        s.resize_and_overwrite(new_size, [](char* buf, size_t n) {
+            memset(buf, pattern, smaller_size);
+            return smaller_size;
+        });
+        BOOST_CHECK_EQUAL(s, sstring(smaller_size, pattern));
+    }
+}


### PR DESCRIPTION
- sstring: specialize uninitialized_string() using 'if constexpr'
- sstring: use resize_and_overwrite if available
- sstring: add `sstring::resize_and_overwrite()`