### PR TITLE
build: cooking.sh: use the same settings when building ingredients

### DIFF
--- a/cooking.sh
+++ b/cooking.sh
@@ -560,6 +560,8 @@ endfunction ()
 function (_cooking_determine_common_cmake_args output)
   string (REPLACE ";" ":::" prefix_path_with_colons "${CMAKE_PREFIX_PATH}")
 
+  set (cmake_args "-G" "${CMAKE_GENERATOR}")
+
   if (CMAKE_CXX_FLAGS)
     list(APPEND cmake_args -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS})
   endif ()

--- a/cooking.sh
+++ b/cooking.sh
@@ -574,7 +574,8 @@ function (_cooking_determine_common_cmake_args output)
     -DCMAKE_PREFIX_PATH=${prefix_path_with_colons}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER})
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
 
   set (${output} ${cmake_args}
     PARENT_SCOPE)


### PR DESCRIPTION
- build: cooking.sh: use the same generator when building ingredients
- build: cooking.sh: use the same BUILD_SHARED_LIBS when building ingredients