### PR TITLE
Fix CLI help for memory diagnostics dump

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3693,7 +3693,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                 " This makes strace output more useful, but slows down the application")
     , dump_memory_diagnostics_on_alloc_failure_kind(*this, "dump-memory-diagnostics-on-alloc-failure-kind", memory::alloc_failure_kind::critical,
                 "Dump diagnostics of the seastar allocator state on allocation failure."
-                 " Accepted values: never, critical (default), always. When set to critical, only allocations marked as critical will trigger diagnostics dump."
+                 " Accepted values: none, critical (default), all. When set to critical, only allocations marked as critical will trigger diagnostics dump."
                  " The diagnostics will be written to the seastar_memory logger, with error level."
                  " Note that if the seastar_memory logger is set to debug or trace level, the diagnostics will be logged irrespective of this setting.")
     , reactor_backend(*this, "reactor-backend", backend_selector_candidates(), reactor_backend_selector::default_backend().name(),


### PR DESCRIPTION
The help for dump_memory_diagnostics_on_alloc_failure_kind listed the options as:

never, critical (default), always

but the correct options (based on the enum name) are:

none, critical (default), all

Change the doc to match the enum.