### PR TITLE
smp: do not inline function when BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,7 +830,8 @@ target_compile_options (seastar
 
 target_compile_definitions(seastar
   PUBLIC
-  SEASTAR_API_LEVEL=${Seastar_API_LEVEL})
+  SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
+  $<$<BOOL:${BUILD_SHARED_LIBS}>:SEASTAR_BUILD_SHARED_LIBS>)
 
 target_compile_features(seastar
   PUBLIC

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -54,10 +54,14 @@ namespace internal {
 
 unsigned smp_service_group_id(smp_service_group ssg) noexcept;
 
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+shard_id* this_shard_id_ptr() noexcept;
+#else
 inline shard_id* this_shard_id_ptr() noexcept {
     static thread_local shard_id g_this_shard_id;
     return &g_this_shard_id;
 }
+#endif
 
 }
 

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -31,6 +31,13 @@ namespace seastar {
 
 extern logger seastar_logger;
 
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+shard_id* internal::this_shard_id_ptr() noexcept {
+    static thread_local shard_id g_this_shard_id;
+    return &g_this_shard_id;
+}
+#endif
+
 void smp_message_queue::work_item::process() {
     schedule(this);
 }


### PR DESCRIPTION
`this_shard_id_ptr()` references a static thread_local variable defined in the function. if Seastar library is built as a static library, the linker will guarantee that there will be only a single definition of `g_this_shard_id`, and all translation unit will use this very instance.

but if Seastar is compiled and linked as a shared library. the shared library would have its own copy of this variable, while the executable would have another one, because this function is defined in the header. a symptom of this problem is that `this_shard_id()` is always 0 if any of the translation unit in the executable calls this function directly.

in this change, `this_shard_id_ptr()` is only declared in the header, and defined in .cc, if Seastar is built as shared library. so we have a single definition in the shared library.

a caveat: this further slows down Seastar applications linked against the shared library. but since the shared library build is in general only used for testing, this does not matter.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>