### PR TITLE
util/conversion: remove inclusion guards

### DIFF
--- a/src/util/conversions.cc
+++ b/src/util/conversions.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifndef CONVERSIONS_CC_
-#define CONVERSIONS_CC_
-
 #include <seastar/util/conversions.hh>
 #include <seastar/core/print.hh>
 #include <boost/algorithm/string.hpp>
@@ -61,4 +58,3 @@ size_t parse_memory_size(std::string_view s) {
 
 }
 
-#endif /* CONVERSIONS_CC_ */


### PR DESCRIPTION
util/conversion.cc has inclusion guards like

```
  #ifndef CONVERSIONS_CC_
  #define CONVERSIONS_CC_
  ...
  #endif /* CONVERSIONS_CC_ */
```

since we don't include this source file in another source file or header file, there is no need to have this guard. so, do avoid unnecessary confusion, let's drop this guard.