### PR TITLE
build: set CMP0135 for Cooking.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ list (APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake
   ${CMAKE_CURRENT_BINARY_DIR})
 
+cmake_policy (SET CMP0090 NEW)
+if (POLICY CMP0135)
+  cmake_policy (SET CMP0135 NEW)
+endif ()
+
 include (Cooking OPTIONAL)
 
 # This variable impacts the way DPDK is configured by cmake-cooking (if DPDK is enabled), so its definition needs to
@@ -39,11 +44,6 @@ set (Seastar_DPDK_MACHINE
 project (Seastar
   VERSION 1.0
   LANGUAGES CXX)
-
-cmake_policy (SET CMP0090 NEW)
-if (POLICY CMP0135)
-  cmake_policy (SET CMP0135 NEW)
-endif ()
 
 # generic boolean values passed as string, potentially from configure.py
 set (True_STRING_VALUES "ON" "yes" "Yes" "YES" "true" "True" "TRUE")


### PR DESCRIPTION
`Cooking.cmake` is included by Seastar's CMakeLists.txt for cooking ingredients. and `Cooking.cmake` uses `ExternalProject` CMake module for building ingredients as external projects. this module in turn downloads the source tarball and builds it. since CMake 3.24, a new policy named CMP0135 was introduced, which updates the timestamp of the extracted content of the downloaded tarball with the time when the tarball is extracted. this ensures artifacts are always rebuilt when the URL specified in `ExternalProject_add()` command is changed. in general, it's desirable to use this new policy. but before this change, we only set it *after* including `Cooking.cmake`. so `Cooking.cmake` is not affected by the new policy. it uses the old one.

since `Cooking.cmake` is an optional part integrated in Seastar's building system, and we don't always build the ingredients using it. more importantly, we don't update the download URL of ingredients in `cooking_recipe.cmake` and relaunch command line like

```
cmake \
-DCooking_INGREDIENTS_DIR=/home/kefu/dev/seastar/build/_cooking/installed
-DCooking_RECIPE=/home/kefu/dev/seastar/cooking_recipe.cmake
-DCooking_EXCLUDED_INGREDIENTS= '-DCooking_INCLUDED_INGREDIENTS=c-ares;fmt;'
```

after building the specified ingredient. instead, we use `cooking.sh` to do this job before starting working on Seastar. so this is not a real issue for most of us.

but CMake newer than 3.24 complains if this policy is not explicitly set.

```
CMake Warning (dev) at /home/kefu/.local/share/cmake-3.26/Modules/ExternalProject.cmake:3086 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```

in this change, the code block setting the new policies is moved before `include (Cooking OPTIONAL)`, this should silence CMake's warning. and as a bonus, this change also addresses the problem we could run into in the unusual use case explained above, where the ingredient(s) is not updated after its URL is changed.