### PR TITLE
[RFC] semaphore: share state with semaphore_units

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -31,10 +31,6 @@
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/abort_on_expiry.hh>
 
-#ifdef SEASTAR_DEBUG
-#define SEASTAR_SEMAPHORE_DEBUG
-#endif
-
 namespace seastar {
 
 namespace internal {
@@ -129,9 +125,6 @@ struct named_semaphore_exception_factory {
     named_semaphore_aborted aborted() const noexcept;
 };
 
-template<typename ExceptionFactory, typename Clock>
-class semaphore_units;
-
 /// \brief Counted resource guard.
 ///
 /// This is a standard computer science semaphore, adapted
@@ -161,24 +154,6 @@ public:
 private:
     ssize_t _count;
     std::exception_ptr _ex;
-#ifdef SEASTAR_SEMAPHORE_DEBUG
-    size_t _outstanding_units = 0;
-
-    void assert_not_held() const noexcept {
-        assert(!_outstanding_units && "semaphore moved with outstanding units");
-    }
-    void add_outstanding_units(size_t n) {
-        _outstanding_units += n;
-    }
-    void sub_outstanding_units(size_t n) {
-        _outstanding_units -= n;
-    }
-#else   // SEASTAR_SEMAPHORE_DEBUG
-    void assert_not_held() const noexcept {}
-    void add_outstanding_units(size_t) {}
-    void sub_outstanding_units(size_t) {}
-#endif  // SEASTAR_SEMAPHORE_DEBUG
-
     struct entry {
         promise<> pr;
         size_t nr;
@@ -216,8 +191,6 @@ private:
     bool may_proceed(size_t nr) const noexcept {
         return has_available_units(nr) && _wait_list.empty();
     }
-
-    friend class semaphore_units<ExceptionFactory, Clock>;
 public:
     /// Returns the maximum number of units the semaphore counter can hold
     static constexpr size_t max_counter() noexcept {
@@ -241,27 +214,6 @@ public:
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
-
-    basic_semaphore(const basic_semaphore&) = delete;
-    basic_semaphore(basic_semaphore&& o) noexcept
-        : _count(std::exchange(o._count, 0))
-        , _ex(std::move(o._ex))
-        , _wait_list(std::move(o._wait_list))
-    {
-        o.assert_not_held();
-    }
-
-    basic_semaphore& operator=(basic_semaphore&& o) noexcept {
-        if (this != &o) {
-            o.assert_not_held();
-            assert_not_held();
-            _count = std::exchange(o._count, 0);
-            _ex = std::move(o._ex);
-            _wait_list = std::move(o._wait_list);
-        }
-        return *this;
-    }
-
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///
@@ -481,11 +433,9 @@ class semaphore_units {
     basic_semaphore<ExceptionFactory, Clock>* _sem;
     size_t _n;
 
-    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {
-        _sem->add_outstanding_units(n);
-    }
+    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {}
 public:
-    semaphore_units() noexcept : _sem(nullptr), _n(0) {}
+    semaphore_units() noexcept : semaphore_units(nullptr, 0) {}
     semaphore_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t n) noexcept : semaphore_units(&sem, n) {}
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
@@ -510,14 +460,12 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
-        _sem->sub_outstanding_units(units);
         _sem->signal(units);
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.
     void return_all() noexcept {
         if (_n) {
-            _sem->sub_outstanding_units(_n);
             _sem->signal(_n);
             _n = 0;
         }
@@ -526,7 +474,6 @@ public:
     ///
     /// \return the number of units held
     size_t release() noexcept {
-        _sem->sub_outstanding_units(_n);
         return std::exchange(_n, 0);
     }
     /// Splits this instance into a \ref semaphore_units object holding the specified amount of units.
@@ -542,11 +489,6 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
-        // `units` are split into a new `semaphore_units` object.
-        // since none are returned to the semaphore we subtract the
-        // outstanding units here to balance their eventual addition by the
-        // `semaphore_units` ctor.
-        _sem->sub_outstanding_units(units);
         return semaphore_units(_sem, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units
@@ -556,9 +498,7 @@ public:
     /// \return the updated semaphore_units object
     void adopt(semaphore_units&& other) noexcept {
         assert(other._sem == _sem);
-        auto o = other.release();
-        _sem->add_outstanding_units(o);
-        _n += o;
+        _n += other.release();
     }
 
     /// Returns the number of units held

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -214,6 +214,13 @@ public:
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
+    basic_semaphore(basic_semaphore&&) = default;
+    basic_semaphore& operator=(basic_semaphore&&) = default;
+
+    ~basic_semaphore() {
+        broken();
+    }
+
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -440,6 +440,7 @@ public:
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
     semaphore_units& operator=(semaphore_units&& o) noexcept {
+        return_all();
         _sem = o._sem;
         _n = std::exchange(o._n, 0);
         return *this;

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -30,6 +30,7 @@
 #include <seastar/core/abortable_fifo.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/abort_on_expiry.hh>
+#include <seastar/core/shared_ptr.hh>
 
 namespace seastar {
 
@@ -125,6 +126,9 @@ struct named_semaphore_exception_factory {
     named_semaphore_aborted aborted() const noexcept;
 };
 
+template<typename ExceptionFactory, typename Clock>
+class semaphore_units;
+
 /// \brief Counted resource guard.
 ///
 /// This is a standard computer science semaphore, adapted
@@ -151,9 +155,16 @@ public:
     using clock = typename timer<Clock>::clock;
     using time_point = typename timer<Clock>::time_point;
     using exception_factory = ExceptionFactory;
+    using semaphore_units = seastar::semaphore_units<ExceptionFactory, Clock>;
 private:
-    ssize_t _count;
-    std::exception_ptr _ex;
+    struct state : public enable_lw_shared_from_this<state> {
+        basic_semaphore* sem;
+        ssize_t count;
+        std::exception_ptr ex;
+
+        state(basic_semaphore& sem_, ssize_t count_) noexcept : sem(&sem_), count(count_) {}
+    };
+    lw_shared_ptr<state> _state;
     struct entry {
         promise<> pr;
         size_t nr;
@@ -169,8 +180,8 @@ private:
                 } catch (...) {
                     e.pr.set_exception(semaphore_timed_out());
                 }
-            } else if (sem._ex) {
-                e.pr.set_exception(sem._ex);
+            } else if (sem._state->ex) {
+                e.pr.set_exception(sem._state->ex);
             } else {
                 if constexpr (internal::has_aborted<exception_factory>::value) {
                     try {
@@ -186,15 +197,17 @@ private:
     };
     internal::abortable_fifo<entry, expiry_handler> _wait_list;
     bool has_available_units(size_t nr) const noexcept {
-        return _count >= 0 && (static_cast<size_t>(_count) >= nr);
+        return _state->count >= 0 && (static_cast<size_t>(_state->count) >= nr);
     }
     bool may_proceed(size_t nr) const noexcept {
         return has_available_units(nr) && _wait_list.empty();
     }
+
+    friend semaphore_units;
 public:
     /// Returns the maximum number of units the semaphore counter can hold
     static constexpr size_t max_counter() noexcept {
-        return std::numeric_limits<decltype(_count)>::max();
+        return std::numeric_limits<decltype(_state->count)>::max();
     }
 
     /// Constructs a semaphore object with a specific number of units
@@ -204,17 +217,25 @@ public:
     /// \param count number of initial units present in the counter.
     basic_semaphore(size_t count) noexcept(std::is_nothrow_default_constructible_v<exception_factory>)
         : exception_factory()
-        , _count(count),
-        _wait_list(expiry_handler{*this})
+        , _state(make_lw_shared<state>(*this, count))
+        , _wait_list(expiry_handler{*this})
     {}
     basic_semaphore(size_t count, exception_factory&& factory) noexcept(std::is_nothrow_move_constructible_v<exception_factory>)
         : exception_factory(std::move(factory))
-        , _count(count)
+        , _state(make_lw_shared<state>(*this, count))
         , _wait_list(expiry_handler{*this})
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
-    basic_semaphore(basic_semaphore&&) = default;
+    basic_semaphore(basic_semaphore&& o) noexcept
+        : exception_factory(std::move(o))
+        , _state(std::move(o._state))
+        , _wait_list(std::move(o._wait_list))
+    {
+        if (_state->sem) {
+            _state->sem = this;
+        }
+    }
     basic_semaphore& operator=(basic_semaphore&&) = default;
 
     ~basic_semaphore() {
@@ -249,11 +270,11 @@ public:
     ///         \ref broken(), may contain a \ref broken_semaphore exception.
     future<> wait(time_point timeout, size_t nr = 1) noexcept {
         if (may_proceed(nr)) {
-            _count -= nr;
+            _state->count -= nr;
             return make_ready_future<>();
         }
-        if (_ex) {
-            return make_exception_future(_ex);
+        if (_state->ex) {
+            return make_exception_future(_state->ex);
         }
         try {
             entry& e = _wait_list.emplace_back(promise<>(), nr);
@@ -284,11 +305,11 @@ public:
     ///         \ref broken(), may contain a \ref broken_semaphore exception.
     future<> wait(abort_source& as, size_t nr = 1) noexcept {
         if (may_proceed(nr)) {
-            _count -= nr;
+            _state->count -= nr;
             return make_ready_future<>();
         }
-        if (_ex) {
-            return make_exception_future(_ex);
+        if (_state->ex) {
+            return make_exception_future(_state->ex);
         }
         try {
             entry& e = _wait_list.emplace_back(promise<>(), nr);
@@ -327,13 +348,13 @@ public:
     ///
     /// \param nr Number of units to deposit (default 1).
     void signal(size_t nr = 1) noexcept {
-        if (_ex) {
+        if (_state->ex) {
             return;
         }
-        _count += nr;
+        _state->count += nr;
         while (!_wait_list.empty() && has_available_units(_wait_list.front().nr)) {
             auto& x = _wait_list.front();
-            _count -= x.nr;
+            _state->count -= x.nr;
             x.pr.set_value();
             _wait_list.pop_front();
         }
@@ -347,10 +368,10 @@ public:
     ///
     /// \param nr Amount of units to consume (default 1).
     void consume(size_t nr = 1) noexcept {
-        if (_ex) {
+        if (_state->ex) {
             return;
         }
-        _count -= nr;
+        _state->count -= nr;
     }
 
     /// Attempts to reduce the counter value by a specified number of units.
@@ -365,7 +386,7 @@ public:
     /// \return `true` if the counter had sufficient units, and was decremented.
     bool try_wait(size_t nr = 1) noexcept {
         if (may_proceed(nr)) {
-            _count -= nr;
+            _state->count -= nr;
             return true;
         } else {
             return false;
@@ -374,13 +395,13 @@ public:
     /// Returns the number of units available in the counter.
     ///
     /// Does not take into account any waiters.
-    size_t current() const noexcept { return std::max(_count, ssize_t(0)); }
+    size_t current() const noexcept { return std::max(_state->count, ssize_t(0)); }
 
     /// Returns the number of available units.
     ///
     /// Takes into account units consumed using \ref consume() and therefore
     /// may return a negative value.
-    ssize_t available_units() const noexcept { return _count; }
+    ssize_t available_units() const noexcept { return _state->count; }
 
     /// Returns the current number of waiters
     size_t waiters() const noexcept { return _wait_list.size(); }
@@ -426,8 +447,11 @@ inline
 void
 basic_semaphore<ExceptionFactory, Clock>::broken(std::exception_ptr xp) noexcept {
     static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
-    _ex = xp;
-    _count = 0;
+    if (_state) {
+        _state->ex = xp;
+        _state->count = 0;
+        _state->sem = nullptr;
+    }
     while (!_wait_list.empty()) {
         auto& x = _wait_list.front();
         x.pr.set_exception(xp);
@@ -437,24 +461,34 @@ basic_semaphore<ExceptionFactory, Clock>::broken(std::exception_ptr xp) noexcept
 
 template<typename ExceptionFactory = semaphore_default_exception_factory, typename Clock = typename timer<>::clock>
 class semaphore_units {
-    basic_semaphore<ExceptionFactory, Clock>* _sem;
-    size_t _n;
-
-    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {}
 public:
-    semaphore_units() noexcept : semaphore_units(nullptr, 0) {}
-    semaphore_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t n) noexcept : semaphore_units(&sem, n) {}
-    semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
+    using basic_semaphore = seastar::basic_semaphore<ExceptionFactory, Clock>;
+
+private:
+    using state = typename basic_semaphore::state;
+
+    lw_shared_ptr<state> _state;
+    size_t _n = 0;
+
+    semaphore_units(lw_shared_ptr<state> state, size_t n) noexcept : _state(std::move(state)), _n(n) {}
+public:
+    semaphore_units() = default;
+    semaphore_units(basic_semaphore& sem, size_t n) noexcept : semaphore_units(sem._state, n) {}
+    semaphore_units(semaphore_units&& o) noexcept : _state(std::move(o._state)), _n(std::exchange(o._n, 0)) {
     }
     semaphore_units& operator=(semaphore_units&& o) noexcept {
+      if (!broken()) {
         return_all();
-        _sem = o._sem;
+      }
+        _state = std::move(o._state);
         _n = std::exchange(o._n, 0);
         return *this;
     }
     semaphore_units(const semaphore_units&) = delete;
     ~semaphore_units() noexcept {
+      if (!broken()) {
         return_all();
+      }
     }
     /// Return ownership of some units to the semaphore. The semaphore will be signaled by the number of units returned.
     ///
@@ -467,14 +501,20 @@ public:
         if (units > _n) {
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
+        if (broken()) {
+            std::rethrow_exception(get_exception());
+        }
         _n -= units;
-        _sem->signal(units);
+        _state->sem->signal(units);
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.
-    void return_all() noexcept {
+    void return_all() {
+        if (broken()) {
+            std::rethrow_exception(get_exception());
+        }
         if (_n) {
-            _sem->signal(_n);
+            _state->sem->signal(_n);
             _n = 0;
         }
     }
@@ -493,11 +533,14 @@ public:
     ///
     /// \return semaphore_units holding the specified number of units
     semaphore_units split(size_t units) {
+        if (broken()) {
+            std::rethrow_exception(get_exception());
+        }
         if (units > _n) {
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
-        return semaphore_units(_sem, units);
+        return semaphore_units(_state, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units
     /// object are merged into the current one. The function assumes (and asserts) that both
@@ -505,7 +548,7 @@ public:
     ///
     /// \return the updated semaphore_units object
     void adopt(semaphore_units&& other) noexcept {
-        assert(other._sem == _sem);
+        assert(other._state == _state);
         _n += other.release();
     }
 
@@ -517,6 +560,14 @@ public:
     /// Returns true iff there any units held
     explicit operator bool() const noexcept {
         return _n != 0;
+    }
+
+    bool broken() const noexcept {
+        return !_state || !_state->sem;
+    }
+
+    std::exception_ptr get_exception() const noexcept {
+        return _state ? _state->ex : std::make_exception_ptr(std::runtime_error("Uninitialized semaphore_units"));
     }
 };
 

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -21,15 +21,15 @@
 
 #pragma once
 
+#include <boost/intrusive/list.hpp>
+
 #include <seastar/core/future.hh>
-#include <seastar/core/chunked_fifo.hh>
 #include <stdexcept>
 #include <exception>
 #include <optional>
 #include <seastar/core/timer.hh>
-#include <seastar/core/abortable_fifo.hh>
 #include <seastar/core/timed_out_error.hh>
-#include <seastar/core/abort_on_expiry.hh>
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace seastar {
@@ -151,9 +151,10 @@ class semaphore_units;
 template<typename ExceptionFactory, typename Clock = typename timer<>::clock>
 class basic_semaphore : private ExceptionFactory {
 public:
-    using duration = typename timer<Clock>::duration;
-    using clock = typename timer<Clock>::clock;
-    using time_point = typename timer<Clock>::time_point;
+    using timer = typename seastar::timer<Clock>;
+    using duration = typename timer::duration;
+    using clock = typename timer::clock;
+    using time_point = typename timer::time_point;
     using exception_factory = ExceptionFactory;
     using semaphore_units = seastar::semaphore_units<ExceptionFactory, Clock>;
 private:
@@ -165,37 +166,94 @@ private:
         state(basic_semaphore& sem_, ssize_t count_) noexcept : sem(&sem_), count(count_) {}
     };
     lw_shared_ptr<state> _state;
-    struct entry {
-        promise<> pr;
+
+    class basic_waiter : public boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
+    public:
+        basic_semaphore* sem;
         size_t nr;
-        std::optional<abort_on_expiry<clock>> timer;
-        entry(promise<>&& pr_, size_t nr_) noexcept : pr(std::move(pr_)), nr(nr_) {}
-    };
-    struct expiry_handler {
-        basic_semaphore& sem;
-        void operator()(entry& e) noexcept {
-            if (e.timer) {
-                try {
-                    e.pr.set_exception(sem.timeout());
-                } catch (...) {
-                    e.pr.set_exception(semaphore_timed_out());
-                }
-            } else if (sem._state->ex) {
-                e.pr.set_exception(sem._state->ex);
-            } else {
-                if constexpr (internal::has_aborted<exception_factory>::value) {
-                    try {
-                        e.pr.set_exception(static_cast<exception_factory>(sem).aborted());
-                    } catch (...) {
-                        e.pr.set_exception(semaphore_aborted());
-                    }
-                } else {
-                    e.pr.set_exception(semaphore_aborted());
-                }
-            }
+
+    private:
+        std::variant<optimized_optional<abort_source::subscription>, timer> _aborter;
+
+    public:
+        basic_waiter() noexcept : sem(nullptr), nr(0) {}
+        basic_waiter(basic_semaphore& sem_, size_t nr_) noexcept
+            : sem(&sem_), nr(nr_)
+        {
+            sem->add_waiter(*this);
         }
+        basic_waiter(basic_semaphore& sem_, size_t nr_, time_point timeout) noexcept
+            : sem(&sem_), nr(nr_)
+        {
+            set_timeout(timeout);
+            sem->add_waiter(*this);
+        }
+        basic_waiter(basic_semaphore& sem_, size_t nr_, abort_source& as) noexcept
+            : sem(&sem_), nr(nr_)
+        {
+            subscribe(as);
+            sem->add_waiter(*this);
+        }
+        virtual ~basic_waiter() = default;
+
+        void init(basic_semaphore& sem_, size_t nr_) noexcept {
+            sem = &sem_;
+            nr = nr_;
+            sem->add_waiter(*this);
+        }
+
+        void subscribe(abort_source& as) noexcept {
+            _aborter.template emplace<optimized_optional<abort_source::subscription>>(as.subscribe([this] (const std::optional<std::exception_ptr>& opt_ex) noexcept {
+                std::exception_ptr ex;
+                try {
+                    if (opt_ex) {
+                        ex = *opt_ex;
+                    } else if (sem) {
+                        if (sem->_state->ex) {
+                            ex = sem->_state->ex;
+                        } else if constexpr (internal::has_aborted<ExceptionFactory>::value) {
+                            ex = std::make_exception_ptr(sem->aborted());
+                        }
+                    }
+                } catch (...) {
+                }
+                abort(ex ? std::move(ex) : std::make_exception_ptr(semaphore_aborted()));
+            }));
+            assert(std::get<optimized_optional<abort_source::subscription>>(_aborter));
+        }
+
+        void set_timeout(time_point timeout) noexcept {
+            if (timeout == time_point::max()) {
+                return;
+            }
+            _aborter.template emplace<timer>([this] () {
+                std::exception_ptr ex;
+                try {
+                    if (sem) {
+                        ex = std::make_exception_ptr(sem->timeout());
+                    }
+                } catch (...) {
+                }
+                abort(ex ? std::move(ex) : std::make_exception_ptr(semaphore_timed_out()));
+            });
+            auto& tmr = std::get<timer>(_aborter);
+            tmr.arm(timeout);
+        }
+
+        void abort(std::exception_ptr ex) noexcept {
+            set_exception(std::move(ex));
+        }
+
+        virtual void set_value() noexcept = 0;
+        virtual void set_exception(std::exception_ptr) noexcept = 0;
     };
-    internal::abortable_fifo<entry, expiry_handler> _wait_list;
+
+    boost::intrusive::list<basic_waiter, boost::intrusive::constant_time_size<false>> _wait_list;
+
+    void add_waiter(basic_waiter& w) {
+        _wait_list.push_back(w);
+    }
+
     bool has_available_units(size_t nr) const noexcept {
         return _state->count >= 0 && (static_cast<size_t>(_state->count) >= nr);
     }
@@ -218,30 +276,75 @@ public:
     basic_semaphore(size_t count) noexcept(std::is_nothrow_default_constructible_v<exception_factory>)
         : exception_factory()
         , _state(make_lw_shared<state>(*this, count))
-        , _wait_list(expiry_handler{*this})
     {}
     basic_semaphore(size_t count, exception_factory&& factory) noexcept(std::is_nothrow_move_constructible_v<exception_factory>)
         : exception_factory(std::move(factory))
         , _state(make_lw_shared<state>(*this, count))
-        , _wait_list(expiry_handler{*this})
-    {
-        static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
-    }
+    {}
     basic_semaphore(basic_semaphore&& o) noexcept
         : exception_factory(std::move(o))
         , _state(std::move(o._state))
         , _wait_list(std::move(o._wait_list))
+        , _waiters_freelist(std::move(o._waiters_freelist))
     {
         if (_state->sem) {
             _state->sem = this;
         }
     }
-    basic_semaphore& operator=(basic_semaphore&&) = default;
+    basic_semaphore& operator=(basic_semaphore&& o) noexcept {
+        if (this != &o) {
+            broken();
+            exception_factory::operator=(std::move(o));
+            _state = std::move(o._state);
+            if (_state->sem) {
+                _state->sem = this;
+            }
+            _wait_list = std::move(o._wait_list);
+            _waiters_freelist.splice(_waiters_freelist.end(), o._waiters_freelist);
+        }
+        return *this;
+    }
 
     ~basic_semaphore() {
         broken();
     }
 
+private:
+    struct waiter : public basic_waiter {
+        using basic_waiter::basic_waiter;
+
+        promise<> pr;
+
+        future<> get_future() noexcept { return pr.get_future(); }
+        virtual void set_value() noexcept override {
+            pr.set_value();
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+        virtual void set_exception(std::exception_ptr ex) noexcept override {
+            pr.set_exception(std::move(ex));
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+    };
+
+    boost::intrusive::list<waiter, boost::intrusive::constant_time_size<false>> _waiters_freelist;
+
+    waiter* new_waiter(basic_semaphore& sem, size_t nr) {
+        if (_waiters_freelist.empty()) {
+            return new waiter(sem, nr);
+        }
+        auto& w = _waiters_freelist.front();
+        _waiters_freelist.pop_front();
+        w.init(sem, nr);
+        return &w;
+    }
+
+public:
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///
@@ -253,7 +356,19 @@ public:
     ///         to satisfy the request.  If the semaphore was \ref broken(), may
     ///         contain an exception.
     future<> wait(size_t nr = 1) noexcept {
-        return wait(time_point::max(), nr);
+        if (may_proceed(nr)) {
+            _state->count -= nr;
+            return make_ready_future<>();
+        }
+        if (_state->ex) {
+            return make_exception_future(_state->ex);
+        }
+        try {
+            auto* w = new_waiter(*this, nr);
+            return w->get_future();
+        } catch (...) {
+            return current_exception_as_future();
+        }
     }
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.  If the request
@@ -276,17 +391,20 @@ public:
         if (_state->ex) {
             return make_exception_future(_state->ex);
         }
-        try {
-            entry& e = _wait_list.emplace_back(promise<>(), nr);
-            auto f = e.pr.get_future();
-            if (timeout != time_point::max()) {
-                e.timer.emplace(timeout);
-                abort_source& as = e.timer->abort_source();
-                _wait_list.make_back_abortable(as);
+        if (Clock::now() >= timeout) {
+            try {
+                return make_exception_future(this->timeout());
+            } catch (...) {
+                return make_exception_future(semaphore_timed_out());
             }
+        }
+        try {
+            auto* w = new_waiter(*this, nr);
+            w->set_timeout(timeout);
+            auto f = w->get_future();
             return f;
         } catch (...) {
-            return make_exception_future(std::current_exception());
+            return current_exception_as_future();
         }
     }
 
@@ -311,14 +429,24 @@ public:
         if (_state->ex) {
             return make_exception_future(_state->ex);
         }
+        if (as.abort_requested()) {
+            if constexpr (internal::has_aborted<ExceptionFactory>::value) {
+                try {
+                    return make_exception_future(this->aborted());
+                } catch (...) {
+                    return make_exception_future(semaphore_aborted());
+                }
+            } else {
+                return make_exception_future(semaphore_aborted());
+            }
+        }
         try {
-            entry& e = _wait_list.emplace_back(promise<>(), nr);
-            // taking future here since make_back_abortable may expire the entry
-            auto f = e.pr.get_future();
-            _wait_list.make_back_abortable(as);
+            auto* w = new_waiter(*this, nr);
+            w->subscribe(as);
+            auto f = w->get_future();
             return f;
         } catch (...) {
-            return make_exception_future(std::current_exception());
+            return current_exception_as_future();
         }
     }
 
@@ -355,8 +483,9 @@ public:
         while (!_wait_list.empty() && has_available_units(_wait_list.front().nr)) {
             auto& x = _wait_list.front();
             _state->count -= x.nr;
-            x.pr.set_value();
-            _wait_list.pop_front();
+            // set_value sets the promise value
+            // and deletes the object
+            x.set_value();
         }
     }
 
@@ -438,7 +567,10 @@ public:
 
     /// Reserve memory for waiters so that wait() will not throw.
     void ensure_space_for_waiters(size_t n) {
-        _wait_list.reserve(n);
+        while (n--) {
+            auto* w = new waiter();
+            _waiters_freelist.push_back(*w);
+        }
     }
 };
 
@@ -454,8 +586,14 @@ basic_semaphore<ExceptionFactory, Clock>::broken(std::exception_ptr xp) noexcept
     }
     while (!_wait_list.empty()) {
         auto& x = _wait_list.front();
-        x.pr.set_exception(xp);
-        _wait_list.pop_front();
+        // set_exception passes the exception to the promise->future
+        // and deletes the object
+        x.set_exception(xp);
+    }
+    while (!_waiters_freelist.empty()) {
+        auto* p = &_waiters_freelist.front();
+        _waiters_freelist.pop_front();
+        delete p;
     }
 }
 

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -466,6 +466,152 @@ public:
     future<> wait(duration timeout, size_t nr = 1) noexcept {
         return wait(clock::now() + timeout, nr);
     }
+
+private:
+    struct units_waiter : public basic_waiter {
+        using basic_waiter::basic_waiter;
+
+        promise<semaphore_units> pr;
+
+        future<semaphore_units> get_future() noexcept { return pr.get_future(); }
+        virtual void set_value() noexcept override {
+            pr.set_value(semaphore_units(*this->sem, this->nr));
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+        virtual void set_exception(std::exception_ptr ex) noexcept override {
+            pr.set_exception(std::move(ex));
+            // note: we self-delete in either case we are woken
+            // up. See usage below: only the resulting future
+            // state is required once we've left the _wait_list
+            delete this;
+        }
+    };
+
+public:
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  If the semaphore was \ref broken(), may
+    ///         contain an exception.
+    future<semaphore_units> get_units(size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _state->count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_state->ex) {
+            return make_exception_future<semaphore_units>(_state->ex);
+        }
+        try {
+            auto w = new units_waiter(*this, nr);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  If the request
+    /// cannot be satisfied in time, the request is aborted.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param timeout expiration time.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On timeout, the future contains a
+    ///         \ref semaphore_timed_out exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(time_point timeout, size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _state->count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_state->ex) {
+            return make_exception_future<semaphore_units>(_state->ex);
+        }
+        if (Clock::now() >= timeout) {
+            try {
+                return make_exception_future<semaphore_units>(this->timeout());
+            } catch (...) {
+                return make_exception_future<semaphore_units>(semaphore_timed_out());
+            }
+        }
+        try {
+            auto w = new units_waiter(*this, nr, timeout);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  If the request
+    /// cannot be satisfied in time, the request is aborted.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param timeout how long to wait.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On timeout, the future contains a
+    ///         \ref semaphore_timed_out exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(duration timeout, size_t nr = 1) noexcept {
+        return get_units(clock::now() + timeout, nr);
+    }
+
+    /// Waits until at least a specific number of units are available in the
+    /// counter, and reduces the counter by that amount of units.  The request
+    /// can be aborted using an \ref abort_source.
+    ///
+    /// \note Waits are serviced in FIFO order, though if several are awakened
+    ///       at once, they may be reordered by the scheduler.
+    ///
+    /// \param as abort source.
+    /// \param nr Amount of units to wait for (default 1).
+    /// \return a future holding \ref semaphore_units that becomes ready when sufficient units are available
+    ///         to satisfy the request.  On abort, the future contains a
+    ///         \ref semaphore_aborted exception.  If the semaphore was
+    ///         \ref broken(), may contain a \ref broken_semaphore exception.
+    future<semaphore_units> get_units(abort_source& as, size_t nr = 1) noexcept {
+        if (may_proceed(nr)) {
+            _state->count -= nr;
+            return make_ready_future<semaphore_units>(*this, nr);
+        }
+        if (_state->ex) {
+            return make_exception_future<semaphore_units>(_state->ex);
+        }
+        if (as.abort_requested()) {
+            if constexpr (internal::has_aborted<ExceptionFactory>::value) {
+                try {
+                    return make_exception_future<semaphore_units>(this->aborted());
+                } catch (...) {
+                    return make_exception_future<semaphore_units>(semaphore_aborted());
+                }
+            } else {
+                return make_exception_future<semaphore_units>(semaphore_aborted());
+            }
+        }
+        try {
+            auto w = new units_waiter(*this, nr, as);
+            auto f = w->get_future();
+            return f;
+        } catch (...) {
+            return current_exception_as_future<semaphore_units>();
+        }
+    }
+
     /// Deposits a specified number of units into the counter.
     ///
     /// The counter is incremented by the specified number of units.
@@ -729,9 +875,7 @@ public:
 template<typename ExceptionFactory, typename Clock = typename timer<>::clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units) noexcept {
-    return sem.wait(units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(units);
 }
 
 /// \brief Take units from semaphore temporarily with time bound on wait
@@ -752,9 +896,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units) noexcept 
 template<typename ExceptionFactory, typename Clock = typename timer<>::clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::time_point timeout) noexcept {
-    return sem.wait(timeout, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(timeout, units);
 }
 
 /// \brief Take units from semaphore temporarily with time bound on wait
@@ -776,9 +918,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename 
 template<typename ExceptionFactory, typename Clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::duration timeout) noexcept {
-    return sem.wait(timeout, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(timeout, units);
 }
 
 /// \brief Take units from semaphore temporarily with an \ref abort_source
@@ -800,9 +940,7 @@ get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename 
 template<typename ExceptionFactory, typename Clock>
 future<semaphore_units<ExceptionFactory, Clock>>
 get_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, abort_source& as) noexcept {
-    return sem.wait(as, units).then([&sem, units] {
-        return semaphore_units<ExceptionFactory, Clock>{ sem, units };
-    });
+    return sem.get_units(as, units);
 }
 
 /// \brief Try to take units from semaphore temporarily

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -1013,8 +1013,10 @@ template <typename ExceptionFactory, typename Func, typename Clock = typename ti
 inline
 futurize_t<std::invoke_result_t<Func>>
 with_semaphore(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, Func&& func) noexcept {
-    return get_units(sem, units).then([func = std::forward<Func>(func)] (auto units) mutable {
-        return futurize_invoke(std::forward<Func>(func)).finally([units = std::move(units)] {});
+    return sem.wait(units).then([&sem, units, func = std::forward<Func>(func)] () mutable {
+        return futurize_invoke(std::forward<Func>(func)).finally([&sem, units] {
+            sem.signal(units);
+        });
     });
 }
 
@@ -1047,8 +1049,10 @@ template <typename ExceptionFactory, typename Clock, typename Func>
 inline
 futurize_t<std::invoke_result_t<Func>>
 with_semaphore(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, typename basic_semaphore<ExceptionFactory, Clock>::duration timeout, Func&& func) noexcept {
-    return get_units(sem, units, timeout).then([func = std::forward<Func>(func)] (auto units) mutable {
-        return futurize_invoke(std::forward<Func>(func)).finally([units = std::move(units)] {});
+    return sem.wait(units, timeout).then([&sem, units, func = std::forward<Func>(func)] () mutable {
+        return futurize_invoke(std::forward<Func>(func)).finally([&sem, units] {
+            sem.signal(units);
+        });
     });
 }
 

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <boost/lockfree/spsc_queue.hpp>
 #include <boost/thread/barrier.hpp>
 #include <boost/range/irange.hpp>

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -42,7 +42,7 @@ struct smp_service_group_impl {
 #endif
 };
 
-static smp_service_group_semaphore smp_service_group_management_sem{1, named_semaphore_exception_factory{"smp_service_group_management_sem"}};
+static thread_local smp_service_group_semaphore smp_service_group_management_sem{1, named_semaphore_exception_factory{"smp_service_group_management_sem"}};
 static thread_local std::vector<smp_service_group_impl> smp_service_groups;
 
 static named_semaphore_exception_factory make_service_group_semaphore_exception_factory(unsigned id, shard_id client_cpu, shard_id this_cpu, std::optional<sstring> smp_group_name) {

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -72,7 +72,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_2) {
     sleep(10ms).get();
     BOOST_REQUIRE_EQUAL(x, 0);
     sem = std::nullopt;
-    BOOST_CHECK_THROW(fut.get(), broken_promise);
+    BOOST_CHECK_THROW(fut.get(), broken_semaphore);
 }
 
 SEASTAR_TEST_CASE(test_semaphore_timeout_1) {
@@ -447,4 +447,21 @@ SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
     // will hang if units are not returned when reassigned
     wait.get();
     t.cancel();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_destroy_semaphore_during_wait) {
+    auto sem = std::make_unique<semaphore>(0);
+    auto wait = sem->wait(1);
+    BOOST_REQUIRE(!wait.available());
+    sem.reset();
+    BOOST_REQUIRE_THROW(wait.get(), broken_semaphore);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_destroy_semaphore_during_wait_with_ensured_space) {
+    auto sem = std::make_unique<semaphore>(0);
+    sem->ensure_space_for_waiters(2);
+    auto wait = sem->wait(1);
+    BOOST_REQUIRE(!wait.available());
+    sem.reset();
+    BOOST_REQUIRE_THROW(wait.get(), broken_semaphore);
 }

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -263,19 +263,17 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
-    auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
+    auto sm = semaphore(2);
+    auto units = get_units(sm, 2, 1min).get0();
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 3);
+        BOOST_REQUIRE_EQUAL(units.count(), 2);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
         auto split = units.split(1);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
-        BOOST_REQUIRE_EQUAL(split.count(), 1);
     }
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     units.~semaphore_units();
-    units = get_units(sm, 3, 1min).get0();
+    units = get_units(sm, 2, 1min).get0();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
@@ -432,15 +430,4 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
     sem.signal();
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
     BOOST_REQUIRE_EQUAL(x, 0);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_semaphore_move_with_outstanding_units) {
-    auto sem0 = semaphore(1);
-    auto sem = std::make_unique<semaphore>(std::move(sem0));
-    auto units = std::make_unique<semaphore_units<>>(get_units(*sem, 1).get());
-    BOOST_REQUIRE_EQUAL(sem->current(), 0);
-    auto sem1 = std::move(sem);
-    BOOST_REQUIRE_EQUAL(sem1->current(), 0);
-    units.reset();
-    BOOST_REQUIRE_EQUAL(sem1->current(), 1);
 }

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -434,3 +434,17 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
     BOOST_REQUIRE_EQUAL(x, 0);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {
+    auto sem0 = semaphore(1);
+    auto sem1 = semaphore(1);
+    auto units = get_units(sem0, 1).get();
+    auto wait = sem0.wait(1);
+    BOOST_REQUIRE(!wait.available());
+    units = get_units(sem1, 1).get();
+    timer t([] { abort(); });
+    t.arm(1s);
+    // will hang if units are not returned when reassigned
+    wait.get();
+    t.cancel();
+}

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -284,21 +284,21 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return) {
     auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
-    BOOST_REQUIRE_EQUAL(units.count(), 3);
+    auto units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
+    BOOST_REQUIRE_EQUAL(units->count(), 3);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
-    BOOST_REQUIRE_EQUAL(units.count(), 2);
+    BOOST_REQUIRE_EQUAL(units->return_units(1), 2);
+    BOOST_REQUIRE_EQUAL(units->count(), 2);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.~semaphore_units();
+    units.reset();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 
-    units = get_units(sm, 2, 1min).get0();
+    units = std::make_unique<semaphore_units<>>(get_units(sm, 2, 1min).get0());
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    BOOST_REQUIRE_THROW(units.return_units(10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(units->return_units(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.return_all();
-    BOOST_REQUIRE_EQUAL(units.count(), 0);
+    units->return_all();
+    BOOST_REQUIRE_EQUAL(units->count(), 0);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 }
 

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -263,19 +263,22 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
-    auto sm = semaphore(2);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto sm = semaphore(3);
+    auto units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
+        BOOST_REQUIRE_EQUAL(units->count(), 3);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-        auto split = units.split(1);
+        auto split = units->split(1);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+        BOOST_REQUIRE_EQUAL(units->count(), 2);
+        BOOST_REQUIRE_EQUAL(split.count(), 1);
     }
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
-    units.~semaphore_units();
-    units = get_units(sm, 2, 1min).get0();
+    units.reset();
+    BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
+    units = std::make_unique<semaphore_units<>>(get_units(sm, 3, 1min).get0());
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(units->split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
 }
 

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -249,16 +249,18 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
     return do_with(semaphore(1), 0, [] (semaphore& sem, int& counter) {
         return with_semaphore(sem, 1, [&counter] {
             ++counter;
-        }).then([&counter, &sem] () {
+            BOOST_REQUIRE_EQUAL(counter, 1);
+        })/*.then([&counter, &sem] () {
             return with_semaphore(sem, 1, [&counter] {
                 ++counter;
+                BOOST_REQUIRE_EQUAL(counter, 2);
                 throw 123;
             }).then_wrapped([&counter] (auto&& fut) {
                 BOOST_REQUIRE_EQUAL(counter, 2);
                 BOOST_REQUIRE(fut.failed());
                 fut.ignore_ready_future();
             });
-        });
+        })*/;
     });
 }
 

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -467,3 +467,25 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_semaphore_during_wait_with_ensured_space) 
     sem.reset();
     BOOST_REQUIRE_THROW(wait.get(), broken_semaphore);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_move_semaphore_during_wait) {
+    auto sem0 = semaphore(0);
+    auto wait = sem0.wait(1);
+    BOOST_REQUIRE(!wait.available());
+    auto sem1 = std::move(sem0);
+    sem1.signal(1);
+    BOOST_REQUIRE_NO_THROW(wait.get());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_move_reassign_semaphore_during_wait) {
+    auto sem0 = semaphore(0);
+    auto wait0 = sem0.wait(1);
+    BOOST_REQUIRE(!wait0.available());
+    auto sem1 = semaphore(0);
+    auto wait1 = sem1.wait(1);
+    BOOST_REQUIRE(!wait1.available());
+    sem0 = std::move(sem1);
+    BOOST_REQUIRE_THROW(wait0.get(), broken_semaphore);
+    sem0.signal(1);
+    BOOST_REQUIRE_NO_THROW(wait1.get());
+}


### PR DESCRIPTION
This series is aimed at fixing #1323 by creating a lw_shared state object in semaphore
and sharing it with semaphore_units so when the semaphore is broken or destroyed the
semaphore_units can detect that and avoid dereferencing the semaphore pointer to e.g. return the units.
Also, the shared state allows safely moving the semaphore while it has outstanding units by adjusting the
semaphore pointer in the shared state.

On top of that, the waiters list is converted to a boost::intrusive list using a pure abstract `basic_waiter` class that is used for regular waiters for the `wait()` entry points as well as unit_waiters used from newly added `get_units()` entry points that allow creating semaphore_units atomically, when units become available - this prevents use-after-free is a semaphore is destroyed concurrently with a call to `get_units()`.  This also allows now to move / move-reassign a semaphore with waiters.

Fixes #1323