### PR TITLE
reactor: add background gate to wait on background tasks

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -52,6 +52,7 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread_cputime_clock.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/net/api.hh>
 #include <seastar/util/eclipse.hh>
 #include <seastar/util/log.hh>
@@ -359,6 +360,7 @@ private:
     bool _have_aio_fsync = false;
     bool _kernel_page_cache = false;
     std::atomic<bool> _dying{false};
+    gate _background_gate;
 private:
     static std::chrono::nanoseconds calculate_poll_time();
     static void block_notifier(int);
@@ -563,6 +565,16 @@ public:
 
     void add_task(task* t) noexcept;
     void add_urgent_task(task* t) noexcept;
+
+    void run_in_background(future<> f);
+
+    template <typename Func>
+    void run_in_background(Func&& func) {
+        run_in_background(futurize_invoke(std::forward<Func>(func)));
+    }
+
+    // Waits for all background tasks on all shards
+    static future<> drain();
 
     /// Set a handler that will be called when there is no task to execute on cpu.
     /// Handler should do a low priority work.

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -2037,3 +2037,15 @@ SEASTAR_TEST_CASE(test_run_in_background) {
     });
     return make_ready_future<>();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_manual_clock_advance) {
+    bool expired = false;
+    auto t = timer<manual_clock>([&] {
+        expired = true;
+    });
+    t.arm(2ms);
+    manual_clock::advance(1ms);
+    BOOST_REQUIRE(!expired);
+    manual_clock::advance(1ms);
+    BOOST_REQUIRE(expired);
+}

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -2025,3 +2025,15 @@ SEASTAR_TEST_CASE(test_make_exception_future) {
 
     return make_ready_future<>();
 }
+
+// Reproduce use-after-free similar to #1514
+SEASTAR_TEST_CASE(test_run_in_background) {
+    engine().run_in_background([] {
+        return sleep(1ms).then([] {
+            return smp::invoke_on_all([] {
+                return sleep(1ms);
+            });
+        });
+    });
+    return make_ready_future<>();
+}


### PR DESCRIPTION
* reactor: add run_in_backround and close
  - run_in_background allows running background tasks safely, coupled with close() that wait on them using a gate.
* manual_clock: advance: use run_in_background to expire_timers
  - Fixes #1514