### PR TITLE
Metrics: Support choosing an aggregation function when using aggregate_by_label

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -246,6 +246,17 @@ public:
 };
 
 /*!
+ * \brief choose how metrics will be aggregated when using aggregate by labels.
+ */
+enum class aggregate_function_type : uint8_t {
+    SUM,
+    AVG,
+    MIN,
+    MAX
+};
+
+
+/*!
  * \namespace impl
  * \brief holds the implementation parts of the metrics layer, do not use directly.
  *
@@ -341,7 +352,28 @@ public:
         return *this;
     }
 
+    /*
+     * \brief Update the current value to reflect weighted average
+     *
+     * avg method calculates the average iteratively.
+     * It performs a weighted average between the current value and a new value.
+     * The weight will reflect the number of values in the series so far.
+     * For example, assume that the series is 1, 2, 3
+     * When adding 2, count would be 1
+     * and the new value would be 1X0.5 + 2X0.5 = 1.5 which eqals also to (1 + 2)/2
+     *
+     * When adding 3 the new value would be: 1.5 * 0.666 + 3 *.0333 = 2 which equals to (1 + 2 + 3)/3
+     *
+     * c - the new value.
+     * count - how many values were counted so far.
+     *
+     */
+    metric_value& avg(const metric_value& c, size_t count);
+
     metric_value operator+(const metric_value& c);
+
+    bool operator<(const metric_value& c) const noexcept;
+
     const histogram& get_histogram() const {
         return std::get<histogram>(u);
     }
@@ -375,11 +407,12 @@ struct metric_definition_impl {
     bool enabled = true;
     skip_when_empty _skip_when_empty = skip_when_empty::no;
     std::vector<std::string> aggregate_labels;
+    aggregate_function_type aggregate_function;
     std::map<sstring, sstring> labels;
     metric_definition_impl& operator ()(bool enabled);
     metric_definition_impl& operator ()(const label_instance& label);
     metric_definition_impl& operator ()(skip_when_empty skip) noexcept;
-    metric_definition_impl& aggregate(const std::vector<label>& labels) noexcept;
+    metric_definition_impl& aggregate(const std::vector<label>& labels, aggregate_function_type ag_function = aggregate_function_type::SUM) noexcept;
     metric_definition_impl& set_skip_when_empty(bool skip=true) noexcept;
     metric_definition_impl& set_type(const sstring& type_name);
     metric_definition_impl(
@@ -388,7 +421,8 @@ struct metric_definition_impl {
         metric_function f,
         description d,
         std::vector<label_instance> labels,
-        std::vector<label> aggregate_labels = {});
+        std::vector<label> aggregate_labels = {},
+        aggregate_function_type ag_function = aggregate_function_type::SUM);
 };
 
 class metric_groups_def {

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -174,6 +174,7 @@ struct metric_family_info {
     description d;
     sstring name;
     std::vector<std::string> aggregate_labels;
+    aggregate_function_type aggregate_function;
 };
 
 
@@ -361,7 +362,7 @@ public:
         return _value_map;
     }
 
-    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip, const std::vector<std::string>& aggregate_labels);
+    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip, const std::vector<std::string>& aggregate_labels, aggregate_function_type ag_function);
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -32,6 +32,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/loop.hh>
 #include <regex>
+#include <algorithm>
 
 namespace seastar {
 
@@ -531,9 +532,12 @@ void write_summary(std::stringstream& s, const config& ctx, const sstring& name,
  */
 class metric_aggregate_by_labels {
     std::vector<std::string> _labels_to_aggregate_by;
+    metrics::aggregate_function_type _aggregate_function;
     std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value> _values;
+    std::unordered_map<std::map<sstring, sstring>, size_t> _count;
 public:
-    metric_aggregate_by_labels(std::vector<std::string> labels) : _labels_to_aggregate_by(std::move(labels)) {
+    metric_aggregate_by_labels(std::vector<std::string> labels, metrics::aggregate_function_type agg_function) :
+        _labels_to_aggregate_by(std::move(labels)), _aggregate_function(agg_function) {
     }
     /*!
      * \brief add a metric
@@ -550,9 +554,27 @@ public:
         }
         std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value>::iterator i = _values.find(labels);
         if ( i == _values.end()) {
+            _count.emplace(labels, 1);
             _values.emplace(std::move(labels), m);
         } else {
-            i->second += m;
+            auto& value = i->second;
+            switch (_aggregate_function) {
+            case metrics::aggregate_function_type::SUM:
+                value += m;
+                break;
+            case metrics::aggregate_function_type::AVG: {
+                auto& count = _count.find(labels)->second;
+                value.avg(m, count);
+                count++;
+                break;
+            }
+            case metrics::aggregate_function_type::MIN:
+                value = std::min(i->second, m);
+                break;
+            case metrics::aggregate_function_type::MAX:
+                value = std::max(i->second, m);
+                break;
+            }
         }
     }
     const std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value>& get_values() const noexcept {
@@ -586,7 +608,7 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
         for (metric_family& metric_family : m) {
             auto name = ctx.prefix + "_" + metric_family.name();
             found = false;
-            metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels);
+            metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels, metric_family.metadata().aggregate_function);
             bool should_aggregate = !metric_family.metadata().aggregate_labels.empty();
             metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help, &filter](auto value, auto value_info) mutable {
                 s.clear();


### PR DESCRIPTION
This series adds support to use different aggregation function with the metrics layer.

The metrics layer already supports aggregate metrics by label, after this series it would be possible to determine which aggregation function would be used.

The supported options are: SUM, MIN, MAX, AVG.

The default aggregation function is SUM, which is the common case.

usage example:
```
ms::make_gauge("messages", ms::description("Average messages"), _msg)
      .aggregate({ms::shard_label}, ms::aggregate_function_type::AVG)
```