### PR TITLE
test: futures: disable -Wself-move for GCC>=13

### DIFF
--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -68,9 +68,9 @@ public:
     expected_exception() : runtime_error("expected") {}
 };
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wself-move"
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
 #endif
 SEASTAR_TEST_CASE(test_self_move) {
     future_state<std::tuple<std::unique_ptr<int>>> s1;
@@ -104,8 +104,8 @@ SEASTAR_TEST_CASE(test_self_move) {
 
     return make_ready_future<>();
 }
-#ifdef __clang__
-#pragma clang diagnostic pop
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 13)
+#pragma GCC diagnostic pop
 #endif
 
 static subscription<int> get_empty_subscription(std::function<future<> (int)> func) {


### PR DESCRIPTION
GCC supports `-Wself-move` now, see
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html. so we should disable this warning when testing self-move.

this should silence the warning from GCC 13:
```
/home/kefu/dev/scylladb/seastar/tests/unit/futures_test.cc: In member function ‘virtual seastar::future<> test_self_move::run_test_case() const’:
/home/kefu/dev/scylladb/seastar/tests/unit/futures_test.cc:78:8: error: moving ‘s1’ of type ‘seastar::future_state<std::tuple<std::unique_ptr<int, std::default_delete<int> > > >’ to itself [-Werror=self-move]
   78 |     s1 = std::move(s1); // no crash, but the value of s1 is not defined.
      |     ~~~^~~~~~~~~~~~~~~
```