### PR TITLE
core/sstring: remove a temporary variable

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -579,8 +579,7 @@ public:
     }
 #if __cpp_lib_three_way_comparison
     constexpr std::strong_ordering operator<=>(const auto& x) const noexcept {
-        int cmp = compare(x);
-        return cmp <=> 0;
+        return compare(x) <=> 0;
     }
 #else
     bool operator<(const basic_sstring& x) const noexcept {


### PR DESCRIPTION
for better reability.