### PR TITLE
build: add FindBenchmark.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,10 @@ option (Seastar_TESTING
   "Enable testing targets."
   ON)
 
+include (CMakeDependentOption)
+cmake_dependent_option (Seastar_BENCHMARK "Enable benchmark testings" OFF
+   "Seastar_TESTING" OFF)
+
 option (Seastar_COMPRESS_DEBUG
   "Compress debug info."
   ON)

--- a/cmake/FindBenchmark.cmake
+++ b/cmake/FindBenchmark.cmake
@@ -1,0 +1,42 @@
+find_package (PkgConfig REQUIRED)
+
+pkg_search_module (Benchmark IMPORTED_TARGET GLOBAL benchmark)
+
+if (Benchmark_FOUND)
+  add_library (Benchmark::benchmark INTERFACE IMPORTED)
+  target_link_libraries (Benchmark::benchmark INTERFACE PkgConfig::Benchmark)
+  set (Benchmark_LIBRARY ${Benchmark_LIBRARIES})
+  set (Benchmark_INCLUDE_DIR ${Benchmark_INCLUDE_DIRS})
+endif ()
+
+if (NOT Benchmark_LIBRARY)
+  find_library (Benchmark_LIBRARY
+    NAMES benchmark)
+endif ()
+
+if (NOT Benchmark_INCLUDE_DIR)
+    find_path (Benchmark_INCLUDE_DIR
+      NAMES benchmark/benchmark.h)
+endif ()
+
+mark_as_advanced (
+  Benchmark_LIBRARY
+  Benchmark_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (Benchmark
+  REQUIRED_VARS
+    Benchmark_LIBRARY
+    Benchmark_INCLUDE_DIR)
+
+if (Benchmark_FOUND)
+  if (NOT (TARGET Benchmark::benchmark))
+    add_library (Benchmark::benchmark UNKNOWN IMPORTED)
+
+    set_target_properties (Benchmark::benchmark
+      PROPERTIES
+        IMPORTED_LOCATION ${Benchmark_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${Benchmark_INCLUDE_DIRS})
+  endif ()
+endif ()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -668,3 +668,13 @@ seastar_add_test (pipe
 
 seastar_add_test (spawn
   SOURCES spawn_test.cc)
+
+if (Seastar_BENCHMARK)
+  find_package (Benchmark REQUIRED)
+
+  add_executable (sstring_benchmark
+    sstring_benchmark.cc)
+  target_link_libraries (sstring_benchmark
+    seastar_private
+    Benchmark::benchmark)
+endif ()

--- a/tests/unit/sstring_benchmark.cc
+++ b/tests/unit/sstring_benchmark.cc
@@ -1,0 +1,24 @@
+#include <string>
+
+#include <benchmark/benchmark.h>
+#include <seastar/core/sstring.hh>
+
+using namespace seastar;
+
+std::string_view foo = "foo";
+std::string bar = "bar";
+sstring zed = "zed";
+const char* baz = "baz";
+
+static void make_sstring(benchmark::State& state) {
+    benchmark::ClobberMemory();
+    for(auto _ : state) {
+        auto s = make_sstring(foo, bar, zed, baz, "bah");
+        benchmark::DoNotOptimize(s.data());
+    }
+}
+
+
+BENCHMARK(make_sstring);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
the goal of this PR is to request for comments on adding benchmark tests for utilities used at the critical paths.

with the build facilities setup here, we will be able to run tests to understand the performance of utilities with minimal efforts.
