### PR TITLE
future: make API level 6 mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ set (Seastar_API_LEVEL
 
 set_property (CACHE Seastar_API_LEVEL
   PROPERTY
-  STRINGS 5 6)
+  STRINGS 6)
 
 set (Seastar_SCHEDULING_GROUPS_COUNT
   "16"

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -110,7 +110,7 @@ API Level History
 | 3   |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
 | 4   |  2020-06  | 2023-03 | Non-variadic futures in when_all_succeed()   |
 | 5   |  2020-08  | 2023-03 | future::get() returns std::monostate() instead of void |
-| 6   |  2020-09  |         | future<T> instead of future<T...>            |
+| 6   |  2020-09  | 2023-03 | future<T> instead of future<T...>            |
 
 
 Note: The "mandatory" column indicates when backwards compatibility

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -32,21 +32,11 @@
 #define SEASTAR_INCLUDE_API_V6
 #endif
 
-#if SEASTAR_API_LEVEL == 5
-#define SEASTAR_INCLUDE_API_V5 inline
-#else
-#define SEASTAR_INCLUDE_API_V5
-#endif
 
 // Declare them here so we don't have to use the macros everywhere
 namespace seastar {
-    SEASTAR_INCLUDE_API_V5 namespace api_v5 {
-        inline namespace and_newer {
-        }
-    }
     SEASTAR_INCLUDE_API_V6 namespace api_v6 {
         inline namespace and_newer {
-            using namespace api_v5::and_newer;
         }
     }
 }

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -34,13 +34,7 @@ namespace seastar {
 
 constexpr unsigned max_scheduling_groups() { return SEASTAR_SCHEDULING_GROUPS_COUNT; }
 
-#if SEASTAR_API_LEVEL < 6
-#define SEASTAR_ELLIPSIS ...
-template <typename SEASTAR_ELLIPSIS T>
-#else
-#define SEASTAR_ELLIPSIS
 template <typename T = void>
-#endif
 class future;
 
 class reactor;


### PR DESCRIPTION
In e215023c78b0e ("future: Make futures non variadic"), we made futures and related types non-variadic, and introduced API level 6 to ease transition. 2½ years later we retire variadic futures completely and make API level 6 mandatory.