### PR TITLE
Ensure logger doesn't allocate

### DIFF
--- a/include/seastar/util/log-impl.hh
+++ b/include/seastar/util/log-impl.hh
@@ -101,6 +101,10 @@ public:
     /// allocated buffer. log_buf doesn't take ownership of the buffer.
     log_buf(char* external_buf, size_t size) noexcept;
     ~log_buf();
+    /// Clear the buffer, setting its position back to the start, but does not
+    /// free any buffers (after this called, size is zero, capacity is unchanged).
+    /// Any existing iterators are invalidated.
+    void clear() { _current = _begin; }
     /// Create an output iterator which allows writing into the buffer.
     inserter_iterator back_insert_begin() noexcept { return inserter_iterator(*this); }
     /// The amount of data written so far.

--- a/include/seastar/util/memory_diagnostics.hh
+++ b/include/seastar/util/memory_diagnostics.hh
@@ -21,9 +21,13 @@
 
 #pragma once
 
+#include <seastar/core/sstring.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 namespace seastar {
+
+enum class log_level;
+
 namespace memory {
 
 /// \brief The kind of allocation failures to dump diagnostics report for.
@@ -74,12 +78,22 @@ using memory_diagnostics_writer = noncopyable_function<void(std::string_view)>;
 ///     the output.
 void set_additional_diagnostics_producer(noncopyable_function<void(memory_diagnostics_writer)> producer);
 
-/// Manually generate a diagnostics report
+/// Generate and return a diagnostics report as a string.
 ///
 /// Note that contrary to the automated report generation (triggered by
 /// allocation failure), this method does allocate memory and can fail in
 /// low-memory conditions.
 sstring generate_memory_diagnostics_report();
+
+namespace internal {
+/// Log the memory diagnostics to the internal logger in the same way as
+/// during an allocation failure, at the given log level. These reports
+/// are not rate limited, unlike the internally generated reports which
+/// are limited to 1 per 10 seconds.
+///
+/// This method attempts to avoid any allocations.
+void log_memory_diagnostics_report(log_level lvl);
+}
 
 } // namespace memory
 } // namespace seastar

--- a/tests/unit/log_buf_test.cc
+++ b/tests/unit/log_buf_test.cc
@@ -96,3 +96,27 @@ SEASTAR_TEST_CASE(log_buf_insert_iterator_format_to) {
     BOOST_REQUIRE_EQUAL(p[pos++], '\n');
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(log_buf_clear) {
+    internal::log_buf buf;
+
+    auto it = buf.back_insert_begin();
+
+    fmt::format_to(it, "abcd");
+
+    BOOST_CHECK_EQUAL(buf.view(), "abcd");
+    auto cap_before = buf.capacity();
+    buf.clear();
+    BOOST_CHECK_EQUAL(cap_before, buf.capacity());
+    BOOST_CHECK_EQUAL(0, buf.size());
+
+    fmt::format_to(it, "uuvvwwxxyyzz");
+
+    BOOST_CHECK_EQUAL(buf.view(), "uuvvwwxxyyzz");
+    cap_before = buf.capacity();
+    buf.clear();
+    BOOST_CHECK_EQUAL(cap_before, buf.capacity());
+    BOOST_CHECK_EQUAL(0, buf.size());
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
In this series we try to ensure that logging (specifically, the memory diagnostics
logging) does not allocate.

It is composed of a test which checks that the allocation count is zero and a
fix for one place where it allocates occasionally.