### PR TITLE
prometheus, http: do not expose httpd::* in seastar

### DIFF
--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -45,8 +45,8 @@ future<> start(httpd::http_server_control& http_server, config ctx);
 /// \defgroup add_prometheus_routes adds a /metrics endpoint that returns prometheus metrics
 ///    in txt format
 /// @{
-future<> add_prometheus_routes(distributed<http_server>& server, config ctx);
-future<> add_prometheus_routes(http_server& server, config ctx);
+future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx);
+future<> add_prometheus_routes(httpd::http_server& server, config ctx);
 /// @}
 }
 }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -632,7 +632,7 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
     });
 }
 
-class metrics_handler : public handler_base  {
+class metrics_handler : public httpd::handler_base  {
     sstring _prefix;
     config _ctx;
     static std::function<bool(const mi::labels_type&)> _true_function;
@@ -714,13 +714,13 @@ std::function<bool(const mi::labels_type&)> metrics_handler::_true_function = []
     return true;
 };
 
-future<> add_prometheus_routes(http_server& server, config ctx) {
-    server._routes.put(GET, "/metrics", new metrics_handler(ctx));
+future<> add_prometheus_routes(httpd::http_server& server, config ctx) {
+    server._routes.put(httpd::GET, "/metrics", new metrics_handler(ctx));
     return make_ready_future<>();
 }
 
-future<> add_prometheus_routes(distributed<http_server>& server, config ctx) {
-    return server.invoke_on_all([ctx](http_server& s) {
+future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx) {
+    return server.invoke_on_all([ctx](httpd::http_server& s) {
         return add_prometheus_routes(s, ctx);
     });
 }

--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -28,8 +28,6 @@
 
 namespace seastar {
 
-using namespace httpd;
-
 %% machine request;
 
 %%{


### PR DESCRIPTION
before this change, all symbols enclosed in seastar::httpd namespace are exposed by http/request_parser.hh which is generated from request_parser.rl, but this is not quite what we intend.

so in this change, `using namespace httpd;` is removed from `request_parser.rl`, and all places assuming the existence of symbols exposed by `using namespace httpd;` are updated to reference `httpd::*`.