### PR TITLE
abort source: add abort_on_{any,all} combiners

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -185,6 +185,12 @@ public:
     virtual std::exception_ptr get_default_exception() const noexcept {
         return make_exception_ptr(abort_requested_exception());
     }
+
+    /// Returns the exception_ptr abort was requested with
+    /// or nullptr if no abort was requested.
+    std::exception_ptr get_exception() const noexcept {
+        return _ex;
+    }
 };
 
 /// @}

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -247,6 +247,63 @@ public:
     }
 };
 
+template <typename... AbortSources>
+class abort_on_all {
+    static constexpr size_t size = sizeof...(AbortSources);
+
+    std::array<seastar::abort_source*, size> _ass;
+    std::array<optimized_optional<seastar::abort_source::subscription>, size> _subs;
+    abort_source _as;
+    int _aborted = 0;
+private:
+    void do_subscribe() {
+        for (size_t i = 0; i < size; i++) {
+            if (_as.abort_requested()) {
+                _subs[i] = {};
+                continue;
+            }
+            auto callback = [this] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+                if (++_aborted >= size && !_as.abort_requested()) {
+                    _as.request_abort_ex(opt_ex.value_or(std::make_exception_ptr(abort_requested_exception())));
+                }
+            };
+            _subs[i] = _ass[i]->subscribe(callback);
+            if (!_subs[i]) {
+                auto opt_ex = std::make_optional(_ass[i]->get_exception());
+                callback(opt_ex);
+            }
+        }
+    }
+public:
+    abort_on_all() = default;
+
+    abort_on_all(AbortSources&... sources)
+        : _ass({&sources...})
+    {
+        do_subscribe();
+    }
+    abort_on_all(abort_on_all&& o)
+        : _ass(std::move(o._ass))
+        , _as(std::move(o._as))
+        , _aborted(std::exchange(o._aborted, 0))
+    {
+        do_subscribe();
+    }
+    abort_on_all& operator=(abort_on_all&& o) {
+        if (this != &o) {
+            _ass = std::move(o._ass);
+            _as = std::move(o._as);
+            _aborted = std::exchange(o._aborted, 0);
+            do_subscribe();
+        }
+        return *this;
+    }
+
+    seastar::abort_source& abort_source() noexcept {
+        return _as;
+    }
+};
+
 /// @}
 
 }

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -193,6 +193,60 @@ public:
     }
 };
 
+template <typename... AbortSources>
+class abort_on_any {
+    static constexpr size_t size = sizeof...(AbortSources);
+
+    std::array<seastar::abort_source*, size> _ass;
+    std::array<optimized_optional<seastar::abort_source::subscription>, size> _subs;
+    abort_source _as;
+private:
+    void do_subscribe() {
+        for (size_t i = 0; i < size; i++) {
+            if (_as.abort_requested()) {
+                _subs[i] = {};
+                continue;
+            }
+            auto callback = [this] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+                if (!_as.abort_requested()) {
+                    _as.request_abort_ex(opt_ex.value_or(std::make_exception_ptr(abort_requested_exception())));
+                }
+            };
+            _subs[i] = _ass[i]->subscribe(callback);
+            if (!_subs[i]) {
+                auto opt_ex = std::make_optional(_ass[i]->get_exception());
+                callback(opt_ex);
+            }
+        }
+    }
+public:
+    abort_on_any() = default;
+
+    abort_on_any(AbortSources&... sources)
+        : _ass({&sources...})
+    {
+        do_subscribe();
+    }
+    abort_on_any(abort_on_any&& o)
+        : _ass(std::move(o._ass))
+        , _as(std::move(o._as))
+    {
+        do_subscribe();
+    }
+    abort_on_any& operator=(abort_on_any&& o) {
+        if (this != &o) {
+            _ass = std::move(o._ass);
+            _as = std::move(o._as);
+            do_subscribe();
+        }
+        return *this;
+    }
+
+    seastar::abort_source& abort_source() noexcept {
+        return _as;
+    }
+};
+
 /// @}
 
 }

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -293,3 +293,146 @@ SEASTAR_THREAD_TEST_CASE(test_abort_on_any_move) {
     BOOST_REQUIRE(aborted_ex);
     BOOST_REQUIRE_THROW(std::rethrow_exception(*aborted_ex), std::runtime_error);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_all) {
+    std::default_random_engine random_engine(testing::local_random_engine());
+    std::uniform_int_distribution<> dist(0, 1);
+    std::array<abort_source, 2> ass;
+    auto awb = abort_on_all(ass[0], ass[1]);
+    auto& as = awb.abort_source();
+    BOOST_REQUIRE(!as.abort_requested());
+
+    int aborted = 0;
+    std::optional<std::exception_ptr> aborted_ex;
+    auto sub = as.subscribe([&] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+        ++aborted;
+        aborted_ex = opt_ex.value_or(std::make_exception_ptr(abort_requested_exception()));
+    });
+    BOOST_REQUIRE(bool(sub));
+
+    int idx = dist(random_engine);
+    ass[idx].request_abort();
+    BOOST_REQUIRE(!as.abort_requested());
+    BOOST_REQUIRE_NO_THROW(as.check());
+
+    ass[idx ^ 1].request_abort();
+    BOOST_REQUIRE_EQUAL(aborted, 1);
+    BOOST_REQUIRE(aborted_ex);
+    BOOST_REQUIRE_THROW(std::rethrow_exception(*aborted_ex), abort_requested_exception);
+    BOOST_REQUIRE(as.abort_requested());
+    BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_all_three) {
+    std::default_random_engine random_engine(testing::local_random_engine());
+    std::uniform_int_distribution<> dist(0, 2);
+    std::array<abort_source, 3> ass;
+    auto awb = abort_on_all(ass[0], ass[1], ass[2]);
+    auto& as = awb.abort_source();
+    BOOST_REQUIRE(!as.abort_requested());
+
+    int aborted = 0;
+    std::optional<std::exception_ptr> aborted_ex;
+    auto sub = as.subscribe([&] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+        ++aborted;
+        aborted_ex = opt_ex.value_or(std::make_exception_ptr(abort_requested_exception()));
+    });
+    BOOST_REQUIRE(bool(sub));
+
+    int idx = dist(random_engine);
+    ass[idx].request_abort();
+    BOOST_REQUIRE(!as.abort_requested());
+    BOOST_REQUIRE_NO_THROW(as.check());
+    BOOST_REQUIRE_EQUAL(aborted, 0);
+
+    ass[++idx % 3].request_abort();
+    BOOST_REQUIRE_EQUAL(aborted, 0);
+    BOOST_REQUIRE(!as.abort_requested());
+    BOOST_REQUIRE_NO_THROW(as.check());
+
+    ass[++idx % 3].request_abort();
+    BOOST_REQUIRE_EQUAL(aborted, 1);
+    BOOST_REQUIRE(aborted_ex);
+    BOOST_REQUIRE_THROW(std::rethrow_exception(*aborted_ex), abort_requested_exception);
+    BOOST_REQUIRE(as.abort_requested());
+    BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_all_already_aborted_once) {
+    std::default_random_engine random_engine(testing::local_random_engine());
+    std::uniform_int_distribution<> dist(0, 1);
+    std::array<abort_source, 2> ass;
+
+    int idx = dist(random_engine);
+    ass[idx].request_abort();
+
+    auto awb = abort_on_all(ass[0], ass[1]);
+    auto& as = awb.abort_source();
+    BOOST_REQUIRE(!as.abort_requested());
+    BOOST_REQUIRE_NO_THROW(as.check());
+
+    int aborted = 0;
+    std::optional<std::exception_ptr> aborted_ex;
+    auto sub = as.subscribe([&] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+        ++aborted;
+        aborted_ex = opt_ex.value_or(std::make_exception_ptr(abort_requested_exception()));
+    });
+    BOOST_REQUIRE(bool(sub));
+
+    ass[idx ^ 1].request_abort();
+    BOOST_REQUIRE_EQUAL(aborted, 1);
+    BOOST_REQUIRE(aborted_ex);
+    BOOST_REQUIRE_THROW(std::rethrow_exception(*aborted_ex), abort_requested_exception);
+    BOOST_REQUIRE(as.abort_requested());
+    BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_all_already_aborted_twice) {
+    std::default_random_engine random_engine(testing::local_random_engine());
+    std::uniform_int_distribution<> dist(0, 1);
+    std::array<abort_source, 2> ass;
+
+    ass[0].request_abort();
+    ass[1].request_abort();
+
+    auto awb = abort_on_all(ass[0], ass[1]);
+    auto& as = awb.abort_source();
+    BOOST_REQUIRE(as.abort_requested());
+    BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
+
+    auto sub = as.subscribe([&] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+    });
+    BOOST_REQUIRE(!sub);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_abort_on_all_move) {
+    std::default_random_engine random_engine(testing::local_random_engine());
+    std::uniform_int_distribution<> dist(0, 1);
+    std::array<abort_source, 2> ass;
+    auto awb0 = abort_on_all(ass[0], ass[1]);
+
+    int aborted = 0;
+    std::optional<std::exception_ptr> aborted_ex;
+    auto sub = awb0.abort_source().subscribe([&] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+        ++aborted;
+        aborted_ex = opt_ex.value_or(std::make_exception_ptr(abort_requested_exception()));
+    });
+    BOOST_REQUIRE(bool(sub));
+
+    auto awb1 = std::move(awb0);
+    auto& as = awb1.abort_source();
+
+    int idx = dist(random_engine);
+    ass[idx].request_abort();
+    BOOST_REQUIRE(!as.abort_requested());
+    BOOST_REQUIRE_NO_THROW(as.check());
+    BOOST_REQUIRE_EQUAL(aborted, 0);
+    BOOST_REQUIRE(!aborted_ex);
+
+    ass[idx ^ 1].request_abort();
+    BOOST_REQUIRE_EQUAL(aborted, 1);
+    BOOST_REQUIRE(aborted_ex);
+    BOOST_REQUIRE_THROW(std::rethrow_exception(*aborted_ex), abort_requested_exception);
+    BOOST_REQUIRE(as.abort_requested());
+    BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
+}

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -174,3 +174,13 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     as.reset();
     BOOST_REQUIRE_EQUAL(aborted, 0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_abort_source_move) {
+    auto as0 = abort_source();
+    int aborted = 0;
+    auto sub = as0.subscribe([&] () noexcept { ++aborted; });
+    auto as1 = std::move(as0);
+    as1.request_abort();
+    BOOST_REQUIRE(as1.abort_requested());
+    BOOST_REQUIRE_EQUAL(aborted, 1);
+}


### PR DESCRIPTION
abort_on_any requests abort when abort is requested on any of the provided abort sources.
abort_on_all requests abort when abort is requested on all of the provided abort sources.