### PR TITLE
memory: do not define variable only for assert

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -979,8 +979,7 @@ cpu_pages::try_foreign_free(void* ptr) {
 }
 
 void cpu_pages::shrink(void* ptr, size_t new_size) {
-    auto obj_cpu = object_cpu_id(ptr);
-    assert(obj_cpu == cpu_id);
+    assert(object_cpu_id(ptr) == cpu_id);
     page* span = to_page(ptr);
     if (span->pool) {
         return;


### PR DESCRIPTION
`obj_cpu` is only used in `assert()`, so it does not deserve a name in this simple use case, and a static analyzer might warn at seeing a defined-but-not-used variable when building a release build where `assert()` calls are optimized out.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>