### PR TITLE
resource: let --memory override --reserve-memory

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -32,6 +32,7 @@
 #include "cgroup.hh"
 #include <seastar/util/log.hh>
 #include <seastar/core/io_queue.hh>
+#include <seastar/core/units.hh>
 
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -210,11 +211,11 @@ optional<T> read_setting_V1V2_as(std::string cg1_path, std::string cg2_fname) {
 namespace resource {
 
 size_t calculate_memory(const configuration& c, size_t available_memory, float panic_factor = 1) {
-    size_t default_reserve_memory = std::max<size_t>(1536 * 1024 * 1024, 0.07 * available_memory) * panic_factor;
+    size_t default_reserve_memory = std::max<size_t>(1.5 * GB, 0.07 * available_memory) * panic_factor;
     auto reserve = c.reserve_memory.value_or(default_reserve_memory);
     auto reserve_additional = c.reserve_additional_memory_per_shard * c.cpus;
     reserve += reserve_additional;
-    size_t min_memory = 500'000'000;
+    size_t min_memory = 500_MiB;
     if (available_memory >= reserve + min_memory) {
         available_memory -= reserve;
     } else {

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -211,28 +211,29 @@ optional<T> read_setting_V1V2_as(std::string cg1_path, std::string cg2_fname) {
 namespace resource {
 
 size_t calculate_memory(const configuration& c, size_t available_memory, float panic_factor = 1) {
-    size_t default_reserve_memory = std::max<size_t>(1.5 * GB, 0.07 * available_memory) * panic_factor;
-    auto reserve = c.reserve_memory.value_or(default_reserve_memory);
     auto reserve_additional = c.reserve_additional_memory_per_shard * c.cpus;
-    reserve += reserve_additional;
-    size_t min_memory = 500_MiB;
-    if (available_memory >= reserve + min_memory) {
-        available_memory -= reserve;
+    if (c.total_memory.has_value()) {
+        if (c.reserve_memory.has_value()) {
+            seastar_logger.warn("'memory' option overrides 'reserve-memory'");
+        }
+        if (*c.total_memory < reserve_additional) {
+            throw std::runtime_error(format("insufficient total memory: reserve {} total {}", reserve_additional, *c.total_memory));
+        }
+        if (*c.total_memory > available_memory) {
+            throw std::runtime_error(format("insufficient physical memory: needed {} available {}", *c.total_memory, available_memory));
+        }
+        return *c.total_memory - reserve_additional ;
     } else {
-        // Allow starting up even in low memory configurations (e.g. 2GB boot2docker VM)
-        available_memory = min_memory;
+        size_t min_memory = 500_MiB;
+        size_t default_reserve_memory = std::max<size_t>(1.5 * GB, 0.07 * available_memory) * panic_factor;
+        auto reserve = reserve_additional + c.reserve_memory.value_or(default_reserve_memory);
+        if (available_memory >= reserve + min_memory) {
+            return available_memory - reserve;
+        } else {
+            // Allow starting up even in low memory configurations (e.g. 2GB boot2docker VM)
+            return min_memory;
+        }
     }
-    if (!c.total_memory.has_value()) {
-        return available_memory;
-    }
-    if (*c.total_memory < reserve_additional) {
-        throw std::runtime_error(format("insufficient total memory: reserve {} total {}", reserve_additional, *c.total_memory));
-    }
-    size_t needed_memory = *c.total_memory - reserve_additional;
-    if (needed_memory > available_memory) {
-        throw std::runtime_error(format("insufficient physical memory: needed {} available {}", needed_memory, available_memory));
-    }
-    return needed_memory;
 }
 
 io_queue_topology::io_queue_topology() {


### PR DESCRIPTION
- resource: use constant and literals defined in units.hh
- resource: let --memory override --reserve-memory

the help message for `--reserve-memory` reads

> memory reserved to OS (if --memory not specified)

what this help message implies is that, if --memory is specified,
unless the physical memory is not able to provision the necessary
amount of memory, Seastar should support this setting.

but the existing code always takes reserve_memory into consideration
even if `--memory` is specified. this practically prevents user from
running a Seastar application on a machine with memory < 1.5GB, but
> 1GB, with the command line option of `--memory 1G`.

after this change, the memory reserved for OS is only considered
when `--memory` is not set. this should allow user to launch a
Seastar application with the above setting, namely

- physical memory is less than 1.5GB, but greater than 1G
- --memory 1G

See also #1513
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>