### PR TITLE
metrics: Allows filtering by dynamic labels

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -436,9 +436,6 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
             throw std::runtime_error("registering metrics " + name + " registered with different type.");
         }
         metric[rm->info().id.labels()] = rm;
-        for (auto&& i : rm->info().id.labels()) {
-            _labels.insert(i.first);
-        }
     } else {
         _value_map[name].info().type = type.base_type;
         _value_map[name].info().d = d;
@@ -446,6 +443,9 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
         _value_map[name].info().name = id.full_name();
         _value_map[name].info().aggregate_labels = aggregate_labels;
         _value_map[name][rm->info().id.labels()] = rm;
+    }
+    for (auto&& i : rm->info().id.labels()) {
+        _labels.insert(i.first);
     }
     dirty();
 }
@@ -488,7 +488,9 @@ future<metric_relabeling_result> impl::set_relabel_configs(const std::vector<rel
                 conflicts.metrics_relabeled_due_to_collision++;
                 rm->info().id.labels()["err"] = id;
             }
-
+            for (auto&& i : rm->info().id.labels()) {
+                _labels.insert(i.first);
+            }
             family.second[lb] = rm;
         }
     }


### PR DESCRIPTION
The metrics relabel API allows the creation of new labels during run time.  It would be helpful to add those labels to the set of all existing labels so that Prometheus will be able to filter by those labels.

This patch adds the labels to the label collection after performing metric relabeling.

Signed-off-by: Amnon Heiman <amnon@scylladb.com>

Fixes #2527