### PR TITLE
Allow multiple abort requests

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -169,7 +169,7 @@ public:
 
     /// Returns whether an abort has been requested.
     bool abort_requested() const noexcept {
-        return !_subscriptions;
+        return bool(_ex);
     }
 
 

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -174,3 +174,10 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     as.reset();
     BOOST_REQUIRE_EQUAL(aborted, 0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_request_abort_twice) {
+    abort_source as;
+    as.request_abort_ex(std::runtime_error(""));
+    as.request_abort();
+    BOOST_REQUIRE_THROW(as.check(), std::runtime_error);
+}


### PR DESCRIPTION
request_abort() can be called on abort source more than once.
All calls but first work as noop.

