### PR TITLE
[RFC] semaphore: track outstanding units

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -347,6 +347,7 @@ public:
     using time_point = typename timer<Clock>::time_point;
     using exception_factory = ExceptionFactory;
     using semaphore_waiter = seastar::internal::semaphore_waiter<ExceptionFactory, Clock>;
+    using semaphore_units = seastar::semaphore_units<ExceptionFactory, Clock>;
 private:
     ssize_t _count;
     std::exception_ptr _ex;
@@ -552,6 +553,152 @@ public:
     future<> wait(duration timeout, size_t nr = 1) noexcept {
         return wait(clock::now() + timeout, nr);
     }
+
+private:
+    struct units_waiter : public semaphore_waiter {
+        using semaphore_waiter::semaphore_waiter;
+
+        promise<semaphore_units> pr;
+
+        future<semaphore_units> get_future() noexcept { return pr.get_future(); }
+        virtual void set_value() noexcept override {
+            pr.set_value(semaphore_units(*this->sem(), this->nr()));
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+        virtual void set_exception(std::exception_ptr ex) noexcept override {
+            pr.set_exception(std::move(ex));
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+    };
+
+public:
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  If the semaphore was \ref broken(), may
+    ///         contain an exception.
+    future<semaphore_units> get_units(size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_ex) {
+            return make_exception_future<semaphore_units>(_ex);
+        }
+        try {
+            auto w = new units_waiter(*this, nr);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  If the request
+    /// cannot be satisfied in time, the request is aborted.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param timeout expiration time.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On timeout, the future contains a
+    ///         \ref semaphore_timed_out exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(time_point timeout, size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_ex) {
+            return make_exception_future<semaphore_units>(_ex);
+        }
+        if (Clock::now() >= timeout) {
+            try {
+                return make_exception_future<semaphore_units>(this->timeout());
+            } catch (...) {
+                return make_exception_future<semaphore_units>(semaphore_timed_out());
+            }
+        }
+        try {
+            auto w = new units_waiter(*this, nr, timeout);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  If the request
+    /// cannot be satisfied in time, the request is aborted.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param timeout how long to wait.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On timeout, the future contains a
+    ///         \ref semaphore_timed_out exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(duration timeout, size_t nr = 1) noexcept {
+        return get_units(clock::now() + timeout, nr);
+    }
+
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  The request
+    /// can be aborted using an \ref abort_source.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param as abort source.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On abort, the future contains a
+    ///         \ref semaphore_aborted exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(abort_source& as, size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_ex) {
+            return make_exception_future<semaphore_units>(_ex);
+        }
+        if (as.abort_requested()) {
+            if constexpr (internal::has_aborted<ExceptionFactory>::value) {
+                try {
+                    return make_exception_future<semaphore_units>(this->aborted());
+                } catch (...) {
+                    return make_exception_future<semaphore_units>(semaphore_aborted());
+                }
+            } else {
+                return make_exception_future<semaphore_units>(semaphore_aborted());
+            }
+        }
+        try {
+            auto w = new units_waiter(*this, nr, as);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+
     /// Deposits a specified number of units into the counter.
     ///
     /// The counter is incremented by the specified number of units.
@@ -700,9 +847,7 @@ basic_semaphore<ExceptionFactory, Clock>::broken(std::exception_ptr xp) noexcept
 template<typename ExceptionFactory, typename Clock = typename timer<>::clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units) noexcept {
-    return sem.wait(units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(units);
 }
 
 /// \brief Take units from semaphore temporarily with time bound on wait
@@ -723,9 +868,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units) noexcept 
 template<typename ExceptionFactory, typename Clock = typename timer<>::clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::time_point timeout) noexcept {
-    return sem.wait(timeout, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(timeout, units);
 }
 
 /// \brief Take units from semaphore temporarily with time bound on wait
@@ -747,9 +890,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename 
 template<typename ExceptionFactory, typename Clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::duration timeout) noexcept {
-    return sem.wait(timeout, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(timeout, units);
 }
 
 /// \brief Take units from semaphore temporarily with an \ref abort_source
@@ -771,9 +912,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename 
 template<typename ExceptionFactory, typename Clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, abort_source& as) noexcept {
-    return sem.wait(as, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(as, units);
 }
 
 /// \brief Try to take units from semaphore temporarily

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -985,8 +985,10 @@ template <typename ExceptionFactory, typename Func, typename Clock = typename ti
 inline
 futurize_t<std::invoke_result_t<Func>>
 with_semaphore(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, Func&& func) noexcept {
-    return get_units(sem, units).then([func = std::forward<Func>(func)] (auto units) mutable {
-        return futurize_invoke(std::forward<Func>(func)).finally([units = std::move(units)] {});
+    return sem.wait(units).then([&sem, units, func = std::forward<Func>(func)] () mutable {
+        return futurize_invoke(std::forward<Func>(func)).finally([&sem, units] {
+            sem.signal(units);
+        });
     });
 }
 
@@ -1019,8 +1021,10 @@ template <typename ExceptionFactory, typename Clock, typename Func>
 inline
 futurize_t<std::invoke_result_t<Func>>
 with_semaphore(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::duration timeout, Func&& func) noexcept {
-    return get_units(sem, units, timeout).then([func = std::forward<Func>(func)] (auto units) mutable {
-        return futurize_invoke(std::forward<Func>(func)).finally([units = std::move(units)] {});
+    return sem.wait(units, timeout).then([&sem, units, func = std::forward<Func>(func)] () mutable {
+        return futurize_invoke(std::forward<Func>(func)).finally([&sem, units] {
+            sem.signal(units);
+        });
     });
 }
 

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -31,10 +31,6 @@
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/abort_on_expiry.hh>
 
-#ifdef SEASTAR_DEBUG
-#define SEASTAR_SEMAPHORE_DEBUG
-#endif
-
 namespace seastar {
 
 namespace internal {
@@ -129,9 +125,6 @@ struct named_semaphore_exception_factory {
     named_semaphore_aborted aborted() const noexcept;
 };
 
-template<typename ExceptionFactory, typename Clock>
-class semaphore_units;
-
 /// \brief Counted resource guard.
 ///
 /// This is a standard computer science semaphore, adapted
@@ -161,24 +154,6 @@ public:
 private:
     ssize_t _count;
     std::exception_ptr _ex;
-#ifdef SEASTAR_SEMAPHORE_DEBUG
-    size_t _outstanding_units = 0;
-
-    void assert_not_held() const noexcept {
-        assert(!_outstanding_units && "semaphore moved with outstanding units");
-    }
-    void add_outstanding_units(size_t n) {
-        _outstanding_units += n;
-    }
-    void sub_outstanding_units(size_t n) {
-        _outstanding_units -= n;
-    }
-#else   // SEASTAR_SEMAPHORE_DEBUG
-    void assert_not_held() const noexcept {}
-    void add_outstanding_units(size_t) {}
-    void sub_outstanding_units(size_t) {}
-#endif  // SEASTAR_SEMAPHORE_DEBUG
-
     struct entry {
         promise<> pr;
         size_t nr;
@@ -216,8 +191,6 @@ private:
     bool may_proceed(size_t nr) const noexcept {
         return has_available_units(nr) && _wait_list.empty();
     }
-
-    friend class semaphore_units<ExceptionFactory, Clock>;
 public:
     /// Returns the maximum number of units the semaphore counter can hold
     static constexpr size_t max_counter() noexcept {
@@ -241,27 +214,6 @@ public:
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
-
-    basic_semaphore(const basic_semaphore&) = delete;
-    basic_semaphore(basic_semaphore&& o) noexcept
-        : _count(std::exchange(o._count, 0))
-        , _ex(std::move(o._ex))
-        , _wait_list(std::move(o._wait_list))
-    {
-        o.assert_not_held();
-    }
-
-    basic_semaphore& operator=(basic_semaphore&& o) noexcept {
-        if (this != &o) {
-            o.assert_not_held();
-            assert_not_held();
-            _count = std::exchange(o._count, 0);
-            _ex = std::move(o._ex);
-            _wait_list = std::move(o._wait_list);
-        }
-        return *this;
-    }
-
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///
@@ -481,11 +433,9 @@ class semaphore_units {
     basic_semaphore<ExceptionFactory, Clock>* _sem;
     size_t _n;
 
-    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {
-        _sem->add_outstanding_units(n);
-    }
+    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {}
 public:
-    semaphore_units() noexcept : _sem(nullptr), _n(0) {}
+    semaphore_units() noexcept : semaphore_units(nullptr, 0) {}
     semaphore_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t n) noexcept : semaphore_units(&sem, n) {}
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
@@ -510,14 +460,12 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
-        _sem->sub_outstanding_units(units);
         _sem->signal(units);
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.
     void return_all() noexcept {
         if (_n) {
-            _sem->sub_outstanding_units(_n);
             _sem->signal(_n);
             _n = 0;
         }
@@ -526,7 +474,6 @@ public:
     ///
     /// \return the number of units held
     size_t release() noexcept {
-        _sem->sub_outstanding_units(_n);
         return std::exchange(_n, 0);
     }
     /// Splits this instance into a \ref semaphore_units object holding the specified amount of units.
@@ -542,11 +489,6 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
-        // `units` are split into a new `semaphore_units` object.
-        // since none are returned to the semaphore we subtract the
-        // outstanding units here to balance their eventual addition by the
-        // `semaphore_units` ctor.
-        _sem->sub_outstanding_units(units);
         return semaphore_units(_sem, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units
@@ -556,9 +498,7 @@ public:
     /// \return the updated semaphore_units object
     void adopt(semaphore_units&& other) noexcept {
         assert(other._sem == _sem);
-        auto o = other.release();
-        _sem->add_outstanding_units(o);
-        _n += o;
+        _n += other.release();
     }
 
     /// Returns the number of units held

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -214,6 +214,13 @@ public:
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
+    basic_semaphore(basic_semaphore&&) = default;
+    basic_semaphore& operator=(basic_semaphore&&) = default;
+
+    ~basic_semaphore() {
+        broken();
+    }
+
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -440,6 +440,7 @@ public:
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
     semaphore_units& operator=(semaphore_units&& o) noexcept {
+        return_all();
         _sem = o._sem;
         _n = std::exchange(o._n, 0);
         return *this;

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <boost/lockfree/spsc_queue.hpp>
 #include <boost/thread/barrier.hpp>
 #include <boost/range/irange.hpp>

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -72,7 +72,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_2) {
     sleep(10ms).get();
     BOOST_REQUIRE_EQUAL(x, 0);
     sem = std::nullopt;
-    BOOST_CHECK_THROW(fut.get(), broken_promise);
+    BOOST_CHECK_THROW(fut.get(), broken_semaphore);
 }
 
 SEASTAR_TEST_CASE(test_semaphore_timeout_1) {
@@ -447,4 +447,21 @@ SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
     // will hang if units are not returned when reassigned
     wait.get();
     t.cancel();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_destroy_semaphore_during_wait) {
+    auto sem = std::make_unique<semaphore>(0);
+    auto wait = sem->wait(1);
+    BOOST_REQUIRE(!wait.available());
+    sem.reset();
+    BOOST_REQUIRE_THROW(wait.get(), broken_semaphore);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_destroy_semaphore_during_wait_with_ensured_space) {
+    auto sem = std::make_unique<semaphore>(0);
+    sem->ensure_space_for_waiters(2);
+    auto wait = sem->wait(1);
+    BOOST_REQUIRE(!wait.available());
+    sem.reset();
+    BOOST_REQUIRE_THROW(wait.get(), broken_semaphore);
 }

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -263,19 +263,17 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
-    auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
+    auto sm = semaphore(2);
+    auto units = get_units(sm, 2, 1min).get0();
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 3);
+        BOOST_REQUIRE_EQUAL(units.count(), 2);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
         auto split = units.split(1);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
-        BOOST_REQUIRE_EQUAL(split.count(), 1);
     }
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     units.~semaphore_units();
-    units = get_units(sm, 3, 1min).get0();
+    units = get_units(sm, 2, 1min).get0();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
@@ -432,15 +430,4 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
     sem.signal();
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
     BOOST_REQUIRE_EQUAL(x, 0);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_semaphore_move_with_outstanding_units) {
-    auto sem0 = semaphore(1);
-    auto sem = std::make_unique<semaphore>(std::move(sem0));
-    auto units = std::make_unique<semaphore_units<>>(get_units(*sem, 1).get());
-    BOOST_REQUIRE_EQUAL(sem->current(), 0);
-    auto sem1 = std::move(sem);
-    BOOST_REQUIRE_EQUAL(sem1->current(), 0);
-    units.reset();
-    BOOST_REQUIRE_EQUAL(sem1->current(), 1);
 }

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -434,3 +434,17 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
     BOOST_REQUIRE_EQUAL(x, 0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
+    auto sem0 = semaphore(1);
+    auto sem1 = semaphore(1);
+    auto units = get_units(sem0, 1).get();
+    auto wait = sem0.wait(1);
+    BOOST_REQUIRE(!wait.available());
+    units = get_units(sem1, 1).get();
+    timer t([] { abort(); });
+    t.arm(1s);
+    // will hang if units are not returned when reassigned
+    wait.get();
+    t.cancel();
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -284,21 +284,21 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return) {
     auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
-    BOOST_REQUIRE_EQUAL(units.count(), 3);
+    auto units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
+    BOOST_REQUIRE_EQUAL(units->count(), 3);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
-    BOOST_REQUIRE_EQUAL(units.count(), 2);
+    BOOST_REQUIRE_EQUAL(units->return_units(1), 2);
+    BOOST_REQUIRE_EQUAL(units->count(), 2);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.~semaphore_units();
+    units.reset();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 
-    units = get_units(sm, 2, 1min).get0();
+    units = std::make_unique<semaphore_units<>>(get_units(sm, 2, 1min).get0());
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    BOOST_REQUIRE_THROW(units.return_units(10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(units->return_units(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.return_all();
-    BOOST_REQUIRE_EQUAL(units.count(), 0);
+    units->return_all();
+    BOOST_REQUIRE_EQUAL(units->count(), 0);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 }
 

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -263,19 +263,22 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
-    auto sm = semaphore(2);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto sm = semaphore(3);
+    auto units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
+        BOOST_REQUIRE_EQUAL(units->count(), 3);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-        auto split = units.split(1);
+        auto split = units->split(1);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+        BOOST_REQUIRE_EQUAL(units->count(), 2);
+        BOOST_REQUIRE_EQUAL(split.count(), 1);
     }
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.~semaphore_units();
-    units = get_units(sm, 2, 1min).get0();
+    units.reset();
+    BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
+    units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(units->split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
 }
 


### PR DESCRIPTION
This series first changes semaphore wait_list into a boost::intrusive list of semaphore_waiter rather than using an expired_fifo.  The list is used to keep track of regular waiters as well as get_units waiters.

On top of it, another boost::intrusive list is used to track outstanding units for the purpose of patching their _sem backpointers on semaphore move as well as releasing them when the semaphore is broken (or destroyed or move-reassigned).

Allocated semaphore_unit_handle objects are used for tracking the semaphore_unit objects.
If there are available units, an allocation of this handle is added on the get_units path.
If wait is needed, the units_waiter class is used both for waiting for available units and as a semaphore_units_handle, once the units become available, so no additional allocation is needed in this case.