### PR TITLE
sstring: operator<< std::unordered_map: delete stray space char

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -765,7 +765,7 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
         } else {
             first = false;
         }
-        os << "{ " << elem.first << " -> " << elem.second << "}";
+        os << "{" << elem.first << " -> " << elem.second << "}";
     }
     os << "}";
     return os;


### PR DESCRIPTION
Currently, unordered maps are printed as: `{{ K0 -> V0}, { K1 -> V1}}`.
Instead, they should look like: `{{K0 -> V0}, {K1 -> V1}}`

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>