### PR TITLE
reactor, core/resource: clean ups

### DIFF
--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -88,7 +88,7 @@ struct configuration {
     optional<size_t> total_memory;
     optional<size_t> reserve_memory;  // if total_memory not specified
     size_t reserve_additional_memory;
-    optional<size_t> cpus;
+    size_t cpus;
     optional<cpuset> cpu_set;
     bool assign_orphan_cpus = false;
     std::vector<dev_t> devices;

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -89,7 +89,7 @@ struct configuration {
     optional<size_t> reserve_memory;  // if total_memory not specified
     size_t reserve_additional_memory;
     size_t cpus;
-    optional<cpuset> cpu_set;
+    cpuset cpu_set;
     bool assign_orphan_cpus = false;
     std::vector<dev_t> devices;
     unsigned num_io_groups;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4088,9 +4088,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
     resource::configuration rc;
 
-    smp::count = 1;
     smp::_tmain = std::this_thread::get_id();
-    auto nr_cpus = resource::nr_processing_units(rc);
     resource::cpuset cpu_set = get_current_cpuset();
 
     if (smp_opts.cpuset) {
@@ -4114,13 +4112,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 
     if (smp_opts.smp) {
-        nr_cpus = smp_opts.smp.get_value();
+        smp::count = smp_opts.smp.get_value();
     } else {
-        nr_cpus = cpu_set.size();
+        smp::count = cpu_set.size();
     }
-    smp::count = nr_cpus;
     logger::set_shard_field_width(std::ceil(std::log10(smp::count)));
-    std::vector<reactor*> reactors(nr_cpus);
+    std::vector<reactor*> reactors(smp::count);
     if (smp_opts.memory) {
         rc.total_memory = parse_memory_size(smp_opts.memory.get_value());
 #ifdef SEASTAR_HAVE_DPDK

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -509,9 +509,9 @@ resources allocate(configuration& c) {
 #endif
     size_t mem = calculate_memory(c, std::min(available_memory,
                                               cgroup::memory_limit()));
-    unsigned available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
     unsigned procs = c.cpus;
-    if (procs > available_procs) {
+    if (unsigned available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+        procs > available_procs) {
         throw std::runtime_error(format("insufficient processing units: needed {} available {}", procs, available_procs));
     }
     if (procs == 0) {

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -512,7 +512,7 @@ resources allocate(configuration& c) {
     size_t mem = calculate_memory(c, std::min(available_memory,
                                               cgroup::memory_limit()));
     unsigned available_procs = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-    unsigned procs = c.cpus.value_or(available_procs);
+    unsigned procs = c.cpus;
     if (procs > available_procs) {
         throw std::runtime_error(format("insufficient processing units: needed {} available {}", procs, available_procs));
     }
@@ -672,8 +672,7 @@ resources allocate(configuration& c) {
 
     auto available_memory = ::sysconf(_SC_PAGESIZE) * size_t(::sysconf(_SC_PHYS_PAGES));
     auto mem = calculate_memory(c, available_memory);
-    auto cpuset_procs = c.cpu_set ? c.cpu_set->size() : nr_processing_units(c);
-    auto procs = c.cpus.value_or(cpuset_procs);
+    auto procs = c.cpus;
     ret.cpus.reserve(procs);
     // limit memory address to fit in 36-bit, see core/memory.cc:Memory map
     constexpr size_t max_mem_per_proc = 1UL << 36;


### PR DESCRIPTION
- core/resource: do not check c.cpus for null
- core/resource: do not check c.cpu_set for null
- core/resource: move a value only for sanity check into `if` clause
- reactor: initialize smp::count without a temporary value