### PR TITLE
condition-variable: replace the coroutine wakeup task with a promise

### DIFF
--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -94,44 +94,26 @@ private:
     };
 
 #ifdef SEASTAR_COROUTINES_ENABLED
-    struct [[nodiscard("must co_await a when() call")]] awaiter : public waiter, private seastar::task {
-        using handle_type = std::coroutine_handle<void>;
-
+    struct [[nodiscard("must co_await a when() call")]] awaiter : public waiter {
         condition_variable* _cv;
-        handle_type _when_ready;
-        std::exception_ptr _ex;
-        task* _waiting_task = nullptr;
+        promise<> _p;
 
         awaiter(condition_variable* cv)
             : _cv(cv)
         {}
 
-        bool await_ready() const {
-            return _cv->check_and_consume_signal();
-        }
-        template<typename T>
-        void await_suspend(std::coroutine_handle<T> h) {
-            _when_ready = h;
-            _waiting_task = &h.promise();
-            _cv->add_waiter(*this);
-        }
-        void run_and_dispose() noexcept override {
-            _when_ready.resume();
-        }
-        task* waiting_task() noexcept override { 
-            return _waiting_task;
-        }
-        void await_resume() {
-            if (_ex) {
-                std::rethrow_exception(std::move(_ex));
-            }
-        }
         void signal() noexcept override {
-            schedule(this);
+            _p.set_value();
         }
         void set_exception(std::exception_ptr ep) noexcept override {
-            _ex = std::move(ep);
-            schedule(this);
+            _p.set_exception(std::move(ep));
+        }
+        auto operator co_await() {
+            if (_cv->check_and_consume_signal()) {
+                return ::seastar::internal::awaiter<false, void>(make_ready_future<>());
+            }
+            _cv->add_waiter(*this);
+            return ::seastar::internal::awaiter<false, void>(_p.get_future());
         }
     };
 
@@ -146,12 +128,6 @@ private:
             : awaiter(cv)
             , _timeout(timeout)
         {}
-        template<typename T>
-        void await_suspend(std::coroutine_handle<T> h) {
-            awaiter::await_suspend(std::move(h));
-            this->set_callback(std::bind(&waiter::timeout, this));
-            this->arm(_timeout);
-        }
         void signal() noexcept override {
             this->cancel();
             awaiter::signal();
@@ -159,6 +135,14 @@ private:
         void set_exception(std::exception_ptr ep) noexcept override {
             this->cancel();
             awaiter::set_exception(std::move(ep));
+        }
+        auto operator co_await() {
+            if (_cv->check_and_consume_signal()) {
+                return ::seastar::internal::awaiter<false, void>(make_ready_future<>());
+            }
+            this->set_callback(std::bind(&waiter::timeout, this));
+            this->arm(_timeout);
+            return awaiter::operator co_await();
         }
     };
 
@@ -170,15 +154,8 @@ private:
             : Base(std::forward<Args>(args)...)
             , _func(std::move(func))
         {}
-        bool await_ready() const {
-            if (!_func()) {
-                Base::await_ready(); // clear out any signal state
-                return false;
-            }
-            return true;
-        }        
         void signal() noexcept override {
-            if (Base::_ex || _func()) {
+            if (_func()) {
                 Base::signal();
             } else {
                 // must re-enter waiter queue
@@ -186,6 +163,14 @@ private:
                 // semantics of moving to back of queue
                 // if predicate fails
                 Base::_cv->add_waiter(*this);
+            }
+        }
+        auto operator co_await() {
+            if (_func()) {
+                return ::seastar::internal::awaiter<false, void>(make_ready_future<>());
+            } else {
+                Base::_cv->check_and_consume_signal(); // clear out any signal state
+                return Base::operator co_await();
             }
         }
     };


### PR DESCRIPTION
condition_variable::awaiter implements the coroutine resumption after signal() by scheduling itself as a task which resumes the coroutine. The awaiter itself is (usually) allocated inside the coroutine frame, and dies after its containing co_await expression is resumed.

This is a problem, because the reactor expects tasks to stay alive while they are running — it saves a pointer to the current task in reactor::_current_task, which is used to find the parent task when printing the tasktrace. Because the awaiter task dies immediately after returning control to its parent, reactor::_current_task is left pointing to some garbage in the coroutine frame and current_tasktrace() will segfault when used before the next task switch.

This patch replaces this wakeup logic with a promise-future pair. Instead of scheduling a handle resume task, signal() just triggers a promise. All coroutine logic is reused from the implementation of co_await for futures.

Fixes #1599