### PR TITLE
treewide: add non-seastar "#include"s

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -21,13 +21,15 @@
 
 #pragma once
 
+#include <seastar/util/concepts.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
 #include <seastar/util/std-compat.hh>
-
 #include <boost/intrusive/list.hpp>
 
 #include <exception>
+#include <optional>
+#include <utility>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -21,12 +21,13 @@
 
 #pragma once
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
-#include <stdexcept>
 #include <exception>
 #include <memory>
-#include <seastar/core/abort_source.hh>
+#include <optional>
+#include <stdexcept>
 
 namespace seastar {
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -27,11 +27,12 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/util/shared_token_bucket.hh>
-#include <functional>
-#include <queue>
 #include <chrono>
-#include <unordered_set>
+#include <cstdint>
+#include <functional>
 #include <optional>
+#include <queue>
+#include <unordered_set>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -35,6 +35,11 @@
 #include <linux/fs.h>
 #include <sys/uio.h>
 #include <unistd.h>
+#include <chrono>
+#include <concepts>
+#include <cstdint>
+#include <functional>
+#include <optional>
 
 namespace seastar {
 

--- a/include/seastar/core/fstream.hh
+++ b/include/seastar/core/fstream.hh
@@ -34,6 +34,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/internal/api-level.hh>
+#include <cstdint>
 
 namespace seastar {
 

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -21,14 +21,17 @@
 
 #pragma once
 
+#include <assert.h>
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
 #include <seastar/core/task.hh>
 #include <seastar/core/thread_impl.hh>
-#include <stdexcept>
-#include <atomic>
-#include <memory>
-#include <type_traits>
-#include <assert.h>
-#include <cstdlib>
 #include <seastar/core/function_traits.hh>
 #include <seastar/util/critical_alloc_section.hh>
 #include <seastar/util/concepts.hh>

--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -23,7 +23,10 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/util/std-compat.hh>
+#include <cassert>
 #include <exception>
+#include <optional>
+#include <utility>
 
 #ifdef SEASTAR_DEBUG
 #define SEASTAR_GATE_HOLDER_DEBUG

--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -25,6 +25,9 @@
 #include <seastar/core/linux-aio.hh>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <cassert>
+#include <cstdint>
+#include <vector>
 #include <sys/types.h>
 #include <sys/socket.h>
 

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -23,11 +23,13 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
-#include <vector>
-#include <tuple>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/util/bool_class.hh>
 #include <boost/intrusive_ptr.hpp>
+#include <cstdint>
+#include <vector>
+#include <tuple>
+#include <sys/uio.h>
 
 namespace seastar {
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -28,6 +28,10 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/io_request.hh>
 #include <seastar/util/spinlock.hh>
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <sys/uio.h>
 
 struct io_queue_for_tests;
 

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -40,6 +40,11 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/util/std-compat.hh>
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -22,9 +22,11 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <vector>
 

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -24,7 +24,10 @@
 #include <seastar/core/resource.hh>
 #include <seastar/core/bitops.hh>
 #include <new>
+#include <cstdint>
 #include <functional>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace seastar {

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -25,6 +25,7 @@
 #include <limits>
 #include <map>
 #include <type_traits>
+#include <variant>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/metrics_registration.hh>

--- a/include/seastar/core/metrics_types.hh
+++ b/include/seastar/core/metrics_types.hh
@@ -20,6 +20,8 @@
  */
 
 #pragma once
+
+#include <cstdint>
 #include <vector>
 
 namespace seastar {

--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -21,7 +21,10 @@
 
 #pragma once
 
+
 #include <seastar/util/std-compat.hh>
+#include <exception>
+#include <string_view>
 
 namespace seastar {
 

--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -21,29 +21,31 @@
 
 #pragma once
 
-#include <set>
 #include <seastar/core/sstring.hh>
 #include "abort_on_ebadf.hh"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <assert.h>
-#include <utility>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/eventfd.h>
-#include <sys/timerfd.h>
-#include <sys/socket.h>
 #include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <signal.h>
-#include <system_error>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <assert.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
+#include <signal.h>
 #include <spawn.h>
-#include <memory>
+#include <unistd.h>
+#include <utility>
+#include <system_error>
 #include <chrono>
-#include <sys/uio.h>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <set>
 
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/std-compat.hh>

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -24,6 +24,7 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/util/std-compat.hh>
+#include <optional>
 
 namespace seastar {
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -37,6 +37,7 @@
 #include <cstring>
 #include <cassert>
 #include <stdexcept>
+#include <string_view>
 #include <unistd.h>
 #include <vector>
 #include <queue>

--- a/include/seastar/core/rwlock.hh
+++ b/include/seastar/core/rwlock.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/core/semaphore.hh>
+#include <cstddef>
 
 namespace seastar {
 

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <typeindex>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/function_traits.hh>

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/map_reduce.hh>
 #include <array>
+#include <typeindex>
 #include <vector>
 
 #pragma once

--- a/include/seastar/core/scollectd_api.hh
+++ b/include/seastar/core/scollectd_api.hh
@@ -6,6 +6,7 @@
 
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/metrics_api.hh>
+#include <vector>
 
 namespace seastar {
 

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -23,13 +23,16 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
-#include <stdexcept>
-#include <exception>
-#include <optional>
 #include <seastar/core/timer.hh>
 #include <seastar/core/abortable_fifo.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/abort_on_expiry.hh>
+#include <cassert>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <stdexcept>
+#include <utility>
 
 #ifdef SEASTAR_DEBUG
 #define SEASTAR_SEMAPHORE_DEBUG

--- a/include/seastar/core/shared_mutex.hh
+++ b/include/seastar/core/shared_mutex.hh
@@ -23,6 +23,8 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
+#include <cassert>
+#include <utility>
 
 namespace seastar {
 

--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -22,14 +22,14 @@
 #pragma once
 
 #include <seastar/core/shared_ptr_debug_helper.hh>
-#include <utility>
-#include <type_traits>
-#include <functional>
-#include <ostream>
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/util/indirect.hh>
-
 #include <boost/intrusive/parent_from_member.hpp>
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <type_traits>
+#include <utility>
 
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
 // to silence the false alarm from GCC 12, see

--- a/include/seastar/core/simple-stream.hh
+++ b/include/seastar/core/simple-stream.hh
@@ -20,8 +20,13 @@
  */
 
 #pragma once
+
 #include <seastar/core/sstring.hh>
 #include <seastar/util/variant_utils.hh>
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
 
 namespace seastar {
 

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -32,6 +32,7 @@
 #include <boost/thread/barrier.hpp>
 #include <boost/range/irange.hpp>
 #include <deque>
+#include <optional>
 #include <thread>
 
 /// \file

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/util/program-options.hh>
+#include <string>
 
 /// \file
 

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -21,9 +21,10 @@
 
 #pragma once
 
-#include <memory>
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/backtrace.hh>
+#include <memory>
+#include <utility>
 
 namespace seastar {
 

--- a/include/seastar/core/temporary_buffer.hh
+++ b/include/seastar/core/temporary_buffer.hh
@@ -24,9 +24,10 @@
 #include <seastar/core/deleter.hh>
 #include <seastar/util/eclipse.hh>
 #include <seastar/util/std-compat.hh>
-#include <malloc.h>
 #include <algorithm>
 #include <cstddef>
+#include <string_view>
+#include <malloc.h>
 
 namespace seastar {
 

--- a/include/seastar/core/thread_impl.hh
+++ b/include/seastar/core/thread_impl.hh
@@ -22,10 +22,11 @@
 
 #pragma once
 #include <seastar/core/preempt.hh>
+#include <seastar/util/std-compat.hh>
 #include <setjmp.h>
 #include <ucontext.h>
 #include <chrono>
-#include <seastar/util/std-compat.hh>
+#include <memory>
 
 namespace seastar {
 /// Clock used for scheduling threads

--- a/include/seastar/core/timer-set.hh
+++ b/include/seastar/core/timer-set.hh
@@ -13,12 +13,13 @@
 
 #pragma once
 
-#include <chrono>
-#include <limits>
-#include <bitset>
-#include <array>
 #include <boost/intrusive/list.hpp>
 #include <seastar/core/bitset-iter.hh>
+#include <array>
+#include <bitset>
+#include <chrono>
+#include <limits>
+#include <memory>
 
 namespace seastar {
 

--- a/include/seastar/core/timer.hh
+++ b/include/seastar/core/timer.hh
@@ -21,13 +21,14 @@
 
 #pragma once
 
-#include <chrono>
-#include <seastar/util/std-compat.hh>
-#include <atomic>
-#include <functional>
 #include <seastar/core/future.hh>
-#include <seastar/core/timer-set.hh>
 #include <seastar/core/scheduling.hh>
+#include <seastar/core/timer-set.hh>
+#include <seastar/util/std-compat.hh>
+#include <boost/intrusive/list.hpp>
+#include <atomic>
+#include <chrono>
+#include <functional>
 
 /// \file
 

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -22,14 +22,16 @@
 
 #pragma once
 
-#include <tuple>
-#include <utility>
-#include <type_traits>
-
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/util/critical_alloc_section.hh>
+#include <cstddef>
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace seastar {
 

--- a/include/seastar/core/with_scheduling_group.hh
+++ b/include/seastar/core/with_scheduling_group.hh
@@ -24,6 +24,9 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/make_task.hh>
+#include <concepts>
+#include <tuple>
+#include <utility>
 
 namespace seastar {
 

--- a/include/seastar/net/const.hh
+++ b/include/seastar/net/const.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace seastar {
 
 namespace net {

--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -24,12 +24,15 @@
 #include <seastar/core/deleter.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/net/const.hh>
-#include <vector>
-#include <cassert>
-#include <algorithm>
-#include <iosfwd>
 #include <seastar/util/std-compat.hh>
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
 #include <functional>
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <vector>
 
 namespace seastar {
 

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -20,14 +20,15 @@
  */
 #pragma once
 
-#include <iosfwd>
-#include <array>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/ip.h>
 #include <seastar/net/byteorder.hh>
 #include <seastar/net/unix_address.hh>
+#include <array>
 #include <cassert>
+#include <functional>
+#include <iosfwd>
 
 namespace seastar {
 

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -23,6 +23,7 @@
 
 #include <execinfo.h>
 #include <iosfwd>
+#include <memory>
 #include <variant>
 #include <boost/container/static_vector.hpp>
 

--- a/include/seastar/util/is_smart_ptr.hh
+++ b/include/seastar/util/is_smart_ptr.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <memory> // for std::unique_ptr
+#include <type_traits>
 
 namespace seastar {
 

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -24,8 +24,9 @@
 #include <seastar/util/concepts.hh>
 #include <seastar/util/std-compat.hh>
 
-#include <type_traits>
 #include <iostream>
+#include <memory>
+#include <type_traits>
 
 namespace seastar {
 

--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -24,6 +24,8 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/print.hh>
 
+#include <fmt/format.h>
+
 #include <boost/any.hpp>
 #include <boost/intrusive/list.hpp>
 

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 
 namespace seastar {
 namespace internal {

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -23,9 +23,12 @@
 
 #include <seastar/core/file.hh>
 #include <seastar/core/shared_ptr.hh>
-
-#include <deque>
 #include <atomic>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <vector>
+#include <sys/uio.h>
 
 namespace seastar {
 class io_queue;

--- a/src/core/scollectd-impl.hh
+++ b/src/core/scollectd-impl.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/net/api.hh>
+#include <chrono>
 
 namespace seastar {
 

--- a/src/core/sharded.cc
+++ b/src/core/sharded.cc
@@ -21,7 +21,7 @@
 
 #include <seastar/core/sharded.hh>
 #include <seastar/core/loop.hh>
-#include <boost/iterator/counting_iterator.hpp>
+#include <boost/range/irange.hpp>
 
 namespace seastar {
 


### PR DESCRIPTION
this change is the first step of a C++20 modularized Seastar, where all Seastar headers will be exposed via C++20 modules. we will have two modules, namely "seastar" and "seastar.experimental". each module is implemented using multiple partitions units. and the dependencies between paritition units and modules are described using `export` and `import` statements. when it comes to the C++ standard library, Boost library and fmtlib library, before they are modularized, we still need to "#include" them. but the parition units are compiled on translation unit (TU for short) basis. each header file will be a module interface unit in the modularized era. and they are compiled individually. they can still reference other modules / partitions, but unlike the textual including approach implemented using "#include", they can only reference the symbols exposed by other modules / partitions. the intra module linkage still exists, but only the in-module symbols can be referenced. the ones from 3rd party libraries are not reachable anymore, even if the included header "#include"s them.

in this change

* all missing includes are added so each TU can be compiled separately without relying on the symbols which are reachable by the included seastar headers. for instance, `<utility>` is added for `std::move()` and `std::exchange()`, `<cstring>` is added for `memmove()`. `sys/uio.h` is added for `struct iovec`.
* some "#include"s are reordered. so all seastar" headers are grouped together, and the headers from standard library are grouped together. in a follow-up change, we will introduce macros to be used in the modularized build, so we can either translate them to corresponding "import" declarations, or remove them from the preprocessed module unit.
* in `src/core/sharded.cc`, since `iterator/counting_iterator.hpp` is not used, it is replace with `range/irange.hpp`.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>