### PR TITLE
util/print_safe, reactor: use concept for type constraints and refactory 

### DIFF
--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -22,10 +22,13 @@
 #pragma once
 
 #include <seastar/util/concepts.hh>
-#include <stdio.h>
+#include <cassert>
+#include <cstring>
 #if __cplusplus > 201703L
 #include <concepts>
 #endif
+#include <stdio.h>
+#include <unistd.h>
 
 namespace seastar {
 
@@ -64,11 +67,11 @@ void print_safe(const char *str) noexcept {
 // Fills a buffer with a hexadecimal representation of an integer
 // and returns a pointer to the first character.
 // For example, convert_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "   c".
-template<typename Integral>
-SEASTAR_CONCEPT( requires std::is_integral_v<Integral> )
+template<typename Integral, char Padding = ' '>
+SEASTAR_CONCEPT( requires std::integral<Integral> )
 char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
     const char *digits = "0123456789abcdef";
-    memset(buf, ' ', bufsz);
+    memset(buf, Padding, bufsz);
     auto* p = buf + bufsz;
     do {
         assert(p > buf);
@@ -83,14 +86,7 @@ char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
 template<typename Integral>
 SEASTAR_CONCEPT( requires std::integral<Integral> )
 void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
-    const char *digits = "0123456789abcdef";
-    memset(buf, '0', bufsz);
-    unsigned i = bufsz;
-    while (n) {
-        assert(i > 0);
-        buf[--i] = digits[n & 0xf];
-        n >>= 4;
-    }
+    convert_hex_safe<'0'>(buf, bufsz, n);
 }
 
 // Prints zero-padded hexadecimal representation of an integer to stderr.

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -21,7 +21,11 @@
 
 #pragma once
 
+#include <seastar/util/concepts.hh>
 #include <stdio.h>
+#if __cplusplus > 201703L
+#include <concepts>
+#endif
 
 namespace seastar {
 
@@ -60,7 +64,7 @@ void print_safe(const char *str) noexcept {
 // Fills a buffer with a zero-padded hexadecimal representation of an integer.
 // For example, convert_zero_padded_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "000c".
 template<typename Integral>
-SEASTAR_CONCEPT( requires std::is_integral_v<Integral> )
+SEASTAR_CONCEPT( requires std::integral<Integral> )
 void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
     const char *digits = "0123456789abcdef";
     memset(buf, '0', bufsz);
@@ -76,9 +80,8 @@ void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept 
 // For example, print_zero_padded_hex_safe(uint16_t(12)) prints "000c".
 // Async-signal safe.
 template<typename Integral>
+SEASTAR_CONCEPT ( requires std::signed_integral<Integral> )
 void print_zero_padded_hex_safe(Integral n) noexcept {
-    static_assert(std::is_integral<Integral>::value && !std::is_signed<Integral>::value, "Requires unsigned integrals");
-
     char buf[sizeof(n) * 2];
     convert_zero_padded_hex_safe(buf, sizeof(buf), n);
     print_safe(buf, sizeof(buf));
@@ -88,10 +91,8 @@ void print_zero_padded_hex_safe(Integral n) noexcept {
 // The argument bufsz is the maximum size of the buffer.
 // For example, print_decimal_safe(buf, 16, 12) prints "12".
 template<typename Integral>
-SEASTAR_CONCEPT( requires std::is_integral_v<Integral> )
+SEASTAR_CONCEPT( requires std::unsigned_integral<Integral> )
 size_t convert_decimal_safe(char *buf, size_t bufsz, Integral n) noexcept {
-    static_assert(std::is_integral<Integral>::value && !std::is_signed<Integral>::value, "Requires unsigned integrals");
-
     char tmp[sizeof(n) * 3];
     unsigned i = bufsz;
     do {

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -61,6 +61,23 @@ void print_safe(const char *str) noexcept {
     print_safe(str, strlen(str));
 }
 
+// Fills a buffer with a hexadecimal representation of an integer
+// and returns a pointer to the first character.
+// For example, convert_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "   c".
+template<typename Integral>
+SEASTAR_CONCEPT( requires std::is_integral_v<Integral> )
+char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
+    const char *digits = "0123456789abcdef";
+    memset(buf, ' ', bufsz);
+    auto* p = buf + bufsz;
+    do {
+        assert(p > buf);
+        *--p = digits[n & 0xf];
+        n >>= 4;
+    } while (n);
+    return p;
+}
+
 // Fills a buffer with a zero-padded hexadecimal representation of an integer.
 // For example, convert_zero_padded_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "000c".
 template<typename Integral>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -721,23 +721,6 @@ void reactor::handle_signal(int signo, noncopyable_function<void ()>&& handler) 
     _signals.handle_signal(signo, std::move(handler));
 }
 
-// Fills a buffer with a hexadecimal representation of an integer
-// and returns a pointer to the first character.
-// For example, convert_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "   c".
-template<typename Integral>
-SEASTAR_CONCEPT( requires std::is_integral_v<Integral> )
-char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
-    const char *digits = "0123456789abcdef";
-    memset(buf, ' ', bufsz);
-    auto* p = buf + bufsz;
-    do {
-        assert(p > buf);
-        *--p = digits[n & 0xf];
-        n >>= 4;
-    } while (n);
-    return p;
-}
-
 // Accumulates an in-memory backtrace and flush to stderr eventually.
 // Async-signal safe.
 class backtrace_buffer {


### PR DESCRIPTION
- util/print_safe: use concept for type constraints
- reactor: move convert_hex_safe() into print_safe.hh
- util/print_safe: dedup convert_hex_safe()