### PR TITLE
build: use ${CMAKE_BINARY_DIR} when running 'cmake --build ..'

### DIFF
--- a/apps/memcached/tests/CMakeLists.txt
+++ b/apps/memcached/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ add_custom_target (app_memcached_test_memcached_run
 
 add_test (
   NAME Seastar.app.memcached.memcached
-  COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target app_memcached_test_memcached_run)
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target app_memcached_test_memcached_run)
 
 set_tests_properties (Seastar.app.memcached.memcached
   PROPERTIES
@@ -69,7 +69,7 @@ add_custom_target (app_memcached_test_ascii_run
 
 add_test (
   NAME Seastar.app.memcached.ascii
-  COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target app_memcached_test_ascii_run)
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target app_memcached_test_ascii_run)
 
 set_tests_properties (Seastar.app.memcached.ascii
   PROPERTIES


### PR DESCRIPTION
this change is a follow-up of 338ba970d01973c0a7ab1bc03c050c55f37e39f7.

before this change, `${CMAKE_CURRENT_BINARY_DIR}` is used for Seastar_BINARY_DIR. if Seastar is a top-level project, the values of `${CMAKE_CURRENT_BINARY_DIR}` and `${CMAKE_BINARY_DIR}` are identical. but if Seastar is embedded in a parent project, `${CMAKE_BINARY_DIR}` would be somewhere like "bulid/seastar" where "build" is the build directory of the parent project. but we are still referencing the build directory with ${Seastar_BINARY_DIR} and issuing commands like
```
cmake --build ${Seastar_BINARY_DIR} --target ${target}
```
if this would fail as the build directory is not ${Seastar_BINARY_DIR} anymore. if the cmake generator is make, the failure would look like:
```
> gmake: *** No rule to make target 'test_unit_abort_source_run'.  Stop.
```
if the cmake generator is ninja, the failure would look like:
```
> 1/95 Test  #1: Seastar.unit.abort_source .....................***Failed    0.02 sec
> ninja: error: loading 'build.ninja': No such file or directory
```
after this change, all occurrences of
```
cmake --build ${Seastar_BINARY_DIR}
```
are changed to
```
cmake --build ${CMAKE_BINARY_DIR}
```
this ensure that these commands can find the build directory at the top level of the build tree.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>