### PR TITLE
build: build dpdk with `-fPIC` if BUILD_SHARED_LIBS

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -282,6 +282,10 @@ endif()
 
 # gcc 10 defaults to -fno-common, which dpdk is not prepared for
 set (dpdk_extra_cflags "-Wno-error -fcommon -fpie")
+if (BUILD_SHARED_LIBS)
+  string (APPEND dpdk_extra_cflags " -fPIC")
+endif ()
+
 set (dpdk_args
   "EXTRA_CFLAGS=${dpdk_extra_cflags}"
   O=<BINARY_DIR>

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -280,9 +280,10 @@ else()
   set (dpdk_quadruple ${CMAKE_SYSTEM_PROCESSOR}-native-linuxapp-gcc)
 endif()
 
+# gcc 10 defaults to -fno-common, which dpdk is not prepared for
+set (dpdk_extra_cflags "-Wno-error -fcommon -fpie")
 set (dpdk_args
-  # gcc 10 defaults to -fno-common, which dpdk is not prepared for
-  "EXTRA_CFLAGS=-Wno-error -fcommon -fpie"
+  "EXTRA_CFLAGS=${dpdk_extra_cflags}"
   O=<BINARY_DIR>
   DESTDIR=<INSTALL_DIR>
   T=${dpdk_quadruple})


### PR DESCRIPTION
we should built the dependencies with -fPIC if Seastar is built as
a shared library.

before this change, dpdk is built without -fPIC, if it is built
with `cooking.sh`. and if user configures the building system with
debug or dev mode, seastar is compiled as a shared library. hence
the linker would fail to link libseastar with dpdk.

after this change, dpdk is compiled with `-fPIC`, so its symbols
are compiled as position-independent code, see
https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fPIC .
so linker is able to link against it to build a shared library.

Fixes #1504
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>