### PR TITLE
doc/building-dpdk.md: drop extraneous '$'

### DIFF
--- a/doc/building-dpdk.md
+++ b/doc/building-dpdk.md
@@ -2,7 +2,7 @@
 
  1. Setup host to compile DPDK:
     - Ubuntu 
-         `sudo apt-get install -y build-essential linux-image-extra-$(uname -r$)` 
+         `sudo apt-get install -y build-essential linux-image-extra-$(uname -r)` 
  2. Configure the project with DPDK enabled: `./configure.py --mode=release --enable-dpdk`
  3. Run `ninja-build build/release`.
 


### PR DESCRIPTION
'$' is not necessary in the sample command line, so let's drop it.