### PR TITLE
Harden outstanding semaphore_units tracking

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -555,12 +555,14 @@ public:
         if (units > _n) {
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
+      if (units) {
         _n -= units;
         // `units` are split into a new `semaphore_units` object.
         // since none are returned to the semaphore we subtract the
         // outstanding units here to balance their eventual addition by the
         // `semaphore_units` ctor.
         _sem->sub_outstanding_units(units);
+      }
         return semaphore_units(_sem, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -262,6 +262,12 @@ public:
         return *this;
     }
 
+#ifdef SEASTAR_SEMAPHORE_DEBUG
+    ~basic_semaphore() {
+        assert(!_outstanding_units && "semaphore destroyed with outstanding units");
+    }
+#endif
+
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -513,14 +513,14 @@ public:
     ///
     /// \return the number of remaining units
     size_t return_units(size_t units) {
-      if (__builtin_expect(units != 0, true)) {
-        if (units > _n) {
-            throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
+        if (__builtin_expect(units != 0, true)) {
+            if (units > _n) {
+                throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
+            }
+            _n -= units;
+            _sem->sub_outstanding_units(units);
+            _sem->signal(units);
         }
-        _n -= units;
-        _sem->sub_outstanding_units(units);
-        _sem->signal(units);
-      }
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -573,8 +573,10 @@ public:
     void adopt(semaphore_units&& other) noexcept {
         assert(other._sem == _sem);
         auto o = other.release();
+      if (__builtin_expect(o != 0, true)) {
         _sem->add_outstanding_units(o);
         _n += o;
+      }
     }
 
     /// Returns the number of units held

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -555,14 +555,14 @@ public:
         if (units > _n) {
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
-      if (units) {
-        _n -= units;
-        // `units` are split into a new `semaphore_units` object.
-        // since none are returned to the semaphore we subtract the
-        // outstanding units here to balance their eventual addition by the
-        // `semaphore_units` ctor.
-        _sem->sub_outstanding_units(units);
-      }
+        if (units) {
+            _n -= units;
+            // `units` are split into a new `semaphore_units` object.
+            // since none are returned to the semaphore we subtract the
+            // outstanding units here to balance their eventual addition by the
+            // `semaphore_units` ctor.
+            _sem->sub_outstanding_units(units);
+        }
         return semaphore_units(_sem, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -535,8 +535,11 @@ public:
     ///
     /// \return the number of units held
     size_t release() noexcept {
-        _sem->sub_outstanding_units(_n);
-        return std::exchange(_n, 0);
+        auto ret = std::exchange(_n, 0);
+        if (__builtin_expect(ret != 0, true)) {
+            _sem->sub_outstanding_units(ret);
+        }
+        return ret;
     }
     /// Splits this instance into a \ref semaphore_units object holding the specified amount of units.
     /// This object will continue holding the remaining units.

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -513,12 +513,14 @@ public:
     ///
     /// \return the number of remaining units
     size_t return_units(size_t units) {
+      if (__builtin_expect(units != 0, true)) {
         if (units > _n) {
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
         _sem->sub_outstanding_units(units);
         _sem->signal(units);
+      }
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -490,6 +490,7 @@ public:
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
     semaphore_units& operator=(semaphore_units&& o) noexcept {
+        return_all();
         _sem = o._sem;
         _n = std::exchange(o._n, 0);
         return *this;

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -573,10 +573,10 @@ public:
     void adopt(semaphore_units&& other) noexcept {
         assert(other._sem == _sem);
         auto o = other.release();
-      if (__builtin_expect(o != 0, true)) {
-        _sem->add_outstanding_units(o);
-        _n += o;
-      }
+        if (__builtin_expect(o != 0, true)) {
+            _sem->add_outstanding_units(o);
+            _n += o;
+        }
     }
 
     /// Returns the number of units held

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -488,7 +488,9 @@ class semaphore_units {
     size_t _n;
 
     semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {
+      if (_n) {
         _sem->add_outstanding_units(n);
+      }
     }
 public:
     semaphore_units() noexcept : _sem(nullptr), _n(0) {}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -483,3 +483,13 @@ SEASTAR_THREAD_TEST_CASE(test_split_after_sem_destroy) {
     sem.reset();
     units.split(0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_adopt_after_sem_destroy) {
+    auto sem = std::make_unique<semaphore>(2);
+    auto units0 = get_units(*sem, 1).get();
+    auto units1 = get_units(*sem, 1).get();
+    units0.release();
+    units1.release();
+    sem.reset();
+    units0.adopt(std::move(units1));
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -445,3 +445,17 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_move_with_outstanding_units) {
     units.reset();
     BOOST_REQUIRE_EQUAL(sem1->current(), 1);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
+    auto sem0 = semaphore(1);
+    auto sem1 = semaphore(1);
+    auto units = get_units(sem0, 1).get();
+    auto wait = sem0.wait(1);
+    BOOST_REQUIRE(!wait.available());
+    units = get_units(sem1, 1).get();
+    timer t([] { abort(); });
+    t.arm(1s);
+    // will hang if units are not returned when reassigned
+    wait.get();
+    t.cancel();
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -467,3 +467,11 @@ SEASTAR_THREAD_TEST_CASE(test_units_after_sem_destroy) {
     sem.reset();
     units.return_units(0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_release_units_after_sem_destroy) {
+    auto sem = std::make_unique<semaphore>(1);
+    auto units = get_units(*sem, 1).get();
+    units.release();
+    sem.reset();
+    units.release();
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -459,3 +459,11 @@ SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
     wait.get();
     t.cancel();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_units_after_sem_destroy) {
+    auto sem = std::make_unique<semaphore>(1);
+    auto units = get_units(*sem, 1).get();
+    units.release();
+    sem.reset();
+    units.return_units(0);
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -475,3 +475,11 @@ SEASTAR_THREAD_TEST_CASE(test_release_units_after_sem_destroy) {
     sem.reset();
     units.release();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_split_after_sem_destroy) {
+    auto sem = std::make_unique<semaphore>(1);
+    auto units = get_units(*sem, 1).get();
+    units.release();
+    sem.reset();
+    units.split(0);
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -284,21 +284,21 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return) {
     auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
-    BOOST_REQUIRE_EQUAL(units.count(), 3);
+    auto units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
+    BOOST_REQUIRE_EQUAL(units->count(), 3);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
-    BOOST_REQUIRE_EQUAL(units.count(), 2);
+    BOOST_REQUIRE_EQUAL(units->return_units(1), 2);
+    BOOST_REQUIRE_EQUAL(units->count(), 2);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.~semaphore_units();
+    units.reset();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 
-    units = get_units(sm, 2, 1min).get0();
+    units = std::make_unique<semaphore_units<>>(get_units(sm, 2, 1min).get0());
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    BOOST_REQUIRE_THROW(units.return_units(10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(units->return_units(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.return_all();
-    BOOST_REQUIRE_EQUAL(units.count(), 0);
+    units->return_all();
+    BOOST_REQUIRE_EQUAL(units->count(), 0);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 }
 


### PR DESCRIPTION
This series adds checks that track outstanding semaphore units only
when their count is not zero, as the semaphore may be safely
destroyed once that count reaches zero, and dereferencing the `_sem`
pointer beyond that point might result in use-after-free.

Respective unit test reproducers are added too.
