### PR TITLE
Extend http client with keep-alive connections

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -51,7 +51,7 @@ class connection : public enable_shared_from_this<connection> {
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
     hook_t _hook;
-    seastar::shared_ptr<connection> _pooled; // temporary
+    future<> _closed;
 
 public:
     /**


### PR DESCRIPTION
Current implementation of the client is class connection which is either one-shot (request, handle reply, close) or the caller should keep track and re-connect on its own. This patch wraps the class connection with class client that maintains pool of connections growing it on demand and closing them on error or when the server closes its end.