### PR TITLE
Keep outgoing queue all cancellable while negotiating

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -432,6 +432,8 @@ class client : public rpc::connection, public weakly_referencable<client> {
             }
         };
     };
+
+    void enqueue_zero_frame();
 public:
     template<typename Reply, typename Func>
     struct reply_handler final : reply_handler_base {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -269,7 +269,7 @@ namespace rpc {
           _outgoing_queue.push_back(d);
           _outgoing_queue_size++;
           auto deleter = [this, it = _outgoing_queue.iterator_to(d)] {
-              // Front entry is most likely (unless _negotiated is unresolved) sitting
+              // Front entry is most likely (unless _negotiated is unresolved, check enqueue_zero_frame()) sitting
               // inside send_entry() continuations and thus it cannot be cancelled.
               if (it != _outgoing_queue.begin()) {
                   withdraw(it);
@@ -713,6 +713,29 @@ namespace rpc {
       }
   }
 
+  // This is the enlightened copy of the connection::send() method. Its intention is to
+  // keep a dummy entry in front of the queue while connect+negotiate is happenning so
+  // that all subsequent entries could abort on timeout or explicit cancellation.
+  void client::enqueue_zero_frame() {
+      if (_error) {
+          return;
+      }
+
+      auto p = std::make_unique<outgoing_entry>(snd_buf(0));
+      auto& d = *p;
+      _outgoing_queue.push_back(d);
+
+      // Make it in the background. Even if the client is stopped it will pick
+      // up all the entries hanging around
+      (void)std::exchange(_outgoing_queue_ready, d.done.get_future()).then_wrapped([this, p = std::move(p)] (auto f) mutable {
+          if (f.failed()) {
+              f.ignore_ready_future();
+          } else {
+              p->done.set_value();
+          }
+      });
+  }
+
   client::client(const logger& l, void* s, client_options ops, socket socket, const socket_address& addr, const socket_address& local)
   : rpc::connection(l, s), _socket(std::move(socket)), _server_addr(addr), _local_addr(local), _options(ops) {
        _socket.set_reuseaddr(ops.reuseaddr);
@@ -811,6 +834,7 @@ namespace rpc {
               _stopped.set_value();
           });
       });
+      enqueue_zero_frame();
   }
 
   client::client(const logger& l, void* s, const socket_address& addr, const socket_address& local)

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/core/sharded.hh>
@@ -41,6 +42,7 @@ struct loopback_error_injector {
     virtual error client_rcv_error() { return error::none; }
     virtual error client_snd_error() { return error::none; }
     virtual error connect_error()    { return error::none; }
+    virtual std::chrono::microseconds connect_delay() { return std::chrono::microseconds(0); }
 };
 
 class loopback_buffer {
@@ -291,7 +293,15 @@ public:
                 return make_foreign(b2);
             });
         }).then([this] (foreign_ptr<lw_shared_ptr<loopback_buffer>> b2) {
-            return _factory.make_new_client_connection(_b1, std::move(b2));
+            if (_error_injector) {
+                auto delay = _error_injector->connect_delay();
+                if (delay != std::chrono::microseconds(0)) {
+                    return seastar::sleep(delay).then([this, b2 = std::move(b2)] () mutable {
+                        return _factory.make_new_client_connection(_b1, std::move(b2));
+                    });
+                }
+            }
+            return make_ready_future<connected_socket>(_factory.make_new_client_connection(_b1, std::move(b2)));
         });
     }
     virtual void set_reuseaddr(bool reuseaddr) override {}

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -110,6 +110,7 @@ public:
             }
         } server_rcv = {}, server_snd = {}, client_rcv = {}, client_snd = {};
         error connect_kind = error::none;
+        std::chrono::microseconds connect_delay = std::chrono::microseconds(0);
     };
 private:
     config _cfg;
@@ -134,6 +135,10 @@ public:
 
     error connect_error() override {
         return _cfg.connect_kind;
+    }
+
+    std::chrono::microseconds connect_delay() override {
+        return _cfg.connect_delay;
     }
 };
 

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1460,3 +1460,41 @@ SEASTAR_TEST_CASE(test_client_info) {
 
     return make_ready_future<>();
 }
+
+void send_messages_and_check_timeouts(rpc_test_env<>& env, test_rpc_proto::client& cln) {
+    env.register_handler(1, [](int v) {
+        return seastar::sleep(std::chrono::seconds(v)).then([v] {
+            return make_ready_future<int>(v);
+        });
+    }).get();
+
+    auto call = env.proto().template make_client<int(int)>(1);
+    auto start = std::chrono::steady_clock::now();
+    auto f1 = call(cln, std::chrono::milliseconds(400), 3).finally([start] {
+        auto end = std::chrono::steady_clock::now();
+        BOOST_REQUIRE(end - start < std::chrono::seconds(1));
+    });
+    auto f2 = call(cln, std::chrono::milliseconds(600), 3).finally([start] {
+        auto end = std::chrono::steady_clock::now();
+        BOOST_REQUIRE(end - start < std::chrono::seconds(1));
+    });
+    BOOST_REQUIRE_THROW(f1.get0(), seastar::rpc::timeout_error);
+    BOOST_REQUIRE_THROW(f2.get0(), seastar::rpc::timeout_error);
+}
+
+SEASTAR_TEST_CASE(test_rpc_send_timeout) {
+    rpc_test_config cfg;
+    return rpc_test_env<>::do_with_thread(cfg, [] (auto& env, auto& cln) {
+        send_messages_and_check_timeouts(env, cln);
+    });
+}
+
+SEASTAR_TEST_CASE(test_rpc_send_timeout_on_connect) {
+    rpc_test_config cfg;
+    rpc_loopback_error_injector::config ecfg;
+    ecfg.connect_delay = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::seconds(5));
+    cfg.inject_error = ecfg;
+    return rpc_test_env<>::do_with_thread(cfg, [] (auto& env, auto& cln) {
+        send_messages_and_check_timeouts(env, cln);
+    });
+}


### PR DESCRIPTION
The outgoing queue of an RPC connection cannot cancel its front request. Before the queue was converted into continuation chain, this "property" was relaxed during connect+negotiate phase, but now it's not such, i.e. -- a regression. This PR makes the queue fully uncancellable while the socket is connecting and negotiating.