### PR TITLE
build: do not always build seastar as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,11 +311,25 @@ set (Seastar_TEST_TIMEOUT
   STRING
   "Maximum allowed time for a test to run, in seconds.")
 
+option (BUILD_SHARED_LIBS
+  "Build seastar library as shared libraries instead of static"
+  OFF)
 # We set the following environment variables
-# * ASAN_OPTIONS=disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1
+# * ASAN_OPTIONS=disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1:verify_asan_link_order=0
 #   By default asan disables core dumps because they used to be
 #   huge. This is no longer the case since the shadow memory is
 #   excluded, so it is safe to enable them.
+#   Also, by default, to make sure it works as expected, asan
+#   verifies if the asan dynamic runtime is the first DSO in the
+#   initial library list by calling dl_iterate_phdr(3). But
+#   Seastar provides this symbol, and its implementation references
+#   some static variables. So if Seastar is built as a shared
+#   library, this causes a chicken and egg problem. On one hard,
+#   ASan tries to reference a symbol which is in turn provided by
+#   yet another shared library which is not necessariy ready its
+#   static variables yet. And this leads leads to a segfault. So,
+#   we have to disable this check when "BUILD_SHARED_LIBS" is
+#   enabled.
 # * UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1
 #   Fail the test if any undefined behavior is found and use abort
 #   instead of exit. Using abort is what causes core dumps to be
@@ -323,17 +337,20 @@ set (Seastar_TEST_TIMEOUT
 # * BOOST_TEST_CATCH_SYSTEM_ERRORS=no
 #   Normally the boost test library handles SIGABRT and prevents core
 #   dumps from being produced.
-
 # This works great with clang and gcc 10.2, but unfortunately not any
 # previous gcc.
-set (Seastar_USE_AFTER_RETURN "")
+set (Seastar_ASAN_OPTIONS "disable_coredump=0:abort_on_error=1")
 if ((NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")) OR
     (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.2))
-  set (Seastar_USE_AFTER_RETURN ":detect_stack_use_after_return=1")
+  string (APPEND Seastar_ASAN_OPTIONS ":detect_stack_use_after_return=1")
+endif ()
+if (BUILD_SHARED_LIBS)
+  string (APPEND Seastar_ASAN_OPTIONS ":verify_asan_link_order=0")
 endif ()
 
+
 set (Seastar_TEST_ENVIRONMENT
-  "ASAN_OPTIONS=disable_coredump=0:abort_on_error=1${Seastar_USE_AFTER_RETURN};UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1;BOOST_TEST_CATCH_SYSTEM_ERRORS=no"
+  "ASAN_OPTIONS=${Seastar_ASAN_OPTIONS};UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1;BOOST_TEST_CATCH_SYSTEM_ERRORS=no"
   CACHE
   STRING
   "Environment variables for running tests")
@@ -453,7 +470,7 @@ if (Seastar_DPDK)
   set (seastar_dpdk_obj seastar-dpdk.o)
 endif ()
 
-add_library (seastar STATIC
+add_library (seastar
   ${http_chunk_parsers_file}
   ${http_request_parser_file}
   ${seastar_dpdk_obj}
@@ -741,12 +758,14 @@ target_include_directories (seastar
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set (Seastar_PRIVATE_CXX_FLAGS
-  -fvisibility=hidden
   -UNDEBUG
   -Wall
   -Werror
   -Wno-array-bounds # Disabled because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93437
   -Wno-error=deprecated-declarations)
+if (NOT BUILD_SHARED_LIBS)
+  list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)
+endif ()
 
 if (Seastar_COMPRESS_DEBUG)
   # -gz doesn't imply -g, so it is safe to add it regardless of debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,7 +1071,6 @@ if (Seastar_INSTALL OR Seastar_TESTING)
   add_library (Seastar::seastar_testing ALIAS seastar_testing)
 
   target_compile_definitions (seastar_testing
-    PUBLIC BOOST_TEST_DYN_LINK
     PRIVATE ${Seastar_PRIVATE_COMPILE_DEFINITIONS})
 
   target_compile_options (seastar_testing
@@ -1080,6 +1079,7 @@ if (Seastar_INSTALL OR Seastar_TESTING)
   target_link_libraries (seastar_testing
     PUBLIC
       Boost::unit_test_framework
+      Boost::dynamic_linking
       seastar)
 
   add_library(seastar_perf_testing

--- a/configure.py
+++ b/configure.py
@@ -191,6 +191,7 @@ def configure_mode(mode):
         '-DCMAKE_CXX_STANDARD={}'.format(args.cpp_standard),
         '-DCMAKE_INSTALL_PREFIX={}'.format(args.install_prefix),
         '-DCMAKE_EXPORT_COMPILE_COMMANDS={}'.format('yes' if args.cc_json else 'no'),
+        '-DBUILD_SHARED_LIBS={}'.format('yes' if mode in ('debug', 'dev') else 'no'),
         '-DSeastar_API_LEVEL={}'.format(args.api_level),
         '-DSeastar_SCHEDULING_GROUPS_COUNT={}'.format(args.scheduling_groups_count),
         tr(args.exclude_tests, 'EXCLUDE_TESTS_FROM_ALL'),

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -103,6 +103,7 @@ function (seastar_add_test name)
     elseif (parsed_args_KIND STREQUAL "BOOST")
       list (APPEND libraries
         Boost::unit_test_framework
+        Boost::dynamic_linking
         seastar_private)
 
       if (NOT (Seastar_JENKINS STREQUAL ""))
@@ -250,15 +251,18 @@ seastar_add_test (checked_ptr
   SOURCES checked_ptr_test.cc)
 
 seastar_add_test (chunked_fifo
+  KIND BOOST
   SOURCES chunked_fifo_test.cc)
 
 seastar_add_test (chunk_parsers
   SOURCES chunk_parsers_test.cc)
 
 seastar_add_test (circular_buffer
+  KIND BOOST
   SOURCES circular_buffer_test.cc)
 
 seastar_add_test (circular_buffer_fixed_capacity
+  KIND BOOST
   SOURCES circular_buffer_fixed_capacity_test.cc)
 
 seastar_add_test (condition_variable
@@ -274,9 +278,11 @@ seastar_add_test (coroutines
   SOURCES coroutines_test.cc)
 
 seastar_add_test (defer
+  KIND BOOST
   SOURCES defer_test.cc)
 
 seastar_add_test (deleter
+  KIND BOOST
   SOURCES deleter_test.cc)
 
 seastar_add_app_test (directory

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -142,13 +142,13 @@ function (seastar_add_test name)
         OUTPUT_NAME ${name}_test)
 
     add_dependencies (unit_tests ${executable_target})
-    set (forwarded_args COMMAND ${executable_target} ${args})
+    set (forwarded_args COMMAND ${CMAKE_COMMAND} -E env "${Seastar_TEST_ENVIRONMENT}" $<TARGET_FILE:${executable_target}> ${args})
   else ()
     if (NOT (parsed_args_KIND STREQUAL "CUSTOM"))
       message (FATAL_ERROR "SOURCES are required for ${parsed_args_KIND} tests")
     endif ()
 
-    set (forwarded_args COMMAND ${parsed_args_RUN_ARGS})
+    set (forwarded_args COMMAND ${CMAKE_COMMAND} -E env "${Seastar_TEST_ENVIRONMENT}" ${parsed_args_RUN_ARGS})
   endif ()
 
   #
@@ -175,8 +175,7 @@ function (seastar_add_test name)
 
   set_tests_properties (Seastar.unit.${name}
     PROPERTIES
-      TIMEOUT ${Seastar_TEST_TIMEOUT}
-      ENVIRONMENT "${Seastar_TEST_ENVIRONMENT}")
+      TIMEOUT ${Seastar_TEST_TIMEOUT})
 endfunction ()
 
 #

--- a/tests/unit/checked_ptr_test.cc
+++ b/tests/unit/checked_ptr_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/checked_ptr.hh>
 #include <seastar/core/weak_ptr.hh>
 

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/chunked_fifo.hh>
 #include <stdlib.h>
 #include <chrono>

--- a/tests/unit/circular_buffer_fixed_capacity_test.cc
+++ b/tests/unit/circular_buffer_fixed_capacity_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <deque>
 #include <random>
 #include <seastar/core/circular_buffer_fixed_capacity.hh>

--- a/tests/unit/circular_buffer_test.cc
+++ b/tests/unit/circular_buffer_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <stdlib.h>
 #include <chrono>
 #include <deque>

--- a/tests/unit/defer_test.cc
+++ b/tests/unit/defer_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/util/defer.hh>
 
 using namespace seastar;

--- a/tests/unit/deleter_test.cc
+++ b/tests/unit/deleter_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/deleter.hh>
 
 using namespace seastar;

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -23,7 +23,7 @@
 #include <exception>
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/util/log.hh>
 #include <seastar/util/backtrace.hh>
 #include <ostream>

--- a/tests/unit/net_config_test.cc
+++ b/tests/unit/net_config_test.cc
@@ -22,7 +22,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <seastar/net/config.hh>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <exception>
 #include <sstream>
 

--- a/tests/unit/noncopyable_function_test.cc
+++ b/tests/unit/noncopyable_function_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/util/noncopyable_function.hh>
 
 using namespace seastar;

--- a/tests/unit/packet_test.cc
+++ b/tests/unit/packet_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/net/packet.hh>
 #include <array>
 

--- a/tests/unit/program_options_test.cc
+++ b/tests/unit/program_options_test.cc
@@ -24,7 +24,7 @@
 #include <seastar/util/program-options.hh>
 
 #include <boost/program_options.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <initializer_list>
 #include <vector>

--- a/tests/unit/shared_ptr_test.cc
+++ b/tests/unit/shared_ptr_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <set>
 #include <unordered_map>
 #include <seastar/core/sstring.hh>

--- a/tests/unit/simple_stream_test.cc
+++ b/tests/unit/simple_stream_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE simple_stream
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/simple-stream.hh>
 
 using namespace seastar;

--- a/tests/unit/source_location_test.cc
+++ b/tests/unit/source_location_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <seastar/util/std-compat.hh>
 

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/sstring.hh>
 #include <list>
 

--- a/tests/unit/tuple_utils_test.cc
+++ b/tests/unit/tuple_utils_test.cc
@@ -23,7 +23,7 @@
 
 #include <seastar/util/tuple_utils.hh>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <sstream>
 #include <type_traits>

--- a/tests/unit/uname_test.cc
+++ b/tests/unit/uname_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/internal/uname.hh>
 
 using namespace seastar::internal;

--- a/tests/unit/unwind_test.cc
+++ b/tests/unit/unwind_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <pthread.h>
 #include <seastar/core/posix.hh>
 #include <seastar/util/backtrace.hh>

--- a/tests/unit/weak_ptr_test.cc
+++ b/tests/unit/weak_ptr_test.cc
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <seastar/core/weak_ptr.hh>
 
 using namespace seastar;


### PR DESCRIPTION
* tests/unit: include unit_test.hpp instead of included/unit_test.hpp
* build: do not always build seastar as a static library
* build: build seastar as a shared library in 'debug' or 'dev' mode

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>