### PR TITLE
Add "IO tick violation time" metrics

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -888,6 +888,20 @@ public:
         });
     }
 
+    void emit_one_metrics(YAML::Emitter& out, sstring m_name) {
+        const auto& values = seastar::metrics::impl::get_value_map();
+        const auto& mf = values.find(m_name);
+        assert(mf != values.end());
+        for (auto&& mi : mf->second) {
+            out << YAML::Key << m_name << YAML::Value << mi.second->get_function()().d();
+            break; // only one out there
+        }
+    }
+
+    void emit_reactor_metrics(YAML::Emitter& out) {
+        emit_one_metrics(out, "reactor_io_latency_goal_violation_sec");
+    }
+
     future<> emit_results(YAML::Emitter& out) {
         return _finished.wait(_cl.size()).then([this, &out] {
             for (auto& cl: _cl) {
@@ -896,6 +910,10 @@ public:
                 cl->emit_results(out);
                 out << YAML::EndMap;
             }
+            out << YAML::Key << "stats";
+            out << YAML::BeginMap;
+            emit_reactor_metrics(out);
+            out << YAML::EndMap;
             return make_ready_future<>();
         });
     }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -330,6 +330,7 @@ private:
     task_queue_list _activating_task_queues;
     task_queue* _at_destroy_tasks;
     sched_clock::duration _task_quota;
+    sched_clock::duration _io_latency_goal;
     task* _current_task = nullptr;
     /// Handler that will be called when there is no task to execute on cpu.
     /// It represents a low priority work.

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -331,6 +331,7 @@ private:
     task_queue* _at_destroy_tasks;
     sched_clock::duration _task_quota;
     sched_clock::duration _io_latency_goal;
+    sched_clock::duration _io_latency_goal_violation_time = {};
     task* _current_task = nullptr;
     /// Handler that will be called when there is no task to execute on cpu.
     /// It represents a low priority work.

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4248,6 +4248,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     //     also pre-resize()-d in advance)
 
     auto alloc_io_queues = [&ioq_topology, &disk_config] (shard_id shard) {
+        engine()._io_latency_goal = std::chrono::duration_cast<sched_clock::duration>(disk_config.latency_goal());
         for (auto& topo : ioq_topology) {
             auto& io_info = topo.second;
             auto group_idx = io_info.shard_to_group[shard];

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2452,6 +2452,9 @@ void reactor::register_metrics() {
             // total_operations value:DERIVE:0:U
             sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::operation_count, _thread_pool.get()),
                     sm::description("Total number of io-threaded-fallbacks operations")),
+            sm::make_counter("io_latency_goal_violation_sec", [this] () -> double {
+                return std::chrono::duration_cast<std::chrono::duration<double>>(this->_io_latency_goal_violation_time).count();
+            }, sm::description("Total time reactor left IO queues without polling above the expected IO latency goal")),
 
     });
 
@@ -2680,9 +2683,19 @@ class reactor::io_queue_submission_pollfn final : public reactor::pollfn {
     // the future
     timer<> _nearest_wakeup { [this] { _armed = false; } };
     bool _armed = false;
+    steady_clock_type::time_point _last_poll;
 public:
-    io_queue_submission_pollfn(reactor& r) : _r(r) {}
+    io_queue_submission_pollfn(reactor& r)
+        : _r(r)
+        , _last_poll(steady_clock_type::now())
+    {}
     virtual bool poll() final override {
+        auto now = steady_clock_type::now();
+        auto delta = now - _last_poll;
+        _last_poll = now;
+        if (delta > _r._io_latency_goal) {
+            _r._io_latency_goal_violation_time += delta - _r._io_latency_goal;
+        }
         return _r.flush_pending_aio();
     }
     virtual bool pure_poll() override final {
@@ -2702,6 +2715,7 @@ public:
         if (_armed) {
             _nearest_wakeup.cancel();
             _armed = false;
+            _last_poll = steady_clock_type::now();
         }
     }
 };


### PR DESCRIPTION
IO scheduler math is built around the assumption that reactor polls it once per io-latency-goal or more frequently. If reactor fails to do it, disk may become underloaded, IO queues would accumulate over time. Another nasty side effect is that rare polls in seastar non-preemptive model result in phantom jams in IO requests flow.

The new metrics is supposed to help observing this effect takes place.

refs: #1311 