### PR TITLE
demos: file_demo: pass a string_view to_open_file_dma()

### DIFF
--- a/demos/file_demo.cc
+++ b/demos/file_demo.cc
@@ -118,8 +118,8 @@ future<> demo_with_file_close_on_failure() {
         // `make_file_output_stream` returns an error. Otherwise, in the error-free path,
         // the opened file is moved to `file_output_stream` that in-turn closes it
         // when the stream is closed.
-        auto make_output_stream = [] (const sstring filename) {
-            return with_file_close_on_failure(open_file_dma(std::move(filename), open_flags::rw | open_flags::create), [] (file f) {
+        auto make_output_stream = [] (std::string_view filename) {
+            return with_file_close_on_failure(open_file_dma(filename, open_flags::rw | open_flags::create), [] (file f) {
                 return make_file_output_stream(std::move(f), aligned_size);
             });
         };


### PR DESCRIPTION
before this change, we pass the filename to `open_file_dma()` by moving away from a const parameter of the lambda, this catches a linter's eye. as moving away from a const variable is a no-op. but what the callee expects is but a string_view. so even if we can move away from filename, it does not help with the performance or correctness.

so, in this change, we just change the signature of the lambda in question, so instead of accepting a `const sstring`, it accepts a `string_view`. this change has two advantages:

* make it explicit that the lambda relies on the caller to keep the filename alive.
* do not send the misleading message that open_file_dma() is able to "consume" the given `name` parameter.

Fixes #1549
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>