### PR TITLE
core/sstring: define <=> operator for sstring

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -24,6 +24,9 @@
 #include <stdint.h>
 #include <algorithm>
 #include <cassert>
+#if __has_include(<compare>)
+#include <compare>
+#endif
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -574,9 +577,16 @@ public:
     bool operator!=(const basic_sstring& x) const noexcept {
         return !operator==(x);
     }
+#if __cpp_lib_three_way_comparison
+    constexpr std::strong_ordering operator<=>(const auto& x) const noexcept {
+        int cmp = compare(x);
+        return cmp <=> 0;
+    }
+#else
     bool operator<(const basic_sstring& x) const noexcept {
         return compare(x) < 0;
     }
+#endif
     basic_sstring operator+(const basic_sstring& x) const {
         basic_sstring ret(initialized_later(), size() + x.size());
         std::copy(begin(), end(), ret.begin());


### PR DESCRIPTION
in scylla, we are using <=> in `data_dictionary::storage_options::s3`, but without the operator<=> defined for sstring, compiler is not able to implicitly define one for us.

so in this change, an operator<=> is added for sstring.

with this change, Clang-17 should be appeased and to define the <=> operator for `data_dictionary::storage_options::s3` in Scylla.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>