### PR TITLE
core: map_reduce: remove unnecessary "mutable"

### DIFF
--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -42,7 +42,7 @@ struct reducer_with_get_traits<T, Ptr, false> {
     using result_type = decltype(std::declval<T>().get());
     using future_type = future<result_type>;
     static future_type maybe_call_get(future<> f, Ptr r) {
-        return f.then([r = std::move(r)] () mutable {
+        return f.then([r = std::move(r)] {
             return make_ready_future<result_type>(std::move(r->reducer).get());
         });
     }


### PR DESCRIPTION
the `mutable` specifier is used when we need to allow the lambda body to mutate the variable(s) captured by copy or to call their non-const member function. but destroying a captured variable initialized with `std::move(r)` does not fall into this bucket. so we don't need to add the `mutable` specifier for the lambda here.

in this change, the `mutable` specifier is dropped.