### PR TITLE
thread_pool: work: notify evenetfd once when idle

### DIFF
--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -36,6 +36,7 @@ void thread_pool::work(sstring name) {
     auto r = ::pthread_sigmask(SIG_BLOCK, &mask, NULL);
     throw_pthread_error(r);
     std::array<syscall_work_queue::work_item*, syscall_work_queue::queue_length> tmp_buf;
+    int64_t last_idle = -1;
     while (true) {
         uint64_t count;
         auto r = ::read(inter_thread_wq._start_eventfd.get_read_fd(), &count, sizeof(count));
@@ -54,7 +55,9 @@ void thread_pool::work(sstring name) {
 
             // Prevent the following load of _main_thread_idle to be hoisted before the writes to _completed above.
             std::atomic_thread_fence(std::memory_order_seq_cst);
-            if (_main_thread_idle.load(std::memory_order_relaxed) >= 0) {
+            int64_t idle = _main_thread_idle.load(std::memory_order_relaxed);
+            if (idle >= 0 && idle != last_idle) {
+                last_idle = idle;
                 uint64_t one = 1;
                 ::write(_reactor->_notify_eventfd.get(), &one, 8);
             }

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -54,7 +54,7 @@ void thread_pool::work(sstring name) {
 
             // Prevent the following load of _main_thread_idle to be hoisted before the writes to _completed above.
             std::atomic_thread_fence(std::memory_order_seq_cst);
-            if (_main_thread_idle.load(std::memory_order_relaxed)) {
+            if (_main_thread_idle.load(std::memory_order_relaxed) >= 0) {
                 uint64_t one = 1;
                 ::write(_reactor->_notify_eventfd.get(), &one, 8);
             }


### PR DESCRIPTION
notifying multiple times with no preemption is wasteful, adding extraneous system calls to this path.

Instead, write to _notify_eventfd only once
while _main_thread_idle remains true.