### PR TITLE
reactor, tests: drop unused include

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -63,7 +63,6 @@
 #include <seastar/core/smp_options.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/read_first_line.hh>
-#include "core/file-impl.hh"
 #include "core/reactor_backend.hh"
 #include "core/syscall_result.hh"
 #include "core/thread_pool.hh"

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -43,8 +43,6 @@
 #include <sys/statfs.h>
 #include <fcntl.h>
 
-#include "core/file-impl.hh"
-
 using namespace seastar;
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
`core/file-impl.hh` is not used by `core/reactor.cc` or `unit/file_io_test.cc`, so do not include it in these two source files.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>