### PR TITLE
reactor/scheduling_group: Handle at_destroy queue special in init_new_scheduling_group_key etc

### DIFF
--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -266,6 +266,7 @@ public:
     bool operator==(scheduling_group x) const noexcept { return _id == x._id; }
     bool operator!=(scheduling_group x) const noexcept { return _id != x._id; }
     bool is_main() const noexcept { return _id == 0; }
+    bool is_at_exit() const noexcept { return _id == 1; }
     template<typename T>
     /**
      * Returnes a reference to this scheduling group specific value

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -69,6 +69,7 @@ shared_backtrace task::get_backtrace() const {
 }
 
 void schedule(task* t) noexcept;
+void schedule_checked(task* t) noexcept;
 void schedule_urgent(task* t) noexcept;
 
 }

--- a/include/seastar/core/with_scheduling_group.hh
+++ b/include/seastar/core/with_scheduling_group.hh
@@ -41,7 +41,7 @@ auto
 schedule_in_group(scheduling_group sg, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>);
     auto tsk = make_task(sg, std::move(func));
-    schedule(tsk);
+    schedule_checked(tsk);
     return tsk->get_future();
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3631,6 +3631,14 @@ void schedule(task* t) noexcept {
     engine().add_task(t);
 }
 
+void schedule_checked(task* t) noexcept {
+    if (t->group().is_at_exit()) {
+        // trying to schedule a task in at_destroy. Not allowed
+        on_internal_error(seastar_logger, "Cannot schedule tasks in at_destroy queue. Use reactor::at_destroy.");
+    }
+    engine().add_task(t);
+}
+
 void schedule_urgent(task* t) noexcept {
     engine().add_urgent_task(t);
 }
@@ -4691,9 +4699,13 @@ reactor::init_new_scheduling_group_key(scheduling_group_key key, scheduling_grou
     return parallel_for_each(_task_queues, [this, cfg, key] (std::unique_ptr<task_queue>& tq) {
         if (tq) {
             scheduling_group sg = scheduling_group(tq->_id);
-            return with_scheduling_group(sg, [this, key, sg] () {
+            if (tq.get() == _at_destroy_tasks) {
                 allocate_scheduling_group_specific_data(sg, key);
-            });
+            } else {
+                return with_scheduling_group(sg, [this, key, sg] () {
+                    allocate_scheduling_group_specific_data(sg, key);
+                });
+            }
         }
         return make_ready_future();
     });

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -345,3 +345,12 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
         }
     }).get0();
 }
+
+SEASTAR_THREAD_TEST_CASE(sg_create_with_destroy_tasks) {
+    struct nada{};
+
+    engine().at_destroy([] {}); // nothing really
+
+    scheduling_group_key_config sg_conf = make_scheduling_group_key_config<nada>();
+    scheduling_group_key_create(sg_conf).get();
+}


### PR DESCRIPTION
Fixes #1511

`init_new_scheduling_group_key` iterates all task queues and calls `with_scheduling_group` calls to each.

This in turn will, for all but the active group, call `internal::schedule_in_group`. This will weirdly enough _work_ even for the _at_destroy group IFF the queue is empty at call, in which case the queue is added to queues to process. This is of course wrong on oh so many planes.

Now, if the at_destroy queue is _not_ empty, we will instead deadlock here, waiting for a task queue that will not be scheduled.

This patch
* Special treats the at_destroy queue in init_new_scheduling_group_key
* Changes with_scheduling_group to schedule tasks "checked", which in turn ensures we don't try to run things in at_destroy queue ahead of time (fatal error, because noexcept) * Adds a test case for the issue