### PR TITLE
net: s/offload_info()/get_offload_info()/

### DIFF
--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -315,7 +315,7 @@ private:
     void linearize(size_t at_frag, size_t desired_size);
     bool allocate_headroom(size_t size);
 public:
-    struct offload_info offload_info() const noexcept { return _impl->_offload_info; }
+    struct offload_info get_offload_info() const noexcept { return _impl->_offload_info; }
     struct offload_info& offload_info_ref() noexcept { return _impl->_offload_info; }
     void set_offload_info(struct offload_info oi) noexcept { _impl->_offload_info = oi; }
 };

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -618,7 +618,7 @@ class dpdk_qp : public net::qp {
          */
         static void set_cluster_offload_info(const packet& p, const dpdk_qp& qp, rte_mbuf* head) {
             // Handle TCP checksum offload
-            auto oi = p.offload_info();
+            auto oi = p.get_offload_info();
             if (oi.needs_ip_csum) {
                 head->ol_flags |= PKT_TX_IP_CKSUM;
                 // TODO: Take a VLAN header into an account here

--- a/src/net/virtio.cc
+++ b/src/net/virtio.cc
@@ -605,7 +605,7 @@ qp::txq::post(circular_buffer<packet>& pb) {
 
         pb.pop_front();
         // Handle TCP checksum offload
-        auto oi = p.offload_info();
+        auto oi = p.get_offload_info();
         if (_dev._dev->hw_features().tx_csum_l4_offload) {
             auto eth_hdr_len = sizeof(eth_hdr);
             auto ip_hdr_len = oi.ip_hdr_len;


### PR DESCRIPTION
this change address a build failure with GCC 13. without it, we'd have following build failure:

```
/home/kefu/dev/seastar/include/seastar/net/packet.hh:318:25: error: declaration of ‘seastar::net::offload_info seastar::net::packet::offload_info() const’ changes meaning of ‘offload_info’ [-fpermissive]
  318 |     struct offload_info offload_info() const noexcept { return _impl->_offload_info; }
      |                         ^~~~~~~~~~~~
/home/kefu/dev/seastar/include/seastar/net/packet.hh:103:9: note: used here to mean ‘struct seastar::net::offload_info’
  103 |         offload_info _offload_info;
      |         ^~~~~~~~~~~~
/home/kefu/dev/seastar/include/seastar/net/packet.hh:46:8: note: declared here
   46 | struct offload_info {
      |        ^~~~~~~~~~~~
```

Fixes #1273
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>