### PR TITLE
doc: compatibility: document API levels 5 and 6

### DIFF
--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -109,6 +109,8 @@ API Level History
 | 2   |  2019-07  | 2020-04 | Non-variadic futures in socket::accept()     |
 | 3   |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
 | 4   |  2020-06  |         | Non-variadic futures in when_all_succeed()   |
+| 5   |  2020-08  |         | future::get() returns std::monostate() instead of void |
+| 6   |  2020-09  |         | future<T> instead of future<T...>            |
 
 
 Note: The "mandatory" column indicates when backwards compatibility


### PR DESCRIPTION
Although I'm about to remove them, it should be understood what we are removing.

API level 5 (73513f68af55a810dc1336e3c1d9767f2041e869) changed the return type of future<>::get() from void to std::monostate, making it less irregular.

API level 6 (e215023c78b0e1efe9a943dcf65323f81fd1a721) changed the definition of the future class template from future<T..> to future<T = void>, making it non-variadic.