### PR TITLE
treewide: drop the support of fmtlib < 8.0.0

### DIFF
--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -125,7 +125,7 @@ macro (seastar_find_dependencies)
   seastar_set_dep_args (dpdk
     OPTION ${Seastar_DPDK})
   seastar_set_dep_args (fmt REQUIRED
-    VERSION 5.0.0)
+    VERSION 8.1.1)
   seastar_set_dep_args (lz4 REQUIRED
     VERSION 1.7.3)
   seastar_set_dep_args (GnuTLS REQUIRED

--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -142,11 +142,7 @@ template <typename... A>
 sstring
 format(const char* fmt, A&&... a) {
     fmt::memory_buffer out;
-#if FMT_VERSION >= 80000
     fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<A>(a)...);
-#else
-    fmt::format_to(out, fmt, std::forward<A>(a)...);
-#endif
     return sstring{out.data(), out.size()};
 }
 

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -295,7 +295,7 @@ public:
         if (is_enabled(level)) {
             try {
                 lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
-#if defined(SEASTAR_LOGGER_COMPILE_TIME_FMT) || FMT_VERSION < 80000
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
                     return fmt::format_to(it, fmt.format, std::forward<Args>(args)...);
 #else
                     return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
@@ -330,11 +330,7 @@ public:
                     if (rl.has_dropped_messages()) {
                         it = fmt::format_to(it, "(rate limiting dropped {} similar messages) ", rl.get_and_reset_dropped_messages());
                     }
-#if FMT_VERSION >= 80000
                     return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
-#else
-                    return fmt::format_to(it, fmt.format, std::forward<Args>(args)...);
-#endif
                 });
                 do_log(level, writer);
             } catch (...) {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2022,11 +2022,7 @@ seastar::internal::log_buf::inserter_iterator do_dump_memory_diagnostics(seastar
 
     if (additional_diagnostics_producer) {
         additional_diagnostics_producer([&it] (std::string_view v) mutable {
-#if FMT_VERSION >= 80000
             it = fmt::format_to(it, fmt::runtime(v));
-#else
-            it = fmt::format_to(it, v);
-#endif
         });
     }
 

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -34,13 +34,9 @@ module;
 #include <algorithm>
 
 #include <fmt/core.h>
-#if FMT_VERSION >= 60000
 #include <fmt/chrono.h>
 #include <fmt/color.h>
 #include <fmt/ostream.h>
-#elif FMT_VERSION >= 50000
-#include <fmt/time.h>
-#endif
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
@@ -100,7 +96,6 @@ template <> struct formatter<wrapped_log_level> {
         };
         int index = static_cast<int>(wll.level);
         std::string_view name = text[index];
-#if FMT_VERSION >= 60000
         static seastar::array_map<text_style, nr_levels> style = {
             { int(log_level::debug), fg(terminal_color::green)  },
             { int(log_level::info),  fg(terminal_color::white)  },
@@ -112,7 +107,6 @@ template <> struct formatter<wrapped_log_level> {
             return fmt::format_to(ctx.out(), "{}",
                 fmt::format(style[index], "{}", name));
         }
-#endif
         return fmt::format_to(ctx.out(), "{}", name);
     }
 };

--- a/tests/unit/log_buf_test.cc
+++ b/tests/unit/log_buf_test.cc
@@ -66,22 +66,14 @@ SEASTAR_TEST_CASE(log_buf_insert_iterator_format_to) {
     memset(str, 'a', size);
     str[size] = '\0';
 
-#if FMT_VERSION >= 80000
     it = fmt::format_to(it, fmt::runtime(str), size);
-#else
-    it = fmt::format_to(it, str, size);
-#endif
     BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
 
     *it++ = '\n';
     BOOST_REQUIRE_NE(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
 
     memset(str, 'b', size);
-#if FMT_VERSION >= 80000
     it = fmt::format_to(it, fmt::runtime(str), size);
-#else
-    it = fmt::format_to(it, str, size);
-#endif
     *it++ = '\n';
 
     const char* p = b.data();


### PR DESCRIPTION
in the light of requirement of newer compiler versions, and distros providing these compiler versions also package newer fmtlib, we can now able to assume that developers should have the access to the fmtlib > 8.1.1 if they are using the compiler(s) shipped by distros. so, to have a cleaner code base and to improve the maintainability, in this series, we bump up the minimal required version of fmtlib from 5.0.0 to 8.1.1, also the code supporting fmtlib < 8.0 is removed.