### PR TITLE
memcached: prolong expiration time to be more tolerant

### DIFF
--- a/apps/memcached/tests/test_memcached.py
+++ b/apps/memcached/tests/test_memcached.py
@@ -257,10 +257,10 @@ class TestCommands(MemcacheTest):
 
     @slow
     def test_expiry_at_epoch_time(self):
-        expiry = int(time.time()) + 1
+        expiry = int(time.time()) + 2
         self.assertEqual(call('set key 0 %d 5\r\nhello\r\n' % expiry), b'STORED\r\n')
         self.assertEqual(call('get key\r\n'), b'VALUE key 0 5\r\nhello\r\nEND\r\n')
-        time.sleep(2)
+        time.sleep(3)
         self.assertEqual(call('get key\r\n'), b'END\r\n')
 
     def test_multiple_keys_in_get(self):


### PR DESCRIPTION
we have random test failures when testing `test_expiry_at_epoch_time`, where the client

1. sets an item with expiration time specified using epoch time of "now() + 1", and
2. lists to see if the item still exists

but we found that sometimes, the item is gone when we list the cache, there are chances that

* wall clock can be updated after the "set" command is sent, and the memcached "leaps" 1 second ahead, so it erases the item right away before the client lists it.
* the client takes more than 1 second to get served by the memcached, this is unlikely, though.

so, in this change, the expiry time is postponed to current + 2 second, in hope to be more tolerant, and hence to alleviate the issue caused by wall clock update and clock drift.

Fixes #1476
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>