### PR TITLE
build: add haswell support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -934,6 +934,7 @@ if (Seastar_DPDK)
   set (Seastar_ARCH_FOR_wsm "westmere")
   set (Seastar_ARCH_FOR_snb "sandybridge")
   set (Seastar_ARCH_FOR_ivb "ivybridge")
+  set (Seastar_ARCH_FOR_hsw "haswell")
   set (Seastar_ARCH_FOR_armv8a "armv8-a")
   set (Seastar_ARCH ${Seastar_ARCH_FOR_${Seastar_DPDK_MACHINE}})
 


### PR DESCRIPTION
Our dpdk branch supports haswell, but our gcc -march <-> dpdk model translation does not. Add this translation.