### PR TITLE
Always try to include <concepts> in seastar/util/concepts.hh

### DIFF
--- a/include/seastar/util/concepts.hh
+++ b/include/seastar/util/concepts.hh
@@ -20,6 +20,10 @@
  */
 #pragma once
 
+#if __has_include(<concepts>)
+#include <concepts>
+#endif
+
 #if defined(__cpp_concepts) && __cpp_concepts >= 201907 && \
     defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 201907
 


### PR DESCRIPTION
There are chances that applications tries to include "seastar/util/concepts.hh" or other headers that don't include `<concepts>` before including "seastar/util/concepts.hh", which would lead to compilation failures

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>