### PR TITLE
reactor: syscall thread: wakeup up reactor with finer granularity

### DIFF
--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -51,12 +51,13 @@ void thread_pool::work(sstring name) {
             auto wi = *p;
             wi->process();
             inter_thread_wq._completed.push(wi);
-        }
-        // Prevent the following load of _main_thread_idle to be hoisted before the writes to _completed above.
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-        if (_main_thread_idle.load(std::memory_order_relaxed)) {
-            uint64_t one = 1;
-            ::write(_reactor->_notify_eventfd.get(), &one, 8);
+
+            // Prevent the following load of _main_thread_idle to be hoisted before the writes to _completed above.
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            if (_main_thread_idle.load(std::memory_order_relaxed)) {
+                uint64_t one = 1;
+                ::write(_reactor->_notify_eventfd.get(), &one, 8);
+            }
         }
     }
 }


### PR DESCRIPTION
If, after we complete a syscall in the syscall thread we find that the reactor is asleep, we wake it up. Currently, we do that after we complete all the already-queued syscalls, but this means that whatever task awaits the first syscall will sleep for too long - until all syscalls are processed.

Fix this by waking up after every syscall is processed.

This is unlikely to make a difference in practice. First, the reactor is usually busy. Second, it will spin before falling asleep. Third, latency-sensitive requests rarely depend on syscalls in Seastar applications, those are more on the metadata management plane. But it's better off fixed.