### PR TITLE
reactor: set_shard_field_width() after resource::allocate()

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4119,7 +4119,6 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         nr_cpus = cpu_set.size();
     }
     smp::count = nr_cpus;
-    logger::set_shard_field_width(std::ceil(std::log10(smp::count)));
     std::vector<reactor*> reactors(nr_cpus);
     if (smp_opts.memory) {
         rc.total_memory = parse_memory_size(smp_opts.memory.get_value());
@@ -4191,6 +4190,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 #endif
 
     auto resources = resource::allocate(rc);
+    logger::set_shard_field_width(std::ceil(std::log10(smp::count)));
     std::vector<resource::cpu> allocations = std::move(resources.cpus);
     if (thread_affinity) {
         smp::pin(allocations[0].cpu_id);


### PR DESCRIPTION
in debug build, if `--smp 0` is passed to seastar, we'd have following error:

```
seastar/src/core/reactor.cc:4139:35: runtime error: -inf is outside the range of representable values of type 'unsigned int'
```

but in the very same function where the runtime error is thrown, `resource::allocate(rc)` is called. this function also checks for 0 number of processors, and throw better runtime_error of "number of processing units must be positive".

in this change, we set the logger's shard field width after `smp::count` is checked for zero. so we can have a better error message.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>