### PR TITLE
reactor: allow registering handler multiple times for a signal.

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -663,7 +663,12 @@ reactor::signals::signal_handler::signal_handler(int signo, noncopyable_function
 void
 reactor::signals::handle_signal(int signo, noncopyable_function<void ()>&& handler) {
     signal_handler h(signo, std::move(handler));
-    _signal_handlers.insert_or_assign(signo, std::move(h));
+    auto [_, inserted] =  _signal_handlers.insert_or_assign(signo, std::move(h));
+    if (!inserted) {
+        // since we register the same handler to OS for all signals, we could
+        // skip sigaction when a handler has already been registered before.
+        return;
+    }
 
     struct sigaction sa;
     sa.sa_sigaction = [](int sig, siginfo_t *info, void *p) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -662,8 +662,8 @@ reactor::signals::signal_handler::signal_handler(int signo, noncopyable_function
 
 void
 reactor::signals::handle_signal(int signo, noncopyable_function<void ()>&& handler) {
-    _signal_handlers.emplace(std::piecewise_construct,
-        std::make_tuple(signo), std::make_tuple(signo, std::move(handler)));
+    signal_handler h(signo, std::move(handler));
+    _signal_handlers.insert_or_assign(signo, std::move(h));
 
     struct sigaction sa;
     sa.sa_sigaction = [](int sig, siginfo_t *info, void *p) {


### PR DESCRIPTION
std::unordered_map::empalce() inserts a new element into the container constructed in-place with the given args only if there is no element with the key in the container, which means we can only register handler for a specific signal only once and that's not reasonable.

We often use the stop_signal(which should have been a standard component of seastar but not yet) to manage SIGINT/SIGTERM for gracefully stopping application. It waits until receiving SIGINT or SIGTERM and then register a no-op handler on destruction to unregister the handler registered on construction, which however cannot work properly since the handler can be registered only once for a signal before this patch.

Signed-off-by: Jianyong Chen <baluschch@gmail.com>