### PR TITLE
websocket_demo: fix coredump.

### DIFF
--- a/demos/websocket_demo.cc
+++ b/demos/websocket_demo.cc
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
             });
             ws.listen(socket_address(ipv4_addr("127.0.0.1", 8123)));
             std::cout << "Listening on 127.0.0.1:8123 for 1 hour (interruptible, hit Ctrl-C to stop)..." << std::endl;
-            seastar::sleep_abortable(std::chrono::hours(1)).get();
+            seastar::sleep_abortable(std::chrono::hours(1)).handle_exception([](auto ignored) {}).get();
             std::cout << "Stopping the server, deepest thanks to all clients, hope we meet again" << std::endl;
         });
     });

--- a/demos/websocket_demo.cc
+++ b/demos/websocket_demo.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     seastar::app_template app;
     app.run(argc, argv, [] () -> seastar::future<> {
         return async([] {
-            static websocket::server ws;
+            websocket::server ws;
             ws.register_handler("echo", [] (input_stream<char>& in,
                         output_stream<char>& out) {
                 return repeat([&in, &out]() {
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
                     });
                 });
             });
-            auto d = defer([] () noexcept {
+            auto d = defer([&ws] () noexcept {
                 ws.stop().get();
             });
             ws.listen(socket_address(ipv4_addr("127.0.0.1", 8123)));

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -69,8 +69,8 @@ enum opcodes {
 
 struct frame_header {
     static constexpr uint8_t FIN = 7;
-    static constexpr uint8_t RSV1 = 6; 
-    static constexpr uint8_t RSV2 = 5; 
+    static constexpr uint8_t RSV1 = 6;
+    static constexpr uint8_t RSV2 = 5;
     static constexpr uint8_t RSV3 = 4;
     static constexpr uint8_t MASKED = 7;
 
@@ -129,7 +129,7 @@ class websocket_parser {
     using buff_t = temporary_buffer<char>;
     // What parser is currently doing.
     parsing_state _state;
-    // State of connection - can be valid, closed or should be closed 
+    // State of connection - can be valid, closed or should be closed
     // due to error.
     connection_state _cstate;
     sstring _buffer;
@@ -151,11 +151,11 @@ class websocket_parser {
         for (uint64_t i = 0, j = 0; i < n; ++i, j = (j + 1) % 4) {
             payload[i] ^= static_cast<char>(((_masking_key << (j * 8)) >> 24));
         }
-    } 
+    }
 public:
     websocket_parser() : _state(parsing_state::flags_and_payload_data),
                          _cstate(connection_state::valid),
-                         _payload_length(0), 
+                         _payload_length(0),
                          _masking_key(0) {}
     future<consumption_result_t> operator()(temporary_buffer<char> data);
     bool is_valid() { return _cstate == connection_state::valid; }
@@ -208,8 +208,8 @@ class connection : public boost::intrusive::list_base_hook<> {
             return data->push_eventually(temporary_buffer<char>{std::move(f.base), f.size});
         }
 
-        size_t buffer_size() const noexcept override { 
-            return data->max_size(); 
+        size_t buffer_size() const noexcept override {
+            return data->max_size();
         }
 
         virtual future<> close() override {
@@ -278,7 +278,7 @@ public:
     void shutdown();
 
     future<> close();
-    
+
 protected:
     future<> read_loop();
     future<> read_one();

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -218,8 +218,6 @@ class connection : public boost::intrusive::list_base_hook<> {
         }
     };
 
-    future<> close(bool send_close);
-
     /*!
      * \brief This function processess received PING frame.
      * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
@@ -275,9 +273,8 @@ public:
     /*!
      * \brief close the socket
      */
-    void shutdown();
-
-    future<> close();
+    void shutdown_input();
+    future<> close(bool send_close = true);
 
 protected:
     future<> read_loop();

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -302,8 +302,7 @@ class server {
     std::vector<server_socket> _listeners;
     boost::intrusive::list<connection> _connections;
     std::map<std::string, handler_t> _handlers;
-    future<> _accept_fut = make_ready_future<>();
-    bool _stopped = false;
+    gate _task_gate;
 public:
     /*!
      * \brief listen for a WebSocket connection on given address
@@ -328,8 +327,8 @@ public:
 
     friend class connection;
 protected:
-    void do_accepts(int which);
-    future<> do_accept_one(int which);
+    void accept(server_socket &listener);
+    future<stop_iteration> accept_one(server_socket &listener);
 };
 
 /// }@

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -204,8 +204,8 @@ future<websocket_parser::consumption_result_t> websocket_parser::operator()(
 
                 // https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
                 // We must close the connection if data isn't masked.
-                if ((!_header->masked) || 
-                        // RSVX must be 0 
+                if ((!_header->masked) ||
+                        // RSVX must be 0
                         (_header->rsv1 | _header->rsv2 | _header->rsv3) ||
                         // Opcode must be known.
                         (!_header->is_opcode_known())) {
@@ -239,7 +239,7 @@ future<websocket_parser::consumption_result_t> websocket_parser::operator()(
                 }
                 _masking_key = be32toh(*(uint32_t const *)(input + offset));
                 _buffer = {};
-            }                
+            }
             _state = parsing_state::payload;
         } else {
             _buffer.append(data.get(), data.size());
@@ -252,7 +252,7 @@ future<websocket_parser::consumption_result_t> websocket_parser::operator()(
             remove_mask(data, data.size());
             _result = std::move(data);
             return websocket_parser::stop(buff_t(0));
-        } else { 
+        } else {
             _result = data.clone();
             remove_mask(_result, _payload_length);
             data.trim_front(_payload_length);
@@ -363,7 +363,7 @@ future<> connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
     msg.append(std::move(buff));
     return _write_buf.write(std::move(msg)).then([this] {
         return _write_buf.flush();
-    }); 
+    });
 }
 
 future<> connection::response_loop() {

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -52,7 +52,6 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
         websocket::connection conn(dummy, acceptor.get0().connection);
         future<> serve = conn.process();
         auto close = defer([&conn, &input, &output, &serve] () noexcept {
-            conn.shutdown();
             conn.close().get();
             input.close().get();
             output.close().get();
@@ -118,7 +117,6 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
         future<> serve = conn.process();
 
         auto close = defer([&conn, &input, &output, &serve] () noexcept {
-            conn.shutdown();
             conn.close().get();
             input.close().get();
             output.close().get();


### PR DESCRIPTION
* websocket_demo: declare ws as non-static to avoid use-after-free.
* websocket: guard background tasks with gate and wait for all the tasks when stopping server.
* websocket: shutdown input of connection first when stopping server to avoid gettings stuck in reading client input.

Signed-off-by: Jianyong Chen <baluschch@gmail.com>