### PR TITLE
include: do not include <concepts> directly

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -37,10 +37,6 @@
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/std-compat.hh>
 
-#if __cplusplus > 201703L
-#include <concepts>
-#endif
-
 namespace seastar {
 
 struct nested_exception : public std::exception {

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -24,9 +24,6 @@
 #include <seastar/util/concepts.hh>
 #include <cassert>
 #include <cstring>
-#if __cplusplus > 201703L
-#include <concepts>
-#endif
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
now that in bef17de954830841b4a7dd2b6d447fce5e2f5cf9, <concepts> is included by `util/concepts.hh`, we should not include the former directly.

let's use `util/concepts.hh` as a stand-in whenever <concepts> is included for better consistency, and it's less error-prune.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>