### PR TITLE
prometheus: remove unused headers

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -22,8 +22,6 @@
 #include <seastar/core/prometheus.hh>
 #include <sstream>
 
-#include <seastar/core/scollectd_api.hh>
-#include "core/scollectd-impl.hh"
 #include <seastar/core/metrics_api.hh>
 #include <seastar/http/function_handlers.hh>
 #include <boost/algorithm/string/replace.hpp>


### PR DESCRIPTION
neither of these two scollectd related headers is used by prometheus.cc, so let's remove them.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>