### PR TITLE
log: call log_level_map explicitly in constructor

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -567,7 +567,7 @@ options::options(program_options::option_group* parent_group)
              "Default log level for log messages. Valid values are trace, debug, info, warn, error."
              )
     , logger_log_level(*this, "logger-log-level",
-             {{}},
+             log_level_map{},
              "Map of logger name to log level. The format is \"NAME0=LEVEL0[:NAME1=LEVEL1:...]\". "
              "Valid logger names can be queried with --help-loggers. "
              "Valid values for levels are trace, debug, info, warn, error. "


### PR DESCRIPTION
without this change, instead of constructing an empty map for the `log_level_map`, we would construct an instance of `std::in_place_t` as the first parameter passed to `std::optional::optional()`. this is not what we are expecting. so, let's construct a map explicitly.

this should address the build failure with Clang17 + libstdc++ from GCC-13, like:

```
/home/kefu/dev/seastar/src/util/log.cc:569:7: error: converting to ‘std::optional<std::unordered_map<seastar::basic_sstring<char, unsigned int, 15>, seastar::log_level> >’ from initializer list would use explicit constructor ‘constexpr std::optional<_Tp>::optional(std::in_place_t, _Args&& ...) [with _Args = {}; typename std::enable_if<__and_v<std::is_constructible<_Tp, _Args ...> >, bool>::type <anonymous> = false; _Tp = std::unordered_map<seastar::basic_sstring<char, unsigned int, 15>, seastar::log_level>]’
  569 |     , logger_log_level(*this, "logger-log-level",
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  570 |              {{}},
      |              ~~~~~
  571 |              "Map of logger name to log level. The format is \"NAME0=LEVEL0[:NAME1=LEVEL1:...]\". "
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  572 |              "Valid logger names can be queried with --help-loggers. "
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  573 |              "Valid values for levels are trace, debug, info, warn, error. "
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  574 |              "This option can be specified multiple times."
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  575 |             )
      |             ~
/home/kefu/dev/seastar/src/util/log.cc:569:7: error: converting to ‘std::in_place_t’ from initializer list would use explicit constructor ‘constexpr std::in_place_t::in_place_t()’
```