### PR TITLE
core: s/reserve_additional_memory/reserve_additional_memory_per_shard/

### DIFF
--- a/include/seastar/core/app-template.hh
+++ b/include/seastar/core/app-template.hh
@@ -74,7 +74,7 @@ public:
         /// This can be used when the application allocates some of its memory using the
         /// seastar allocator, and some using the system allocator, in particular when it
         /// uses the mmap system call with MAP_ANONYMOUS which is not overridden in seastar.
-        size_t reserve_additional_memory = 0;
+        size_t reserve_additional_memory_per_shard = 0;
         config() {}
     };
 

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -87,7 +87,7 @@ struct topology_holder {};
 struct configuration {
     optional<size_t> total_memory;
     optional<size_t> reserve_memory;  // if total_memory not specified
-    size_t reserve_additional_memory;
+    size_t reserve_additional_memory_per_shard;
     size_t cpus;
     cpuset cpu_set;
     bool assign_orphan_cpus = false;

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -98,8 +98,8 @@ struct smp_options : public program_options::option_group {
     seastar::memory_allocator memory_allocator = memory_allocator::seastar;
 
     /// \cond internal
-    /// Additional memory reserved to OS (added to the default value or the value specified by \ref reserve_memory).
-    size_t reserve_additional_memory = 0;
+    /// Additional memory reserved to OS for each shard (added to the default value or the value specified by \ref reserve_memory).
+    size_t reserve_additional_memory_per_shard = 0;
     /// \endcond
 public:
     smp_options(program_options::option_group* parent_group);

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -51,7 +51,7 @@ seastar_options_from_config(app_template::config cfg) {
     opts.auto_handle_sigint_sigterm = std::move(cfg.auto_handle_sigint_sigterm);
     opts.reactor_opts.task_quota_ms.set_default_value(cfg.default_task_quota / 1ms);
     opts.reactor_opts.max_networking_io_control_blocks.set_default_value(cfg.max_networking_aio_io_control_blocks);
-    opts.smp_opts.reserve_additional_memory = cfg.reserve_additional_memory;
+    opts.smp_opts.reserve_additional_memory_per_shard = cfg.reserve_additional_memory_per_shard;
     return opts;
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4143,7 +4143,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     if (smp_opts.reserve_memory) {
         rc.reserve_memory = parse_memory_size(smp_opts.reserve_memory.get_value());
     }
-    rc.reserve_additional_memory = smp_opts.reserve_additional_memory;
+    rc.reserve_additional_memory_per_shard = smp_opts.reserve_additional_memory_per_shard;
     std::optional<std::string> hugepages_path;
     if (smp_opts.hugepages) {
         hugepages_path = smp_opts.hugepages.get_value();

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -223,6 +223,9 @@ size_t calculate_memory(const configuration& c, size_t available_memory, float p
     if (!c.total_memory.has_value()) {
         return available_memory;
     }
+    if (*c.total_memory < c.reserve_additional_memory) {
+        throw std::runtime_error(format("insufficient total memory: reserve {} total {}", c.reserve_additional_memory, *c.total_memory));
+    }
     size_t needed_memory = *c.total_memory - c.reserve_additional_memory;
     if (needed_memory > available_memory) {
         throw std::runtime_error(format("insufficient physical memory: needed {} available {}", needed_memory, available_memory));

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -220,11 +220,14 @@ size_t calculate_memory(const configuration& c, size_t available_memory, float p
         // Allow starting up even in low memory configurations (e.g. 2GB boot2docker VM)
         available_memory = min_memory;
     }
-    size_t mem = c.total_memory ? *c.total_memory - c.reserve_additional_memory : available_memory;
-    if (mem > available_memory) {
-        throw std::runtime_error(format("insufficient physical memory: needed {} available {}", mem, available_memory));
+    if (!c.total_memory.has_value()) {
+        return available_memory;
     }
-    return mem;
+    size_t needed_memory = *c.total_memory - c.reserve_additional_memory;
+    if (needed_memory > available_memory) {
+        throw std::runtime_error(format("insufficient physical memory: needed {} available {}", needed_memory, available_memory));
+    }
+    return needed_memory;
 }
 
 io_queue_topology::io_queue_topology() {


### PR DESCRIPTION
this change is a follow-up of 88b85b88, which added an option named
`reserve_additional_memory` for configuring the memory subsystem, so
we can reserve addition system memory for application which uses
both seastar allocator and system allocator.

but seastar is designed to be a multi-core friendly framework, the
seastar applications always run on multiple shards. if we want to
reserve addition memory for a given application, what we actually
need is to reserve memory for each shard on which the application
allocates memory from system allocator. but in general, user cannot
predict the number of shards of the machine on which the aopplication
is deployed. it is a runtime setting / configuration, and hence can
by retrieved at runtime. so an option for total size of reserve memory
for a sharded application is inherently unscalable.

in this change, the option is renamed to
`reserve_additional_memory_per_shard`.
and when we validate the available memory size,
reserve_additional_memory_per_shard * smp::count is used for the
reserved memory size.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>