### PR TITLE
[RFC] reactor: optionally print decoded stack traces on abort

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "dpdk"]
 	path = dpdk
 	url = ../dpdk
+[submodule "libbacktrace"]
+	path = libbacktrace
+	url = https://github.com/ianlancetaylor/libbacktrace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,7 @@ find_package (ragel 6.10 REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
+find_package (libbacktrace REQUIRED)
 
 #
 # Code generation helpers.
@@ -789,6 +790,7 @@ target_link_libraries (seastar
     lksctp-tools::lksctp-tools
     rt::rt
     yaml-cpp::yaml-cpp
+    libbacktrace
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)
 

--- a/cmake/Findlibbacktrace.cmake
+++ b/cmake/Findlibbacktrace.cmake
@@ -1,0 +1,19 @@
+include(GNUInstallDirs)
+include(ExternalProject)
+
+set(config_flags "CPPFLAGS=-fPIC -g -O2")  # parameters desired for ./configure of Autotools
+
+ExternalProject_Add(my_libbacktrace
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libbacktrace
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure ${config_flags}
+    BUILD_COMMAND make -j
+    BINARY_DIR libbacktrace
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    BUILD_BYPRODUCTS <BINARY_DIR>/.libs/libbacktrace.a
+)
+
+ExternalProject_Get_property(my_libbacktrace BINARY_DIR)
+add_library(libbacktrace INTERFACE IMPORTED GLOBAL)
+add_dependencies(libbacktrace PRIVATE my_libbacktrace)
+target_link_libraries(libbacktrace INTERFACE ${BINARY_DIR}/.libs/libbacktrace.a)

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -157,6 +157,9 @@ struct reactor_options : public program_options::option_group {
     bool _auto_handle_sigint_sigterm = true;
     /// \endcond
 
+    /// \brief On abort, print a decoded backtrace in addition to the regular
+    /// backtrace. For use in testing and development, not in production.
+    program_options::value<bool> print_decoded_backtrace_on_abort;
 public:
     /// \cond internal
     reactor_options(program_options::option_group* parent_group);

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -236,4 +236,6 @@ throw_with_backtrace(Args&&... args) {
     std::rethrow_exception(make_backtraced_exception_ptr<Exc>(std::forward<Args>(args)...));
 };
 
+void print_decoded_backtrace();
+
 }

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -84,14 +84,14 @@ char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
 template<typename Integral>
 SEASTAR_CONCEPT( requires std::integral<Integral> )
 void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
-    convert_hex_safe<'0'>(buf, bufsz, n);
+    convert_hex_safe<Integral, '0'>(buf, bufsz, n);
 }
 
 // Prints zero-padded hexadecimal representation of an integer to stderr.
 // For example, print_zero_padded_hex_safe(uint16_t(12)) prints "000c".
 // Async-signal safe.
 template<typename Integral>
-SEASTAR_CONCEPT ( requires std::signed_integral<Integral> )
+SEASTAR_CONCEPT ( requires std::unsigned_integral<Integral> )
 void print_zero_padded_hex_safe(Integral n) noexcept {
     char buf[sizeof(n) * 2];
     convert_zero_padded_hex_safe(buf, sizeof(buf), n);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -803,14 +803,14 @@ static void print_with_backtrace(backtrace_buffer& buf, bool oneline) noexcept {
         buf.append_decimal(this_shard_id());
     }
 
-  if (!oneline) {
-    buf.append(".\nBacktrace:\n");
-    buf.append_backtrace();
-  } else {
-    buf.append(". Backtrace:");
-    buf.append_backtrace_oneline();
-    buf.append("\n");
-  }
+    if (!oneline) {
+        buf.append(".\nBacktrace:\n");
+        buf.append_backtrace();
+    } else {
+        buf.append(". Backtrace:");
+        buf.append_backtrace_oneline();
+        buf.append("\n");
+    }
     buf.flush();
 }
 

--- a/src/util/libbacktrace.h
+++ b/src/util/libbacktrace.h
@@ -1,0 +1,1 @@
+../../libbacktrace/backtrace.h


### PR DESCRIPTION
Decoding stack traces requires access to all binaries appearing in the backtrace, and a manual invocation of seastar-addr2line on the backtrace cop-pasted from logs. This is very inconvenient, especially since seastar became a shared library in debug mode, which makes the main executable alone insufficient to decode a backtrace.

In Scylla, we have backtrace.scylladb.com to automate this, but it is only applicable to public builds, not to local or CI builds.

This series adds an option, implemented using libbacktrace, which prints a decoded backtrace in addition to the regular backtrace.
It is only used on aborts, because the decoding can cause huge stalls.