### PR TITLE
abort_on_expiry chaining

### DIFF
--- a/include/seastar/core/abort_on_expiry.hh
+++ b/include/seastar/core/abort_on_expiry.hh
@@ -50,7 +50,7 @@ public:
     abort_on_expiry(abort_on_expiry&&) = delete;
 
     /// \returns abort source associated with the timeout
-    seastar::abort_source& abort_source() {
+    seastar::abort_source& abort_source() noexcept {
         return _as;
     }
 };

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -185,6 +185,12 @@ public:
     virtual std::exception_ptr get_default_exception() const noexcept {
         return make_exception_ptr(abort_requested_exception());
     }
+
+    /// Returns the exception_ptr abort was requested with
+    /// or nullptr if no abort was requested.
+    std::exception_ptr get_exception() const noexcept {
+        return _ex;
+    }
 };
 
 /// @}

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -19,12 +19,15 @@
  * Copyright (C) 2017 ScyllaDB
  */
 
+#include "seastar/core/abort_source.hh"
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/abort_on_expiry.hh>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -173,4 +176,11 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     sub4 = std::move(sub3);
     as.reset();
     BOOST_REQUIRE_EQUAL(aborted, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_expiry) {
+    auto aoe = abort_on_expiry<manual_clock>(manual_clock::now() + 1ms);
+    BOOST_REQUIRE(!aoe.abort_source().abort_requested());
+    manual_clock::advance(2ms);
+    BOOST_REQUIRE_THROW(aoe.abort_source().check(), abort_requested_exception);
 }


### PR DESCRIPTION
Abort will be requested on the abort_on_expiry::abort_source()
either when the timeout expires or abort is requested on the
chained abort_source, the earliest of which.

The motivation for this feature is to be able to abort rpc messages either
on timeout or via an external abort source (that may be triggered e.g. on shutdown).
