### PR TITLE
future: schedule: get_available_state_ref under SEASTAR_DEBUG

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1395,7 +1395,7 @@ private:
         // other build modes.
 #ifdef SEASTAR_DEBUG
         if (_state.available()) {
-            tws->set_state(std::move(_state));
+            tws->set_state(get_available_state_ref());
             ::seastar::schedule(tws);
             return;
         }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1641,6 +1641,16 @@ SEASTAR_TEST_CASE(test_warn_on_broken_promise_with_no_future) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_destroy_promise_after_state_take_value) {
+    future<> f = make_ready_future<>();
+    auto p = std::make_unique<seastar::promise<>>();
+    f = p->get_future();
+    p->set_value();
+    auto g = f.then([] {});
+    p.reset();
+    return g;
+}
+
 SEASTAR_THREAD_TEST_CASE(test_exception_future_with_backtrace) {
     int counter = 0;
     auto inner = [&] (bool return_exception) mutable {


### PR DESCRIPTION
Currently, in future::schedule(), only _state
is moved to the continuation under SEASTAR_DEBUG
and this future might still be attached to a promise.
    
This trips an assert when the promise is destroyed,
calling promise::clear, where it observes _future
as engaged, while the promise._state was moved
into the contiuation, and the one that the promise
points to goes under move_it() which sets its state
to state::invalid, therefore it is considered as
`!_state->available()` in `promise_base::clear()`
and `set_to_broken_promise(*_state)` is called.
Next, state.set_exception is called, tripping:
`assert(_u.st == state::future);`

See following backtrace:
```
    futures_test: /home/bhalevy/dev/seastar/include/seastar/core/future.hh:543: void seastar::future_state_base::set_exception(std::exception_ptr &&): Assertion `_u.st == state::future' failed.
    
    seastar::future_state_base::set_exception(std::__exception_ptr::exception_ptr&&) at /home/bhalevy/dev/seastar/include/seastar/core/future.hh:543
    seastar::internal::set_to_broken_promise(seastar::future_state_base&) at /home/bhalevy/dev/seastar/src/core/future.cc:73
    seastar::internal::promise_base::clear() at /home/bhalevy/dev/seastar/src/core/future.cc:92
    ~promise_base at /home/bhalevy/dev/seastar/include/seastar/core/future.hh:843
    ~promise_base_with_type at /home/bhalevy/dev/seastar/include/seastar/core/future.hh:907
    ~promise at /home/bhalevy/dev/seastar/include/seastar/core/future.hh:971
    std::default_delete<seastar::promise<void> >::operator()(seastar::promise<void>*) const at /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:95
    std::__uniq_ptr_impl<seastar::promise<void>, std::default_delete<seastar::promise<void> > >::reset(seastar::promise<void>*) at /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:203
    std::unique_ptr<seastar::promise<void>, std::default_delete<seastar::promise<void> > >::reset(seastar::promise<void>*) at /usr/bin/../lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_ptr.h:501
    test_destroy_promise_after_state_take_value::run_test_case() const at /home/bhalevy/dev/seastar/tests/unit/futures_test.cc:1650
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>
