### PR TITLE
Perf stall detector related improvements

### DIFF
--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -155,6 +155,11 @@ private:
         void skip(uint64_t bytes_to_skip) {
             _tail += bytes_to_skip;
         }
+        // skip all the remaining data in the buffer, as-if calling read until
+        // have_data returns false (but much faster)
+        void skip_all() {
+            _tail = _head;
+        }
         bool have_data() const {
             return _head != _tail;
         }

--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -76,6 +76,7 @@ private:
     void maybe_report();
     virtual void arm_timer() = 0;
     void report_suppressions(sched_clock::time_point now);
+    void reset_suppression_state(sched_clock::time_point now);
 public:
     using clock_type = thread_cputime_clock;
 public:

--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -68,7 +68,7 @@ protected:
     cpu_stall_detector_config _config;
     seastar::metrics::metric_groups _metrics;
     friend reactor;
-    virtual bool reap_event_and_check_spuriousness() {
+    virtual bool is_spurious_signal() {
         return false;
     }
     virtual void maybe_report_kernel_trace() {}
@@ -109,6 +109,10 @@ class cpu_stall_detector_linux_perf_event : public cpu_stall_detector {
     struct ::perf_event_mmap_page* _mmap;
     char* _data_area;
     size_t _data_area_mask;
+    // after the detector has been armed (i.e., _enabled is true), this
+    // is the moment at or after which the next signal is expected to occur
+    // and can be used for detecting spurious signals
+    sched_clock::time_point _next_signal_time{};
 private:
     class data_area_reader {
         cpu_stall_detector_linux_perf_event& _p;
@@ -160,7 +164,7 @@ public:
     ~cpu_stall_detector_linux_perf_event();
     virtual void arm_timer() override;
     virtual void start_sleep() override;
-    virtual bool reap_event_and_check_spuriousness() override;
+    virtual bool is_spurious_signal() override;
     virtual void maybe_report_kernel_trace() override;
 };
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -689,7 +689,9 @@ public:
     void set_bypass_fsync(bool value);
     void update_blocked_reactor_notify_ms(std::chrono::milliseconds ms);
     std::chrono::milliseconds get_blocked_reactor_notify_ms() const;
-    // For testing:
+    /// For testing, sets the stall reporting function which is called when
+    /// a stall is detected (and not suppressed). Setting the function also
+    /// resets the supression state.
     void set_stall_detector_report_function(std::function<void ()> report);
     std::function<void ()> get_stall_detector_report_function() const;
 };

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -229,6 +229,8 @@ if args.test:
     for line, expected in data:
         res = parser(line.strip())
         assert res == expected, f"{line}:\nExpected {expected}\nBut got  {res}"
+    if args.verbose:
+        print(f'All {len(data)} tests passed successfully.')
     exit(0)
 
 if args.addresses and args.file:

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -224,6 +224,22 @@ if args.test:
                 {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': 'libc.so.6', 'addr': '0x00007fd2dab4f950'}]}),
         ('#2 0x00000000015c4cd3  n/a (/path/to/scylla + 0x15c4cd3)',
                 {'type': BacktraceResolver.BacktraceParser.Type.ADDRESS, 'prefix': None, 'addresses': [{'path': '/path/to/scylla', 'addr': '0x00000000015c4cd3'}]}),
+
+        ('kernel callstack: ', None),
+        ('kernel callstack: 0xffffffffffffff80',
+            {
+                'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
+                'prefix': 'kernel callstack: ',
+                'addresses': [{'path': '<kernel>', 'addr': '0xffffffffffffff80'}]
+            }
+        ),
+        ('kernel callstack: 0xffffffffffffff80 0xffffffffaf15ccca',
+            {
+                'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
+                'prefix': 'kernel callstack: ',
+                'addresses': [{'path': '<kernel>', 'addr': '0xffffffffffffff80'}, {'path': '<kernel>', 'addr': '0xffffffffaf15ccca'}]
+            }
+        )
     ]
     parser = BacktraceResolver.BacktraceParser()
     for line, expected in data:

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1162,9 +1162,14 @@ void cpu_stall_detector::report_suppressions(sched_clock::time_point now) {
             buf.append("\n");
             buf.flush();
         }
-        _reported = 0;
-        _minute_mark = now;
+        reset_suppression_state(now);
     }
+}
+
+void
+cpu_stall_detector::reset_suppression_state(sched_clock::time_point now) {
+    _reported = 0;
+    _minute_mark = now;
 }
 
 void cpu_stall_detector_posix_timer::arm_timer() {
@@ -1385,6 +1390,7 @@ reactor::set_stall_detector_report_function(std::function<void ()> report) {
     auto cfg = _cpu_stall_detector->get_config();
     cfg.report = std::move(report);
     _cpu_stall_detector->update_config(std::move(cfg));
+    _cpu_stall_detector->reset_suppression_state(reactor::now());
 }
 
 std::function<void ()>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1228,6 +1228,10 @@ cpu_stall_detector_linux_perf_event::arm_timer() {
     auto period = _threshold * _report_at + _slack;
     uint64_t ns =  period / 1ns;
     _next_signal_time = reactor::now() + period;
+    
+    // clear out any existing records in the ring buffer, so when we get interrupted next time
+    // we have only the stack associated with that interrupt, and so we don't overflow.
+    data_area_reader(*this).skip_all();
     if (__builtin_expect(_enabled && _current_period == ns, 1)) {
         // Common case - we're re-arming with the same period, the counter
         // is already enabled.

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -19,6 +19,8 @@
  * Copyright (C) 2018 ScyllaDB Ltd.
  */
 
+#include <boost/test/tools/old/interface.hpp>
+#include <cstddef>
 #include <seastar/core/internal/stall_detector.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread_cputime_clock.hh>
@@ -28,37 +30,55 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <atomic>
 #include <chrono>
+#include <sys/mman.h>
 
 using namespace seastar;
 using namespace std::chrono_literals;
+
+static seastar::logger testlog("testlog");
 
 class temporary_stall_detector_settings {
     std::chrono::milliseconds _old_threshold;
     std::function<void ()> _old_report;
 public:
-    temporary_stall_detector_settings(std::chrono::duration<double> threshold, std::function<void ()> report)
+    /**
+     * Temporarily (until destructor) overload the stall detector threshold and reporting function.
+     *
+     * Also resets the reported stalls counter to zero, so the next backtraces will not be supressed.
+     */
+    temporary_stall_detector_settings(std::chrono::duration<double> threshold, std::function<void ()> report = {})
             : _old_threshold(engine().get_blocked_reactor_notify_ms())
             , _old_report(engine().get_stall_detector_report_function()) {
         engine().update_blocked_reactor_notify_ms(std::chrono::duration_cast<std::chrono::milliseconds>(threshold));
         engine().set_stall_detector_report_function(std::move(report));
     }
+
     ~temporary_stall_detector_settings() {
         engine().update_blocked_reactor_notify_ms(_old_threshold);
         engine().set_stall_detector_report_function(std::move(_old_report));
     }
 };
 
-void spin(std::chrono::duration<double> how_much) {
+using void_fn = std::function<void()>;
+
+void spin(std::chrono::duration<double> how_much, void_fn body = []{}) {
     auto end = internal::cpu_stall_detector::clock_type::now() + how_much;
     while (internal::cpu_stall_detector::clock_type::now() < end) {
-        // spin!
+        body(); // spin!
     }
 }
 
-void spin_some_cooperatively(std::chrono::duration<double> how_much) {
+static void spin_user_hires(std::chrono::duration<double> how_much) {
+    auto end = std::chrono::high_resolution_clock::now() + how_much;
+    while (std::chrono::high_resolution_clock::now() < end) {
+
+    }
+}
+
+void spin_some_cooperatively(std::chrono::duration<double> how_much, void_fn body = []{}) {
     auto end = std::chrono::steady_clock::now() + how_much;
     while (std::chrono::steady_clock::now() < end) {
-        spin(200us);
+        spin(200us, body);
         if (need_preempt()) {
             thread::yield();
         }
@@ -105,4 +125,50 @@ SEASTAR_THREAD_TEST_CASE(no_poll_no_stall) {
     }).get();
     f.get();
     BOOST_REQUIRE_EQUAL(reports, 0);
+}
+
+// Triggers stalls by spinning with a specify "body" function
+// which takes most of the spin time.
+static void test_spin_with_body(const char* what, void_fn body) {
+    // The !count_stacks mode outputs stall notification to stderr as usual
+    // and do not assert anything, but are intended for diagnosing
+    // stall problems by inspecting the output. We expect the userspace
+    // spin test to show no kernel callstack, and the kernel test to
+    // show kernel backtraces in the mmap or munmap path, but this is
+    // not exact since neither test spends 100% of its time in the
+    // selected mode (of course, kernel stacks only appear if the
+    // perf-based stall detected could be enabled).
+    //
+    // Then the count_stacks mode tests that the right number of stacks
+    // were output.
+    for (auto count_stacks : {false, true}) {
+        testlog.info("Starting spin test: {}", what);
+        std::atomic<unsigned> reports{};
+        std::function<void()> reporter = count_stacks ? std::function<void()>{[&]{ ++reports; }} : nullptr;
+        temporary_stall_detector_settings tsds(10ms, std::move(reporter));
+        constexpr unsigned nr = 5;
+        for (unsigned i = 0; i < nr; ++i) {
+            spin_some_cooperatively(100ms, body);
+            spin(20ms, body);
+        }
+        testlog.info("Ending spin test: {}", what);
+        BOOST_CHECK_EQUAL(reports, count_stacks ? 5 : 0);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(spin_in_userspace) {
+    // a body which spends almost all of its time in userspace
+    test_spin_with_body("userspace", [] { spin_user_hires(1ms); });
+}
+
+static void mmap_populate(size_t len) {
+    void *p = mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, 0, 0);
+    BOOST_REQUIRE(p != MAP_FAILED);
+    BOOST_REQUIRE(munmap(p, len) == 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(spin_in_kernel) {
+    // a body which spends almost all of its time in the kernel
+    // doing 128K mmaps
+    test_spin_with_body("kernel", [] { mmap_populate(128 * 1024); });
 }


### PR DESCRIPTION
This patch series improves the perf-based stall detector in the following areas:

 - Adds decoding of the kernel backtraces to the seastar-addr2line script
 - Fixes an issue with spurious triggering of the overflow interrupt when armed on the "simple" path
 - Fixes an issue with the user-kernel shared ring buffer which resulted in multiple and wrong kernel stacks being associated with stall events

Please see the individual commits for more details.