### PR TITLE
map_reduce: do not move a temporary object

### DIFF
--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -186,7 +186,7 @@ map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Initial initial, Reduc
     while (begin != end) {
         ret = futurize_invoke(s->mapper, *begin++).then_wrapped([s = s.get(), ret = std::move(ret)] (auto f) mutable {
             try {
-                s->result = s->reduce(std::move(s->result), std::move(f.get0()));
+                s->result = s->reduce(std::move(s->result), f.get0());
                 return std::move(ret);
             } catch (...) {
                 return std::move(ret).then_wrapped([ex = std::current_exception()] (auto f) {


### PR DESCRIPTION
C++17 enforces copy ellision on prvalue like this, which is a temporary. so there is no need to use `std::move()` here, moreover, it could prevent the compiler from performing copy elision. and this hurts the performance.

this change also silences warning like:
```
/home/kefu/dev/scylladb/seastar/include/seastar/core/map_reduce.hh:189:27: error: moving a temporary object prevents copy elision [-Werror=pessimizing-move]
/home/kefu/dev/scylladb/seastar/include/seastar/core/map_reduce.hh:189:27: note: remove ‘std::move’ call
```