### PR TITLE
testing: test_runner: call _exit in thread on error

### DIFF
--- a/include/seastar/testing/test_runner.hh
+++ b/include/seastar/testing/test_runner.hh
@@ -56,7 +56,7 @@ public:
     ~test_runner();
     void run_sync(std::function<future<>()> task);
     // Returns the return value of the underlying `seastar::app::run()`.
-    int finalize();
+    int finalize(int exit_code = 0);
 };
 
 test_runner& global_test_runner();

--- a/src/testing/entry_point.cc
+++ b/src/testing/entry_point.cc
@@ -61,7 +61,7 @@ int entry_point(int argc, char** argv) {
 #endif
 
     const int boost_exit_code = ::boost::unit_test::unit_test_main(&init_unit_test_suite, argc, argv);
-    const int seastar_exit_code = seastar::testing::global_test_runner().finalize();
+    const int seastar_exit_code = seastar::testing::global_test_runner().finalize(boost_exit_code);
     if (boost_exit_code) {
         return boost_exit_code;
     }


### PR DESCRIPTION
Seastar doesn't have a clean way to drain background tasks so as @michoecho explain in
https://github.com/scylladb/seastar/issues/1514#issuecomment-1438615134:
```
while the reactor is being destroyed, some promises are destroyed,
so their futures are marked as broken and the tasks of these futures
are scheduled, but at this point the reactor's task queues might
already be destroyed and the schedule fails with a segfault.
```

Calling _exit after the test completes works around
that, though ideally, we better have a way to stop the reactor
engine cleanly and wait for it to drain all tasks.
    
We still return 0 on the present path on success
as no seastar tasks should be left behind in this case.

Fixes #1514
Refs scylladb/scylladb#13128