### PR TITLE
Enable multiple abort requests and chaining of abort source

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -104,13 +104,14 @@ private:
     std::exception_ptr _ex;
 
     void do_request_abort(std::optional<std::exception_ptr> ex) noexcept {
-        assert(_subscriptions);
-        _ex = ex.value_or(get_default_exception());
-        auto subs = std::exchange(_subscriptions, std::nullopt);
-        while (!subs->empty()) {
-            subscription& s = subs->front();
-            s.unlink();
-            s.on_abort(ex);
+        if (_subscriptions) {
+            _ex = ex.value_or(get_default_exception());
+            auto subs = std::exchange(_subscriptions, std::nullopt);
+            while (!subs->empty()) {
+                subscription& s = subs->front();
+                s.unlink();
+                s.on_abort(ex);
+            }
         }
     }
 

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -174,3 +174,10 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     as.reset();
     BOOST_REQUIRE_EQUAL(aborted, 0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_request_abort_twice) {
+    abort_source as;
+    as.request_abort_ex(std::runtime_error(""));
+    as.request_abort();
+    BOOST_REQUIRE_THROW(as.check(), std::runtime_error);
+}

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -181,3 +181,16 @@ SEASTAR_THREAD_TEST_CASE(test_request_abort_twice) {
     as.request_abort();
     BOOST_REQUIRE_THROW(as.check(), std::runtime_error);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_scope_abort_source) {
+    abort_source as;
+    scope_abort_source sas{as};
+    auto expected_message = "expected";
+    as.request_abort_ex(std::runtime_error(expected_message));
+    BOOST_REQUIRE_THROW(sas.check(), std::runtime_error);
+    try {
+        sas.check();
+    } catch (const std::runtime_error& e) {
+        BOOST_REQUIRE_EQUAL(e.what(), expected_message);
+    }
+}


### PR DESCRIPTION
Abort on abort source can be requested multiple times.
The latter requests work as noop.

 Adds a class deriving from abort_source that allows chaining 
 abort sources on the same shard. When abort is requested 
 on parent abort_source, it is propagated to all descendants.
