### PR TITLE
treewide: do not inline tls variables in shared library

### DIFF
--- a/include/seastar/core/lowres_clock.hh
+++ b/include/seastar/core/lowres_clock.hh
@@ -59,8 +59,12 @@ public:
     using time_point = std::chrono::time_point<lowres_clock, duration>;
     static constexpr bool is_steady = true;
 private:
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+    static thread_local time_point _now;
+#else
     // Use inline variable to prevent the compiler from introducing an initialization guard
     inline static thread_local time_point _now;
+#endif
 public:
     ///
     /// \note Outside of a Seastar application, the result is undefined.
@@ -89,8 +93,12 @@ public:
     using time_point = std::chrono::time_point<lowres_system_clock, duration>;
     static constexpr bool is_steady = false;
 private:
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+    static thread_local time_point _now;
+#else
     // Use inline variable to prevent the compiler from introducing an initialization guard
     inline static thread_local time_point _now;
+#endif
     friend class lowres_clock; // for updates
 public:
     ///

--- a/include/seastar/core/preempt.hh
+++ b/include/seastar/core/preempt.hh
@@ -34,11 +34,15 @@ struct preemption_monitor {
     std::atomic<uint32_t> tail;
 };
 
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+const preemption_monitor*& get_need_preempt_var();
+#else
 inline const preemption_monitor*& get_need_preempt_var() {
     static preemption_monitor bootstrap_preemption_monitor;
     static thread_local const preemption_monitor* g_need_preempt = &bootstrap_preemption_monitor;
     return g_need_preempt;
 }
+#endif
 
 void set_need_preempt_var(const preemption_monitor* pm);
 

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -326,6 +326,10 @@ scheduling_group_from_index(unsigned index) noexcept {
     return scheduling_group(index);
 }
 
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+scheduling_group*
+current_scheduling_group_ptr() noexcept;
+#else
 inline
 scheduling_group*
 current_scheduling_group_ptr() noexcept {
@@ -333,7 +337,7 @@ current_scheduling_group_ptr() noexcept {
     static thread_local scheduling_group sg;
     return &sg;
 }
-
+#endif
 }
 /// \endcond
 

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -46,11 +46,15 @@ struct scheduling_group_specific_thread_local_data {
     std::vector<scheduling_group_key_config> scheduling_group_key_configs;
 };
 
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+scheduling_group_specific_thread_local_data** get_scheduling_group_specific_thread_local_data_ptr() noexcept;
+#else
 inline
 scheduling_group_specific_thread_local_data** get_scheduling_group_specific_thread_local_data_ptr() noexcept {
     static thread_local scheduling_group_specific_thread_local_data* data;
     return &data;
 }
+#endif
 inline
 scheduling_group_specific_thread_local_data& get_scheduling_group_specific_thread_local_data() noexcept {
     return **get_scheduling_group_specific_thread_local_data_ptr();

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -88,7 +88,11 @@ class logger {
     static std::atomic<bool> _ostream;
     static std::atomic<bool> _syslog;
     static unsigned _shard_field_width;
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+    static thread_local bool silent;
+#else
     static inline thread_local bool silent = false;
+#endif
 
 public:
     class log_writer {

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -281,6 +281,9 @@ std::ostream* logger::_out = &std::cerr;
 std::atomic<bool> logger::_ostream = { true };
 std::atomic<bool> logger::_syslog = { false };
 unsigned logger::_shard_field_width = 1;
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+thread_local bool logger::silent = false;
+#endif
 
 logger::logger(sstring name) : _name(std::move(name)) {
     global_logger_registry().register_logger(this);


### PR DESCRIPTION
this change is a follow-up of 97cd37098004194ff82612c792dd8fd8fe171ed0 for the same reason, we cannot include the tls variables in the header files.

in this change, all inline static variables are defined in .cc files when building shared library.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>