### PR TITLE
build: use target_link_options() to pass options to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -956,8 +956,7 @@ if (Seastar_IO_URING)
 endif ()
 
 if (Seastar_LD_FLAGS)
-  # In newer versions of CMake, there is `target_link_options`.
-  target_link_libraries (seastar
+  target_link_options (seastar
     PRIVATE ${Seastar_LD_FLAGS})
 endif ()
 


### PR DESCRIPTION
instead of using `target_link_libraries()` to pass linker flags, it is better to use `target_link_options()` for this purpose. As the former is used for linking against libraries, not for passing flags.

now that the minimum required CMake version of Seastar is now 3.13, we have the luxury of using the more appropriate command to do this job.

in this change, `target_link_options()` is used in place of `target_link_libraries()` when appropriate.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>