### PR TITLE
build: do not populate package registry by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ project (Seastar
   VERSION 1.0
   LANGUAGES CXX)
 
+cmake_policy (SET CMP0090 NEW)
 if (POLICY CMP0135)
   cmake_policy (SET CMP0135 NEW)
 endif ()


### PR DESCRIPTION
before this change, we always populate the package registry by writing to CMake registry file in $HOME, like:
```
$HOME/.cmake/packages/Seastar/fa3ead70757accdda096b789d64bb1e0
```
as instructed by the command of `export (PACKAGE Seastar)`.

this behavior is enabled by default. but we perform the gating test in a docker container, where `$HOME` is `/` by default, and we don't override `$HOME` in `docker/dev/Dockerfile`, so CMake always fails to populate the Seastart package registry when performing tests, like
```
CMake Warning at CMakeLists.txt:1305 (export):
  Cannot create package registry file:

    //.cmake/packages/Seastar/fa3ead70757accdda096b789d64bb1e0

  No such file or directory
```
this warning is distracting and is not relevant. as we don't build an application which finds Seastar using its package registry in the docker based test. it'd be desirable if we can silence this warning.

after this change, we use the new behavior of defined by CMake policy of `CMP0090`, which prevents `export(PACKAGE)` from populating package registry unless `CMAKE_EXPORT_PACKAGE_REGISTRY` is defined. so the warning is silenced.

if any developers' workflows depend on this behavior, they should set `CMAKE_EXPORT_PACKAGE_REGISTRY` to reenable it.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>