### PR TITLE
reactor: trade comment for type constraints

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -135,7 +135,8 @@ class reactor_stall_sampler;
 class cpu_stall_detector;
 class buffer_allocator;
 
-template <typename Func> // signature: bool ()
+template <typename Func>
+SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
 std::unique_ptr<pollfn> make_pollfn(Func&& func);
 
 class poller {
@@ -144,7 +145,8 @@ class poller {
     class deregistration_task;
     registration_task* _registration_task = nullptr;
 public:
-    template <typename Func> // signature: bool ()
+    template <typename Func>
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
     static poller simple(Func&& poll) {
         return poller(make_pollfn(std::forward<Func>(poll)));
     }
@@ -698,7 +700,8 @@ public:
     std::function<void ()> get_stall_detector_report_function() const;
 };
 
-template <typename Func> // signature: bool ()
+template <typename Func>
+SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
 inline
 std::unique_ptr<seastar::pollfn>
 internal::make_pollfn(Func&& func) {


### PR DESCRIPTION
before this change, we are using comments for explaining the typing requirement of the `Func` template parameter. but the comment cannot be consumed by compiler, and is not specific enough even from human reader's perspective.

so, in this change, the "signature: bool()" comments are replaced with type constraints, so both compiler and human reader can consume and check this on a more specific common ground.