### PR TITLE
core/bitops.hh: add type constraits to templates

### DIFF
--- a/include/seastar/core/bitops.hh
+++ b/include/seastar/core/bitops.hh
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <limits>
+#include <type_traits>
+#include <seastar/util/concepts.hh>
 
 namespace seastar {
 
@@ -56,7 +58,7 @@ constexpr unsigned count_trailing_zeros(unsigned long long x) {
 }
 
 template<typename T>
-//requires stdx::is_integral_v<T>
+SEASTAR_CONCEPT( requires std::is_integral_v<T> )
 inline constexpr unsigned log2ceil(T n) {
     if (n == 1) {
         return 0;
@@ -65,7 +67,7 @@ inline constexpr unsigned log2ceil(T n) {
 }
 
 template<typename T>
-//requires stdx::is_integral_v<T>
+SEASTAR_CONCEPT( requires std::is_integral_v<T> )
 inline constexpr unsigned log2floor(T n) {
     return std::numeric_limits<T>::digits - count_leading_zeros(n) - 1;
 }


### PR DESCRIPTION
for better readability and better developer experience

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>