### PR TITLE
test: alien_test: test alien::run_on() also

### DIFF
--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -29,6 +29,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/later.hh>
+#include <stdexcept>
 
 using namespace seastar;
 
@@ -53,10 +54,10 @@ int main(int argc, char** argv)
         // wait until the seastar engine is ready
         int r = ::eventfd_read(engine_ready_fd, &result);
         if (r < 0) {
-            return -EINVAL;
+            throw std::runtime_error("failed to wait for seastar engine");
         }
         if (result != ENGINE_READY) {
-            return -EINVAL;
+            throw std::runtime_error("seastar failed to sent us the ready message");
         }
         std::vector<std::future<int>> counts;
         for (auto i : boost::irange(0u, smp::count)) {

--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/later.hh>
 #include <stdexcept>
+#include <tuple>
 
 using namespace seastar;
 
@@ -59,6 +60,13 @@ int main(int argc, char** argv)
         if (result != ENGINE_READY) {
             throw std::runtime_error("seastar failed to sent us the ready message");
         }
+        // test for alien::run_on()
+        std::promise<char> question;
+        auto answer = question.get_future();
+        alien::run_on(app.alien(), 0, [&question]() noexcept {
+            question.set_value('*');
+        });
+        // test for alien::submit_to(), which returns a std::future<int>
         std::vector<std::future<int>> counts;
         for (auto i : boost::irange(0u, smp::count)) {
             // send messages from alien.
@@ -66,7 +74,7 @@ int main(int argc, char** argv)
                 return seastar::make_ready_future<int>(i);
             }));
         }
-        // std::future<void>
+        // test for alien::submit_to(), which returns a std::future<void>
         alien::submit_to(app.alien(), 0, [] {
             return seastar::make_ready_future<>();
         }).wait();
@@ -76,7 +84,7 @@ int main(int argc, char** argv)
         }
         // i am done. dismiss the engine
         ::eventfd_write(alien_done, ALIEN_DONE);
-        return total;
+        return std::make_tuple(answer.get(), total);
     });
 
     eventfd_t result = 0;
@@ -107,7 +115,11 @@ int main(int argc, char** argv)
             seastar::engine().exit(0);
         });
     });
-    int total = zim.get();
+    auto [everything, total] = zim.get();
+    if (char expected = '*'; everything != '*') {
+        std::cerr << "Bad everything: " << everything << " != " << expected << std::endl;
+        return 1;
+    }
     const auto shards = boost::irange(0u, smp::count);
     auto expected = std::accumulate(std::begin(shards), std::end(shards), 0);
     if (total != expected) {


### PR DESCRIPTION
would be nice if we have more coverage of alien::* helpers. so,
in this change, the test exercising alien::run_on() is added.
please note, noexcept specifier is added to the lambda passed to
alien::run_on() to explain that this function does not throw, also,
this paves the road to the type constraint to be added to
alien::run_on() in a coming commit.
