### PR TITLE
api-level: update IDE fallback

### DIFF
--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -23,7 +23,7 @@
 
 // For IDEs that don't see SEASTAR_API_LEVEL, generate a nice default
 #ifndef SEASTAR_API_LEVEL
-#define SEASTAR_API_LEVEL 3
+#define SEASTAR_API_LEVEL 6
 #endif
 
 #if SEASTAR_API_LEVEL == 6


### PR DESCRIPTION
We have a fallback for IDEs that don't see the cmake definition. Update it to the latest level.