### PR TITLE
fstream: drop API level 2 (make_file_output_stream() returning non-future)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,11 @@ set (Seastar_API_LEVEL
   "6"
   CACHE
   STRING
-  "Seastar compatibility API level (2=server_socket::accept() returns accept_result, 3=make_file_output_stream(), make_file_data_sink() returns future<...>, 4=when_all_succeed returns future<std::tuple<>>, 5=future<T>::get() returns T&&), 6=future is not variadic")
+  "Seastar compatibility API level (3=make_file_output_stream(), make_file_data_sink() returns future<...>, 4=when_all_succeed returns future<std::tuple<>>, 5=future<T>::get() returns T&&), 6=future is not variadic")
 
 set_property (CACHE Seastar_API_LEVEL
   PROPERTY
-  STRINGS 2 3 4 5 6)
+  STRINGS 3 4 5 6)
 
 set (Seastar_SCHEDULING_GROUPS_COUNT
   "16"

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -107,7 +107,7 @@ API Level History
 |Level|Introduced |Mandatory|Description                                   |
 |:---:|:---------:|:-------:| -------------------------------------------- |
 | 2   |  2019-07  | 2020-04 | Non-variadic futures in socket::accept()     |
-| 3   |  2020-05  |         | make_file_data_sink() closes file and returns a future<>  |
+| 3   |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
 | 4   |  2020-06  |         | Non-variadic futures in when_all_succeed()   |
 
 

--- a/include/seastar/core/fstream.hh
+++ b/include/seastar/core/fstream.hh
@@ -97,34 +97,6 @@ struct file_output_stream_options {
     ::seastar::io_priority_class io_priority_class = default_priority_class();
 };
 
-SEASTAR_INCLUDE_API_V2 namespace api_v2 {
-
-/// Create an output_stream for writing starting at the position zero of a
-/// newly created file.
-/// NOTE: flush() should be the last thing to be called on a file output stream.
-[[deprecated("use Seastar_API_LEVEL=3 instead")]]
-output_stream<char> make_file_output_stream(
-        file file,
-        uint64_t buffer_size = 8192);
-
-/// Create an output_stream for writing starting at the position zero of a
-/// newly created file.
-/// NOTE: flush() should be the last thing to be called on a file output stream.
-[[deprecated("use Seastar_API_LEVEL=3 instead")]]
-output_stream<char> make_file_output_stream(
-        file file,
-        file_output_stream_options options);
-
-/// Create a data_sink for writing starting at the position zero of a
-/// newly created file.
-[[deprecated("use Seastar_API_LEVEL=3 instead")]]
-data_sink make_file_data_sink(file, file_output_stream_options);
-
-}
-
-SEASTAR_INCLUDE_API_V3 namespace api_v3 {
-inline namespace and_newer {
-
 /// Create an output_stream for writing starting at the position zero of a
 /// newly created file.
 /// NOTE: flush() should be the last thing to be called on a file output stream.
@@ -145,8 +117,5 @@ future<output_stream<char>> make_file_output_stream(
 /// newly created file.
 /// Closes the file if the sink creation fails.
 future<data_sink> make_file_data_sink(file, file_output_stream_options) noexcept;
-
-}
-}
 
 }

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -50,23 +50,12 @@
 #define SEASTAR_INCLUDE_API_V3
 #endif
 
-#if SEASTAR_API_LEVEL == 2
-#define SEASTAR_INCLUDE_API_V2 inline
-#else
-#define SEASTAR_INCLUDE_API_V2
-#endif
-
 // Declare them here so we don't have to use the macros everywhere
 namespace seastar {
-    SEASTAR_INCLUDE_API_V2 namespace api_v2 {
-    }
     SEASTAR_INCLUDE_API_V3 namespace api_v3 {
-        inline namespace and_newer {
-        }
     }
     SEASTAR_INCLUDE_API_V4 namespace api_v4 {
         inline namespace and_newer {
-            using namespace api_v3::and_newer;
         }
     }
     SEASTAR_INCLUDE_API_V5 namespace api_v5 {

--- a/tests/perf/fstream_perf.cc
+++ b/tests/perf/fstream_perf.cc
@@ -53,7 +53,7 @@ int main(int ac, char** av) {
             foso.buffer_size = buffer_size;
             foso.preallocation_size = 32 << 20;
             foso.write_behind = concurrency;
-            return api_v3::and_newer::make_file_output_stream(f, foso).then([=] (output_stream<char>&& os) {
+            return make_file_output_stream(f, foso).then([=] (output_stream<char>&& os) {
                 return do_with(std::move(os), std::move(f), unsigned(0), [=] (output_stream<char>& os, file& f, unsigned& completed) {
                     auto start = std::chrono::steady_clock::now();
                     return repeat([=, &os, &completed] {

--- a/tests/unit/fsnotifier_test.cc
+++ b/tests/unit/fsnotifier_test.cc
@@ -56,7 +56,7 @@ SEASTAR_THREAD_TEST_CASE(test_notify_modify_close_delete) {
         | fsnotifier::flags::close
     ).get0();
 
-    auto os = api_v3::and_newer::make_file_output_stream(f).get0();
+    auto os = make_file_output_stream(f).get0();
     os.write("kossa").get();
     os.flush().get();
 
@@ -89,7 +89,7 @@ SEASTAR_THREAD_TEST_CASE(test_notify_overwrite) {
 
     auto write_file = [](fs::path& p, sstring content) {
         auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
-        auto os = api_v3::and_newer::make_file_output_stream(f).get0();
+        auto os = make_file_output_stream(f).get0();
         os.write(content).get();
         os.flush().get();
         os.close().get();

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -48,7 +48,7 @@ namespace fs = std::filesystem;
 struct writer {
     output_stream<char> out;
     static future<shared_ptr<writer>> make(file f) {
-        return api_v3::and_newer::make_file_output_stream(std::move(f)).then([] (output_stream<char>&& os) {
+        return make_file_output_stream(std::move(f)).then([] (output_stream<char>&& os) {
             return make_shared<writer>(writer{std::move(os)});
         });
     }
@@ -228,7 +228,7 @@ future<> test_consume_until_end(uint64_t size) {
     auto filename = (t.get_path() / "testfile.tmp").native();
     return open_file_dma(filename,
             open_flags::rw | open_flags::create | open_flags::truncate).then([size] (file f) {
-          return api_v3::and_newer::make_file_output_stream(f).then([size] (output_stream<char>&& os) {
+          return make_file_output_stream(f).then([size] (output_stream<char>&& os) {
             return do_with(std::move(os), [size] (output_stream<char>& out) {
                 std::vector<char> buf(size);
                 std::iota(buf.begin(), buf.end(), 0);
@@ -293,7 +293,7 @@ SEASTAR_TEST_CASE(test_input_stream_esp_around_eof) {
         auto f = open_file_dma(filename,
                 open_flags::rw | open_flags::create | open_flags::truncate).get0();
         auto close_f = deferred_close(f);
-        auto out = api_v3::and_newer::make_file_output_stream(f).get0();
+        auto out = make_file_output_stream(f).get0();
         out.write(reinterpret_cast<const char*>(data.data()), data.size()).get();
         out.flush().get();
         //out.close().get();  // FIXME: closes underlying stream:?!


### PR DESCRIPTION
Back in 2020, we changed make_file_output_stream() to return a future<file>. Since this is a breaking change, we introduced API level 2 to allow applications time to upgrade. More than enough time has passed, so it is now removed.

Since API level 3 and above is mandatory, the namespace api_v3::and_newer is also removed, and its contents are incorporated into the seastar namespace.

The documentation is updated.

I tried to build-test older API levels, but we seem to have broken them earlier and no one noticed. I plan to follow up with more API level removals as it's not worth fixing the compatibility code.