### PR TITLE
rpc: Abort connection if send_entry() fails

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -300,8 +300,10 @@ namespace rpc {
 
               p->uncancellable();
               return send_entry(*p).then_wrapped([this, p = std::move(p)] (auto f) mutable {
-                  _error |= f.failed();
-                  f.ignore_ready_future();
+                  if (f.failed()) {
+                      f.ignore_ready_future();
+                      abort();
+                  }
                   p->done.set_value();
               });
           });


### PR DESCRIPTION
If we fail to send for any reason we mark the connection as failed. We also need to wake up a receiver side as well for it to see that connection should be closed.

fixes: #1146

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>