### PR TITLE
semaphore: semaphore_units: return units when reassigned

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -490,8 +490,8 @@ public:
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
     semaphore_units& operator=(semaphore_units&& o) noexcept {
-        _sem = o._sem;
-        _n = std::exchange(o._n, 0);
+        std::swap(_sem, o._sem);
+        std::swap(_n, o._n);
         return *this;
     }
     semaphore_units(const semaphore_units&) = delete;

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -444,3 +444,17 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_move_with_outstanding_units) {
     units.reset();
     BOOST_REQUIRE_EQUAL(sem1->current(), 1);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
+    auto sem0 = semaphore(1);
+    auto sem1 = semaphore(1);
+    auto units = get_units(sem0, 1).get();
+    auto wait = sem0.wait(1);
+    BOOST_REQUIRE(!wait.available());
+    units = get_units(sem1, 1).get();
+    timer t([] { abort(); });
+    t.arm(1s);
+    // will hang if units are not returned when reassigned
+    wait.get();
+    t.cancel();
+}


### PR DESCRIPTION
When semaphore_units are (move-) reassigned with
other units, the held units aren't currently
returned to the semaphore.

This change implements the move-reassignment operator by swapping the semaphore and the units counter
so that when the moved-from semaphore_units object is destroyed, the units will be returned to the semaphore via `~semaphore_units` -> `return_all`.

Add a unit test reproducer.

Fixes #1465

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>