### PR TITLE
Update lowres_clock when reactor stall is detected

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1137,6 +1137,8 @@ void cpu_stall_detector::on_signal() {
         // no task was processed - report unless supressed
         maybe_report();
         _report_at <<= 1;
+        // Both lowres clocks could become outdated after a reactor stall.
+        lowres_clock::update();
     } else {
         _last_tasks_processed_seen.store(tasks_processed, std::memory_order_relaxed);
     }


### PR DESCRIPTION
Currently, when reactor is blocked the counters for `lowres_clock` and `lowres_system_clock` are not updated. 
Because of that, right after the reactor stall the `lowres_clock::now()` method can return stale value. The difference between the actual clock and the stale one depends on the duration of the reactor stall.

This may cause problems in the following scenario:

```
  stall_reactor_for_1s();
  auto deadline = lowres_clock::now() + 100ms;
  co_await some_io_operation(deadline);
```

The last line throws timed_out_error exception because internally it compares the `deadline` parameter with `lowres_clock::now()` which jumps 1s forward after a scheduling point.

This PR fixes the problem by refreshing the counters when the stall is actually detected.