### PR TITLE
seastar-json2code: generate better-formatted code

### DIFF
--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -258,10 +258,8 @@ def resolve_model_order(data):
 
 def create_enum_wrapper(model_name, name, values):
     enum_name = model_name + "_" + name
-    res = "  enum class " + enum_name + " {"
-    for enum_entry in values:
-        res = res + "  " + enum_entry + ", "
-    res = res + "NUM_ITEMS};\n"
+    res = Template("""  enum class $enum_name { $enumerators, NUM_ITEMS };
+""").substitute(enum_name=enum_name, enumerators=", ".join(values))
     wrapper = name + "_wrapper"
     res = res + Template("""  struct $wrapper : public json::jsonable  {
         $wrapper() = default;

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -116,14 +116,13 @@ def type_change(param, member):
 
 
 
-def print_ind_comment(f, ind, *params):
+def print_ind_comment(f, ind, comment):
     fprintln(f, ind, "/**")
-    for s in params:
-        fprintln(f, ind, " * ", s)
+    fprintln(f, ind, " * ", comment)
     fprintln(f, ind, " */")
 
-def print_comment(f, *params):
-    print_ind_comment(f, spacing, *params)
+def print_comment(f, comment):
+    print_ind_comment(f, spacing, comment)
 
 def print_copyrights(f):
     fprintln(f, "/*")

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -5,7 +5,7 @@
 #    https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md
 # And the 2.0 format
 #    https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
-# 
+#
 # Swagger 2.0 is not only different in its structure (apis have moved, and
 # models are now under definitions) It also moved from multiple file structure
 # to a single file.
@@ -214,7 +214,7 @@ def is_model_valid(name, model):
         type = getitem(properties[var], "type", name + ":" + var)
         if type == "array":
             items = getitem(properties[var], "items", name + ":" + var)
-            try :
+            try:
                 type = getitem(items, "type", name + ":" + var + ":items")
             except Exception as e:
                 try:
@@ -258,10 +258,10 @@ def resolve_model_order(data):
 
 def create_enum_wrapper(model_name, name, values):
     enum_name = model_name + "_" + name
-    res =  "  enum class " + enum_name + " {"
+    res = "  enum class " + enum_name + " {"
     for enum_entry in values:
         res = res + "  " + enum_entry + ", "
-    res = res +  "NUM_ITEMS};\n"
+    res = res + "NUM_ITEMS};\n"
     wrapper = name + "_wrapper"
     res = res + Template("""  struct $wrapper : public json::jsonable  {
         $wrapper() = default;
@@ -519,7 +519,7 @@ def format_as_json_object(data):
 def check_for_models(data, param):
     model_name = param.replace(".json", ".def.json")
     if not os.path.isfile(model_name):
-        return 
+        return
     try:
         with open(model_name) as myfile:
             json_data = myfile.read()


### PR DESCRIPTION
- seastar-json2code: remove redundant spaces and trailing spaces
- seastar-json2code: have less spaces in "enum class"
- seastar-json2code: use textwrap for proper indent enum class
- seastar-json2code: let print_comment() accept a single param
- seastar-json2code: use Template in create_h_file