### PR TITLE
build, rpc: lz4 related cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,10 +986,6 @@ if (Seastar_NUMA)
     PRIVATE numactl::numactl)
 endif ()
 
-if (lz4_HAVE_COMPRESS_DEFAULT)
-  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_LZ4_COMPRESS_DEFAULT)
-endif ()
-
 seastar_supports_flag ("-Werror=unused-result" ErrorUnused_FOUND)
 if (ErrorUnused_FOUND)
   if (Seastar_UNUSED_RESULT_ERROR)

--- a/cmake/FindPthreadSetName.cmake
+++ b/cmake/FindPthreadSetName.cmake
@@ -1,3 +1,4 @@
+include (CheckSymbolExists)
 include (CMakePushCheckState)
 
 cmake_push_check_state (RESET)

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -50,11 +50,6 @@ find_package_handle_standard_args (lz4
 
 if (lz4_FOUND)
   set (CMAKE_REQUIRED_LIBRARIES ${lz4_LIBRARY})
-  include (CheckSymbolExists)
-
-  check_symbol_exists (LZ4_compress_default
-    ${lz4_INCLUDE_DIR}/lz4.h
-    lz4_HAVE_COMPRESS_DEFAULT)
 
   set (lz4_LIBRARIES ${lz4_LIBRARY})
   set (lz4_INCLUDE_DIRS ${lz4_INCLUDE_DIR})

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -46,7 +46,7 @@ find_package_handle_standard_args (lz4
   REQUIRED_VARS
     lz4_LIBRARY
     lz4_INCLUDE_DIR
-  VERSION_VAR lz4_VERSION)
+  VERSION_VAR PC_lz4_VERSION)
 
 if (lz4_FOUND)
   set (CMAKE_REQUIRED_LIBRARIES ${lz4_LIBRARY})

--- a/include/seastar/rpc/lz4_compressor.hh
+++ b/include/seastar/rpc/lz4_compressor.hh
@@ -23,7 +23,6 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/rpc/rpc_types.hh>
-#include <lz4.h>
 
 namespace seastar {
 

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/rpc/lz4_compressor.hh>
 #include <seastar/core/byteorder.hh>
+#include <lz4.h>
 
 namespace seastar {
 

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -139,12 +139,7 @@ snd_buf lz4_compressor::compress(size_t head_space, snd_buf data) {
         auto src_size = data.size;
         auto src = reusable_buffer_decompressed_data.prepare(data.bufs, data.size);
 
-#ifdef SEASTAR_HAVE_LZ4_COMPRESS_DEFAULT
         auto size = LZ4_compress_default(src, dst + head_space, src_size, LZ4_compressBound(src_size));
-#else
-        // Safe since output buffer is sized properly.
-        auto size = LZ4_compress(src, dst + head_space, src_size);
-#endif
         if (size == 0) {
             throw std::runtime_error("RPC frame LZ4 compression failure");
         }


### PR DESCRIPTION
- rpc: do not include lz4.h in header
- build: include CheckSymbolExists
- build: set the correct version when finding lz4
- build, rpc: do not support lz4 < 1.7.3