### PR TITLE
build: use target_sources() to add sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,14 +449,16 @@ seastar_generate_ragel (
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/http/response_parser.rl
   OUT_FILE ${Seastar_GEN_BINARY_DIR}/include/seastar/http/response_parser.hh)
 
+add_library (seastar STATIC)
 if (Seastar_DPDK)
-  set (seastar_dpdk_obj seastar-dpdk.o)
+  target_sources (seastar
+    PRIVATE
+    seastar-dpdk.o)
 endif ()
-
-add_library (seastar STATIC
+target_sources (seastar
+  PRIVATE
   ${http_chunk_parsers_file}
   ${http_request_parser_file}
-  ${seastar_dpdk_obj}
   include/seastar/core/abort_source.hh
   include/seastar/core/alien.hh
   include/seastar/core/align.hh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,6 @@ target_sources (seastar
   include/seastar/core/gate.hh
   include/seastar/core/iostream-impl.hh
   include/seastar/core/iostream.hh
-  include/seastar/util/later.hh
   include/seastar/core/layered_file.hh
   include/seastar/core/linux-aio.hh
   include/seastar/core/loop.hh
@@ -617,6 +616,7 @@ target_sources (seastar
   include/seastar/util/gcc6-concepts.hh
   include/seastar/util/indirect.hh
   include/seastar/util/is_smart_ptr.hh
+  include/seastar/util/later.hh
   include/seastar/util/lazy.hh
   include/seastar/util/log-cli.hh
   include/seastar/util/log-impl.hh


### PR DESCRIPTION
it helps to drop one more temporary variable of `seastar_dpdk_obj` for better readability.

this change is also the first one of a series which prepares for the C++ modules support on the CMake side. because, CMake adds C++ modules using `target_sources(FILE_SET)`. but we are not there yet, even after this change. as each `FILE_SET` only adds a set of file located in the same directory. while currently, Seastar adds all source files in multiple directories in a single batch for building "seastar" library. we will need to refactory the CMakeLists to either build the source files as C++ modules, or to replicate part of the source list so we only build/preprocess the header files to the module interface files. but either way, we will need to build them in smaller batches. before this happens, let's keep it in a single batch.

also, please note, the "PRIVATE" keyword might be controversial as some header files are used when building the seastar library's dependents. this is not quite right, as marking them "PUBLIC" will populate them to the dependent with the absolute path, so in addition to the list source files passed to, for instance, `demo.cc` in `add_executable (seastar_demo demo.cc)`, `include/seastar/core/app-template.hh` is listed as one of the source files for building `seastar_demo`. this would lead to
```
  Target "seastar" INTERFACE_SOURCES property contains path:

    "/home/kefu/dev/ceph/src/seastar/include/seastar/util/closeable.hh"

  which is prefixed in the source directory.`
```
as per https://cmake.org/cmake/help/latest/policy/CMP0076.html, `target_sources()` converts the relative paths to absolute ones. but a library's "PUBLIC" headers is not supposed to contain absolute paths, because it is supposed to be relocatable. so, if we have to include header files using "PUBLIC", we'd have to put something like:

```cmake
target_sources (seasetar
PUBLIC
  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/seastar/util/closeable.hh
  $<INSTALL_INTERFACE:include/include/seastar/util/closeable.hh>)
```

so a simpler solution would to add them to as the `PUBLIC_HEADER` property of the `seastar` library or just list them as a `HEADERS` FILE_SET if CMake 3.23 is allowed to be required. but we don't need either of them at this moment. as we don't install the `seastar` target's header files with its `PUBLIC_HEADER` or `FILE_SET` attached to this target yet. we just install the whole directories using `install (DIRECTORY ...)` call. we could use a more target-centric or finer grained approach in future.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>