### PR TITLE
rpc: client_info: add retrieve_auxiliary_opt

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -73,6 +73,22 @@ struct client_info {
     typename std::add_const<T>::type& retrieve_auxiliary(const sstring& key) const {
         return const_cast<client_info*>(this)->retrieve_auxiliary<typename std::add_const<T>::type>(key);
     }
+    template <typename T>
+    T* retrieve_auxiliary_opt(const sstring& key) noexcept {
+        auto it = user_data.find(key);
+        if (it == user_data.end()) {
+            return nullptr;
+        }
+        return &boost::any_cast<T&>(it->second);
+    }
+    template <typename T>
+    const T* retrieve_auxiliary_opt(const sstring& key) const noexcept {
+        auto it = user_data.find(key);
+        if (it == user_data.end()) {
+            return nullptr;
+        }
+        return &boost::any_cast<const T&>(it->second);
+    }
 };
 
 class error : public std::runtime_error {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1437,3 +1437,21 @@ SEASTAR_TEST_CASE(test_connection_id_format) {
 }
 
 static_assert(std::is_same_v<decltype(rpc::tuple(1U, 1L)), rpc::tuple<unsigned, long>>, "rpc::tuple deduction guid not working");
+
+SEASTAR_TEST_CASE(test_client_info) {
+    rpc::client_info info;
+    const rpc::client_info& const_info = *const_cast<rpc::client_info*>(&info);
+
+    info.attach_auxiliary("key", 0);
+    BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 0);
+    info.retrieve_auxiliary<int>("key") = 1;
+    BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 1);
+
+    BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("key"), &info.retrieve_auxiliary<int>("key"));
+    BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("key"), &const_info.retrieve_auxiliary<int>("key"));
+
+    BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("missing"), nullptr);
+    BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("missing"), nullptr);
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
To facilitate optional passing of the host_id in client_info.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>