### PR TITLE
prometheus: Don't report labels that starts with __

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -82,9 +82,11 @@ static void add_name(std::ostream& s, const sstring& name, const std::map<sstrin
 
     if (!labels.empty()) {
         for (auto l : labels) {
-            s << delimiter;
-            s << l.first  << "=\"" << l.second << '"';
-            delimiter = ",";
+            if (!boost::algorithm::starts_with(l.first, "__")) {
+                s << delimiter;
+                s << l.first  << "=\"" << l.second << '"';
+                delimiter = ",";
+            }
         }
     }
     s << "} ";


### PR DESCRIPTION
There's a common practice with Prometheus to use labels that starts with a double underscore (i.e., __) for internal label manipulation.  This patch follows the same idea for seastar.

Labels that start with __ will not be reported. This makes it easier to add labels for metrics manipulation without the cost of sending those labels on the wire.  Those labels can be used for filtering (like we already support __name __)

Signed-off-by: Amnon Heiman <amnon@scylladb.com>