### PR TITLE
future: make API level 5 mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,11 @@ set (Seastar_API_LEVEL
   "6"
   CACHE
   STRING
-  "Seastar compatibility API level (4=when_all_succeed returns future<std::tuple<>>, 5=future<T>::get() returns T&&), 6=future is not variadic")
+  "Seastar compatibility API level (5=future<T>::get() returns T&&, 6=future is not variadic")
 
 set_property (CACHE Seastar_API_LEVEL
   PROPERTY
-  STRINGS 4 5 6)
+  STRINGS 5 6)
 
 set (Seastar_SCHEDULING_GROUPS_COUNT
   "16"

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -109,7 +109,7 @@ API Level History
 | 2   |  2019-07  | 2020-04 | Non-variadic futures in socket::accept()     |
 | 3   |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
 | 4   |  2020-06  | 2023-03 | Non-variadic futures in when_all_succeed()   |
-| 5   |  2020-08  |         | future::get() returns std::monostate() instead of void |
+| 5   |  2020-08  | 2023-03 | future::get() returns std::monostate() instead of void |
 | 6   |  2020-09  |         | future<T> instead of future<T...>            |
 
 

--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -178,11 +178,7 @@ struct return_type_of<Func, false> {
     using return_tuple_t = typename futurize<std::invoke_result_t<Func>>::tuple_type;
     using type = std::tuple_element_t<0, return_tuple_t>;
     static void set(std::promise<type>& p, return_value_t<Func>&& t) {
-#if SEASTAR_API_LEVEL < 5
-        p.set_value(std::get<0>(std::move(t)));
-#else
         p.set_value(std::move(t));
-#endif
     }
 };
 template <typename Func> using return_type_t = typename return_type_of<Func>::type;

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -239,31 +239,19 @@ struct future_stored_type;
 
 template <>
 struct future_stored_type<> {
-#if SEASTAR_API_LEVEL < 5
-    using type = std::tuple<>;
-#else
     using type = monostate;
-#endif
 };
 
 template <typename T>
 struct future_stored_type<T> {
-#if SEASTAR_API_LEVEL < 5
-    using type = std::tuple<T>;
-#else
     using type = std::conditional_t<std::is_void_v<T>, internal::monostate, T>;
-#endif
 };
 
 template <typename... T>
 using future_stored_type_t = typename future_stored_type<T...>::type;
 
 template<typename T>
-#if SEASTAR_API_LEVEL < 5
-using future_tuple_type_t = T;
-#else
 using future_tuple_type_t = std::conditional_t<std::is_same_v<T, monostate>, std::tuple<>, std::tuple<T>>;
-#endif
 
 // It doesn't seem to be possible to use std::tuple_element_t with an empty tuple. There is an static_assert in it that
 // fails the build even if it is in the non enabled side of std::conditional.
@@ -581,11 +569,7 @@ struct future_for_get_promise_marker {};
 template <typename T>
 struct future_state :  public future_state_base, private internal::uninitialized_wrapper<T> {
     static constexpr bool copy_noexcept = std::is_nothrow_copy_constructible<T>::value;
-#if SEASTAR_API_LEVEL < 5
-    static constexpr bool has_trivial_move_and_destroy = internal::is_tuple_effectively_trivially_move_constructible_and_destructible<T>;
-#else
     static constexpr bool has_trivial_move_and_destroy = internal::is_trivially_move_constructible_and_destructible<T>::value;
-#endif
     static_assert(std::is_nothrow_move_constructible<T>::value,
                   "Types must be no-throw move constructible");
     static_assert(std::is_nothrow_destructible<T>::value,
@@ -693,11 +677,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
     }
 
     get0_return_type get0() {
-#if SEASTAR_API_LEVEL < 5
-        return get0(std::move(*this).get());
-#else
         return std::move(*this).get();
-#endif
     }
 };
 
@@ -1388,11 +1368,7 @@ public:
     /// Equivalent to: \c std::get<0>(f.get()).
     using get0_return_type = typename future_state::get0_return_type;
     get0_return_type get0() {
-#if SEASTAR_API_LEVEL < 5
-        return future_state::get0(get());
-#else
         return (get0_return_type)get();
-#endif
     }
 
     /// Wait for the future to be available (in a seastar::thread)
@@ -1500,14 +1476,10 @@ private:
                 pr.set_exception(static_cast<future_state_base&&>(std::move(state)));
             } else {
                 futurator::satisfy_with_result_of(std::move(pr), [&func, &state] {
-#if SEASTAR_API_LEVEL < 5
-                    return std::apply(func, std::move(state).get_value());
-#else
                     // clang thinks that "state" is not used, below, for future<>.
                     // Make it think it is used to avoid an unused-lambda-capture warning.
                     (void)state;
                     return internal::future_invoke(func, std::move(state).get_value());
-#endif
                 });
             }
         });
@@ -1522,11 +1494,7 @@ private:
         if (failed()) {
             return futurator::make_exception_future(static_cast<future_state_base&&>(get_available_state_ref()));
         } else if (available()) {
-#if SEASTAR_API_LEVEL < 5
-            return futurator::apply(std::forward<Func>(func), get_available_state_ref().take_value());
-#else
             return futurator::invoke(std::forward<Func>(func), get_available_state_ref().take_value());
-#endif
         }
 #endif
         return then_impl_nrvo<Func, Result>(std::forward<Func>(func));
@@ -1924,7 +1892,6 @@ struct futurize : public internal::futurize_base<T> {
         return type(ready_future_marker(), value);
     }
 
-#if SEASTAR_API_LEVEL >= 5
     /// Convert the tuple representation into a future
     static type from_tuple(value_type&& value) {
         return type(ready_future_marker(), std::move(value));
@@ -1933,7 +1900,6 @@ struct futurize : public internal::futurize_base<T> {
     static type from_tuple(const value_type& value) {
         return type(ready_future_marker(), value);
     }
-#endif
 private:
     /// Forwards the result of, or exception thrown by, func() to the
     /// promise. This avoids creating a future if func() doesn't

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -38,29 +38,10 @@
 #define SEASTAR_INCLUDE_API_V5
 #endif
 
-#if SEASTAR_API_LEVEL == 4
-#define SEASTAR_INCLUDE_API_V4 inline
-#else
-#define SEASTAR_INCLUDE_API_V4
-#endif
-
-#if SEASTAR_API_LEVEL == 3
-#define SEASTAR_INCLUDE_API_V3 inline
-#else
-#define SEASTAR_INCLUDE_API_V3
-#endif
-
 // Declare them here so we don't have to use the macros everywhere
 namespace seastar {
-    SEASTAR_INCLUDE_API_V3 namespace api_v3 {
-    }
-    SEASTAR_INCLUDE_API_V4 namespace api_v4 {
-        inline namespace and_newer {
-        }
-    }
     SEASTAR_INCLUDE_API_V5 namespace api_v5 {
         inline namespace and_newer {
-            using namespace api_v4::and_newer;
         }
     }
     SEASTAR_INCLUDE_API_V6 namespace api_v6 {

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -35,11 +35,7 @@ static_assert(std::is_nothrow_move_constructible<future_state<std::tuple<int>>>:
 static_assert(sizeof(future_state<std::tuple<>>) <= 8, "future_state<std::tuple<>> is too large");
 static_assert(sizeof(future_state<std::tuple<long>>) <= 16, "future_state<std::tuple<long>> is too large");
 static_assert(future_state<std::tuple<>>::has_trivial_move_and_destroy, "future_state<std::tuple<>> not trivial");
-#if SEASTAR_API_LEVEL < 5
-static_assert(future_state<std::tuple<long>>::has_trivial_move_and_destroy, "future_state<std::tuple<long>> not trivial");
-#else
 static_assert(future_state<long>::has_trivial_move_and_destroy, "future_state<long> not trivial");
-#endif
 
 // We need to be able to move and copy std::exception_ptr in and out
 // of future/promise/continuations without that producing a new

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -77,11 +77,7 @@ SEASTAR_TEST_CASE(test_self_move) {
     s1.set(std::make_unique<int>(42));
     s1 = std::move(s1); // no crash, but the value of s1 is not defined.
 
-#if SEASTAR_API_LEVEL < 5
-    future_state<std::tuple<std::unique_ptr<int>>> s2;
-#else
     future_state<std::unique_ptr<int>> s2;
-#endif
     s2.set(std::make_unique<int>(42));
     std::swap(s2, s2);
     BOOST_REQUIRE_EQUAL(*std::move(s2).get0(), 42);
@@ -1259,9 +1255,6 @@ SEASTAR_TEST_CASE(test_futurize_from_tuple) {
     future<int> fut1 = futurize<int>::from_tuple(v1);
     future<> fut2 = futurize<void>::from_tuple(v2);
     BOOST_REQUIRE(fut1.get0() == std::get<0>(v1));
-#if SEASTAR_API_LEVEL < 5
-    BOOST_REQUIRE(fut2.get() == v2);
-#endif
     return make_ready_future<>();
 }
 


### PR DESCRIPTION
future::get() now return T (not wrapped in a tuple) and returns std::monostate for future<void>.