### PR TITLE
http: more flexible exceptional responses

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -61,9 +61,8 @@ private:
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url)
-            : base_exception("", http::reply::status_type::moved_permanently), url(
-                    url) {
+    redirect_exception(const std::string& url, reply::status_type status = reply::status_type::moved_permanently)
+            : base_exception("", status), url(url) {
     }
     std::string url;
 };

--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -39,6 +39,15 @@ public:
             : _msg(msg), _status(status) {
     }
 
+    /**
+     * A base_exception with a content_type is specifying a full response body, whereas
+     * a base_exception with only a _status is specifying a string that may be wrapped
+     * in e.g. a json_exception.
+     */
+    base_exception(const std::string& msg, reply::status_type status, const std::string &content_type)
+            : _msg(msg), _status(status), _content_type(content_type) {
+    }
+
     virtual const char* what() const throw () {
         return _msg.c_str();
     }
@@ -50,9 +59,14 @@ public:
     virtual const std::string& str() const {
         return _msg;
     }
+
+    virtual const std::string& content_type() const {
+        return _content_type;
+    }
 private:
     std::string _msg;
     http::reply::status_type _status;
+    std::string _content_type;
 
 };
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -101,7 +101,7 @@ public:
     future<> start_response();
 
     future<bool> generate_reply(std::unique_ptr<http::request> req);
-    void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg);
+    void generate_error_reply_and_close(std::unique_ptr<http::request> req, reply::status_type status, const sstring& msg, const sstring &content_type={});
 
     future<> write_body();
 

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -82,7 +82,12 @@ std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
         }
         std::rethrow_exception(eptr);
     } catch (const base_exception& e) {
-        rep->set_status(e.status(), json_exception(e).to_json());
+        if (e.content_type().size()) {
+            rep->set_status(e.status(), e.str());
+            rep->set_content_type(e.content_type());
+        } else {
+            rep->set_status(e.status(), json_exception(e).to_json());
+        }
     } catch (...) {
         rep->set_status(http::reply::status_type::internal_server_error,
                 json_exception(std::current_exception()).to_json());

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -37,6 +37,17 @@ void verify_param(const http::request& req, const sstring& param) {
     }
 }
 routes::routes() : _general_handler([this](std::exception_ptr eptr) mutable {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const redirect_exception& _e) {
+        auto rep = std::make_unique<http::reply>();
+        rep->add_header("Location", _e.url).set_status(_e.status()).done(
+                "json");
+        return rep;
+    } catch (...) {
+        // Fall through to return exception reply
+    }
+
     return exception_reply(eptr);
 }) {}
 


### PR DESCRIPTION

It is convenient for HTTP request handlers to be able to throw an exceptions with arbitrary responses:
- for general exceptions, setting the response content type and providing the full body.
- for redirects, specify what kind of redirect status should be used

An example of needing to set content type + body in Redpanda is where we have a configuration PUT handler that validates the request, and on invalid input returns a 400 status with a JSON body containing a dict of config key to the validation error.  This wasn't possible when the HTTP exception classes would always assume the content of a `httpd::base_exception` was a plain string, and wrap it in a generic exception JSON doc.

An example of setting a custom status on a redirect is where we redirect certain HTTP requests to raft leader nodes, where the default `moved_permanently` status doesn't make sense, and we use `temporary_redirect` instead.