### PR TITLE
timer-set: remove unnecessary ";"

### DIFF
--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -859,6 +859,6 @@ typed_value::typed_value(const type_id& tid, const scollectd::type_instance& ti,
 
 // Send a message packet (string)
 future<> send_notification(const type_instance_id & id, const sstring & msg);
-};
+}
 
 }

--- a/include/seastar/core/timer-set.hh
+++ b/include/seastar/core/timer-set.hh
@@ -251,4 +251,4 @@ public:
         return Timer::clock::now();
     }
 };
-};
+}


### PR DESCRIPTION
there is no need to add a `;` after `}` which ends a namespace, so let's remove it.