### PR TITLE
file: Generalize in/out streams making

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -88,6 +88,11 @@ class file;
 class file_impl;
 class io_intent;
 class file_handle;
+class data_sink;
+class data_source;
+
+struct file_input_stream_options;
+struct file_output_stream_options;
 
 // A handle that can be transported across shards and used to
 // create a dup(2)-like `file` object referring to the same underlying file
@@ -146,6 +151,9 @@ public:
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc, io_intent*) {
         return dma_read_bulk(offset, range_size, pc);
     }
+
+    virtual data_sink make_data_sink(file me, file_output_stream_options o);
+    virtual data_source make_data_source(file me, uint64_t off, uint64_t len, file_input_stream_options o);
 
     friend class reactor;
 };
@@ -556,6 +564,12 @@ public:
     /// \note Use on read-only files.
     ///
     file_handle dup();
+
+    /// @private
+    data_sink as_data_sink(file_output_stream_options o) &&;
+    /// @private
+    data_source as_data_source(uint64_t off, uint64_t len, file_input_stream_options o) &&;
+
 private:
     future<temporary_buffer<uint8_t>>
     dma_read_bulk_impl(uint64_t offset, size_t range_size, const io_priority_class& pc, io_intent* intent) noexcept;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -39,6 +39,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/report_exception.hh>
 #include <seastar/core/linux-aio.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/internal/magic.hh>
 #include <seastar/util/internal/iovec_utils.hh>
@@ -1271,6 +1272,16 @@ file::dma_read_impl(uint64_t aligned_pos, uint8_t* aligned_buffer, size_t aligne
 seastar::file_handle
 file::dup() {
     return seastar::file_handle(_file_impl->dup());
+}
+
+data_sink file::as_data_sink(file_output_stream_options opts) && {
+    auto& impl = *_file_impl;
+    return impl.make_data_sink(std::move(*this), std::move(opts));
+}
+
+data_source file::as_data_source(uint64_t off, uint64_t len, file_input_stream_options opts) && {
+    auto& impl = *_file_impl;
+    return impl.make_data_source(std::move(*this), off, len, std::move(opts));
 }
 
 file_impl* file_impl::get_file_impl(file& f) {


### PR DESCRIPTION
In order to make input/output stream for a file there are two helpers -- make_file_(input|output)_stream out there. Both make file-based sink or source, but these sink and source implementations silently assume that the file is a file-on-disk. Strictly speaking, these are compatible with posix_file_impl, but not with generic file. E.g. pipes (if they exist) might break on read-ahead and write-behind.

This patch adds a customization point to file_impl so that custom file implementations could generate specific sink/source for the stream.

One of the next users of it would be S3 file, which supports posix-ish data_source, but will require very specific data_sink with append-only and extra buffering of 5Mb scattered chunks.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>