### PR TITLE
build: do not set c-ares_FOUND with PARENT_SCOPE

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -22,24 +22,27 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_check_modules (c-ares IMPORTED_TARGET GLOBAL libcares)
+pkg_check_modules (PC_c-ares IMPORTED_TARGET GLOBAL libcares)
 
-if (c-ares_FOUND)
+if (PC_c-ares_FOUND AND NOT (TARGET c-ares::cares))
   add_library (c-ares::cares INTERFACE IMPORTED)
-  target_link_libraries (c-ares::cares INTERFACE PkgConfig::c-ares)
-  set(c-ares_INCLUDE_DIR ${c-ares_INCLUDE_DIRS})
+  target_link_libraries (c-ares::cares INTERFACE PkgConfig::PC_c-ares)
+  set(c-ares_INCLUDE_DIR ${PC_c-ares_INCLUDE_DIRS})
 endif ()
 
 # for the full path of libcares
 find_library (c-ares_LIBRARY
-   NAMES cares
-   HINTS
-     ${c-ares_LIBDIR}
-     ${c-ares_LIBRARY_DIRS})
+  NAMES cares
+  HINTS
+    ${PC_c-ares_LIBDIR}
+    ${PC_c-ares_LIBRARY_DIRS})
 
 if (NOT c-ares_INCLUDE_DIR)
   find_path (c-ares_INCLUDE_DIR
-    NAMES ares_dns.h)
+    NAMES ares_dns.h
+    HINTS
+      ${PC_c-ares_INCLUDEDIR}
+      ${PC_c-ares_INCLUDE_DIRS})
 endif ()
 
 mark_as_advanced (
@@ -52,7 +55,7 @@ find_package_handle_standard_args (c-ares
   REQUIRED_VARS
     c-ares_LIBRARY
     c-ares_INCLUDE_DIR
-  VERSION_VAR c-ares_PC_VERSION)
+  VERSION_VAR PC_c-ares_VERSION)
 
 if (c-ares_FOUND)
   set (c-ares_LIBRARIES ${c-ares_LIBRARY})


### PR DESCRIPTION
before this change, we use "c-ares" as the prefix passed to `pkg_check_modules()` when checking c-ares package configurations. this sets c-ares_FOUND variable with PARENT_SCOPE, while we still add the `c-ares::cares` library target with the scope in the directory where the find_package(c-ares ..) is called and below. the scope follows the convention of Find<Package>.cmake modules provided by CMake project.

it is found that grpc project uses c-ares_FOUND before calling find_package(c-ares REQUIRED) for resolving its dependency, and skip the find_package() call if c-ares_FOUND is TRUE.

the discrepancy between the scopes of c-ares_FOUND and c-ares::cares can break the build of projects using both Seastar and the projects like grpc. as the parent project would fail to link against grpc library targets without cares::c-ares defined a directory where c-ares_FOUND evaluates to "TRUE" while cares::c-ares is not defined after find_package(c-ares) is called.

after this change, instead of using c-ares as the prefix of variables defined by pkg_check_modules(), use PC_c-ares as the prefix to avoid the name collision and to ensure that the scopes of c-ares_FOUND and c-ares::cares are the same, so that the former can imply the availability of the latter.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>