### PR TITLE
core/on_internal_error: always log error with backtrace

### DIFF
--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -38,14 +38,17 @@ bool set_abort_on_internal_error(bool do_abort) noexcept;
 /// Report an internal error
 ///
 /// Depending on the value passed to set_abort_on_internal_error, this
-/// will either log to \p logger and abort or throw a std::runtime_error.
+/// will either abort or throw a std::runtime_error.
+/// In both cases an error will be logged with \p logger, containing
+/// \p reason and the current backtrace.
 [[noreturn]] void on_internal_error(logger& logger, std::string_view reason);
 
 /// Report an internal error
 ///
 /// Depending on the value passed to set_abort_on_internal_error, this
-/// will either log to \p logger and abort or throw the passed-in
-/// \p ex.
+/// will either abort or throw the passed-in \p ex.
+/// In both cases an error will be logged with \p logger, containing
+/// \p ex and the current backtrace.
 /// This overload cannot attach a backtrace to the exception, so if the
 /// caller wishes to have one attached they have to do it themselves.
 [[noreturn]] void on_internal_error(logger& logger, std::exception_ptr ex);

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -33,22 +33,22 @@ bool seastar::set_abort_on_internal_error(bool do_abort) noexcept {
     return abort_on_internal_error.exchange(do_abort);
 }
 
-static void log_error_and_backtrace(logger& logger, std::string_view msg) noexcept {
+template <typename Message>
+static void log_error_and_backtrace(logger& logger, const Message& msg) noexcept {
     logger.error("{}, at: {}", msg, current_backtrace());
 }
 
 void seastar::on_internal_error(logger& logger, std::string_view msg) {
+    log_error_and_backtrace(logger, msg);
     if (abort_on_internal_error.load()) {
-        log_error_and_backtrace(logger, msg);
         abort();
     } else {
-        logger.error(msg);
         throw_with_backtrace<std::runtime_error>(std::string(msg));
     }
 }
 
 void seastar::on_internal_error(logger& logger, std::exception_ptr ex) {
-    logger.error("{}", ex);
+    log_error_and_backtrace(logger, ex);
     if (abort_on_internal_error.load()) {
         abort();
     } else {


### PR DESCRIPTION
For some reason the backtrace was only logged when `abort_on_internal_error` was set to true, otherwise the backtrace was only attached to the exception thrown but not the log message. This doesn't makes sense and it means that if the exception is not printed (correctly) the backtrace is lost completely. This patch fixes this and makes sure the error message is logged with a backtrace, regardless of what `abort_on_internal_error` is set to. No performance degradation is expected from this, internal error should be *very* rare and once they happen, the performance of the affected code path is not interesting anymore.