### PR TITLE
reactor: pass fd opened in blocking mode to spawned process

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1986,6 +1986,11 @@ reactor::spawn(std::string_view pathname,
                 std::get<pipefd_read_end>(cin_pipe).spawn_actions_add_close(&actions);
                 std::get<pipefd_write_end>(cout_pipe).spawn_actions_add_close(&actions);
                 std::get<pipefd_write_end>(cerr_pipe).spawn_actions_add_close(&actions);
+                // tools like "cat" expect a fd opened in blocking mode when performing I/O
+                std::get<pipefd_read_end>(cin_pipe).template ioctl<int>(FIONBIO, 0);
+                std::get<pipefd_write_end>(cout_pipe).template ioctl<int>(FIONBIO, 0);
+                std::get<pipefd_write_end>(cerr_pipe).template ioctl<int>(FIONBIO, 0);
+
                 r = ::posix_spawnattr_init(&attr);
                 throw_pthread_error(r);
                 // make sure the following signals are not ignored by the child process

--- a/tests/unit/spawn_test.cc
+++ b/tests/unit/spawn_test.cc
@@ -99,7 +99,7 @@ SEASTAR_TEST_CASE(test_spawn_input) {
         auto stdout = process.stdout();
         return do_with(std::move(process), std::move(stdin), std::move(stdout), [](auto& p, auto& stdin, auto& stdout) {
             return stdin.write(text).then([&stdin] {
-                return stdin.flush();
+                return stdin.close();
             }).handle_exception_type([] (std::system_error& e) {
                 BOOST_TEST_ERROR(fmt::format("failed to write to stdin: {}", e));
             }).then([&stdout] {
@@ -110,7 +110,11 @@ SEASTAR_TEST_CASE(test_spawn_input) {
             }).then([] (temporary_buffer<char> echo) {
                 BOOST_CHECK_EQUAL(sstring(echo.get(), echo.size()), text);
             }).finally([&p] {
-                return p.wait().discard_result();
+                return p.wait().then([](process::wait_status wstatus) {
+                    auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
+                    BOOST_REQUIRE(exit_status != nullptr);
+                    BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
+                 });
             });
         });
     });
@@ -133,7 +137,7 @@ SEASTAR_TEST_CASE(test_spawn_kill) {
             // sleep should be terminated in 10ms.
             // pidfd_open(2) may fail and thus p.wait() falls back to
             // waitpid(2) with backoff (at least 20ms).
-            // the minimal backoff is added to 10ms, so the test can pass on 
+            // the minimal backoff is added to 10ms, so the test can pass on
             // older kernels as well.
             BOOST_CHECK_LE(ms, 10 + 20);
         });

--- a/tests/unit/spawn_test.cc
+++ b/tests/unit/spawn_test.cc
@@ -92,7 +92,7 @@ SEASTAR_TEST_CASE(test_spawn_echo) {
     });
 }
 
-SEASTAR_TEST_CASE(test_spawn_input, *boost::unit_test::expected_failures(3)) {
+SEASTAR_TEST_CASE(test_spawn_input) {
     static const sstring text = "hello world\n";
     return spawn_process("/bin/cat").then([] (auto process) {
         auto stdin = process.stdin();


### PR DESCRIPTION
It turns out tools like "cat" expect fd opened blocking mode,
while the pipe fds are always created in non-blocking mode.
So in order to appease these tools, let's set the fds passed
to the spawned process to blocking mode.

Fixes #1320

Signed-off-by: Kefu Chai kefu.chai@scylladb.com
Signed-off-by: Jianyong Chen <baluschch@gmail.com>