### PR TITLE
scheduling: add a `rename` callback to scheduling_group_key_config

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -428,6 +428,7 @@ private:
     void account_runtime(task_queue& tq, sched_clock::duration runtime);
     void account_idle(sched_clock::duration idletime);
     void allocate_scheduling_group_specific_data(scheduling_group sg, scheduling_group_key key);
+    future<> rename_scheduling_group_specific_data(scheduling_group sg);
     future<> init_scheduling_group(scheduling_group sg, sstring name, float shares);
     future<> init_new_scheduling_group_key(scheduling_group_key key, scheduling_group_key_config cfg);
     future<> destroy_scheduling_group(scheduling_group sg) noexcept;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -137,6 +137,8 @@ struct scheduling_group_key_config {
     std::type_index type_index;
     /// A function that will be called for each newly allocated value
     std::function<void (void*)> constructor;
+    /// A function that will be called for each value after the scheduling group is renamed.
+    std::function<void (void*)> rename;
     /// A function that will be called for each element that is about
     /// to be dealocated.
     std::function<void (void*)> destructor;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4628,6 +4628,20 @@ reactor::allocate_scheduling_group_specific_data(scheduling_group sg, scheduling
 }
 
 future<>
+reactor::rename_scheduling_group_specific_data(scheduling_group sg) {
+    return with_scheduling_group(sg, [this, sg] {
+        auto& sg_data = _scheduling_group_specific_data;
+        auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
+        for (size_t i = 0; i < sg_data.scheduling_group_key_configs.size(); ++i) {
+            auto &c = sg_data.scheduling_group_key_configs[i];
+            if (c.rename) {
+                (c.rename)(this_sg.specific_vals[i]);
+            }
+        }
+    });
+}
+
+future<>
 reactor::init_scheduling_group(seastar::scheduling_group sg, sstring name, float shares) {
     auto& sg_data = _scheduling_group_specific_data;
     auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
@@ -4754,6 +4768,7 @@ rename_scheduling_group(scheduling_group sg, sstring new_name) noexcept {
     }
     return smp::invoke_on_all([sg, new_name] {
         engine()._task_queues[sg._id]->rename(new_name);
+        return engine().rename_scheduling_group_specific_data(sg);
     });
 }
 


### PR DESCRIPTION
Per-scheduling-group values might want to know the name of their scheduling group, e.g. if they hold some metrics for the group. But scheduling groups can be renamed, and currently there is no way to propagate that info to the values.

This patch allows the user of per-scheduling-group values to pass a callback called when the scheduling group is renamed. As with its sibling callbacks (`constructor` and `destructor`) it is called in the relevant scheduling group, so the value can learn the new name of its group using `current_scheduling_group()`.