### PR TITLE
build: revert use pkg_search_module(.. IMPORTED_TARGET ..) changes

### DIFF
--- a/cmake/FindGnuTLS.cmake
+++ b/cmake/FindGnuTLS.cmake
@@ -22,24 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (GnuTLS IMPORTED_TARGET GLOBAL gnutls)
+pkg_check_modules (PC_GnuTLS QUIET gnutls)
 
-if (GnuTLS_FOUND)
-  add_library (GnuTLS::gnutls INTERFACE IMPORTED)
-  target_link_libraries (GnuTLS::gnutls INTERFACE PkgConfig::GnuTLS)
-  set (GnuTLS_LIBRARY ${GnuTLS_LIBRARIES})
-  set (GnuTLS_INCLUDE_DIR ${GnuTLS_INCLUDE_DIRS})
-endif ()
+find_library (GnuTLS_LIBRARY
+  NAMES gnutls
+  HINTS
+    ${PC_GnuTLS_LIBDIR}
+    ${PC_GnuTLS_LIBRARY_DIRS})
 
-if (NOT GnuTLS_LIBRARY)
-  find_library (GnuTLS_LIBRARY
-    NAMES gnutls)
-endif ()
-
-if (NOT GnuTLS_INCLUDE_DIR)
-  find_path (GnuTLS_INCLUDE_DIR
-    NAMES gnutls/gnutls.h)
-endif ()
+find_path (GnuTLS_INCLUDE_DIR
+  NAMES gnutls/gnutls.h
+  HINTS
+    ${PC_GnuTLS_INCLUDEDIR}
+    ${PC_GnuTLS_INCLUDE_DIRS})
 
 mark_as_advanced (
   GnuTLS_LIBRARY
@@ -51,7 +46,7 @@ find_package_handle_standard_args (GnuTLS
   REQUIRED_VARS
     GnuTLS_LIBRARY
     GnuTLS_INCLUDE_DIR
-  VERSION_VAR GnuTLS_VERSION)
+  VERSION_VAR PC_GnuTLS_VERSION)
 
 if (GnuTLS_FOUND)
   set (GnuTLS_LIBRARIES ${GnuTLS_LIBRARY})

--- a/cmake/FindLibUring.cmake
+++ b/cmake/FindLibUring.cmake
@@ -22,22 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (LibUring IMPORTED_TARGET GLOBAL liburing)
-
-if (LibUring_FOUND)
-  add_library (URING::uring INTERFACE IMPORTED)
-  target_link_libraries (URING::uring INTERFACE PkgConfig::LibUring)
-  set (URING_INCLUDE_DIR ${LibUring_INCLUDE_DIRS})
-endif ()
+pkg_check_modules (PC_URING QUIET liburing)
 
 find_library (URING_LIBRARY
   NAMES uring
-  HINTS ${URING_LIBDIR})
+  HINTS
+    ${PC_URING_LIBDIR}
+    ${PC_URING_LIBRARY_DIRS})
 
-if (NOT URING_INCLUDE_DIR)
-  find_path (URING_INCLUDE_DIR
-    NAMES liburing.h)
-endif ()
+find_path (URING_INCLUDE_DIR
+  NAMES liburing.h
+  HINTS
+    ${PC_URING_INCLUDEDIR}
+    ${PC_URING_INCLUDE_DIRS})
 
 if (URING_INCLUDE_DIR)
   include (CheckStructHasMember)
@@ -61,7 +58,7 @@ find_package_handle_standard_args (LibUring
     URING_LIBRARY
     URING_INCLUDE_DIR
     HAVE_IOURING_FEATURES
-  VERSION_VAR LibUring_VERSION)
+  VERSION_VAR PC_URING_VERSION)
 
 if (LibUring_FOUND)
   set (URING_LIBRARIES ${URING_LIBRARY})

--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -23,16 +23,13 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (valgrind IMPORTED_TARGET GLOBAL valgrind)
+pkg_check_modules (PC_valgrind QUIET valgrind)
 
-if (valgrind_FOUND)
-  set (valgrind_INCLUDE_DIR ${valgrind_INCLUDE_DIRS})
-endif ()
-
-if (NOT Valgrind_INCLUDE_DIR)
-  find_path (Valgrind_INCLUDE_DIR
-    NAMES valgrind/valgrind.h)
-endif ()
+find_path (Valgrind_INCLUDE_DIR
+  NAMES valgrind/valgrind.h
+  HINTS
+    ${PC_valgrind_INCLUDEDIR}
+    ${PC_valgrind_INCLUDE_DIRS})
 
 mark_as_advanced (
   Valgrind_INCLUDE_DIR)

--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -22,28 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_check_modules (PC_c-ares IMPORTED_TARGET GLOBAL libcares)
+pkg_check_modules (PC_c-ares QUIET libcares)
 
-if (PC_c-ares_FOUND AND NOT (TARGET c-ares::cares))
-  add_library (c-ares::cares INTERFACE IMPORTED)
-  target_link_libraries (c-ares::cares INTERFACE PkgConfig::PC_c-ares)
-  set(c-ares_INCLUDE_DIR ${PC_c-ares_INCLUDE_DIRS})
-endif ()
-
-# for the full path of libcares
 find_library (c-ares_LIBRARY
   NAMES cares
   HINTS
     ${PC_c-ares_LIBDIR}
     ${PC_c-ares_LIBRARY_DIRS})
 
-if (NOT c-ares_INCLUDE_DIR)
-  find_path (c-ares_INCLUDE_DIR
-    NAMES ares_dns.h
-    HINTS
-      ${PC_c-ares_INCLUDEDIR}
-      ${PC_c-ares_INCLUDE_DIRS})
-endif ()
+find_path (c-ares_INCLUDE_DIR
+  NAMES ares_dns.h
+  HINTS
+    ${PC_c-ares_INCLUDEDIR}
+    ${PC_c-ares_INCLUDE_DIRS})
 
 mark_as_advanced (
   c-ares_LIBRARY

--- a/cmake/Findhwloc.cmake
+++ b/cmake/Findhwloc.cmake
@@ -22,24 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (hwloc IMPORTED_TARGET GLOBAL hwloc)
+pkg_search_module (PC_hwloc QUIET hwloc)
 
-if (hwloc_FOUND)
-  add_library (hwloc::hwloc INTERFACE IMPORTED)
-  target_link_libraries (hwloc::hwloc INTERFACE PkgConfig::hwloc)
-  set (hwloc_LIBRARY ${hwloc_LIBRARIES})
-  set (hwloc_INCLUDE_DIR ${hwloc_INCLUDE_DIRS})
-endif ()
+find_library (hwloc_LIBRARY
+  NAMES hwloc
+  HINTS
+    ${PC_hwloc_LIBDIR}
+    ${PC_hwloc_LIBRARY_DIRS})
 
-if (NOT hwloc_LIBRARY)
-  find_library (hwloc_LIBRARY
-    NAMES hwloc)
-endif ()
-
-if (NOT hwloc_INCLUDE_DIR)
-  find_path (hwloc_INCLUDE_DIR
-    NAMES hwloc.h)
-endif ()
+find_path (hwloc_INCLUDE_DIR
+  NAMES hwloc.h
+  HINTS
+    ${PC_hwloc_INCLUDEDIR}
+    ${PC_hwloc_INCLUDE_DIRS})
 
 mark_as_advanced (
   hwloc_LIBRARY

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -22,24 +22,19 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (lz4 IMPORTED_TARGET GLOBAL liblz4)
+pkg_search_module (PC_lz4 QUIET liblz4)
 
-if (liblz4_FOUND)
-  add_library (lz4::lz4 INTERFACE IMPORTED)
-  target_link_libraries (lz4::lz4 INTERFACE PkgConfig::liblz4)
-  set (lz4_LIBRARY ${lz4_LIBRARIES})
-  set (lz4_INCLUDE_DIR ${lz4_INCLUDE_DIRS})
-endif ()
+find_library (lz4_LIBRARY
+  NAMES lz4
+  HINTS
+    ${PC_lz4_LIBDIR}
+    ${PC_lz4_LIBRARY_DIRS})
 
-if (NOT lz4_LIBRARY)
-  find_library (lz4_LIBRARY
-    NAMES lz4)
-endif ()
-
-if (NOT lz4_INCLUDE_DIR)
-  find_path (lz4_INCLUDE_DIR
-    NAMES lz4.h)
-endif ()
+find_path (lz4_INCLUDE_DIR
+  NAMES lz4.h
+  HINTS
+    ${PC_lz4_INCLUDEDIR}
+    ${PC_lz4_INCLUDE_DIRS})
 
 mark_as_advanced (
   lz4_LIBRARY

--- a/cmake/Findyaml-cpp.cmake
+++ b/cmake/Findyaml-cpp.cmake
@@ -22,24 +22,29 @@
 
 find_package (PkgConfig REQUIRED)
 
-pkg_search_module (yaml-cpp yaml-cpp)
+pkg_search_module (PC_yaml-cpp QUIET yaml-cpp)
 
 find_library (yaml-cpp_LIBRARY_RELEASE
  NAMES yaml-cpp
- HINTS ${yaml-cpp_LIBDIR})
+ HINTS
+   ${PC_yaml-cpp_LIBDIR}
+   ${PC_yaml-cpp_LIBRARY_DIRS})
 
 find_library (yaml-cpp_LIBRARY_DEBUG
  NAMES yaml-cppd
- HINTS ${yaml-cpp_LIBDIR})
+ HINTS
+   ${PC_yaml-cpp_LIBDIR}
+   ${PC_yaml-cpp_LIBRARY_DIRS})
 
 include (SelectLibraryConfigurations)
 select_library_configurations (yaml-cpp)
 
-if (NOT yaml-cpp_INCLUDE_DIR)
- find_path (yaml-cpp_INCLUDE_DIR
-    NAMES yaml-cpp/yaml.h
-    PATH_SUFFIXES yaml-cpp)
-endif ()
+find_path (yaml-cpp_INCLUDE_DIR
+  NAMES yaml-cpp/yaml.h
+  PATH_SUFFIXES yaml-cpp
+  HINTS
+    ${PC_yaml-cpp_INCLUDEDIR}
+    ${PC_yaml-cpp_INCLUDE_DIRS})
 
 mark_as_advanced (
   yaml-cpp_LIBRARY_RELEASE


### PR DESCRIPTION
* revert use pkg_search_module(.. IMPORTED_TARGET ..) changes
* pass QUIET to pkg_check_modules(). as FPHSA also prints out message when checking the required variables. and pkg_check_modules() only provides hints to `find_*()` functions.
* use `pkg_check_module()` instead of `pkg_search_module()`, as we don't "search" for a module in some candidates, we just want to check for a single one. `pkg_check_module()` reflects our intention here better.

before the change, `pkg_check_modules(..., IMPORTED_TARGET)` is used in find modules. but per the discussion at
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8037,

quote from CMake maintainer Brad King's comment:

> Actually, using `pkg_check_modules` with `IMPORTED_TARGET` is not
> a good pattern for find modules.  Instead, the `pkg_check_modules`
> results should only be used as hints to the main `find_*` code
> path, and then the results should be added as an imported target
> explicitly.  Otherwise features like `CMAKE_FIND_ROOT_PATH` do
> not work correctly.

and recent fixes also echo Brad's comment:

- 64ec3388e9c5b10cb6ea449499309fc7734691bd
- 3db15b5681c460a759641a3907eb9db84bdcf395

so this is not a recommended practice.

after this change, the change series of
"use pkg_search_module(.. IMPORTED_TARGET ..) ..." are partially reverted, see f57253810fd6b2dc09182209e888a7056af70ebf for an instance of this series. but the following changes are preserved:

- bump the required cmake version to 3.13: because some succeeding CMake related changes could depend on the required CMake version.
- do not set <Package>_LIBRARIES or <Package>_INCLUDE_DIRS unless the <Package> is found: this change is still relevant.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>