### PR TITLE
memory: support reallocing foreign (non-Seastar) memory on a reactor thread

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1926,14 +1926,12 @@ void* realloc(void* ptr, size_t size) {
         // If ptr is a null pointer, the behavior is the same as calling std::malloc(new_size).
         return malloc(size);
     } else if (!is_seastar_memory(ptr)) {
-        // we can't realloc foreign memory on a shard
-        if (is_reactor_thread) {
-            abort();
-        }
         // original_realloc_func might be null when previous ctor allocates
         if (original_realloc_func) {
             return original_realloc_func(ptr, size);
         }
+        // we can't realloc foreign memory without the original libc function
+        abort();
     }
     // if we're here, it's a non-null seastar memory ptr
     // or original functions aren't available.


### PR DESCRIPTION
In general, memory allocated on a reactor thread should come from the Seastar memory allocator. But in certain scenarios, it doesn't. Once such example is

 - seastar built as a shared library
 - another shared library (openssl) is loaded ahead of seastar and allocates some global storage in its module initializer
 - seastar loaded, initializes the shard memory allocator
 - another call into openssl, ends up reallocating the previously allocated memory

This crashes in realloc(). Fortunately, swapping the two if statements in that branch is enough to fix the problem, so this patch does just that.