### PR TITLE
Relax per tick IO grab threshold

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -240,7 +240,7 @@ public:
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };
 
-    explicit fair_group(config cfg);
+    explicit fair_group(config cfg, unsigned nr_queues);
     fair_group(fair_group&&) = delete;
 
     fair_queue_ticket cost_capacity() const noexcept { return _cost_capacity; }

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -209,6 +209,7 @@ private:
 
     const fair_queue_ticket _cost_capacity;
     token_bucket_t _token_bucket;
+    const capacity_t _per_tick_threshold;
 
 public:
 
@@ -245,6 +246,7 @@ public:
 
     fair_queue_ticket cost_capacity() const noexcept { return _cost_capacity; }
     capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
+    capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
     capacity_t grab_capacity(capacity_t cap) noexcept;
     clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
     void release_capacity(capacity_t cap) noexcept;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -171,7 +171,7 @@ private:
 
 class io_group {
 public:
-    explicit io_group(io_queue::config io_cfg);
+    explicit io_group(io_queue::config io_cfg, unsigned nr_queues);
     ~io_group();
     struct priority_class_data;
 

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -105,6 +105,7 @@ struct memory {
 struct io_queue_topology {
     std::vector<std::unique_ptr<io_queue>> queues;
     std::vector<unsigned> shard_to_group;
+    std::vector<unsigned> shards_in_group;
     std::vector<std::shared_ptr<io_group>> groups;
 
     util::spinlock lock;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -92,7 +92,7 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
             std::max<int32_t>(a._size - b._size, 0));
 }
 
-fair_group::fair_group(config cfg)
+fair_group::fair_group(config cfg, unsigned nr_queues)
         : _cost_capacity(cfg.weight_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count(), cfg.size_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count())
         , _token_bucket(cfg.rate_factor * fixed_point_factor,
                         std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), ticket_capacity(fair_queue_ticket(cfg.limit_min_weight, cfg.limit_min_size))),
@@ -100,7 +100,7 @@ fair_group::fair_group(config cfg)
                        )
 {
     assert(_cost_capacity.is_non_zero());
-    seastar_logger.info("Created fair group {}, capacity rate {}, limit {}, rate {} (factor {}), threshold {}", cfg.label,
+    seastar_logger.info("Created fair group {} for {} queues, capacity rate {}, limit {}, rate {} (factor {}), threshold {}", cfg.label, nr_queues,
             _cost_capacity, _token_bucket.limit(), _token_bucket.rate(), cfg.rate_factor, _token_bucket.threshold());
 
     if (cfg.rate_factor * fixed_point_factor > _token_bucket.max_rate) {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -569,15 +569,15 @@ static void maybe_warn_latency_goal_auto_adjust(const fair_group& fg, const io_q
     seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, cfg.devid);
 }
 
-io_group::io_group(io_queue::config io_cfg)
+io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
     : _config(std::move(io_cfg))
     , _allocated_on(this_shard_id())
 {
     auto fg_cfg = make_fair_group_config(_config);
-    _fgs.push_back(std::make_unique<fair_group>(fg_cfg));
+    _fgs.push_back(std::make_unique<fair_group>(fg_cfg, nr_queues));
     maybe_warn_latency_goal_auto_adjust(*_fgs.back(), io_cfg);
     if (_config.duplex) {
-        _fgs.push_back(std::make_unique<fair_group>(fg_cfg));
+        _fgs.push_back(std::make_unique<fair_group>(fg_cfg, nr_queues));
         maybe_warn_latency_goal_auto_adjust(*_fgs.back(), io_cfg);
     }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4288,7 +4288,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 if (!iog) {
                     struct io_queue::config qcfg = disk_config.generate_config(topo.first, io_info.groups.size());
                     iog = std::make_shared<io_group>(std::move(qcfg));
-                    seastar_logger.debug("allocate {} IO group, dev {}", group_idx, topo.first);
+                    seastar_logger.debug("allocate {} IO group with {} queues, dev {}", group_idx, io_info.shards_in_group[group_idx], topo.first);
                 }
                 group = iog;
             }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4287,7 +4287,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 auto& iog = io_info.groups[group_idx];
                 if (!iog) {
                     struct io_queue::config qcfg = disk_config.generate_config(topo.first, io_info.groups.size());
-                    iog = std::make_shared<io_group>(std::move(qcfg));
+                    iog = std::make_shared<io_group>(std::move(qcfg), io_info.shards_in_group[group_idx]);
                     seastar_logger.debug("allocate {} IO group with {} queues, dev {}", group_idx, io_info.shards_in_group[group_idx], topo.first);
                 }
                 group = iog;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4288,13 +4288,13 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 if (!iog) {
                     struct io_queue::config qcfg = disk_config.generate_config(topo.first, io_info.groups.size());
                     iog = std::make_shared<io_group>(std::move(qcfg));
-                    seastar_logger.debug("allocate {} IO group", group_idx);
+                    seastar_logger.debug("allocate {} IO group, dev {}", group_idx, topo.first);
                 }
                 group = iog;
             }
 
             io_info.queues[shard] = std::make_unique<io_queue>(std::move(group), engine()._io_sink);
-            seastar_logger.debug("attached {} queue to {} IO group", shard, group_idx);
+            seastar_logger.debug("attached {} queue to {} IO group, dev {}", shard, group_idx, topo.first);
         }
     };
 

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -47,7 +47,7 @@ struct local_fq_and_class {
     seastar::fair_queue& queue(bool local) noexcept { return local ? fq : sfq; }
 
     local_fq_and_class(seastar::fair_group& sfg)
-        : fg(fg_config())
+        : fg(fg_config(), 1)
         , fq(fg, seastar::fair_queue::config())
         , sfq(sfg, seastar::fair_queue::config())
     {
@@ -87,7 +87,7 @@ struct perf_fair_queue {
     }
 
     perf_fair_queue()
-        : shared_fg(fg_config())
+        : shared_fg(fg_config(), smp::count)
     {
         local_fq.start(std::ref(shared_fg)).get();
     }

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -81,7 +81,7 @@ class test_env {
     }
 public:
     test_env(unsigned capacity)
-        : _fg(fg_config(capacity))
+        : _fg(fg_config(capacity), 1)
         , _fq(_fg, fq_config())
     {}
 

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -76,7 +76,7 @@ struct io_queue_for_tests {
     timer<> kicker;
 
     io_queue_for_tests()
-        : group(std::make_shared<io_group>(io_queue::config{0}))
+        : group(std::make_shared<io_group>(io_queue::config{0}, 1))
         , sink()
         , queue(group, sink)
         , kicker([this] { kick(); })


### PR DESCRIPTION
Each tick a queue is not allowed to grab all the capacity that's  available on the group. If it hits this local limit, it stops     dispatching, but is allowed to push more data into disk next tick if the capacity is available. There's an apparent mis-calculation in this per-tick threshold, which is now group_limit / smp::count. That's wrong because group limit is shared between queues in the group, not between the whole node. The fix is to calculate the numer of queues each group has and divide group capacity by this value, not smp::count.