### PR TITLE
http: url_decode: translate plus back into char

### DIFF
--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -70,6 +70,8 @@ bool url_decode(const std::string_view& in, sstring& out) {
             } else {
                 return false;
             }
+        } else if (in[i] == '+') {
+            buff[pos++] = ' ';
         } else {
             buff[pos++] = in[i];
         }


### PR DESCRIPTION
As seen in https://github.com/scylladb/scylladb/issues/12393, the client may encode space characters into `+` in the url query parameters (as well as to `%20`)

https://en.wikipedia.org/wiki/URL_encoding#The_application.2Fx-www-form-urlencoded_type explains that:

> When data that has been entered into HTML forms is submitted,
> the form field names and values are encoded and sent to the
> server in an HTTP request message using method GET or POST,
> or, historically, via email. The encoding used by default is
> based on an early version of the general URI percent-encoding
> rules, with a number of modifications such as newline normalization
> and replacing spaces with + instead of %20.

and that is used for encoding is used by the Python requests library, that is used by our scylla-api-client.
See https://github.com/scylladb/scylla-api-client/blob/485b25d95df0e8c56c1639a8a8be99b6c676e799/scylla_api_client/rest/__init__.py#L96

Refs scylladb/scylladb#12393
Fixes scylladb/seastar#1530