### PR TITLE
backtrace: fix size calculation in dl_iterate_phdr

### DIFF
--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -40,8 +40,8 @@ static int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size, void
     for (int i = 0; i < info->dlpi_phnum; i++) {
         const auto hdr = info->dlpi_phdr[i];
 
-        // Only account loadable, executable (text) segments
-        if (hdr.p_type == PT_LOAD && (hdr.p_flags & PF_X) == PF_X) {
+        // Only account loadable segments
+        if (hdr.p_type == PT_LOAD) {
             total_size += hdr.p_memsz;
         }
     }


### PR DESCRIPTION
Summing only the sizes of executable segments is a mistake. Since we use it only to find .text symbol offsets, it would still work if executable segments were always the first segments in the image. However, that's not true -- in fact, they are usually second.

For example, here's a fragment of debug mode Scylla /proc/PID/maps:

7ffff1600000-7ffff54b3000 r--p 00000000 fd:03 1280976814 /home/user/scylla/build/debug/seastar/libseastar.so 7ffff54b3000-7ffff6d0a000 r-xp 03eb2000 fd:03 1280976814 /home/user/scylla/build/debug/seastar/libseastar.so 7ffff6d0a000-7ffff6def000 r--p 05708000 fd:03 1280976814 /home/user/scylla/build/debug/seastar/libseastar.so 7ffff6def000-7ffff7ef5000 rw-p 057ec000 fd:03 1280976814 /home/user/scylla/build/debug/seastar/libseastar.so

Due to the bug, backtrace.cc badly calculates the size of libseastar.so to be 0x7ffff6d0a000 - 0x7ffff54b3000 == 0x1857000, and thinks that libseastar.so spans [0x7ffff1600000, 0x7ffff2e57000), which doesn't even intersect .text

This bug sometimes causes Seastar to print raw addresses for shared libraries in stack traces instead of the expected path+offset form.