### PR TITLE
future: drop libc++ std::tuple compatibility hack

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -334,15 +334,6 @@ template <typename T> struct uninitialized_wrapper_base<T, true> : private T {
 
 template <typename T>
 constexpr bool can_inherit =
-#ifdef _LIBCPP_VERSION
-// We expect std::tuple<> to be trivially constructible and
-// destructible. That is not the case with libc++
-// (https://bugs.llvm.org/show_bug.cgi?id=41714).  We could avoid this
-// optimization when using libc++ and relax the asserts, but
-// inspection suggests that std::tuple<> is trivial, it is just not
-// marked as such.
-        std::is_same<std::tuple<>, T>::value ||
-#endif
         (std::is_trivially_destructible<T>::value && std::is_trivially_constructible<T>::value &&
                 std::is_class<T>::value && !std::is_final<T>::value);
 


### PR DESCRIPTION
We have a compatibility hack asserting that std::tuple<> is trivially constructible. Since libc++ 9 this is so [1], and in fact it was since standardized (LWG 3211), so drop the hack.

[1] https://github.com/llvm/llvm-project/commit/405570dc7a95cdf43cdee14b8a9f9c1657a6ad13