### PR TITLE
treewide: add C++ modules support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,11 @@ set (CMAKE_CXX_STANDARD
   STRING
   "C++ standard to build with.")
 
+include (CMakeDependentOption)
+cmake_dependent_option (Seastar_MODULE
+  "Build a C++20 module instead of a traditional library" OFF
+  "CMAKE_VERSION VERSION_GREATER_EQUAL 3.26;CMAKE_CXX_STANDARD GREATER_EQUAL 20" OFF)
+
 set (CMAKE_C_FLAGS_SANITIZE
   "-Os -g"
   CACHE
@@ -812,6 +817,10 @@ endif ()
 set( MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --leak-check=no --trace-children=yes" )
 include (CTest)
 
+if (Seastar_MODULE)
+  include (CxxModulesRules)
+  add_subdirectory (src)
+endif ()
 #
 # We want asserts enabled on all modes, but cmake defaults to passing
 # -DNDEBUG in some modes. We add -UNDEBUG to our private options to

--- a/cmake/CxxModulesRules.cmake
+++ b/cmake/CxxModulesRules.cmake
@@ -1,0 +1,15 @@
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  message (FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
+endif ()
+
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+  message (FATAL "C++20 module needs Clang++-16 or up")
+endif ()
+
+set (CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP 1)
+set (CMAKE_EXPERIMENTAL_CXX_SCANDEP_SOURCE "")
+set (CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API  "2182bf5c-ef0d-489a-91da-49dbc3090d2a")
+
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+# C++ extension does work with C++ module support so far
+set (CMAKE_CXX_EXTENSIONS OFF)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -122,3 +122,13 @@ seastar_add_demo (tutorial_examples
 
 seastar_add_demo (http_client
   SOURCES http_client_demo.cc)
+
+if (Seastar_MODULE)
+  add_executable (hello_cxx_module)
+  target_sources (hello_cxx_module
+    PRIVATE
+      hello-cxx-module.cc)
+  target_link_libraries (hello_cxx_module
+    PRIVATE
+      seastar-module)
+endif ()

--- a/demos/hello-cxx-module.cc
+++ b/demos/hello-cxx-module.cc
@@ -1,0 +1,33 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB Ltd.
+ */
+
+import seastar;
+
+using namespace seastar;
+logger applog("app");
+
+int main(int argc, char** argv) {
+    seastar::app_template app;
+    app.run(argc, argv, [] () -> future<> {
+        applog.info("Hello world!");
+        return make_ready_future<>();
+    });
+}

--- a/include/seastar/core/abort_on_ebadf.hh
+++ b/include/seastar/core/abort_on_ebadf.hh
@@ -21,7 +21,11 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// Determines whether seastar should throw or abort when operation made by
 /// seastar fails because the target file descriptor is not valid. This is
@@ -32,5 +36,7 @@ void set_abort_on_ebadf(bool do_abort);
 /// Queries the current setting for seastar's behavior on invalid file descriptor access.
 /// See set_abort_on_ebadf().
 bool is_abort_on_ebadf_enabled();
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/abort_on_expiry.hh
+++ b/include/seastar/core/abort_on_expiry.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -32,6 +33,7 @@ namespace seastar {
 
 /// Facility to tie a timeout with an abort source
 /// Can be used to make abortanle fibers also support timeouts
+SEASTAR_MODULE_EXPORT
 template<typename Clock = lowres_clock>
 class abort_on_expiry {
     timer<Clock> _tr;

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -22,19 +22,24 @@
 #pragma once
 
 #include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
 #include <seastar/util/std-compat.hh>
-#include <boost/intrusive/list.hpp>
 
+#ifndef SEASTAR_MODULE
+#include <boost/intrusive/list.hpp>
 #include <exception>
 #include <optional>
 #include <type_traits>
 #include <utility>
+#endif
 
 namespace bi = boost::intrusive;
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup fiber-module
 /// @{
@@ -190,5 +195,7 @@ public:
 };
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -24,11 +24,15 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <exception>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -22,24 +22,27 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <atomic>
 #include <deque>
 #include <future>
 #include <memory>
-
+#include <type_traits>
 #include <boost/lockfree/queue.hpp>
+#endif
 
 #include <seastar/core/future.hh>
 #include <seastar/core/cacheline.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/util/concepts.hh>
-#include <type_traits>
+#include <seastar/util/modules.hh>
 
 /// \file
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class reactor;
 
 /// \brief Integration with non-seastar applications.
@@ -114,6 +117,7 @@ struct qs_deleter {
 /// system, there is just one instance, but for in-process clustering testing
 /// there may be more than one. Function such as run_on() direct messages to
 /// and (instance, shard) tuple.
+SEASTAR_MODULE_EXPORT
 class instance {
     using qs = std::unique_ptr<message_queue[], internal::qs_deleter>;
 public:
@@ -141,6 +145,7 @@ extern instance* default_instance;
 ///          message queue managed by the shard executing the alien thread which is
 ///          interested to the return value. Please use \c submit_to() instead, if
 ///          \c func throws.
+SEASTAR_MODULE_EXPORT
 template <typename Func>
 SEASTAR_CONCEPT(requires std::is_nothrow_invocable_r_v<void, Func>)
 void run_on(instance& instance, unsigned shard, Func func) {
@@ -196,6 +201,7 @@ template <typename Func> using return_type_t = typename return_type_of<Func>::ty
 ///          the caller must guarantee that it will survive the call.
 /// \return whatever \c func returns, as a \c std::future<>
 /// \note the caller must keep the returned future alive until \c func returns
+SEASTAR_MODULE_EXPORT
 template<typename Func, typename T = internal::return_type_t<Func>>
 SEASTAR_CONCEPT(requires std::invocable<Func>)
 std::future<T> submit_to(instance& instance, unsigned shard, Func func) {

--- a/include/seastar/core/align.hh
+++ b/include/seastar/core/align.hh
@@ -21,10 +21,15 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
+#include <seastar/util/modules.hh>
 #include <cstdint>
 #include <cstdlib>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename T>
 inline constexpr
@@ -51,5 +56,7 @@ T* align_down(T* v, size_t align) {
     static_assert(sizeof(T) == 1, "align byte pointers only");
     return reinterpret_cast<T*>(align_down(reinterpret_cast<uintptr_t>(v), align));
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/aligned_buffer.hh
+++ b/include/seastar/core/aligned_buffer.hh
@@ -19,15 +19,20 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 #pragma once
+#ifndef SEASTAR_MODULE
 #include <stdlib.h>
 #include <memory>
 #include <stdexcept>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
 namespace internal {
 void* allocate_aligned_buffer_impl(size_t size, size_t align);
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct free_deleter {
     void operator()(void* p) { ::free(p); }
@@ -41,5 +46,6 @@ std::unique_ptr<CharType[], free_deleter> allocate_aligned_buffer(size_t size, s
     return std::unique_ptr<CharType[], free_deleter>(reinterpret_cast<CharType *>(ret));
 }
 
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/app-template.hh
+++ b/include/seastar/core/app-template.hh
@@ -20,8 +20,11 @@
  */
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/program_options.hpp>
 #include <functional>
+#include <chrono>
+#endif
 #include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/smp_options.hh>
@@ -30,7 +33,7 @@
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/scollectd.hh>
 #include <seastar/util/log-cli.hh>
-#include <chrono>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -40,6 +43,7 @@ class instance;
 
 }
 
+SEASTAR_MODULE_EXPORT
 class app_template {
 public:
     struct config {

--- a/include/seastar/core/array_map.hh
+++ b/include/seastar/core/array_map.hh
@@ -21,16 +21,20 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <array>
 #include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
 // unordered_map implemented as a simple array
 
+SEASTAR_MODULE_EXPORT
 template <typename Value, size_t Max>
 class array_map {
     std::array<Value, Max> _a {};

--- a/include/seastar/core/bitops.hh
+++ b/include/seastar/core/bitops.hh
@@ -21,11 +21,16 @@
 
 #pragma once
 
+#include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <limits>
 #include <type_traits>
-#include <seastar/util/concepts.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 inline
 constexpr unsigned count_leading_zeros(unsigned x) {
@@ -71,5 +76,7 @@ SEASTAR_CONCEPT( requires std::is_integral_v<T> )
 inline constexpr unsigned log2floor(T n) {
     return std::numeric_limits<T>::digits - count_leading_zeros(n) - 1;
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/bitset-iter.hh
+++ b/include/seastar/core/bitset-iter.hh
@@ -13,8 +13,11 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <bitset>
 #include <limits>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -32,7 +35,7 @@ static constexpr int ulong_bits = std::numeric_limits<unsigned long>::digits;
  * which is returned when value == 1.
  */
 template<typename T>
-inline size_t count_leading_zeros(T value) noexcept;
+size_t count_leading_zeros(T value) noexcept;
 
 /**
  * Returns the number of trailing zeros in value's binary representation.
@@ -43,7 +46,7 @@ inline size_t count_leading_zeros(T value) noexcept;
  * The highest value that can be returned is std::numeric_limits<T>::digits - 1.
  */
 template<typename T>
-static inline size_t count_trailing_zeros(T value) noexcept;
+size_t count_trailing_zeros(T value) noexcept;
 
 template<>
 inline size_t count_leading_zeros<unsigned long>(unsigned long value) noexcept
@@ -102,7 +105,7 @@ size_t count_trailing_zeros<long long>(long long value) noexcept
  * Result is undefined if bitset.any() == false.
  */
 template<size_t N>
-static inline size_t get_first_set(const std::bitset<N>& bitset) noexcept
+inline size_t get_first_set(const std::bitset<N>& bitset) noexcept
 {
     static_assert(N <= ulong_bits, "bitset too large");
     return count_trailing_zeros(bitset.to_ulong());
@@ -113,11 +116,13 @@ static inline size_t get_first_set(const std::bitset<N>& bitset) noexcept
  * Result is undefined if bitset.any() == false.
  */
 template<size_t N>
-static inline size_t get_last_set(const std::bitset<N>& bitset) noexcept
+inline size_t get_last_set(const std::bitset<N>& bitset) noexcept
 {
     static_assert(N <= ulong_bits, "bitset too large");
     return ulong_bits - 1 - count_leading_zeros(bitset.to_ulong());
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template<size_t N>
 class set_iterator
@@ -202,10 +207,12 @@ private:
 };
 
 template<size_t N>
-static inline set_range<N> for_each_set(std::bitset<N> bitset, int offset = 0) noexcept
+inline set_range<N> for_each_set(std::bitset<N> bitset, int offset = 0) noexcept
 {
     return set_range<N>(bitset, offset);
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }
 

--- a/include/seastar/core/byteorder.hh
+++ b/include/seastar/core/byteorder.hh
@@ -21,11 +21,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <boost/endian/conversion.hpp>
 #include <seastar/core/unaligned.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename T>
 inline T cpu_to_le(T x) noexcept {
@@ -105,5 +110,7 @@ produce_be(char*& p, T datum) noexcept {
     write_be<T>(p, datum);
     p += sizeof(T);
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/cacheline.hh
+++ b/include/seastar/core/cacheline.hh
@@ -21,12 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cstddef>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 // Platform-dependent cache line size for alignment and padding purposes.
-static constexpr size_t cache_line_size =
+constexpr size_t cache_line_size =
 #if defined(__x86_64__) || defined(__i386__)
     64;
 #elif defined(__s390x__) || defined(__zarch__)
@@ -38,5 +43,7 @@ static constexpr size_t cache_line_size =
 #else
 #error "cache_line_size not defined for this architecture"
 #endif
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/checked_ptr.hh
+++ b/include/seastar/core/checked_ptr.hh
@@ -23,13 +23,17 @@
 
 /// \file
 /// \brief Contains a seastar::checked_ptr class implementation.
-
+#ifndef SEASTAR_MODULE
 #include <exception>
 #include <memory>
 #include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 /// \namespace seastar
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// The exception thrown by a default_null_deref_action.
 class checked_ptr_is_null_exception : public std::exception {};
@@ -45,6 +49,7 @@ struct default_null_deref_action {
         throw checked_ptr_is_null_exception();
     }
 };
+SEASTAR_MODULE_EXPORT_END
 
 /// \cond internal
 /// \namespace seastar::internal
@@ -93,6 +98,7 @@ inline T* checked_ptr_do_get(T* ptr) noexcept {
 ///
 /// \tparam NullDerefAction a functor that is invoked when a user tries to dereference a not engaged pointer.
 ///
+SEASTAR_MODULE_EXPORT
 template<typename Ptr, typename NullDerefAction = default_null_deref_action>
 /// \cond SEASTAR_CONCEPT_DOC
 SEASTAR_CONCEPT( requires std::is_default_constructible<NullDerefAction>::value && requires (NullDerefAction action) {
@@ -187,6 +193,7 @@ public:
 
 namespace std {
 /// std::hash specialization for seastar::checked_ptr class
+SEASTAR_MODULE_EXPORT
 template<typename T>
 struct hash<seastar::checked_ptr<T>> {
     /// Get the hash value for the given seastar::checked_ptr object.

--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -21,8 +21,11 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <algorithm>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -82,6 +85,7 @@ namespace seastar {
 // uses move/copy constructors instead of move/copy assignments, which are
 // less efficient.
 
+SEASTAR_MODULE_EXPORT
 template <typename T, size_t items_per_chunk = 128>
 class chunked_fifo {
     static_assert((items_per_chunk & (items_per_chunk - 1)) == 0,

--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -24,8 +24,11 @@
 #include <seastar/core/transfer.hh>
 #include <seastar/core/bitops.hh>
 #include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <algorithm>
+#endif
 
 namespace seastar {
 
@@ -55,6 +58,7 @@ namespace seastar {
 ///     * pop_back() will invalidate end().
 ///
 /// reserve() may also invalidate all iterators and references.
+SEASTAR_MODULE_EXPORT
 template <typename T, typename Alloc = std::allocator<T>>
 class circular_buffer {
     struct impl : Alloc {

--- a/include/seastar/core/circular_buffer_fixed_capacity.hh
+++ b/include/seastar/core/circular_buffer_fixed_capacity.hh
@@ -28,11 +28,13 @@
 // Similar to libstdc++'s std::deque, except that it uses a single level
 // store, and so is more efficient for simple stored items.
 
+#ifndef SEASTAR_MODULE
 #include <type_traits>
 #include <cstddef>
 #include <iterator>
 #include <utility>
-
+#include <seastar/util/modules.hh>
+#endif
 
 /// \file
 
@@ -45,6 +47,7 @@ namespace seastar {
 ///
 /// \tparam T type of objects stored in the container; must be noexcept move enabled
 /// \tparam Capacity maximum number of objects that can be stored in the container; must be a power of 2
+SEASTAR_MODULE_EXPORT
 template <typename T, size_t Capacity>
 class circular_buffer_fixed_capacity {
     size_t _begin = 0;

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -21,18 +21,23 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
+#include <chrono>
+#include <exception>
+#include <functional>
+#endif
 
 #include <seastar/core/timer.hh>
 #ifdef SEASTAR_COROUTINES_ENABLED
 #   include <seastar/core/coroutine.hh>
 #endif
 #include <seastar/core/loop.hh>
-#include <chrono>
-#include <exception>
-#include <functional>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup fiber-module
 /// @{
@@ -395,5 +400,7 @@ public:
 };
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -21,14 +21,19 @@
 
 #pragma once
 
-#include <seastar/core/future.hh>
 
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/exception.hh>
+#include <seastar/util/modules.hh>
+#include <seastar/util/std-compat.hh>
+
+
+#ifndef SEASTAR_MODULE
 #ifndef SEASTAR_COROUTINES_ENABLED
 #error Coroutines support disabled.
 #endif
-
-#include <seastar/coroutine/exception.hh>
 #include <coroutine>
+#endif
 
 namespace seastar {
 
@@ -205,6 +210,8 @@ public:
 
 } // seastar::internal
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 template<typename... T>
 auto operator co_await(future<T...> f) noexcept {
     return internal::awaiter<true, T...>(std::move(f));
@@ -270,11 +277,14 @@ auto operator co_await(coroutine::without_preemption_check<T...> f) noexcept {
     return internal::awaiter<false, T...>(std::move(f));
 }
 
+SEASTAR_MODULE_EXPORT_END
+
 } // seastar
 
 
 namespace std {
 
+SEASTAR_MODULE_EXPORT
 template<typename... T, typename... Args>
 class coroutine_traits<seastar::future<T...>, Args...> : public seastar::internal::coroutine_traits_base<T...> {
 };

--- a/include/seastar/core/deleter.hh
+++ b/include/seastar/core/deleter.hh
@@ -21,10 +21,13 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <cassert>
 #include <cstdlib>
 #include <type_traits>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -44,6 +47,7 @@ namespace seastar {
 ///  - decrementing a reference count somewhere
 ///
 /// A deleter performs its action from its destructor.
+SEASTAR_MODULE_EXPORT
 class deleter final {
 public:
     /// \cond internal
@@ -158,6 +162,8 @@ object_deleter_impl<Object>* make_object_deleter_impl(deleter next, Object obj) 
 }
 /// \endcond
 
+
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Makes a \ref deleter that encapsulates the action of
 /// destroying an object, as well as running another deleter.  The input
 /// object is moved to the deleter, and destroyed when the deleter is destroyed.
@@ -181,6 +187,7 @@ deleter
 make_deleter(Object o) {
     return make_deleter(deleter(), std::move(o));
 }
+SEASTAR_MODULE_EXPORT_END
 
 /// \cond internal
 struct free_deleter_impl final : deleter::impl {
@@ -233,6 +240,7 @@ void deleter::append(deleter d) {
     d._impl = nullptr;
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Makes a deleter that calls \c std::free() when it is destroyed.
 ///
 /// \param obj object to free.
@@ -275,6 +283,7 @@ deleter
 make_object_deleter(deleter d, T&& obj) {
     return deleter{make_object_deleter_impl(std::move(d), std::move(obj))};
 }
+SEASTAR_MODULE_EXPORT_END
 
 /// @}
 

--- a/include/seastar/core/distributed.hh
+++ b/include/seastar/core/distributed.hh
@@ -21,12 +21,18 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/sharded.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename Service>
 using distributed = sharded<Service>;
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/do_with.hh
+++ b/include/seastar/core/do_with.hh
@@ -21,10 +21,13 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
+#include <seastar/util/modules.hh>
 #include <utility>
 #include <memory>
 #include <tuple>
+#endif
 
 namespace seastar {
 
@@ -103,6 +106,9 @@ do_with_impl(T1&& rv1, T2&& rv2, More&&... more) {
 }
 }
 
+
+SEASTAR_MODULE_EXPORT_BEGIN
+
 /// \addtogroup future-util
 /// @{
 
@@ -149,5 +155,7 @@ auto with_lock(Lock& lock, Func&& func) {
 }
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/enum.hh
+++ b/include/seastar/core/enum.hh
@@ -27,12 +27,16 @@
  * it possible to inherit from this type to
  */
 
+#ifndef SEASTAR_MODULE
 #include <type_traits>
 #include <functional>
 #include <cstddef>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 template <typename T>
 class enum_hash {
     static_assert(std::is_enum<T>::value, "must be an enum");

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -32,12 +32,15 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/container/static_vector.hpp>
+#endif
 
 namespace seastar {
 
@@ -118,6 +121,7 @@ std::reference_wrapper<T> unwrap_for_es(reference_wrapper_for_es<T> ref) {
 /// \endcond
 
 /// Base execution stage class
+SEASTAR_MODULE_EXPORT
 class execution_stage {
 public:
     struct stats {
@@ -446,6 +450,7 @@ struct concrete_execution_stage_helper<Ret, std::tuple<Args...>> {
 /// \param fn function to be executed by the stage
 /// \return concrete_execution_stage
 ///
+SEASTAR_MODULE_EXPORT
 template<typename Function>
 auto make_execution_stage(const sstring& name, scheduling_group sg, Function&& fn) {
     using traits = function_traits<Function>;
@@ -485,6 +490,7 @@ auto make_execution_stage(const sstring& name, scheduling_group sg, Function&& f
 /// \param fn function to be executed by the stage
 /// \return concrete_execution_stage
 ///
+SEASTAR_MODULE_EXPORT
 template<typename Function>
 auto make_execution_stage(const sstring& name, Function&& fn) {
     return make_execution_stage(name, scheduling_group(), std::forward<Function>(fn));
@@ -513,6 +519,7 @@ auto make_execution_stage(const sstring& name, Function&& fn) {
 /// \param name unique name of the execution stage
 /// \param fn member function to be executed by the stage
 /// \return concrete_execution_stage
+SEASTAR_MODULE_EXPORT
 template<typename Ret, typename Object, typename... Args>
 concrete_execution_stage<Ret, Object*, Args...>
 make_execution_stage(const sstring& name, scheduling_group sg, Ret (Object::*fn)(Args...)) {

--- a/include/seastar/core/expiring_fifo.hh
+++ b/include/seastar/core/expiring_fifo.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
 #include <stdexcept>
@@ -29,6 +30,8 @@
 #include <seastar/core/timer.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -52,6 +55,7 @@ struct promise_expiry {
 ///
 /// The container can only be moved before any elements are pushed.
 ///
+SEASTAR_MODULE_EXPORT
 template <typename T, typename OnExpiry = dummy_expiry<T>, typename Clock = lowres_clock>
 class expiring_fifo {
 public:

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/util/shared_token_bucket.hh>
+
 #include <chrono>
 #include <cstdint>
 #include <functional>

--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -21,11 +21,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <type_traits>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup fileio-module
 /// @{
@@ -136,5 +141,7 @@ inline constexpr file_permissions operator&(file_permissions a, file_permissions
 }
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 } // namespace seastar

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -29,6 +29,8 @@
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/file-types.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <system_error>
 #include <sys/statvfs.h>
 #include <sys/ioctl.h>
@@ -40,8 +42,11 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup fileio-module
 /// @{
@@ -860,5 +865,7 @@ public:
         return "cancelled";
     }
 };
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/fsnotify.hh
+++ b/include/seastar/core/fsnotify.hh
@@ -21,14 +21,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <sys/inotify.h>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar::experimental {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \defgroup fsnotifier FileSystem Notifier
 ///
@@ -197,5 +202,7 @@ inline void operator&=(fsnotifier::flags& a, fsnotifier::flags b) {
 }
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/fstream.hh
+++ b/include/seastar/core/fstream.hh
@@ -29,14 +29,19 @@
 // on sector boundaries.  The adapters in this file provide a byte stream
 // interface to files, while retaining the zero-copy characteristics of
 // seastar files.
-
 #include <seastar/core/file.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/internal/api-level.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <cstdint>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 class file_input_stream_history {
     static constexpr uint64_t window_size = 4 * 1024 * 1024;
@@ -121,5 +126,7 @@ future<output_stream<char>> make_file_output_stream(
 /// newly created file.
 /// Closes the file if the sink creation fails.
 future<data_sink> make_file_data_sink(file, file_output_stream_options) noexcept;
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -21,12 +21,15 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <cassert>
 #include <exception>
 #include <optional>
 #include <utility>
+#endif
 
 #ifdef SEASTAR_DEBUG
 #define SEASTAR_GATE_HOLDER_DEBUG
@@ -39,6 +42,7 @@ namespace seastar {
 
 /// Exception thrown when a \ref gate object has been closed
 /// by the \ref gate::close() method.
+SEASTAR_MODULE_EXPORT
 class gate_closed_exception : public std::exception {
 public:
     virtual const char* what() const noexcept override {
@@ -51,6 +55,7 @@ public:
 /// When stopping a service that serves asynchronous requests, we are faced with
 /// two problems: preventing new requests from coming in, and knowing when existing
 /// requests have completed.  The \c gate class provides a solution.
+SEASTAR_MODULE_EXPORT
 class gate {
     size_t _count = 0;
     std::optional<promise<>> _stopped;
@@ -283,6 +288,7 @@ invoke_func_with_gate(gate& g, Func&& func) noexcept {
 /// \returns whatever \c func returns
 ///
 /// \relates gate
+SEASTAR_MODULE_EXPORT
 template <typename Func>
 inline
 auto
@@ -302,6 +308,7 @@ with_gate(gate& g, Func&& func) {
 /// \returns whatever \c func returns.
 ///
 /// \relates gate
+SEASTAR_MODULE_EXPORT
 template <typename Func>
 inline
 auto
@@ -313,5 +320,6 @@ try_with_gate(gate& g, Func&& func) noexcept {
     return internal::invoke_func_with_gate(g, std::forward<Func>(func));
 }
 /// @}
+
 
 }

--- a/include/seastar/core/idle_cpu_handler.hh
+++ b/include/seastar/core/idle_cpu_handler.hh
@@ -21,11 +21,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 /// \file
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// Indicates the outcome of a user callback installed to take advantage of
 /// idle CPU cycles.
@@ -55,5 +60,7 @@ using idle_cpu_handler = noncopyable_function<idle_cpu_handler_result(work_waiti
 /// Handler's argument is a function that returns true if a task which should be executed on cpu appears or false
 /// otherwise. This function should be used by a handler to return early if a task appears.
 void set_idle_cpu_handler(idle_cpu_handler&& handler);
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/internal/io_intent.hh
+++ b/include/seastar/core/internal/io_intent.hh
@@ -21,14 +21,18 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <utility>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/slist.hpp>
+#endif
 
 namespace bi = boost::intrusive;
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class io_intent;
 
 namespace internal {

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -25,18 +25,23 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/util/bool_class.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <boost/intrusive_ptr.hpp>
 #include <cstdint>
 #include <vector>
 #include <tuple>
 #include <sys/uio.h>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 class reactor;
 class pollable_fd;
 class pollable_fd_state;
 class socket_address;
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 
@@ -46,6 +51,7 @@ class buffer_allocator;
 
 namespace net {
 
+SEASTAR_MODULE_EXPORT
 class packet;
 
 }

--- a/include/seastar/core/internal/read_state.hh
+++ b/include/seastar/core/internal/read_state.hh
@@ -19,7 +19,10 @@
  * Copyright 2021 ScyllaDB
  */
 
+#ifndef SEASTAR_MODULE
 #include <cstring>
+#endif
+
 #include <seastar/core/align.hh>
 #include <seastar/core/internal/io_intent.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -22,16 +22,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <signal.h>
 #include <atomic>
 #include <limits>
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <linux/perf_event.h>
+#endif
 #include <seastar/core/posix.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/scheduling.hh>
-#include <linux/perf_event.h>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 

--- a/include/seastar/core/internal/uname.hh
+++ b/include/seastar/core/internal/uname.hh
@@ -22,10 +22,13 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+#include <seastar/util/std-compat.hh>
+#ifndef SEASTAR_MODULE
 #include <string>
 #include <initializer_list>
-#include <seastar/util/std-compat.hh>
 #include <iosfwd>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/core/io_intent.hh
+++ b/include/seastar/core/io_intent.hh
@@ -21,9 +21,12 @@
 
 #pragma once
 
-#include <boost/container/small_vector.hpp>
 #include <seastar/core/internal/io_intent.hh>
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
+#include <boost/container/small_vector.hpp>
+#endif
 
 namespace seastar {
 
@@ -37,6 +40,7 @@ namespace seastar {
 ///
 /// If no intent is provided, then the request is processed till its
 /// completion be it success or error
+SEASTAR_MODULE_EXPORT
 class io_intent {
     struct intents_for_queue {
         dev_t dev;

--- a/include/seastar/core/io_priority_class.hh
+++ b/include/seastar/core/io_priority_class.hh
@@ -21,15 +21,21 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
+#include <seastar/util/modules.hh>
 
 #include <array>
 #include <mutex>
+#endif
 
 namespace seastar {
 
 class io_queue;
+
+SEASTAR_MODULE_EXPORT_BEGIN
+
 using io_priority_class_id = unsigned;
 
 #if SEASTAR_API_LEVEL < 7
@@ -102,6 +108,8 @@ private:
 const io_priority_class& default_priority_class();
 
 #endif
+
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 #if SEASTAR_API_LEVEL >= 7

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -21,23 +21,27 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/container/small_vector.hpp>
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <sys/uio.h>
+#endif
 #include <seastar/core/sstring.hh>
 #include <seastar/core/fair_queue.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/io_request.hh>
 #include <seastar/util/spinlock.hh>
-#include <chrono>
-#include <memory>
-#include <vector>
-#include <sys/uio.h>
+#include <seastar/util/modules.hh>
 
 struct io_queue_for_tests;
 
 namespace seastar {
 
 #if SEASTAR_API_LEVEL < 7
+SEASTAR_MODULE_EXPORT
 class io_priority_class;
 
 [[deprecated("Use io_priority_class.rename")]]
@@ -45,6 +49,7 @@ future<>
 rename_priority_class(io_priority_class pc, sstring new_name);
 #endif
 
+SEASTAR_MODULE_EXPORT
 class io_intent;
 
 namespace internal {

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -35,20 +35,25 @@
 
 #pragma once
 
-#include <boost/intrusive/slist.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
+#include <boost/intrusive/slist.hpp>
 #include <algorithm>
 #include <memory>
 #include <optional>
 #include <variant>
 #include <vector>
+#endif
 
 namespace bi = boost::intrusive;
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 namespace net { class packet; }
 
@@ -445,6 +450,7 @@ private:
 template <typename CharType>
 future<> copy(input_stream<CharType>&, output_stream<CharType>&);
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 #include "iostream-impl.hh"

--- a/include/seastar/core/layered_file.hh
+++ b/include/seastar/core/layered_file.hh
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/file.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -36,6 +39,7 @@ namespace seastar {
 /// of layered files by performing standard tasks such as setting up the
 /// file alignment. Actual implementation of the I/O methods is left for the
 /// derived class.
+SEASTAR_MODULE_EXPORT
 class layered_file_impl : public file_impl {
 protected:
     file _underlying_file;

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cstddef>
 #include <iterator>
@@ -29,13 +30,16 @@
 #include <optional>
 #include <type_traits>
 #include <vector>
-
+#endif
 #include <seastar/core/future.hh>
 #include <seastar/core/task.hh>
 #include <seastar/util/bool_class.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/core/semaphore.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup future-util
 /// @{
@@ -757,5 +761,7 @@ max_concurrent_for_each(Range&& range, size_t max_concurrent, Func&& func) noexc
 }
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 } // namespace seastar

--- a/include/seastar/core/lowres_clock.hh
+++ b/include/seastar/core/lowres_clock.hh
@@ -21,15 +21,20 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/cacheline.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/util/modules.hh>
 
 #include <cstdint>
 
 #include <atomic>
 #include <chrono>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 //
 // Forward declarations.
@@ -119,5 +124,6 @@ public:
 
 extern template class timer<lowres_clock>;
 
+SEASTAR_MODULE_EXPORT_END
 }
 

--- a/include/seastar/core/make_task.hh
+++ b/include/seastar/core/make_task.hh
@@ -21,11 +21,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <seastar/core/task.hh>
 #include <seastar/core/future.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename Func>
 class lambda_task final : public task {
@@ -58,5 +63,7 @@ lambda_task<Func>*
 make_task(scheduling_group sg, Func&& func) noexcept {
     return new lambda_task<Func>(sg, std::forward<Func>(func));
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/manual_clock.hh
+++ b/include/seastar/core/manual_clock.hh
@@ -21,13 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/timer.hh>
+#include <seastar/util/modules.hh>
 
 #include <atomic>
 #include <chrono>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class manual_clock {
 public:
     using rep = int64_t;

--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -22,12 +22,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <iterator>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup future-util
 /// @{
@@ -275,5 +280,7 @@ public:
 };
 
 /// @}
+
+SEASTAR_MODULE_EXPORT_END
 
 } // namespace seastar

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -23,12 +23,15 @@
 
 #include <seastar/core/resource.hh>
 #include <seastar/core/bitops.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <new>
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>
 #include <vector>
+#endif
 
 namespace seastar {
 
@@ -227,6 +230,8 @@ void set_reclaim_hook(
 
 /// \endcond
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 /// \brief Set the global state of the abort on allocation failure behavior.
 ///
 /// If enabled, an allocation failure (i.e., the requested memory
@@ -405,6 +410,8 @@ public:
     scoped_heap_profiling() noexcept;
     ~scoped_heap_profiling();
 };
+
+SEASTAR_MODULE_EXPORT_END
 
 }
 }

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -21,18 +21,22 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <functional>
 #include <limits>
 #include <map>
 #include <type_traits>
 #include <variant>
 #include <fmt/format.h>
+#endif
+#include "future.hh"
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/metrics_types.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/bool_class.hh>
+#include <seastar/util/modules.hh>
 
 /*! \file metrics.hh
  *  \brief header for metrics creation.
@@ -93,6 +97,8 @@ namespace seastar {
  */
 
 namespace metrics {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 class double_registration : public std::runtime_error {
 public:
@@ -244,6 +250,7 @@ public:
         return key;
     }
 };
+SEASTAR_MODULE_EXPORT_END
 
 /*!
  * \namespace impl

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -22,9 +22,12 @@
 #pragma once
 
 #include <seastar/core/metrics.hh>
-#include <unordered_map>
+#include <seastar/util/modules.hh>
 #include <seastar/core/sharded.hh>
+#ifndef SEASTAR_MODULE
+#include <unordered_map>
 #include <boost/functional/hash.hpp>
+#endif
 
 /*!
  * \file metrics_api.hh
@@ -61,6 +64,8 @@ struct hash<seastar::metrics::impl::labels_type> {
 
 namespace seastar {
 namespace metrics {
+
+SEASTAR_MODULE_EXPORT
 struct relabel_config;
 
 /*!
@@ -74,6 +79,7 @@ struct relabel_config;
  * Non zero value indicates there were name collisions.
  *
  */
+SEASTAR_MODULE_EXPORT
 struct metric_relabeling_result {
     size_t metrics_relabeled_due_to_collision;
 };

--- a/include/seastar/core/metrics_registration.hh
+++ b/include/seastar/core/metrics_registration.hh
@@ -21,10 +21,13 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <vector>
 
 #include <seastar/core/sstring.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 /*!
  * \file metrics_registration.hh
@@ -55,6 +58,8 @@ class metric_groups_def;
 struct metric_definition_impl;
 class metric_groups_impl;
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 using group_name_type = sstring; /*!< A group of logically related metrics */
 class metric_groups;
@@ -168,6 +173,7 @@ public:
     metric_group(const group_name_type& name, std::initializer_list<metric_definition> l);
 };
 
+SEASTAR_MODULE_EXPORT_END
 
 }
 }

--- a/include/seastar/core/metrics_types.hh
+++ b/include/seastar/core/metrics_types.hh
@@ -21,12 +21,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cstdint>
 #include <vector>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 namespace metrics {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /*!
  * \brief Histogram bucket type
@@ -79,6 +83,8 @@ struct histogram {
     histogram operator+(histogram&& h) const;
 
 };
+
+SEASTAR_MODULE_EXPORT_END
 
 }
 

--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -23,10 +23,15 @@
 
 
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <exception>
 #include <string_view>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 class logger;
 
@@ -67,4 +72,5 @@ void on_internal_error_noexcept(logger& logger, std::string_view reason) noexcep
 /// This overload can be used to replace assert().
 [[noreturn]] void on_fatal_internal_error(logger& logger, std::string_view reason) noexcept;
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/pipe.hh
+++ b/include/seastar/core/pipe.hh
@@ -25,6 +25,7 @@
 #include <seastar/core/queue.hh>
 
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 
 /// \defgroup fiber-module Fibers
 ///
@@ -60,9 +61,11 @@
 /// Seastar API namespace
 namespace seastar {
 
+
+
 /// \addtogroup fiber-module
 /// @{
-
+SEASTAR_MODULE_EXPORT
 class broken_pipe_exception : public std::exception {
 public:
     virtual const char* what() const noexcept {
@@ -70,6 +73,7 @@ public:
     }
 };
 
+SEASTAR_MODULE_EXPORT
 class unread_overflow_exception : public std::exception {
 public:
     virtual const char* what() const noexcept {
@@ -122,6 +126,7 @@ public:
 } // namespace internal
 /// \endcond
 
+SEASTAR_MODULE_EXPORT_BEGIN
 template <typename T>
 class pipe;
 
@@ -263,6 +268,7 @@ private:
     pipe(internal::pipe_buffer<T> *bufp) noexcept : reader(bufp), writer(bufp) { }
 };
 
+SEASTAR_MODULE_EXPORT_END
 
 /// @}
 

--- a/include/seastar/core/polymorphic_temporary_buffer.hh
+++ b/include/seastar/core/polymorphic_temporary_buffer.hh
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/memory.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -31,6 +34,7 @@ namespace seastar {
 ///
 /// \param allocator allocator to use when allocating the temporary_buffer
 /// \param size      size of the temporary buffer
+SEASTAR_MODULE_EXPORT
 template <typename CharType>
 temporary_buffer<CharType> make_temporary_buffer(std::pmr::polymorphic_allocator<CharType>* allocator, std::size_t size) {
     if (allocator == memory::malloc_allocator) {

--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -21,8 +21,7 @@
 
 #pragma once
 
-#include <seastar/core/sstring.hh>
-#include "abort_on_ebadf.hh"
+#ifndef SEASTAR_MODULE
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/ioctl.h>
@@ -36,7 +35,6 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
-#include <signal.h>
 #include <spawn.h>
 #include <unistd.h>
 #include <utility>
@@ -46,11 +44,16 @@
 #include <functional>
 #include <memory>
 #include <set>
-
+#endif
+#include "abort_on_ebadf.hh"
+#include <seastar/core/sstring.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \file
 /// \defgroup posix-support POSIX Support
@@ -360,9 +363,9 @@ private:
 
 namespace posix {
 
-static constexpr unsigned rcv_shutdown = 0x1;
-static constexpr unsigned snd_shutdown = 0x2;
-static inline constexpr unsigned shutdown_mask(int how) { return how + 1; }
+constexpr unsigned rcv_shutdown = 0x1;
+constexpr unsigned snd_shutdown = 0x2;
+inline constexpr unsigned shutdown_mask(int how) { return how + 1; }
 
 /// Converts a duration value to a `timespec`
 ///
@@ -513,4 +516,5 @@ std::set<unsigned> get_current_cpuset();
 
 /// @}
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/preempt.hh
+++ b/include/seastar/core/preempt.hh
@@ -20,7 +20,10 @@
  */
 
 #pragma once
+#ifndef SEASTAR_MODULE
 #include <atomic>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -48,6 +51,7 @@ void set_need_preempt_var(const preemption_monitor* pm);
 
 }
 
+SEASTAR_MODULE_EXPORT
 inline bool need_preempt() noexcept {
 #ifndef SEASTAR_DEBUG
     // prevent compiler from eliminating loads in a loop

--- a/include/seastar/core/prefetch.hh
+++ b/include/seastar/core/prefetch.hh
@@ -21,14 +21,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <atomic>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <seastar/core/align.hh>
 #include <seastar/core/cacheline.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <size_t N, int RW, int LOC>
 struct prefetcher;
@@ -112,5 +117,6 @@ template<size_t L, size_t C, typename T, int LOC = 3>
 void prefetchw_n(T** pptr) {
     boost::mpl::for_each< boost::mpl::range_c<size_t,0,C> >( [pptr] (size_t x) { prefetchw<L, LOC>(*(pptr + x)); } );
 }
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -21,13 +21,16 @@
 
 #pragma once
 
+#include <seastar/core/sstring.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <iostream>
 #include <iomanip>
 #include <chrono>
 #include <sstream>
-#include <seastar/core/sstring.hh>
+#endif
 
 #if 0
 inline
@@ -40,6 +43,7 @@ operator<<(std::ostream& os, const void* ptr) {
 }
 #endif
 
+SEASTAR_MODULE_EXPORT
 inline
 std::ostream&
 operator<<(std::ostream&& os, const void* ptr) {

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -21,14 +21,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/http/httpd.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <optional>
+#endif
 
 namespace seastar {
 
 namespace prometheus {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /*!
  * Holds prometheus related configuration
@@ -48,5 +53,6 @@ future<> start(httpd::http_server_control& http_server, config ctx);
 future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx);
 future<> add_prometheus_routes(httpd::http_server& server, config ctx);
 /// @}
+SEASTAR_MODULE_EXPORT_END
 }
 }

--- a/include/seastar/core/queue.hh
+++ b/include/seastar/core/queue.hh
@@ -23,8 +23,11 @@
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future.hh>
-#include <queue>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
+#include <queue>
+#endif
 
 namespace seastar {
 
@@ -35,6 +38,7 @@ namespace seastar {
 /// Note: queue requires the data type T to be nothrow move constructible as it's
 /// returned as future<T> by \ref pop_eventually and seastar futurized data type
 /// are required to be nothrow move-constructible.
+SEASTAR_MODULE_EXPORT
 template <typename T>
 SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
 class queue {

--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/eclipse.hh>
@@ -28,7 +29,9 @@
 #include <memory>
 #include <cassert>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/core/future.hh>
+#endif
 
 namespace seastar {
 
@@ -91,6 +94,7 @@ public:
     }
 };
 
+SEASTAR_MODULE_EXPORT_BEGIN
 
 // CRTP
 template <typename ConcreteParser>
@@ -148,5 +152,6 @@ inline void trim_trailing_spaces_and_tabs(sstring& str) {
     }
     str.resize(i);
 }
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -57,6 +57,11 @@
 #include <seastar/util/eclipse.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#include "internal/pollable_fd.hh"
+#include "internal/poll.hh"
+
+#ifndef SEASTAR_MODULE
 #include <boost/container/static_vector.hpp>
 #include <boost/lockfree/spsc_queue.hpp>
 #include <boost/next_prior.hpp>
@@ -84,8 +89,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/ip.h>
-#include "internal/pollable_fd.hh"
-#include "internal/poll.hh"
 
 #ifdef HAVE_OSV
 #include <osv/sched.hh>
@@ -93,7 +96,9 @@
 #include <osv/condvar.h>
 #include <osv/newpoll.hh>
 #endif
+#endif
 
+struct statfs;
 struct _Unwind_Exception;
 
 namespace seastar {
@@ -104,6 +109,7 @@ namespace alien {
 class message_queue;
 class instance;
 }
+SEASTAR_MODULE_EXPORT
 class reactor;
 
 }
@@ -171,6 +177,7 @@ void increase_thrown_exceptions_counter() noexcept;
 
 class kernel_completion;
 class io_queue;
+SEASTAR_MODULE_EXPORT
 class io_intent;
 class disk_config_params;
 
@@ -182,6 +189,7 @@ public:
     virtual void set_exception(std::exception_ptr eptr) noexcept = 0;
 };
 
+SEASTAR_MODULE_EXPORT
 class reactor {
 private:
     struct task_queue;
@@ -734,10 +742,12 @@ internal::make_pollfn(Func&& func) {
 extern __thread reactor* local_engine;
 extern __thread size_t task_quota;
 
+SEASTAR_MODULE_EXPORT
 inline reactor& engine() {
     return *local_engine;
 }
 
+SEASTAR_MODULE_EXPORT
 inline bool engine_is_ready() {
     return local_engine != nullptr;
 }

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
+#endif
 #include <seastar/util/program-options.hh>
 #include <seastar/util/memory_diagnostics.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -38,6 +41,7 @@ class reactor_backend_selector;
 class network_stack_factory;
 
 /// Configuration for the reactor.
+SEASTAR_MODULE_EXPORT
 struct reactor_options : public program_options::option_group {
     /// \brief Select network stack to use.
     ///

--- a/include/seastar/core/relabel_config.hh
+++ b/include/seastar/core/relabel_config.hh
@@ -18,10 +18,15 @@
 /*
  * Copyright 2022 ScyllaDB
  */
+#ifndef SEASTAR_MODULE
 #include <regex>
+#endif
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 namespace metrics {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /*!
  * \brief a wrapper class around regex with the original expr
@@ -97,5 +102,8 @@ struct relabel_config {
  * \brief a helper function to translate a string to relabel_config::relabel_action enum values
  */
 relabel_config::relabel_action relabel_config_action(const std::string& action);
+
+SEASTAR_MODULE_EXPORT_END
+
 }
 }

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -21,11 +21,13 @@
 
 #pragma once
 
+#include <seastar/util/std-compat.hh>
+#include <seastar/util/spinlock.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cstdlib>
 #include <string>
-#include <seastar/util/std-compat.hh>
-#include <seastar/util/spinlock.hh>
 #include <vector>
 #include <set>
 #include <sched.h>
@@ -33,6 +35,7 @@
 #include <unordered_map>
 #ifdef SEASTAR_HAVE_HWLOC
 #include <hwloc.h>
+#endif
 #endif
 
 namespace seastar {
@@ -84,6 +87,8 @@ struct topology_holder {};
 
 } // namespace hwloc::internal
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 struct configuration {
     optional<size_t> total_memory;
     optional<size_t> reserve_memory;  // if total_memory not specified
@@ -129,7 +134,10 @@ struct resources {
 resources allocate(configuration& c);
 unsigned nr_processing_units(configuration& c);
 
+SEASTAR_MODULE_EXPORT_END
+
 std::optional<resource::cpuset> parse_cpuset(std::string value);
+
 
 }
 }

--- a/include/seastar/core/rwlock.hh
+++ b/include/seastar/core/rwlock.hh
@@ -21,13 +21,17 @@
 
 #pragma once
 
-#include <seastar/core/semaphore.hh>
+#ifndef SEASTAR_MODULE
 #include <cstddef>
+#endif
+#include <seastar/core/semaphore.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 /// \cond internal
 // lock / unlock semantics for rwlock, so it can be used with with_lock()
+SEASTAR_MODULE_EXPORT
 template<typename Clock>
 class basic_rwlock;
 
@@ -66,6 +70,7 @@ public:
 /// fibers running in the same CPU that may use the same resource.
 /// Acquiring the write lock will effectively cause all readers not to be executed
 /// until the write part is done.
+SEASTAR_MODULE_EXPORT
 template<typename Clock = typename timer<>::clock>
 class basic_rwlock : private rwlock_for_read<Clock>, rwlock_for_write<Clock> {
     using semaphore_type = basic_semaphore<semaphore_default_exception_factory, Clock>;
@@ -190,6 +195,7 @@ public:
     friend class rwlock_for_write<Clock>;
 };
 
+SEASTAR_MODULE_EXPORT
 using rwlock = basic_rwlock<>;
 
 /// @}

--- a/include/seastar/core/scattered_message.hh
+++ b/include/seastar/core/scattered_message.hh
@@ -25,12 +25,16 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/net/packet.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <vector>
-#include <seastar/util/std-compat.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 template <typename CharType>
 class scattered_message {
 private:

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -21,17 +21,21 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
 #include <functional>
 #include <typeindex>
+#endif
 #include <seastar/core/sstring.hh>
 #include <seastar/core/function_traits.hh>
 #include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
 
 /// \file
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 constexpr unsigned max_scheduling_groups() { return SEASTAR_SCHEDULING_GROUPS_COUNT; }
 
 template <typename T = void>
@@ -43,6 +47,7 @@ class scheduling_group;
 class scheduling_group_key;
 
 using sched_clock = std::chrono::steady_clock;
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 
@@ -57,6 +62,7 @@ T* scheduling_group_get_specific_ptr(scheduling_group sg, scheduling_group_key k
 
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// Creates a scheduling group with a specified number of shares.
 ///
@@ -169,6 +175,7 @@ private:
     friend unsigned long internal::scheduling_group_key_id(scheduling_group_key key) noexcept;
 };
 
+SEASTAR_MODULE_EXPORT_END
 namespace internal {
 
 inline unsigned long scheduling_group_key_id(scheduling_group_key key) noexcept {
@@ -198,6 +205,7 @@ void apply_constructor(void* pre_alocated_mem, Tuple args, std::index_sequence<I
     new (pre_alocated_mem) ConstructorType(std::get<Idx>(args)...);
 }
 }
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /**
  * A template function that builds a scheduling group specific value configuration.
@@ -326,6 +334,7 @@ public:
 };
 
 /// \cond internal
+SEASTAR_MODULE_EXPORT_END
 namespace internal {
 
 inline
@@ -355,6 +364,7 @@ current_scheduling_group_ptr() noexcept {
 }
 /// \endcond
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Returns the current scheduling group
 inline
 scheduling_group
@@ -368,6 +378,8 @@ default_scheduling_group() noexcept {
     return scheduling_group();
 }
 
+SEASTAR_MODULE_EXPORT_END
+
 inline
 bool
 scheduling_group::active() const noexcept {
@@ -378,6 +390,7 @@ scheduling_group::active() const noexcept {
 
 namespace std {
 
+SEASTAR_MODULE_EXPORT
 template <>
 struct hash<seastar::scheduling_group> {
     size_t operator()(seastar::scheduling_group sg) const noexcept {

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -19,12 +19,15 @@
  * Copyright (C) 2019 Scylla DB Ltd
  */
 
+#ifndef SEASTAR_MODULE
 #include <boost/range/adaptor/filtered.hpp>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/map_reduce.hh>
+#include <seastar/util/modules.hh>
 #include <array>
 #include <typeindex>
 #include <vector>
+#endif
 
 #pragma once
 
@@ -85,6 +88,8 @@ T* scheduling_group_get_specific_ptr(scheduling_group sg, scheduling_group_key k
 }
 
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /**
  * Returns a reference to the given scheduling group specific data.
@@ -190,5 +195,7 @@ reduce_scheduling_group_specific(Reducer reducer, Initial initial_val, schedulin
             | boost::adaptors::filtered(std::mem_fn(&per_scheduling_group::queue_is_initialized)),
             mapper, std::move(initial_val), reducer);
 }
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <type_traits>
 #include <utility>
 #include <functional>
@@ -31,6 +32,7 @@
 #include <string>
 #include <tuple>
 #include <chrono>
+#endif
 
 #include <seastar/core/future.hh>
 #include <seastar/net/byteorder.hh>
@@ -38,7 +40,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/program-options.hh>
-
+#include <seastar/util/modules.hh>
 #include <seastar/core/metrics_api.hh>
 
 namespace seastar {
@@ -283,7 +285,7 @@ struct typed {
 };
 
 template<typename T>
-static inline typed<T> make_typed(data_type type, T&& t) {
+inline typed<T> make_typed(data_type type, T&& t) {
     return typed<T>(type, std::forward<T>(t));
 }
 

--- a/include/seastar/core/scollectd_api.hh
+++ b/include/seastar/core/scollectd_api.hh
@@ -4,13 +4,18 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/metrics_api.hh>
+#include <seastar/util/modules.hh>
 #include <vector>
+#endif
 
 namespace seastar {
 
 namespace scollectd {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 using collectd_value  = seastar::metrics::impl::metric_value;
 
@@ -31,6 +36,9 @@ void enable(const scollectd::type_instance_id& id, bool enable);
 
 
 metrics::impl::value_map get_value_map();
+
+SEASTAR_MODULE_EXPORT_END
+
 }
 
 }

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -53,13 +53,18 @@
 #include <seastar/core/posix.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include "./internal/api-level.hh"
+#ifndef SEASTAR_MODULE
 #include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <string_view>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 // iostream.hh
 template <class CharType> class input_stream;
@@ -432,4 +437,7 @@ future<process> spawn_process(const std::filesystem::path& pathname,
 future<process> spawn_process(const std::filesystem::path& pathname);
 /// @}
 }
+
+SEASTAR_MODULE_EXPORT_END
+
 }

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -21,17 +21,21 @@
 
 #pragma once
 
+#include "future.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/abortable_fifo.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/abort_on_expiry.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <cassert>
 #include <exception>
 #include <optional>
 #include <stdexcept>
 #include <utility>
+#endif
 
 namespace seastar {
 
@@ -58,7 +62,7 @@ public:
 
 /// \addtogroup fiber-module
 /// @{
-
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Exception thrown when a semaphore is broken by
 /// \ref semaphore::broken().
 class broken_semaphore : public std::exception {
@@ -448,6 +452,7 @@ public:
         _wait_list.reserve(n);
     }
 };
+SEASTAR_MODULE_EXPORT_END
 
 template<typename ExceptionFactory, typename Clock>
 inline
@@ -462,6 +467,8 @@ basic_semaphore<ExceptionFactory, Clock>::broken(std::exception_ptr xp) noexcept
         _wait_list.pop_front();
     }
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template<typename ExceptionFactory = semaphore_default_exception_factory, typename Clock = typename timer<>::clock>
 class semaphore_units {
@@ -756,6 +763,8 @@ with_semaphore(basic_semaphore<ExceptionFactory, Clock>& sem, size_t units, type
 /// on error conditions.
 using semaphore = basic_semaphore<semaphore_default_exception_factory>;
 using named_semaphore = basic_semaphore<named_semaphore_exception_factory>;
+
+SEASTAR_MODULE_EXPORT_END
 
 /// @}
 

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -30,10 +30,14 @@
 #include <seastar/util/concepts.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <boost/iterator/counting_iterator.hpp>
 #include <functional>
 #if __has_include(<concepts>)
 #include <concepts>
+#endif
 #endif
 
 /// \defgroup smp-module Multicore
@@ -48,11 +52,15 @@
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 template <typename Func, typename... Param>
 class sharded_parameter;
 
 template <typename Service>
 class sharded;
+
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 
@@ -100,6 +108,8 @@ using sharded_unwrap_t = typename sharded_unwrap<T>::type;
 
 /// \addtogroup smp-module
 /// @{
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename T>
 class sharded;
@@ -553,7 +563,7 @@ private:
 /// \example sharded_parameter_demo.cc
 ///
 /// Example use of \ref sharded_parameter.
-
+SEASTAR_MODULE_EXPORT_END
 /// @}
 
 template <typename Service>
@@ -810,9 +820,9 @@ inline bool sharded<Service>::local_is_initialized() const noexcept {
            _instances[this_shard_id()].service;
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// \addtogroup smp-module
 /// @{
-
 /// Smart pointer wrapper which makes it safe to move across CPUs.
 ///
 /// \c foreign_ptr<> is a smart pointer wrapper which, unlike
@@ -966,5 +976,7 @@ foreign_ptr<T> make_foreign(T ptr) {
 
 template<typename T>
 struct is_smart_ptr<foreign_ptr<T>> : std::true_type {};
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -22,13 +22,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/core/abortable_fifo.hh>
 #include <seastar/core/abort_on_expiry.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/util/modules.hh>
 #include <exception>
 #include <optional>
 #include <tuple>
+#endif
 
 namespace seastar {
 
@@ -293,6 +296,7 @@ public:
 /// When the shared_promise is made ready, every waiter is also made ready.
 ///
 /// Like the shared_future, the types in the parameter pack T must all be copy-constructible.
+SEASTAR_MODULE_EXPORT
 template <typename... T>
 class shared_promise {
 public:

--- a/include/seastar/core/shared_mutex.hh
+++ b/include/seastar/core/shared_mutex.hh
@@ -21,12 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/util/modules.hh>
 #include <cassert>
 #include <utility>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \addtogroup fiber-module
 /// @{
@@ -254,5 +259,6 @@ with_lock(shared_mutex& sm, Func&& func) noexcept {
 }
 
 /// @}
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/shared_ptr_debug_helper.hh
+++ b/include/seastar/core/shared_ptr_debug_helper.hh
@@ -23,10 +23,13 @@
 
 #ifdef SEASTAR_DEBUG_SHARED_PTR
 
+#ifndef SEASTAR_MODULE
 #include <thread>
 #include <cassert>
 
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -35,6 +38,7 @@ extern logger seastar_logger;
 // A counter that is only comfortable being incremented on the cpu
 // it was created on.  Useful for verifying that a shared_ptr
 // or lw_shared_ptr isn't misued across cores.
+SEASTAR_MODULE_EXPORT
 class debug_shared_ptr_counter_type {
     long _counter = 0;
     std::thread::id _cpu = std::this_thread::get_id();

--- a/include/seastar/core/simple-stream.hh
+++ b/include/seastar/core/simple-stream.hh
@@ -23,12 +23,17 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/variant_utils.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <cstddef>
 #include <stdexcept>
 #include <type_traits>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 class measuring_output_stream {
     size_t _size = 0;
@@ -590,6 +595,8 @@ public:
     friend decltype(auto) with_serialized_stream(Stream& stream, StreamVisitor&& visitor);
 };
 
+SEASTAR_MODULE_EXPORT_END
+
 inline simple_memory_input_stream simple_memory_output_stream::to_input_stream() const {
     return simple_memory_input_stream(_p, _size);
 }
@@ -624,21 +631,24 @@ inline memory_input_stream<Iterator> memory_output_stream<Iterator>::to_input_st
 // Using with_stream() there is at most one dynamic dispatch per such
 // function, instead of one per each skip() and deserialize() call.
 
+SEASTAR_MODULE_EXPORT_BEGIN
 template<typename Stream, typename StreamVisitor, typename = std::enable_if_t<Stream::has_with_stream::value>>
 [[gnu::always_inline]]
- static inline decltype(auto)
+ inline decltype(auto)
  with_serialized_stream(Stream& stream, StreamVisitor&& visitor) {
     return stream.with_stream(std::forward<StreamVisitor>(visitor));
 }
 
 template<typename Stream, typename StreamVisitor, typename = std::enable_if_t<!Stream::has_with_stream::value>, typename = void>
 [[gnu::always_inline]]
- static inline decltype(auto)
+ inline decltype(auto)
  with_serialized_stream(Stream& stream, StreamVisitor&& visitor) {
     return visitor(stream);
 }
 
 using simple_input_stream = simple_memory_input_stream;
 using simple_output_stream = simple_memory_output_stream;
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/sleep.hh
+++ b/include/seastar/core/sleep.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
 #include <functional>
 
@@ -29,8 +30,12 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \file
 
@@ -90,4 +95,5 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as);
 extern template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration, abort_source&);
 extern template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration, abort_source&);
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -28,27 +28,34 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <boost/lockfree/spsc_queue.hpp>
 #include <boost/thread/barrier.hpp>
 #include <boost/range/irange.hpp>
 #include <deque>
 #include <optional>
 #include <thread>
+#endif
 
 /// \file
 
 namespace seastar {
 
+class reactor_backend_selector;
+
+SEASTAR_MODULE_EXPORT_BEGIN
 using shard_id = unsigned;
 
 class smp_service_group;
-class reactor_backend_selector;
 
 namespace alien {
 
 class instance;
 
 }
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 
@@ -64,6 +71,8 @@ inline shard_id* this_shard_id_ptr() noexcept {
 #endif
 
 }
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// Returns shard_id of the of the current shard.
 inline shard_id this_shard_id() noexcept {
@@ -119,12 +128,15 @@ private:
     friend future<> destroy_smp_service_group(smp_service_group) noexcept;
 };
 
+SEASTAR_MODULE_EXPORT_END
+
 inline
 unsigned
 internal::smp_service_group_id(smp_service_group ssg) noexcept {
     return ssg._id;
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Returns the default smp_service_group. This smp_service_group
 /// does not impose any limits on concurrency in the target shard.
 /// This makes is deadlock-safe, but can consume unbounded resources,
@@ -153,8 +165,11 @@ using smp_timeout_clock = lowres_clock;
 using smp_service_group_semaphore = basic_semaphore<named_semaphore_exception_factory, smp_timeout_clock>;
 using smp_service_group_semaphore_units = semaphore_units<named_semaphore_exception_factory, smp_timeout_clock>;
 
+SEASTAR_MODULE_EXPORT_END
+
 static constexpr smp_timeout_clock::time_point smp_no_timeout = smp_timeout_clock::time_point::max();
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Options controlling the behaviour of \ref smp::submit_to().
 struct smp_submit_to_options {
     /// Controls resource allocation.
@@ -473,5 +488,7 @@ private:
 public:
     static unsigned count;
 };
+
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -21,12 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/util/program-options.hh>
+#include <seastar/util/modules.hh>
 #include <string>
+#endif
 
 /// \file
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 enum class memory_allocator {
     /// Seastar's own allocator, optimized for its shard-per core design.
@@ -100,4 +105,5 @@ public:
     smp_options(program_options::option_group* parent_group);
 };
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <stdint.h>
 #include <algorithm>
 #include <cassert>
@@ -38,11 +39,15 @@
 #include <functional>
 #include <type_traits>
 #include <fmt/ostream.h>
+#endif
 #include <seastar/util/concepts.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/core/temporary_buffer.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename char_type, typename Size, Size max_size, bool NulTerminate = true>
 class basic_sstring;
@@ -57,12 +62,15 @@ using sstring = basic_sstring<char, uint32_t, 15>;
 using sstring = std::string;
 #endif
 
+SEASTAR_MODULE_EXPORT_END
+
 namespace internal {
 [[noreturn]] void throw_bad_alloc();
 [[noreturn]] void throw_sstring_overflow();
 [[noreturn]] void throw_sstring_out_of_range();
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 class basic_sstring {
     static_assert(
@@ -630,6 +638,7 @@ template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 struct is_sstring<basic_sstring<char_type, Size, max_size, NulTerminate>> : std::true_type {};
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename string_type = sstring>
 string_type uninitialized_string(size_t size) {
     if constexpr (internal::is_sstring<string_type>::value) {
@@ -645,6 +654,7 @@ string_type uninitialized_string(size_t size) {
     }
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename size_type, size_type Max, size_type N, bool NulTerminate>
 inline
 basic_sstring<char_type, size_type, Max, NulTerminate>
@@ -663,6 +673,7 @@ size_t constexpr str_len(const T& s) {
     return std::string_view(s).size();
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename size_type, size_type max_size>
 inline
 void swap(basic_sstring<char_type, size_type, max_size>& x,
@@ -671,6 +682,7 @@ void swap(basic_sstring<char_type, size_type, max_size>& x,
     return x.swap(y);
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename size_type, size_type max_size, bool NulTerminate, typename char_traits>
 inline
 std::basic_ostream<char_type, char_traits>&
@@ -679,6 +691,7 @@ operator<<(std::basic_ostream<char_type, char_traits>& os,
     return os.write(s.begin(), s.size());
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename size_type, size_type max_size, bool NulTerminate, typename char_traits>
 inline
 std::basic_istream<char_type, char_traits>&
@@ -694,6 +707,7 @@ operator>>(std::basic_istream<char_type, char_traits>& is,
 
 namespace std {
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename size_type, size_type max_size, bool NulTerminate>
 struct hash<seastar::basic_sstring<char_type, size_type, max_size, NulTerminate>> {
     size_t operator()(const seastar::basic_sstring<char_type, size_type, max_size, NulTerminate>& s) const {
@@ -753,6 +767,8 @@ string_type to_sstring(T value) {
 }
 
 namespace std {
+
+SEASTAR_MODULE_EXPORT
 template <typename T>
 inline
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
@@ -770,6 +786,7 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
     return os;
 }
 
+SEASTAR_MODULE_EXPORT
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash, KeyEqual, Allocator>& v) {
     bool first = true;
@@ -789,6 +806,7 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
 
 #if FMT_VERSION >= 90000
 
+SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>> : fmt::formatter<std::basic_string_view<char_type>> {
     template <typename FormatContext>

--- a/include/seastar/core/stream.hh
+++ b/include/seastar/core/stream.hh
@@ -22,11 +22,16 @@
 #pragma once
 
 #include <seastar/core/future.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <exception>
 #include <functional>
 #include <cassert>
+#endif
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 // A stream/subscription pair is similar to a promise/future pair,
 // but apply to a sequence of values instead of a single value.
@@ -147,6 +152,7 @@ public:
 
     friend class stream<T...>;
 };
+SEASTAR_MODULE_EXPORT_END
 
 template <typename... T>
 inline

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -23,11 +23,15 @@
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/backtrace.hh>
+
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <utility>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class task {
 protected:
     scheduling_group _sg;
@@ -68,7 +72,10 @@ shared_backtrace task::get_backtrace() const {
 #endif
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
+
 void schedule(task* t) noexcept;
 void schedule_urgent(task* t) noexcept;
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/temporary_buffer.hh
+++ b/include/seastar/core/temporary_buffer.hh
@@ -21,13 +21,16 @@
 
 #pragma once
 
-#include <seastar/core/deleter.hh>
-#include <seastar/util/eclipse.hh>
-#include <seastar/util/std-compat.hh>
+#ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <cstddef>
 #include <string_view>
 #include <malloc.h>
+#endif
+#include <seastar/core/deleter.hh>
+#include <seastar/util/eclipse.hh>
+#include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -59,6 +62,7 @@ namespace seastar {
 ///    tcp output)
 ///
 /// \tparam CharType underlying character type (must be a variant of \c char).
+SEASTAR_MODULE_EXPORT
 template <typename CharType>
 class temporary_buffer {
     static_assert(sizeof(CharType) == 1, "must buffer stream of bytes");

--- a/include/seastar/core/thread.hh
+++ b/include/seastar/core/thread.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/thread_impl.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/do_with.hh>
@@ -32,8 +33,10 @@
 #include <type_traits>
 #include <chrono>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <ucontext.h>
 #include <boost/intrusive/list.hpp>
+#endif
 
 /// \defgroup thread-module Seastar threads
 ///
@@ -70,7 +73,7 @@ namespace seastar {
 
 /// \addtogroup thread-module
 /// @{
-
+SEASTAR_MODULE_EXPORT_BEGIN
 class thread;
 class thread_attributes;
 
@@ -81,7 +84,7 @@ public:
     // For stack_size 0, a default value will be used (128KiB when writing this comment)
     size_t stack_size = 0;
 };
-
+SEASTAR_MODULE_EXPORT_END
 
 /// \cond internal
 extern thread_local jmp_buf_link g_unthreaded_context;
@@ -133,7 +136,7 @@ public:
 
 /// \endcond
 
-
+SEASTAR_MODULE_EXPORT
 /// \brief thread - stateful thread of execution
 ///
 /// Threads allow using seastar APIs in a blocking manner,
@@ -214,6 +217,7 @@ thread::join() {
     return _context->_done.get_future();
 }
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Executes a callable in a seastar thread.
 ///
 /// Runs a block of code in a threaded context,
@@ -282,4 +286,5 @@ async(Func&& func, Args&&... args) noexcept {
 }
 /// @}
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/thread_cputime_clock.hh
+++ b/include/seastar/core/thread_cputime_clock.hh
@@ -21,9 +21,11 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
 #include <time.h>
 #include <cassert>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/core/timed_out_error.hh
+++ b/include/seastar/core/timed_out_error.hh
@@ -22,10 +22,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <exception>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class timed_out_error : public std::exception {
 public:
     virtual const char* what() const noexcept {
@@ -33,6 +37,7 @@ public:
     }
 };
 
+SEASTAR_MODULE_EXPORT
 struct default_timeout_exception_factory {
     static auto timeout() {
         return timed_out_error();

--- a/include/seastar/core/timer-set.hh
+++ b/include/seastar/core/timer-set.hh
@@ -13,13 +13,15 @@
 
 #pragma once
 
-#include <boost/intrusive/list.hpp>
 #include <seastar/core/bitset-iter.hh>
+#ifndef SEASTAR_MODULE
+#include <boost/intrusive/list.hpp>
 #include <array>
 #include <bitset>
 #include <chrono>
 #include <limits>
 #include <memory>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/core/timer.hh
+++ b/include/seastar/core/timer.hh
@@ -25,10 +25,13 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/timer-set.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
 #include <atomic>
 #include <chrono>
 #include <functional>
+#endif
 
 /// \file
 
@@ -48,6 +51,8 @@
 /// is required, a timer can launch a continuation.
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 using steady_clock_type = std::chrono::steady_clock;
 
@@ -221,6 +226,6 @@ extern template class timer<steady_clock_type>;
 
 
 /// @}
-
+SEASTAR_MODULE_EXPORT_END
 }
 

--- a/include/seastar/core/transfer.hh
+++ b/include/seastar/core/transfer.hh
@@ -33,11 +33,15 @@
 // transfer_pass1() simply moves the objects and destroys the source, and
 // transfer_pass2() does nothing.
 
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
+SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename T, typename Alloc>
 inline
@@ -70,6 +74,6 @@ transfer_pass2(Alloc& a, T* from, T*,
         typename std::enable_if<!std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
     std::allocator_traits<Alloc>::destroy(a, from);
 }
-
+SEASTAR_MODULE_EXPORT_END
 }
 

--- a/include/seastar/core/unaligned.hh
+++ b/include/seastar/core/unaligned.hh
@@ -46,10 +46,14 @@
 // cause the sanitizer not to generate runtime alignment checks for this
 // access.
 
+#ifndef SEASTAR_MODULE
 #include <type_traits>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 template <typename T>
 struct unaligned {
     // This is made to support only simple types, so it is fine to

--- a/include/seastar/core/units.hh
+++ b/include/seastar/core/units.hh
@@ -21,17 +21,23 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cstddef>
+#endif
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
-static constexpr size_t KB = 1 << 10;
-static constexpr size_t MB = 1 << 20;
-static constexpr size_t GB = 1 << 30;
+SEASTAR_MODULE_EXPORT_BEGIN
+
+constexpr size_t KB = 1 << 10;
+constexpr size_t MB = 1 << 20;
+constexpr size_t GB = 1 << 30;
 
 constexpr size_t operator"" _KiB(unsigned long long n) { return n << 10; }
 constexpr size_t operator"" _MiB(unsigned long long n) { return n << 20; }
 constexpr size_t operator"" _GiB(unsigned long long n) { return n << 30; }
 constexpr size_t operator"" _TiB(unsigned long long n) { return n << 40; }
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/vector-data-sink.hh
+++ b/include/seastar/core/vector-data-sink.hh
@@ -21,10 +21,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT
 class vector_data_sink final : public data_sink_impl {
 public:
     using vector_type = std::vector<net::packet>;

--- a/include/seastar/core/weak_ptr.hh
+++ b/include/seastar/core/weak_ptr.hh
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -37,6 +40,7 @@ namespace seastar {
 /// the to-be-referenced object.
 ///
 /// \see weakly_referencable
+SEASTAR_MODULE_EXPORT
 template<typename T>
 class weak_ptr {
     template<typename U>

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -22,16 +22,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/util/critical_alloc_section.hh>
+#include <seastar/util/modules.hh>
 #include <cstddef>
 #include <exception>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
+#endif
 
 namespace seastar {
 
@@ -247,6 +250,7 @@ when_all_impl(Futs&&... futs) noexcept {
 /// \param fut_or_funcs futures or functions that return futures
 /// \return an \c std::tuple<> of all futures returned; when ready,
 ///         all contained futures will be ready as well.
+SEASTAR_MODULE_EXPORT
 template <typename... FutOrFuncs>
 inline auto when_all(FutOrFuncs&&... fut_or_funcs) noexcept {
     return internal::when_all_impl(futurize_invoke_if_func(std::forward<FutOrFuncs>(fut_or_funcs))...);
@@ -315,6 +319,7 @@ do_when_all(FutureIterator begin, FutureIterator end) noexcept {
 /// \param end an \c InputIterator designating the end of the range of futures
 /// \return an \c std::vector<> of all the futures in the input; when
 ///         ready, all contained futures will be ready as well.
+SEASTAR_MODULE_EXPORT
 template <typename FutureIterator>
 SEASTAR_CONCEPT( requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; } )
 inline
@@ -489,6 +494,7 @@ inline auto when_all_succeed_impl(Futures&&... futures) noexcept {
 ///
 /// \param fut_or_funcs futures or functions that return futures
 /// \return future containing values of futures returned by funcs
+SEASTAR_MODULE_EXPORT
 template <typename... FutOrFuncs>
 inline auto when_all_succeed(FutOrFuncs&&... fut_or_funcs) noexcept {
     return internal::when_all_succeed_impl(futurize_invoke_if_func(std::forward<FutOrFuncs>(fut_or_funcs))...);
@@ -504,6 +510,7 @@ inline auto when_all_succeed(FutOrFuncs&&... fut_or_funcs) noexcept {
 /// \param begin an \c InputIterator designating the beginning of the range of futures
 /// \param end an \c InputIterator designating the end of the range of futures
 /// \return an \c std::vector<> of all the valus in the input
+SEASTAR_MODULE_EXPORT
 template <typename FutureIterator, typename = typename std::iterator_traits<FutureIterator>::value_type>
 SEASTAR_CONCEPT( requires requires (FutureIterator i) {
      *i++;

--- a/include/seastar/core/when_any.hh
+++ b/include/seastar/core/when_any.hh
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <iterator>
 #include <cstddef>
 #include <type_traits>
@@ -32,6 +33,8 @@
 #include <utility>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -70,6 +73,7 @@ public:
 /// \param end an \c InputIterator designating the end of the range of futures
 /// \return a \c when_any_result of all the futures in the input; when
 ///         ready, at least one of the contained futures (the one indicated by index) will be ready.
+SEASTAR_MODULE_EXPORT
 template <class FutureIterator>
 SEASTAR_CONCEPT( requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; } )
 auto when_any(FutureIterator begin, FutureIterator end) noexcept
@@ -142,6 +146,7 @@ when_any_impl(std::index_sequence<I...>, Futures&&... futs) noexcept
 /// \return a \c when_any_result containing a tuple of all futures
 ///  and and index; when ready, at least one of the contained futures
 ///  (the one indicated by index) will be ready.
+SEASTAR_MODULE_EXPORT
 template <class... FutOrFuncs>
 auto when_any(FutOrFuncs&&... fut_or_funcs) noexcept
 {

--- a/include/seastar/core/with_scheduling_group.hh
+++ b/include/seastar/core/with_scheduling_group.hh
@@ -22,11 +22,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <seastar/core/future.hh>
 #include <seastar/core/make_task.hh>
+#include <seastar/util/modules.hh>
 #include <concepts>
 #include <tuple>
 #include <utility>
+#endif
 
 namespace seastar {
 
@@ -58,6 +61,7 @@ schedule_in_group(scheduling_group sg, Func func) noexcept {
 /// \param func function to run; must be movable or copyable
 /// \param args arguments to the function; may be copied or moved, so use \c std::ref()
 ///             to force passing references
+SEASTAR_MODULE_EXPORT
 template <typename Func, typename... Args>
 SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
 inline

--- a/include/seastar/core/with_timeout.hh
+++ b/include/seastar/core/with_timeout.hh
@@ -23,11 +23,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/util/modules.hh>
+#endif
 
 namespace seastar {
 
@@ -46,6 +49,7 @@ namespace seastar {
 /// \param timeout time point after which the returned future should be failed
 ///
 /// \return a future which will be either resolved with f or a timeout exception
+SEASTAR_MODULE_EXPORT
 template<typename ExceptionFactory = default_timeout_exception_factory, typename Clock, typename Duration, typename... T>
 future<T...> with_timeout(std::chrono::time_point<Clock, Duration> timeout, future<T...> f) {
     if (f.available()) {

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -21,14 +21,19 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
+#endif
 #include <seastar/net/api.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
 
 namespace bi = boost::intrusive;
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 namespace tls { class certificate_credentials; }
 
@@ -217,4 +222,5 @@ public:
 
 } // http namespace
 
+SEASTAR_MODULE_EXPORT_END
 } // seastar namespace

--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <unordered_map>
+#endif
+
 #include <seastar/core/sstring.hh>
 #include <seastar/core/iostream.hh>
 
@@ -38,6 +41,7 @@ output_stream<char> make_http_content_length_output_stream(output_stream<char>& 
 
 namespace httpd {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 
 class parameters {
     std::unordered_map<sstring, sstring> params;
@@ -88,4 +92,5 @@ sstring type2str(operation_type type);
 
 }
 
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -20,13 +20,17 @@
  */
 
 #pragma once
+
 #include <seastar/util/log.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/json/json_elements.hh>
 
 namespace seastar {
 
 namespace httpd {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /**
  * The base_exception is a base for all http exception.
@@ -145,6 +149,7 @@ private:
     }
 };
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 }

--- a/include/seastar/http/file_handler.hh
+++ b/include/seastar/http/file_handler.hh
@@ -23,11 +23,13 @@
 
 #include <seastar/http/handlers.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace httpd {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /**
  * This is a base class for file transformer.
  *
@@ -167,6 +169,7 @@ private:
     bool force_path;
 };
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 }

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -21,6 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
+#include <iostream>
+#include <algorithm>
+#include <unordered_map>
+#include <queue>
+#include <bitset>
+#include <limits>
+#include <cctype>
+#include <vector>
+#include <boost/intrusive/list.hpp>
+#endif
 #include <seastar/http/request_parser.hh>
 #include <seastar/http/request.hh>
 #include <seastar/core/seastar.hh>
@@ -32,15 +43,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/util/std-compat.hh>
-#include <iostream>
-#include <algorithm>
-#include <unordered_map>
-#include <queue>
-#include <bitset>
-#include <limits>
-#include <cctype>
-#include <vector>
-#include <boost/intrusive/list.hpp>
+#include <seastar/util/modules.hh>
 #include <seastar/http/routes.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -48,16 +51,20 @@
 namespace seastar {
 
 namespace http {
+SEASTAR_MODULE_EXPORT
 struct reply;
 }
 
 namespace httpd {
 
+SEASTAR_MODULE_EXPORT
 class http_server;
+SEASTAR_MODULE_EXPORT
 class http_stats;
 
 using namespace std::chrono_literals;
 
+SEASTAR_MODULE_EXPORT_BEGIN
 class http_stats {
     metrics::metric_groups _metric_groups;
 public:
@@ -222,7 +229,7 @@ public:
     future<> listen(socket_address addr, listen_options lo);
     distributed<http_server>& server();
 };
-
+SEASTAR_MODULE_EXPORT_END
 }
 
 }

--- a/include/seastar/http/json_path.hh
+++ b/include/seastar/http/json_path.hh
@@ -21,13 +21,17 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <vector>
 #include <unordered_map>
 #include <tuple>
+#endif
+
 #include <seastar/http/common.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/http/routes.hh>
 #include <seastar/http/function_handlers.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -38,6 +42,7 @@ namespace httpd {
  * operation are associated to a path, that can
  * have multiple methods
  */
+SEASTAR_MODULE_EXPORT
 struct json_operation {
     /**
      * default constructor
@@ -75,6 +80,7 @@ struct json_operation {
  * definition file, during auto code generation in the
  * compilation.
  */
+SEASTAR_MODULE_EXPORT
 struct path_description {
     //
     enum class url_component_type {

--- a/include/seastar/http/mime_types.hh
+++ b/include/seastar/http/mime_types.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -24,6 +25,7 @@ namespace mime_types {
  * @param extension the file extension
  * @return the mime type as a string
  */
+SEASTAR_MODULE_EXPORT
 const char* extension_to_type(const sstring& extension);
 
 } // namespace mime_types

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -31,13 +31,18 @@
 //
 #pragma once
 
-#include <seastar/core/sstring.hh>
+#ifndef SEASTAR_MODULE
 #include <unordered_map>
+#endif
+#include <seastar/core/sstring.hh>
 #include <seastar/http/mime_types.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct http_response;
 
@@ -232,6 +237,7 @@ namespace httpd {
 using reply [[deprecated("Use http::reply instead")]] = http::reply;
 }
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 #if FMT_VERSION >= 90000

--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -21,18 +21,22 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
+#include <boost/program_options/variables_map.hpp>
+#include <unordered_map>
+#endif
+
 #include <seastar/http/matchrules.hh>
 #include <seastar/http/handlers.hh>
 #include <seastar/http/common.hh>
 #include <seastar/http/reply.hh>
-
-#include <boost/program_options/variables_map.hpp>
-#include <unordered_map>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace httpd {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /**
  * The url helps defining a route.
  */
@@ -294,6 +298,7 @@ public:
     ~rule_registration();
 };
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 }

--- a/include/seastar/http/transformers.hh
+++ b/include/seastar/http/transformers.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/http/handlers.hh>
 #include <seastar/http/file_handler.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -39,6 +40,7 @@ namespace httpd {
  * It could be extend if we will need it
  *
  */
+SEASTAR_MODULE_EXPORT
 class content_replace : public file_transformer {
 public:
     virtual output_stream<char> transform(std::unique_ptr<http::request> req,

--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -21,20 +21,25 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <string>
 #include <vector>
 #include <unordered_map>
 #include <map>
 #include <time.h>
 #include <sstream>
+#endif
+
 #include <seastar/core/loop.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace json {
 
+SEASTAR_MODULE_EXPORT
 class jsonable;
 
 typedef struct tm date_time;
@@ -44,6 +49,7 @@ typedef struct tm date_time;
  * it overload to_json method for each of the supported format
  * all to_json parameters are passed as a pointer
  */
+SEASTAR_MODULE_EXPORT
 class formatter {
     enum class state {
         none, array, map

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -21,19 +21,25 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <string>
 #include <vector>
 #include <time.h>
 #include <sstream>
+#endif
+
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/json/formatter.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace json {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /**
  * The base class for all json element.
@@ -355,6 +361,7 @@ std::function<future<>(output_stream<char>&&)> stream_object(T val) {
     };
 }
 
+SEASTAR_MODULE_EXPORT_END
 }
 
 }

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -21,10 +21,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <chrono>
 #include <memory>
 #include <vector>
 #include <cstring>
+#include <sys/types.h>
+#endif
+
 #include <seastar/core/future.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/net/socket_defs.hh>
@@ -34,7 +38,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/program-options.hh>
-#include <sys/types.h>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 

--- a/include/seastar/net/arp.hh
+++ b/include/seastar/net/arp.hh
@@ -22,10 +22,13 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
+#include <unordered_map>
+#endif
 #include <seastar/net/net.hh>
 #include <seastar/core/byteorder.hh>
 #include <seastar/net/ethernet.hh>
-#include <unordered_map>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 

--- a/include/seastar/net/byteorder.hh
+++ b/include/seastar/net/byteorder.hh
@@ -21,11 +21,14 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <arpa/inet.h>  // for ntohs() and friends
 #include <iosfwd>
 #include <utility>
+#endif
 
 #include <seastar/core/unaligned.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 

--- a/include/seastar/net/inet_address.hh
+++ b/include/seastar/net/inet_address.hh
@@ -21,17 +21,22 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <iosfwd>
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <stdexcept>
 #include <vector>
+#endif
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 namespace net {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct ipv4_address;
 struct ipv6_address;
@@ -120,10 +125,12 @@ public:
 std::ostream& operator<<(std::ostream&, const inet_address&);
 std::ostream& operator<<(std::ostream&, const inet_address::family&);
 
+SEASTAR_MODULE_EXPORT_END
 }
 }
 
 namespace std {
+SEASTAR_MODULE_EXPORT
 template<>
 struct hash<seastar::net::inet_address> {
     size_t operator()(const seastar::net::inet_address&) const;

--- a/include/seastar/net/ip.hh
+++ b/include/seastar/net/ip.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <boost/asio/ip/address_v4.hpp>
 #include <arpa/inet.h>
 #include <unordered_map>
@@ -30,6 +31,8 @@
 #include <map>
 #include <list>
 #include <chrono>
+#endif
+
 #include <seastar/core/array_map.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/byteorder.hh>
@@ -41,6 +44,7 @@
 #include <seastar/net/toeplitz.hh>
 #include <seastar/net/udp.hh>
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/util/modules.hh>
 
 #include "ipv4_address.hh"
 #include "ipv6_address.hh"

--- a/include/seastar/net/ip_checksum.hh
+++ b/include/seastar/net/ip_checksum.hh
@@ -22,9 +22,12 @@
 #pragma once
 
 #include <seastar/net/packet.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <cstdint>
 #include <cstddef>
 #include <arpa/inet.h>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/net/ipv4_address.hh
+++ b/include/seastar/net/ipv4_address.hh
@@ -24,10 +24,13 @@
 
 #include <seastar/net/socket_defs.hh>
 #include <seastar/core/byteorder.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace net {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct ipv4_address {
     ipv4_address() noexcept : ip(0) {}
@@ -71,9 +74,11 @@ struct ipv4_address {
     }
 } __attribute__((packed));
 
-static inline bool is_unspecified(ipv4_address addr) noexcept { return addr.ip == 0; }
+inline bool is_unspecified(ipv4_address addr) noexcept { return addr.ip == 0; }
 
 std::ostream& operator<<(std::ostream& os, const ipv4_address& a);
+
+SEASTAR_MODULE_EXPORT_END
 
 }
 
@@ -81,6 +86,7 @@ std::ostream& operator<<(std::ostream& os, const ipv4_address& a);
 
 namespace std {
 
+SEASTAR_MODULE_EXPORT
 template <>
 struct hash<seastar::net::ipv4_address> {
     size_t operator()(seastar::net::ipv4_address a) const { return a.ip; }

--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -25,6 +25,8 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/net/const.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -33,10 +35,13 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#endif
 
 namespace seastar {
 
 namespace net {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct fragment {
     char* base;
@@ -321,6 +326,8 @@ public:
 };
 
 std::ostream& operator<<(std::ostream& os, const packet& p);
+
+SEASTAR_MODULE_EXPORT_END
 
 inline
 packet::packet(packet&& x) noexcept

--- a/include/seastar/net/proxy.hh
+++ b/include/seastar/net/proxy.hh
@@ -17,7 +17,9 @@
  */
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
+#endif
 #include <seastar/net/net.hh>
 #include <seastar/net/packet.hh>
 

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -20,17 +20,21 @@
  */
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/ip.h>
-#include <seastar/net/byteorder.hh>
-#include <seastar/net/unix_address.hh>
 #include <array>
 #include <cassert>
 #include <functional>
 #include <iosfwd>
+#endif
+#include <seastar/net/byteorder.hh>
+#include <seastar/net/unix_address.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 namespace net {
 class inet_address;
@@ -156,7 +160,7 @@ std::ostream& operator<<(std::ostream&, const ipv6_addr&);
 inline bool operator==(const ipv4_addr &lhs, const ipv4_addr& rhs) noexcept {
     return lhs.ip == rhs.ip && lhs.port == rhs.port;
 }
-
+SEASTAR_MODULE_EXPORT_END
 }
 
 namespace std {

--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -21,17 +21,7 @@
 
 #pragma once
 
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/core/queue.hh>
-#include <seastar/core/semaphore.hh>
-#include <seastar/core/byteorder.hh>
-#include <seastar/core/metrics.hh>
-#include <seastar/net/net.hh>
-#include <seastar/net/ip_checksum.hh>
-#include <seastar/net/ip.hh>
-#include <seastar/net/const.hh>
-#include <seastar/net/packet-util.hh>
-#include <seastar/util/std-compat.hh>
+#ifndef SEASTAR_MODULE
 #include <unordered_map>
 #include <map>
 #include <functional>
@@ -43,6 +33,19 @@
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
 #include <cryptopp/md5.h>
+#endif
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/byteorder.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/net/net.hh>
+#include <seastar/net/ip_checksum.hh>
+#include <seastar/net/ip.hh>
+#include <seastar/net/const.hh>
+#include <seastar/net/packet-util.hh>
+#include <seastar/util/std-compat.hh>
 
 namespace seastar {
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -20,11 +20,12 @@
  */
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <functional>
 #include <unordered_set>
 #include <map>
-
 #include <boost/any.hpp>
+#endif
 
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/api-level.hh>
@@ -33,6 +34,7 @@
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 #include <seastar/net/api.hh>
 
 namespace seastar {
@@ -53,7 +55,9 @@ class socket_address;
  * with OpenSSL or similar.
  *
  */
+SEASTAR_MODULE_EXPORT
 namespace tls {
+
     enum class x509_crt_format {
         DER,
         PEM,
@@ -408,4 +412,3 @@ namespace tls {
     std::ostream& operator<<(std::ostream&, subject_alt_name_type);
 }
 }
-

--- a/include/seastar/net/toeplitz.hh
+++ b/include/seastar/net/toeplitz.hh
@@ -43,9 +43,11 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cstdint>
 #include <string_view>
 #include <vector>
+#endif
 
 namespace seastar {
 
@@ -76,7 +78,7 @@ static constexpr uint8_t default_rsskey_52bytes_v[] = {
 static constexpr rss_key_type default_rsskey_52bytes{default_rsskey_52bytes_v, sizeof(default_rsskey_52bytes_v)};
 
 template<typename T>
-static inline uint32_t
+inline uint32_t
 toeplitz_hash(rss_key_type key, const T& data)
 {
 	uint32_t hash = 0, v;

--- a/include/seastar/net/udp.hh
+++ b/include/seastar/net/udp.hh
@@ -22,12 +22,16 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <unordered_map>
 #include <assert.h>
+#endif
+
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/const.hh>
 #include <seastar/net/net.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 

--- a/include/seastar/net/unix_address.hh
+++ b/include/seastar/net/unix_address.hh
@@ -20,13 +20,16 @@
  */ 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <iosfwd>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <string>
+#endif
+#include <seastar/util/modules.hh>
 
 namespace seastar {
-
+SEASTAR_MODULE_EXPORT_BEGIN
 /*!
     A helper struct for creating/manipulating UNIX-domain sockets.
 
@@ -71,5 +74,5 @@ struct unix_domain_addr {
 };
 
 std::ostream& operator<<(std::ostream&, const unix_domain_addr&);
-
+SEASTAR_MODULE_EXPORT_END
 } // namespace seastar

--- a/include/seastar/net/virtio.hh
+++ b/include/seastar/net/virtio.hh
@@ -21,7 +21,9 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <memory>
+#endif
 #include <seastar/net/net.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/program-options.hh>

--- a/include/seastar/util/alloc_failure_injector.hh
+++ b/include/seastar/util/alloc_failure_injector.hh
@@ -21,11 +21,15 @@
 
 #pragma once
 
+#include "modules.hh"
+#ifndef SEASTAR_MODULE
 #include <limits>
 #include <cstdint>
 #include <functional>
+#endif
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/critical_alloc_section.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 namespace memory {
@@ -46,6 +50,7 @@ namespace memory {
 ///             // expected
 ///         }
 ///     }
+SEASTAR_MODULE_EXPORT
 class alloc_failure_injector {
     uint64_t _alloc_count = 0;
     uint64_t _fail_at = std::numeric_limits<uint64_t>::max();
@@ -95,6 +100,7 @@ extern thread_local alloc_failure_injector the_alloc_failure_injector;
 /// \endcond
 
 /// \brief Return the shard-local \ref alloc_failure_injector instance.
+SEASTAR_MODULE_EXPORT
 inline
 alloc_failure_injector& local_failure_injector() {
     return the_alloc_failure_injector;
@@ -114,6 +120,7 @@ struct [[deprecated("Use scoped_critical_section instead")]] disable_failure_gua
 };
 
 /// \brief Marks a point in code which should be considered for failure injection.
+SEASTAR_MODULE_EXPORT
 inline
 void on_alloc_point() {
 #ifdef SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
@@ -126,6 +133,7 @@ void on_alloc_point() {
 /// Initially, allocations start to fail immediately. In each
 /// subsequent run the failures start one allocation later. This
 /// returns when func is run and no allocation failures are detected.
+SEASTAR_MODULE_EXPORT
 void with_allocation_failures(noncopyable_function<void()> func);
 
 }

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -21,16 +21,19 @@
 
 #pragma once
 
+#include <seastar/core/sstring.hh>
+#include <seastar/core/print.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <execinfo.h>
 #include <iosfwd>
 #include <memory>
 #include <variant>
 #include <boost/container/static_vector.hpp>
-
-#include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
-#include <seastar/core/scheduling.hh>
-#include <seastar/core/shared_ptr.hh>
+#endif
 
 namespace seastar {
 
@@ -53,6 +56,7 @@ bool operator==(const frame& a, const frame& b) noexcept;
 frame decorate(uintptr_t addr) noexcept;
 
 // Invokes func for each frame passing it as argument.
+SEASTAR_MODULE_EXPORT
 template<typename Func>
 void backtrace(Func&& func) noexcept(noexcept(func(frame()))) {
     constexpr size_t max_backtrace = 100;
@@ -65,6 +69,7 @@ void backtrace(Func&& func) noexcept(noexcept(func(frame()))) {
 }
 
 // Represents a call stack of a single thread.
+SEASTAR_MODULE_EXPORT
 class simple_backtrace {
 public:
     using vector_type = boost::container::static_vector<frame, 64>;
@@ -117,6 +122,7 @@ public:
 
 // Extended backtrace which consists of a backtrace of the currently running task
 // and information about the chain of tasks waiting for the current operation to complete.
+SEASTAR_MODULE_EXPORT
 class tasktrace {
 public:
     using entry = std::variant<shared_backtrace, task_entry>;
@@ -147,6 +153,7 @@ public:
 
 namespace std {
 
+SEASTAR_MODULE_EXPORT
 template<>
 struct hash<seastar::simple_backtrace> {
     size_t operator()(const seastar::simple_backtrace& b) const {
@@ -154,6 +161,7 @@ struct hash<seastar::simple_backtrace> {
     }
 };
 
+SEASTAR_MODULE_EXPORT
 template<>
 struct hash<seastar::tasktrace> {
     size_t operator()(const seastar::tasktrace& b) const {
@@ -212,6 +220,7 @@ public:
 /// \tparam Args types of arguments forwarded to the constructor of Exc
 /// \param args arguments forwarded to the constructor of Exc
 /// \return std::exception_ptr containing the exception with the backtrace.
+SEASTAR_MODULE_EXPORT
 template <class Exc, typename... Args>
 std::exception_ptr make_backtraced_exception_ptr(Args&&... args) {
     using exc_type = std::decay_t<Exc>;
@@ -229,6 +238,7 @@ std::exception_ptr make_backtraced_exception_ptr(Args&&... args) {
      * @param args arguments forwarded to the constructor of Exc
      * @return never returns (throws an exception)
      */
+SEASTAR_MODULE_EXPORT
 template <class Exc, typename... Args>
 [[noreturn]]
 void

--- a/include/seastar/util/conversions.hh
+++ b/include/seastar/util/conversions.hh
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <cstdlib>
 #include <string_view>
 #include <vector>
+#endif
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -43,6 +46,7 @@ namespace seastar {
 // "7GB" -> (7 << 30)
 // "1TiB" -> (1 << 40)
 // anything else: exception
+SEASTAR_MODULE_EXPORT
 size_t parse_memory_size(std::string_view s);
 
 static inline std::vector<char> string2vector(std::string_view str) {

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -21,10 +21,14 @@
 
 #pragma once
 
+#include "modules.hh"
+#ifndef SEASTAR_MODULE
 #include <type_traits>
 #include <utility>
-
+#endif
+#include <seastar/util/modules.hh>
 #include <seastar/util/concepts.hh>
+
 
 #ifdef SEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT
 #define SEASTAR_DEFERRED_ACTION_NOEXCEPT noexcept
@@ -64,6 +68,7 @@ public:
     void cancel() { _cancelled = true; }
 };
 
+SEASTAR_MODULE_EXPORT
 template <typename Func>
 SEASTAR_CONCEPT( requires deferrable_action<Func> )
 inline

--- a/include/seastar/util/file.hh
+++ b/include/seastar/util/file.hh
@@ -22,12 +22,14 @@
 
 #pragma once
 
+#include "modules.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/short_streams.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
@@ -44,6 +46,7 @@ namespace seastar {
 /// The function bails out on first error. In that case, some files and/or sub-directories
 /// (and their contents) may be left behind at the level in which the error was detected.
 ///
+SEASTAR_MODULE_EXPORT
 future<> recursive_remove_directory(std::filesystem::path path) noexcept;
 
 /// @}
@@ -59,6 +62,7 @@ namespace util {
 /// \addtogroup fileio-util
 /// @{
 
+SEASTAR_MODULE_EXPORT_BEGIN
 template <typename Func>
 SEASTAR_CONCEPT(requires requires(Func func, input_stream<char>& in) {
      { func(in) };
@@ -90,6 +94,7 @@ future<std::vector<temporary_buffer<char>>> read_entire_file(std::filesystem::pa
 /// \param path path of the file to be read.
 future<sstring> read_entire_file_contiguous(std::filesystem::path path);
 
+SEASTAR_MODULE_EXPORT_END
 /// @}
 
 } // namespace util

--- a/include/seastar/util/internal/iovec_utils.hh
+++ b/include/seastar/util/internal/iovec_utils.hh
@@ -19,7 +19,9 @@
  * Copyright (C) 2022 ScyllaDB.
  */
 
+#ifndef SEASTAR_MODULE
 #include <sys/types.h>
+#endif
 
 #pragma once
 

--- a/include/seastar/util/internal/magic.hh
+++ b/include/seastar/util/internal/magic.hh
@@ -21,7 +21,9 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <linux/magic.h>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/util/log-cli.hh
+++ b/include/seastar/util/log-cli.hh
@@ -21,15 +21,18 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
+#include <boost/program_options.hpp>
+
+#include <algorithm>
+#include <unordered_map>
+#endif
+
 #include <seastar/util/log.hh>
 #include <seastar/util/program-options.hh>
 
 #include <seastar/core/sstring.hh>
 
-#include <boost/program_options.hpp>
-
-#include <algorithm>
-#include <unordered_map>
 
 /// \addtogroup logging
 /// @{

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -25,7 +25,9 @@
 #include <seastar/util/log-impl.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/modules.hh>
 
+#ifndef SEASTAR_MODULE
 #include <unordered_map>
 #include <exception>
 #include <iosfwd>
@@ -33,12 +35,14 @@
 #include <mutex>
 #include <boost/lexical_cast.hpp>
 #include <fmt/format.h>
-
+#endif
 
 /// \addtogroup logging
 /// @{
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 /// \brief log level used with \see {logger}
 /// used with the logger.do_log method.
@@ -55,6 +59,8 @@ enum class log_level {
 
 std::ostream& operator<<(std::ostream& out, log_level level);
 std::istream& operator>>(std::istream& in, log_level& level);
+
+SEASTAR_MODULE_EXPORT_END
 }
 
 // Boost doesn't auto-deduce the existence of the streaming operators for some reason
@@ -66,7 +72,7 @@ seastar::log_level lexical_cast(const std::string& source);
 }
 
 namespace seastar {
-
+SEASTAR_MODULE_EXPORT_BEGIN
 class logger;
 class logger_registry;
 
@@ -515,6 +521,8 @@ struct logging_settings final {
 /// Shortcut for configuring the logging system all at once.
 ///
 void apply_logging_settings(const logging_settings&);
+
+SEASTAR_MODULE_EXPORT_END
 
 /// \cond internal
 

--- a/include/seastar/util/memory_diagnostics.hh
+++ b/include/seastar/util/memory_diagnostics.hh
@@ -23,8 +23,11 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 enum class log_level;
 
@@ -84,6 +87,8 @@ void set_additional_diagnostics_producer(noncopyable_function<void(memory_diagno
 /// allocation failure), this method does allocate memory and can fail in
 /// low-memory conditions.
 sstring generate_memory_diagnostics_report();
+
+SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
 /// Log the memory diagnostics to the internal logger in the same way as

--- a/include/seastar/util/modules.hh
+++ b/include/seastar/util/modules.hh
@@ -1,0 +1,32 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+#pragma once
+
+#ifdef SEASTAR_MODULE
+#  define SEASTAR_MODULE_EXPORT export
+#  define SEASTAR_MODULE_EXPORT_BEGIN export {
+#  define SEASTAR_MODULE_EXPORT_END }
+#else
+#  define SEASTAR_MODULE_EXPORT
+#  define SEASTAR_MODULE_EXPORT_BEGIN
+#  define SEASTAR_MODULE_EXPORT_END
+#endif

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -21,11 +21,15 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
 #include <seastar/util/used_size.hh>
 #include <seastar/util/concepts.hh>
+
+#ifndef SEASTAR_MODULE
 #include <utility>
 #include <type_traits>
 #include <functional>
+#endif
 
 namespace seastar {
 
@@ -98,6 +102,7 @@ struct is_nothrow_if_object<> {
 
 /// A clone of \c std::function, but only invokes the move constructor
 /// of the contained function.
+SEASTAR_MODULE_EXPORT
 template <typename Ret, typename... Args, bool Noexcept>
 class noncopyable_function<Ret (Args...) noexcept(Noexcept)> : private internal::noncopyable_function_base {
     using call_type = Ret (*)(const noncopyable_function* func, Args...);

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -23,10 +23,12 @@
 
 #include <seastar/util/concepts.hh>
 #include <seastar/util/std-compat.hh>
-
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <iostream>
 #include <memory>
 #include <type_traits>
+#endif
 
 namespace seastar {
 
@@ -46,6 +48,7 @@ concept OptimizableOptional =
 /// their data externally and expect pointer to this data to be always non-null.
 /// In such case there is no real need for another flag signifying whether
 /// the optional is engaged.
+SEASTAR_MODULE_EXPORT
 template<typename T>
 class optimized_optional {
     T _object;

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -21,15 +21,20 @@
 
 #pragma once
 
-#include <seastar/util/concepts.hh>
+#ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cerrno>
 #include <cstring>
 #include <stdio.h>
 #include <unistd.h>
+#endif
+
+#include <seastar/util/concepts.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 //
 // Collection of async-signal safe printing functions.
 //
@@ -125,5 +130,5 @@ void print_decimal_safe(Integral n) noexcept {
     auto len = convert_decimal_safe(buf, i, n);
     print_safe(buf, len);
 }
-
+SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/util/process.hh
+++ b/include/seastar/util/process.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <sys/types.h>
 #include <algorithm>
 #include <filesystem>
@@ -32,6 +33,7 @@
 #include <variant>
 #include <vector>
 #include <fmt/format.h>
+#endif
 #include <seastar/core/iostream.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/sstring.hh>
@@ -41,6 +43,7 @@ namespace seastar::experimental {
 /// The optional parameters for spawning a subprocess
 ///
 /// \note see \c execve(2) for more details on \c argv and \c env.
+SEASTAR_MODULE_EXPORT
 struct spawn_parameters {
     /// The arguments passed to the program
     std::vector<sstring> argv;
@@ -53,6 +56,7 @@ struct spawn_parameters {
 /// \note the spawned subprocess should always be \c wait()'ed. Otherwise,
 /// the Seastar application spawning the subprocess will leave us with
 /// one ore more zombie subprocesses after it exists.
+SEASTAR_MODULE_EXPORT
 class process {
     struct create_tag {};
     /// Spawn a subprocess using \c posix_spawn(3)

--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -23,7 +23,9 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/print.hh>
+#include <seastar/util/modules.hh>
 
+#ifndef SEASTAR_MODULE
 #include <fmt/format.h>
 
 #include <boost/any.hpp>
@@ -33,6 +35,7 @@
 #include <unordered_map>
 #include <vector>
 #include <set>
+#endif
 
 /// \defgroup program-options Program Options
 ///
@@ -114,10 +117,10 @@ using list_base_hook = boost::intrusive::list_base_hook<boost::intrusive::link_m
 
 } // namespace program_options
 
+SEASTAR_MODULE_EXPORT_BEGIN
 enum class log_level;
 enum class logger_timestamp_style;
 enum class logger_ostream_type;
-
 namespace memory {
     enum class alloc_failure_kind;
 }
@@ -617,5 +620,6 @@ public:
 /// @}
 
 }
+SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/util/read_first_line.hh
+++ b/include/seastar/util/read_first_line.hh
@@ -1,6 +1,8 @@
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/sstring.hh>
+#ifndef SEASTAR_MODULE
 #include <boost/lexical_cast.hpp>
+#endif
 
 namespace seastar {
 

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -31,11 +31,11 @@
 namespace seastar {
 namespace internal {
 
-static inline uint64_t wrapping_difference(const uint64_t& a, const uint64_t& b) noexcept {
+inline uint64_t wrapping_difference(const uint64_t& a, const uint64_t& b) noexcept {
     return std::max<int64_t>(a - b, 0);
 }
 
-static inline uint64_t fetch_add(std::atomic<uint64_t>& a, uint64_t b) noexcept {
+inline uint64_t fetch_add(std::atomic<uint64_t>& a, uint64_t b) noexcept {
     return a.fetch_add(b);
 }
 

--- a/include/seastar/util/short_streams.hh
+++ b/include/seastar/util/short_streams.hh
@@ -22,11 +22,13 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
 
 namespace util {
 
+SEASTAR_MODULE_EXPORT_BEGIN
 /// Returns all bytes from the stream until eof, accessible in chunks.
 ///
 /// \note use only on short streams to avoid running out of memory.
@@ -46,6 +48,7 @@ future<sstring> read_entire_stream_contiguous(input_stream<char>& inp);
 /// \param inp \ref input_stream to be read.
 future<> skip_entire_stream(input_stream<char>& inp);
 
+SEASTAR_MODULE_EXPORT_END
 } // namespace util
 
 } // namespace seastar

--- a/include/seastar/util/spinlock.hh
+++ b/include/seastar/util/spinlock.hh
@@ -21,11 +21,15 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <atomic>
 #include <cassert>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <xmmintrin.h>
+#endif
 #endif
 
 namespace seastar {
@@ -80,6 +84,7 @@ namespace util {
 // BasicLockable.
 // Async-signal safe.
 // unlock() "synchronizes with" lock().
+SEASTAR_MODULE_EXPORT
 class spinlock {
     std::atomic<bool> _busy = { false };
 public:

--- a/include/seastar/util/std-compat.hh
+++ b/include/seastar/util/std-compat.hh
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
+
 #include <optional>
 #include <string_view>
 #include <variant>
@@ -62,17 +66,25 @@ namespace std::pmr {
 #endif
 
 #if defined(__cpp_lib_source_location) && !defined(SEASTAR_BROKEN_SOURCE_LOCATION)
-namespace seastar::compat {
-using source_location = std::source_location;
-}
+// good
 #elif __has_include(<experimental/source_location>) && !defined(SEASTAR_BROKEN_SOURCE_LOCATION)
 #include <experimental/source_location>
-namespace seastar::compat {
-using source_location = std::experimental::source_location;
-}
 #else
 #include <seastar/util/source_location-compat.hh>
-namespace seastar::compat {
-using source_location = seastar::internal::source_location;
-}
 #endif
+
+#endif // !defined(SEASTAR_MODULE)
+
+namespace seastar::compat {
+SEASTAR_MODULE_EXPORT_BEGIN
+
+#if defined(__cpp_lib_source_location) && !defined(SEASTAR_BROKEN_SOURCE_LOCATION)
+using source_location = std::source_location;
+#elif __has_include(<experimental/source_location>) && !defined(SEASTAR_BROKEN_SOURCE_LOCATION)
+using source_location = std::experimental::source_location;
+#else
+using source_location = seastar::internal::source_location;
+#endif
+
+SEASTAR_MODULE_EXPORT_END
+}

--- a/include/seastar/util/used_size.hh
+++ b/include/seastar/util/used_size.hh
@@ -21,8 +21,10 @@
 
 #pragma once
 
+#ifndef SEASTAR_MODULE
 #include <stddef.h>
 #include <type_traits>
+#endif
 
 namespace seastar {
 namespace internal {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,137 @@
+add_library (seastar-module)
+add_dependencies (seastar-module
+    seastar_http_chunk_parsers
+    seastar_http_request_parser
+    seastar_http_response_parser)
+target_sources (seastar-module
+  PUBLIC
+    FILE_SET CXX_MODULES
+    TYPE CXX_MODULES
+    FILES
+      seastar.cc
+  PRIVATE
+    core/alien.cc
+    core/app-template.cc
+    core/condition-variable.cc
+    core/exception_hacks.cc
+    core/execution_stage.cc
+    core/fair_queue.cc
+    core/file.cc
+    core/fsnotify.cc
+    core/fstream.cc
+    core/future-util.cc
+    core/future.cc
+    core/io_queue.cc
+    core/linux-aio.cc
+    core/memory.cc
+    core/metrics.cc
+    core/on_internal_error.cc
+    core/posix.cc
+    core/program_options.cc
+    core/reactor.cc
+    core/reactor_backend.cc
+    core/resource.cc
+    core/sharded.cc
+    core/scollectd.cc
+    core/semaphore.cc
+    core/smp.cc
+    core/sstring.cc
+    core/systemwide_memory_barrier.cc
+    core/thread.cc
+    core/thread_pool.cc
+    core/uname.cc
+    util/alloc_failure_injector.cc
+    util/backtrace.cc
+    util/conversions.cc
+    util/file.cc
+    util/log.cc
+    util/process.cc
+    util/program-options.cc
+    util/read_first_line.cc
+    util/short_streams.cc
+    net/config.cc
+    net/arp.cc
+    net/dhcp.cc
+    net/dpdk.cc
+    net/ip.cc
+    net/tcp.cc
+    net/udp.cc
+    net/stack.cc
+    net/native-stack.cc
+    net/posix-stack.cc
+    net/net.cc
+    net/proxy.cc
+    net/ip_checksum.cc
+    net/packet.cc
+    net/inet_address.cc
+    net/socket_address.cc
+    net/tls.cc
+    net/virtio.cc
+    http/common.cc
+    http/file_handler.cc
+    http/httpd.cc
+    http/json_path.cc
+    http/matcher.cc
+    http/mime_types.cc
+    http/reply.cc
+    http/request.cc
+    http/routes.cc
+    http/transformers.cc
+    http/url.cc
+    json/formatter.cc
+    json/json_elements.cc
+  )
+target_include_directories (seastar-module
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${Seastar_GEN_BINARY_DIR}/include>
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)
+target_compile_definitions (seastar-module
+  PUBLIC
+    $<$<BOOL:${Seastar_SSTRING}>:SEASTAR_SSTRING>
+    SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
+    SEASTAR_SCHEDULING_GROUPS_COUNT=${Seastar_SCHEDULING_GROUPS_COUNT}
+  PRIVATE
+    SEASTAR_MODULE)
+target_compile_options (seastar-module
+  PUBLIC
+    -U_FORTIFY_SOURCE)
+
+target_link_libraries (seastar-module
+  PUBLIC
+    Boost::boost
+    Boost::program_options
+    Boost::thread
+    c-ares::cares
+    cryptopp::cryptopp
+    fmt::fmt
+    lz4::lz4
+    SourceLocation::source_location
+  PRIVATE
+    ${CMAKE_DL_LIBS}
+    GnuTLS::gnutls
+    StdAtomic::atomic
+    lksctp-tools::lksctp-tools
+    rt::rt
+    yaml-cpp::yaml-cpp
+    "$<BUILD_INTERFACE:Valgrind::valgrind>"
+    Threads::Threads)
+
+install (
+  TARGETS seastar-module
+  LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  CXX_MODULES_BMI
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cxx/bmi"
+    COMPONENT "bmi"
+  FILE_SET CXX_MODULES
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cxx/modules"
+    COMPONENT "modules")
+export (
+  TARGETS
+    seastar-module
+  NAMESPACE Seastar::
+  APPEND FILE "${CMAKE_CURRENT_BINARY_DIR}/SeastarModules.cmake"
+  CXX_MODULES_DIRECTORY "cxx-modules")

--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -20,14 +20,23 @@
  * Copyright (C) 2018 Red Hat
  */
 
-#include <seastar/core/alien.hh>
-#include <seastar/core/reactor.hh>
-#include <seastar/core/metrics.hh>
-#include <seastar/core/prefetch.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <atomic>
 #include <iterator>
 #include <memory>
 #include <vector>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/alien.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/prefetch.hh>
+#endif
 
 namespace seastar {
 namespace alien {

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -19,6 +19,21 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <fstream>
+#include <cstdlib>
+#include <chrono>
+#include <iostream>
+#include <fmt/format.h>
+#include <boost/program_options.hpp>
+#include <boost/make_shared.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/app-template.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/alien.hh>
@@ -28,12 +43,8 @@
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
 #include <seastar/net/native-stack.hh>
-#include <boost/program_options.hpp>
-#include <boost/make_shared.hpp>
-#include <fstream>
-#include <cstdlib>
-
 #include "program_options.hh"
+#endif
 
 namespace seastar {
 

--- a/src/core/condition-variable.cc
+++ b/src/core/condition-variable.cc
@@ -18,8 +18,15 @@
 /*
  * Copyright (C) 2020 ScyllaDB, Ltd.
  */
-
+#ifdef SEASTAR_MODULE
+module;
+#include <cassert>
+#include <exception>
+#include <utility>
+module seastar;
+#else
 #include <seastar/core/condition-variable.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -52,14 +52,23 @@
 // entirely. By calling the callback with old version of dl_phdr_info from
 // our dl_iterate_phdr we can effectively make libgcc callback thread safe.
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <link.h>
 #include <dlfcn.h>
 #include <assert.h>
 #include <vector>
 #include <cstddef>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/exception_hacks.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/backtrace.hh>
+#endif
 
 namespace seastar {
 using dl_iterate_fn = int (*) (int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data);
@@ -138,7 +147,7 @@ int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, voi
 extern "C"
 [[gnu::visibility("default")]]
 [[gnu::used]]
-int _Unwind_RaiseException(struct _Unwind_Exception *h) {
+int _Unwind_RaiseException(struct ::_Unwind_Exception *h) {
     using throw_fn =  int (*)(void *);
     static throw_fn org = nullptr;
 

--- a/src/core/execution_stage.cc
+++ b/src/core/execution_stage.cc
@@ -19,10 +19,17 @@
  * Copyright (C) 2018 ScyllaDB Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <algorithm>
+#include <stdexcept>
+module seastar;
+#else
 #include <seastar/core/execution_stage.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/make_task.hh>
 #include <seastar/util/defer.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -19,8 +19,24 @@
  * Copyright 2019 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <chrono>
+#include <functional>
+#include <queue>
+#include <unordered_set>
+#include <utility>
 #include <boost/container/small_vector.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
+
+#include "fmt/format.h"
+#include "fmt/ostream.h"
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/fair_queue.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -28,13 +44,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
-#include <chrono>
-#include <functional>
-#include <queue>
-#include <unordered_set>
-
-#include "fmt/format.h"
-#include "fmt/ostream.h"
+#endif
 
 namespace seastar {
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -19,6 +19,19 @@
  * Copyright 2019 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <deque>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
 #define __user /* empty */  // for xfs includes, below
 
 #include <sys/syscall.h>
@@ -33,14 +46,10 @@
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min
-#include <algorithm>
-#include <atomic>
-#include <deque>
-#include <filesystem>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <vector>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/internal/read_state.hh>
 #include <seastar/core/internal/uname.hh>
 #include <seastar/core/reactor.hh>
@@ -54,6 +63,7 @@
 #include "core/file-impl.hh"
 #include "core/syscall_result.hh"
 #include "core/thread_pool.hh"
+#endif
 
 namespace seastar {
 

--- a/src/core/fsnotify.cc
+++ b/src/core/fsnotify.cc
@@ -19,10 +19,24 @@
  * Copyright 2020 ScyllaDB Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+
+module;
+
+#include <cerrno>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+#include <sys/inotify.h>
+
+module seastar;
+
+#else
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/fsnotify.hh>
+#endif
 
 namespace seastar::experimental {
 

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -19,6 +19,22 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <malloc.h>
+#include <string.h>
+#include <cassert>
+#include <ratio>
+#include <optional>
+#include <utility>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/fstream.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -26,10 +42,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/io_intent.hh>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-#include <malloc.h>
-#include <string.h>
+#endif
 
 namespace seastar {
 

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -18,12 +18,23 @@
 /*
  * Copyright (C) 2017 ScyllaDB
  */
-
+#ifdef SEASTAR_MODULE
+module;
+#include <cstddef>
+#include <exception>
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+module seastar;
+#else
 #include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/semaphore.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -19,11 +19,21 @@
  * Copyright (C) 2020 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cassert>
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+module seastar;
+#else
 #include <seastar/core/future.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/report_exception.hh>
 #include <seastar/util/backtrace.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -19,8 +19,27 @@
  * Copyright 2019 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
+#include <compare>
+#include <atomic>
+#include <cassert>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <utility>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <boost/intrusive/parent_from_member.hpp>
+#include <boost/container/small_vector.hpp>
+#include <sys/uio.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/file.hh>
 #include <seastar/core/fair_queue.hh>
 #include <seastar/core/io_queue.hh>
@@ -33,11 +52,7 @@
 #include <seastar/core/internal/io_sink.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/util/log.hh>
-#include <chrono>
-#include <mutex>
-#include <array>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#endif
 
 namespace seastar {
 

--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -19,15 +19,27 @@
  * Copyright (C) 2017 ScyllaDB
  */
 
-#include <seastar/core/linux-aio.hh>
-#include <seastar/core/print.hh>
-#include <unistd.h>
-#include <sys/syscall.h>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <compare>
 #include <atomic>
 #include <algorithm>
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <fmt/format.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 #include <valgrind/valgrind.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/linux-aio.hh>
+#include <seastar/core/print.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -19,15 +19,26 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 
-#include <seastar/core/metrics.hh>
-#include <seastar/core/metrics_api.hh>
-#include <seastar/core/relabel_config.hh>
-#include <seastar/core/reactor.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <memory>
+#include <regex>
+#include <random>
 #include <boost/range/algorithm.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
-#include <random>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/relabel_config.hh>
+#include <seastar/core/reactor.hh>
+#endif
 
 namespace seastar {
 extern seastar::logger seastar_logger;

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -19,11 +19,24 @@
  * Copyright 2020 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <compare>
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string_view>
+#include <cstdlib>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
-
-#include <atomic>
+#endif
 
 static std::atomic<bool> abort_on_internal_error{false};
 

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -19,11 +19,28 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <memory>
+#include <cassert>
+#include <set>
+#include <vector>
+#include <functional>
+#include <fmt/format.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/inotify.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/posix.hh>
 #include <seastar/core/align.hh>
 #include <seastar/util/critical_alloc_section.hh>
-#include <sys/mman.h>
-#include <sys/inotify.h>
+#endif
 
 namespace seastar {
 

--- a/src/core/program_options.cc
+++ b/src/core/program_options.cc
@@ -19,6 +19,16 @@
  * Copyright (C) 2021 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cstdlib>
+#include <string>
+#include <stdexcept>
+#include <boost/program_options.hpp>
+#include <boost/type.hpp>
+#include <fmt/format.h>
+module seastar;
+#else
 #include "core/program_options.hh"
 
 #include <seastar/util/log-cli.hh>
@@ -26,6 +36,7 @@
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
 #include <seastar/core/smp.hh>
+#endif
 
 namespace seastar::program_options {
 

--- a/src/core/program_options.hh
+++ b/src/core/program_options.hh
@@ -19,10 +19,13 @@
  * Copyright (C) 2021 Cloudius Systems, Ltd.
  */
 
+#ifndef SEASTAR_MODULE
 #include <boost/program_options.hpp>
-#include <seastar/util/program-options.hh>
-
 #include <stack>
+#endif
+
+#include <seastar/util/program-options.hh>
+#include <seastar/util/modules.hh>
 
 namespace bpo = boost::program_options;
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -18,6 +18,36 @@
 /*
  * Copyright 2019 ScyllaDB
  */
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <compare>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <thread>
+#include <utility>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/epoll.h>
+#include <sys/poll.h>
+#include <sys/syscall.h>
+#include <sys/resource.h>
+#include <boost/container/small_vector.hpp>
+
+#ifdef SEASTAR_HAVE_URING
+#include <liburing.h>
+#endif
+
+#ifdef HAVE_OSV
+#include <osv/newpoll.hh>
+#endif
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include "core/reactor_backend.hh"
 #include "core/thread_pool.hh"
 #include "core/syscall_result.hh"
@@ -28,19 +58,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
-
-#include <chrono>
-#include <filesystem>
-#include <sys/poll.h>
-#include <sys/syscall.h>
-#include <sys/resource.h>
-
-#ifdef SEASTAR_HAVE_URING
-#include <liburing.h>
-#endif
-
-#ifdef HAVE_OSV
-#include <osv/newpoll.hh>
 #endif
 
 namespace seastar {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -27,6 +27,9 @@
 #include <seastar/core/internal/poll.hh>
 #include <seastar/core/linux-aio.hh>
 #include <seastar/core/cacheline.hh>
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
 #include <fmt/ostream.h>
 #include <sys/time.h>
 #include <signal.h>
@@ -38,6 +41,7 @@
 
 #ifdef HAVE_OSV
 #include <osv/newpoll.hh>
+#endif
 #endif
 
 namespace seastar {

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -20,21 +20,30 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <regex>
+#include <stdlib.h>
+#include <limits>
+#include <filesystem>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/resource.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/print.hh>
 #include <seastar/util/read_first_line.hh>
-#include <stdlib.h>
-#include <limits>
-#include "cgroup.hh"
 #include <seastar/util/log.hh>
 #include <seastar/core/io_queue.hh>
-
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/copy.hpp>
+#include "cgroup.hh"
+#endif
 
 namespace seastar {
 

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -19,6 +19,14 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <functional>
 #include <unordered_map>
 #include <forward_list>
@@ -28,6 +36,9 @@
 #include <iostream>
 #include <unordered_map>
 
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/seastar.hh>
 #include <seastar/core/scollectd_api.hh>
 #include <seastar/core/metrics_api.hh>
@@ -35,6 +46,7 @@
 #include <seastar/core/print.hh>
 
 #include "core/scollectd-impl.hh"
+#endif
 
 namespace seastar {
 

--- a/src/core/semaphore.cc
+++ b/src/core/semaphore.cc
@@ -19,8 +19,17 @@
  * Copyright (C) 2020 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <fmt/format.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/semaphore.hh>
+#endif
 
 namespace seastar {
 

--- a/src/core/sharded.cc
+++ b/src/core/sharded.cc
@@ -19,9 +19,18 @@
  * Copyright (C) 2018 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <boost/range/irange.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/sharded.hh>
 #include <seastar/core/loop.hh>
-#include <boost/range/irange.hpp>
+#endif
 
 namespace seastar {
 

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -18,14 +18,22 @@
 /*
  * Copyright 2019 ScyllaDB
  */
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
+#include <boost/range/algorithm/find_if.hpp>
+#include <vector>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/smp.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/on_internal_error.hh>
-#include <boost/range/algorithm/find_if.hpp>
-#include <vector>
+#endif
 
 namespace seastar {
 

--- a/src/core/sstring.cc
+++ b/src/core/sstring.cc
@@ -19,7 +19,15 @@
  * Copyright (C) 2020 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cstddef>
+#include <new>
+#include <stdexcept>
+module seastar;
+#else
 #include <seastar/core/sstring.hh>
+#endif
 
 using namespace seastar;
 

--- a/src/core/syscall_work_queue.hh
+++ b/src/core/syscall_work_queue.hh
@@ -26,7 +26,10 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/modules.hh>
+#ifndef SEASTAR_MODULE
 #include <boost/lockfree/spsc_queue.hpp>
+#endif
 
 namespace seastar {
 

--- a/src/core/systemwide_memory_barrier.cc
+++ b/src/core/systemwide_memory_barrier.cc
@@ -19,9 +19,10 @@
  * Copyright 2015 Scylla DB
  */
 
-#include <seastar/core/systemwide_memory_barrier.hh>
-#include <seastar/core/cacheline.hh>
-#include <seastar/util/log.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <sys/mman.h>
 #include <unistd.h>
 #include <cassert>
@@ -32,6 +33,14 @@
 #include <linux/membarrier.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#endif
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/systemwide_memory_barrier.hh>
+#include <seastar/core/cacheline.hh>
+#include <seastar/util/log.hh>
 #endif
 
 namespace seastar {

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -19,14 +19,26 @@
 /*
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
+#include <ucontext.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <valgrind/valgrind.h>
+#include <algorithm>
+#include <exception>
+#include <utility>
+#include <boost/intrusive/list.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/thread.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor.hh>
-#include <ucontext.h>
-#include <algorithm>
-
-#include <valgrind/valgrind.h>
+#endif
 
 /// \cond internal
 

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -19,8 +19,20 @@
  * Copyright (C) 2019 ScyllaDB Ltd.
  */
 
+
+#ifdef SEASTAR_MODULE
+module;
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <array>
+#include <pthread.h>
+#include <signal.h>
+module seastar;
+#else
 #include <seastar/core/reactor.hh>
 #include "core/thread_pool.hh"
+#endif
 
 namespace seastar {
 

--- a/src/core/uname.cc
+++ b/src/core/uname.cc
@@ -20,11 +20,22 @@
  * Copyright (C) 2019 ScyllaDB
  */
 
-#include <seastar/core/internal/uname.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <memory>
+#include <optional>
 #include <regex>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <sys/utsname.h>
 #include <iostream>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/internal/uname.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -19,6 +19,10 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+module seastar;
+#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/reactor.hh>
@@ -29,6 +33,7 @@
 #include <seastar/http/response_parser.hh>
 #include <seastar/http/internal/content_source.hh>
 #include <seastar/util/short_streams.hh>
+#endif
 
 namespace seastar {
 logger http_log("http");

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -19,8 +19,20 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <cstdlib>
+#include <memory>
+#include <utility>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/http/common.hh>
 #include <seastar/core/iostream-impl.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -19,15 +19,25 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#include <seastar/http/file_handler.hh>
-#include <seastar/core/seastar.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <algorithm>
 #include <iostream>
+#include <memory>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/http/file_handler.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/http/exception.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -19,6 +19,26 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <memory>
+#include <algorithm>
+#include <bitset>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <queue>
+#include <unordered_map>
+#include <vector>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/sstring.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -27,19 +47,13 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/print.hh>
-#include <iostream>
-#include <algorithm>
-#include <unordered_map>
-#include <queue>
-#include <bitset>
-#include <limits>
-#include <cctype>
-#include <vector>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/internal/content_source.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/log.hh>
+#endif
+
 
 using namespace std::chrono_literals;
 

--- a/src/http/json_path.cc
+++ b/src/http/json_path.cc
@@ -19,7 +19,13 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <vector>
+module seastar;
+#else
 #include <seastar/http/json_path.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/matcher.cc
+++ b/src/http/matcher.cc
@@ -19,9 +19,17 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#include <seastar/http/matcher.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
 #include <iostream>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/http/matcher.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/mime_types.cc
+++ b/src/http/mime_types.cc
@@ -8,7 +8,12 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#ifdef SEASTAR_MODULE
+module;
+module seastar;
+#else
 #include <seastar/http/mime_types.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -28,12 +28,20 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
+
+#ifdef SEASTAR_MODULE
+module;
+#include <iostream>
+#include <utility>
+module seastar;
+#else
 #include <seastar/http/reply.hh>
 #include <seastar/core/print.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/common.hh>
 #include <seastar/http/response_parser.hh>
 #include <seastar/core/loop.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -19,9 +19,21 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <cassert>
+#include <string_view>
+#include <utility>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/http/request.hh>
 #include <seastar/http/url.hh>
 #include <seastar/http/common.hh>
+#endif
 
 namespace seastar {
 namespace http {

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -19,11 +19,17 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
-#include <seastar/core/ragel.hh>
+#ifndef SEASTAR_MODULE
 #include <memory>
 #include <unordered_map>
+#endif
+
+#include <seastar/core/ragel.hh>
+#include <seastar/util/modules.hh>
 
 namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
 
 struct http_response {
     sstring _version;
@@ -176,5 +182,5 @@ public:
         return _state == state::error;
     }
 };
-
+SEASTAR_MODULE_EXPORT_END
 }

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -19,11 +19,18 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <exception>
+#include <memory>
+module seastar;
+#else
 #include <seastar/http/routes.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/http/json_path.hh>
+#endif
 
 namespace seastar {
 

--- a/src/http/transformers.cc
+++ b/src/http/transformers.cc
@@ -19,11 +19,21 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <boost/algorithm/string/replace.hpp>
+#include <list>
+#include <memory>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
-#include <boost/algorithm/string/replace.hpp>
 #include <seastar/http/transformers.hh>
-#include <list>
+#endif
 
 namespace seastar {
 

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -19,7 +19,17 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <string_view>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/http/url.hh>
+#endif
 
 namespace seastar {
 namespace http {

--- a/src/json/formatter.cc
+++ b/src/json/formatter.cc
@@ -19,10 +19,23 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#include <seastar/json/formatter.hh>
-#include <seastar/json/json_elements.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <cmath>
 #include <algorithm>
+#include <iomanip>
+#include <ios>
+#include <sstream>
+#include <string_view>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/json/formatter.hh>
+#include <seastar/json/json_elements.hh>
+#endif
 
 namespace seastar {
 

--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -19,13 +19,22 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#include <seastar/core/loop.hh>
-#include <seastar/core/print.hh>
-#include <seastar/json/json_elements.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <string.h>
 #include <string>
 #include <vector>
 #include <sstream>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/loop.hh>
+#include <seastar/core/print.hh>
+#include <seastar/json/json_elements.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/arp.cc
+++ b/src/net/arp.cc
@@ -19,7 +19,15 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cstdint>
+#include <optional>
+#include <utility>
+module seastar;
+#else
 #include <seastar/net/arp.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/config.cc
+++ b/src/net/config.cc
@@ -19,8 +19,10 @@
  * Copyright 2017 Marek Waszkiewicz ( marek.waszkiewicz77@gmail.com )
  */
 
-#include <seastar/net/config.hh>
-#include <seastar/core/print.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/none_of.hpp>
 #include <boost/next_prior.hpp>
@@ -29,6 +31,13 @@
 #include <istream>
 #include <unordered_map>
 #include <string>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/net/config.hh>
+#include <seastar/core/print.hh>
+#endif
 
 using namespace boost::algorithm;
 

--- a/src/net/dhcp.cc
+++ b/src/net/dhcp.cc
@@ -19,16 +19,25 @@
  * Copyright 2014 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <chrono>
 #include <unordered_map>
 #include <array>
 #include <random>
 #include <iostream>
+#include <arpa/inet.h>
 
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/dhcp.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/net/udp.hh>
 #include <seastar/net/stack.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -20,31 +20,14 @@
  */
 #ifdef SEASTAR_HAVE_DPDK
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <cinttypes>
-#include <seastar/core/posix.hh>
-#include "core/vla.hh"
-#include <seastar/core/reactor.hh>
-#include <seastar/net/virtio-interface.hh>
-#include <seastar/core/stream.hh>
-#include <seastar/core/circular_buffer.hh>
-#include <seastar/core/align.hh>
-#include <seastar/core/sstring.hh>
-#include <seastar/core/memory.hh>
-#include <seastar/core/metrics.hh>
-#include <seastar/util/function_input_iterator.hh>
-#include <seastar/util/transform_iterator.hh>
 #include <atomic>
 #include <vector>
 #include <queue>
-#include <seastar/util/std-compat.hh>
-#include <boost/preprocessor.hpp>
-#include <seastar/net/ip.hh>
-#include <seastar/net/const.hh>
-#include <seastar/core/dpdk_rte.hh>
-#include <seastar/net/dpdk.hh>
-#include <seastar/net/toeplitz.hh>
-#include <seastar/net/native-stack.hh>
-
 #include <getopt.h>
 #include <malloc.h>
 
@@ -57,6 +40,32 @@
 #include <rte_cycles.h>
 #include <rte_memzone.h>
 #include <rte_vfio.h>
+
+#include <boost/preprocessor.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/posix.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/net/virtio-interface.hh>
+#include <seastar/core/stream.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/align.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/util/function_input_iterator.hh>
+#include <seastar/util/transform_iterator.hh>
+#include <seastar/util/std-compat.hh>
+#include <seastar/net/ip.hh>
+#include <seastar/net/const.hh>
+#include <seastar/core/dpdk_rte.hh>
+#include <seastar/net/dpdk.hh>
+#include <seastar/net/toeplitz.hh>
+#include <seastar/net/native-stack.hh>
+#include "core/vla.hh"
+#endif
 
 #if RTE_VERSION <= RTE_VERSION_NUM(2,0,0,16)
 
@@ -2301,7 +2310,17 @@ std::unique_ptr<net::device> create_dpdk_net_device(
 }
 
 #else
+
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/dpdk.hh>
+#endif
+
 #endif // SEASTAR_HAVE_DPDK
 
 namespace seastar::net {

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -19,15 +19,25 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <ostream>
 #include <arpa/inet.h>
 #include <boost/functional/hash.hpp>
+#include <fmt/ostream.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/print.hh>
+#endif
 
 static_assert(std::is_nothrow_default_constructible_v<seastar::net::ipv4_address>);
 static_assert(std::is_nothrow_copy_constructible_v<seastar::net::ipv4_address>);

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -20,11 +20,19 @@
  *
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <chrono>
+#include <string>
+#include <boost/asio/ip/address_v4.hpp>
+module seastar;
+#else
 #include <seastar/net/ip.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/toeplitz.hh>
 #include <seastar/core/metrics.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/ip_checksum.cc
+++ b/src/net/ip_checksum.cc
@@ -19,9 +19,18 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <arpa/inet.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/ip_checksum.hh>
 #include <seastar/net/net.hh>
-#include <arpa/inet.h>
+#endif
 
 namespace seastar {
 

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -21,8 +21,11 @@
 
 #pragma once
 
-#include <seastar/net/stack.hh>
+#ifndef SEASTAR_MODULE
 #include <iostream>
+#endif
+
+#include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
 
 namespace seastar {

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -19,6 +19,32 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <cassert>
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <queue>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#ifdef HAVE_OSV
+#include <osv/firmware.hh>
+#include <gnu/libc-version.h>
+#endif
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/native-stack.hh>
 #include "net/native-stack-impl.hh"
 #include <seastar/net/net.hh>
@@ -32,16 +58,7 @@
 #include <seastar/net/dhcp.hh>
 #include <seastar/net/config.hh>
 #include <seastar/core/reactor.hh>
-#include <memory>
-#include <queue>
-#include <fstream>
-#ifdef HAVE_OSV
-#include <osv/firmware.hh>
-#include <gnu/libc-version.h>
 #endif
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 namespace seastar {
 

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -20,15 +20,24 @@
  *
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <boost/asio/ip/address_v4.hpp>
 #include <boost/algorithm/string.hpp>
-#include <seastar/net/net.hh>
 #include <utility>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/net/net.hh>
 #include <seastar/net/toeplitz.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/print.hh>
 #include <seastar/net/inet_address.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/packet.cc
+++ b/src/net/packet.cc
@@ -19,12 +19,24 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#include <seastar/core/print.hh>
-#include <seastar/core/smp.hh>
-#include <seastar/net/packet.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <iostream>
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/core/print.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/net/packet.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -19,14 +19,30 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#include <random>
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
-#include <sys/socket.h>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <random>
+#include <variant>
+
+#include <unistd.h>
 #include <linux/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <arpa/inet.h>
 #include <net/route.h>
+#include <netinet/tcp.h>
+#include <netinet/sctp.h>
+#include <sys/socket.h>
 
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/posix-stack.hh>
@@ -35,8 +51,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/util/std-compat.hh>
-#include <netinet/tcp.h>
-#include <netinet/sctp.h>
+#endif
 
 namespace std {
 

--- a/src/net/proxy.cc
+++ b/src/net/proxy.cc
@@ -15,8 +15,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <seastar/net/proxy.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <utility>
+#include <vector>
+#include <cstdlib>
+#include <cstdint>
+#include <memory>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/net/proxy.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/socket_address.cc
+++ b/src/net/socket_address.cc
@@ -23,14 +23,23 @@
 
     Extracted from inet_address.cc.
  */
-#include <ostream>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <arpa/inet.h>
+#include <sys/un.h>
+#include <ostream>
+#include <boost/functional/hash.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/print.hh>
-#include <boost/functional/hash.hpp>
-
+#endif
 
 using namespace std::string_literals;
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -19,8 +19,21 @@
  * Copyright 2015 Cloudius Systems
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/tcp.cc
+++ b/src/net/tcp.cc
@@ -19,12 +19,23 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <compare>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <utility>
+module seastar;
+#else
 #include <seastar/net/tcp.hh>
 #include <seastar/net/tcp-stack.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/future.hh>
 #include "net/native-stack-impl.hh"
+#endif
 
 namespace seastar {
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -19,11 +19,30 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#include <gnutls/gnutls.h>
-#include <gnutls/x509.h>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <filesystem>
 #include <stdexcept>
 #include <system_error>
+#include <memory>
+#include <chrono>
 
+#include <netinet/in.h>
+#include <sys/stat.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+
+#include <boost/any.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/range/adaptor/map.hpp>
+
+#include <fmt/core.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
@@ -39,10 +58,7 @@
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/variant_utils.hh>
 #include <seastar/core/fsnotify.hh>
-
-#include <boost/range/iterator_range.hpp>
-#include <boost/range/adaptor/map.hpp>
-
+#endif
 
 namespace seastar {
 

--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -19,9 +19,21 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cstdint>
+#include <utility>
+#include <cstring>
+#include <exception>
+#include <system_error>
+#include <optional>
+#include <memory>
+module seastar;
+#else
 #include <seastar/net/ip.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
+#endif
 
 namespace seastar {
 

--- a/src/net/virtio.cc
+++ b/src/net/virtio.cc
@@ -19,11 +19,34 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <atomic>
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <queue>
+#include <string>
+#include <vector>
+#include <fcntl.h>
+#include <seastar/net/virtio-interface.hh>
+#include <linux/vhost.h>
+#include <linux/if_tun.h>
+#include <net/if.h>
+#ifdef HAVE_OSV
+#include <osv/virtio-assign.hh>
+#endif
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/net/virtio.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include "core/vla.hh"
-#include <seastar/net/virtio-interface.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/stream.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -31,18 +54,9 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/util/function_input_iterator.hh>
 #include <seastar/util/transform_iterator.hh>
-#include <atomic>
-#include <vector>
-#include <queue>
-#include <fcntl.h>
-#include <linux/vhost.h>
-#include <linux/if_tun.h>
 #include <seastar/net/ip.hh>
 #include <seastar/net/const.hh>
 #include <seastar/net/native-stack.hh>
-
-#ifdef HAVE_OSV
-#include <osv/virtio-assign.hh>
 #endif
 
 namespace seastar {

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -1,0 +1,332 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2019 ScyllaDB
+ */
+
+// we could split the subsystems into multiple module partitions for a cleaner
+// structure of the module, but the dependencies between Seastar subsystems
+// form a cylic graph, if we split the sources at the boundary of the
+// subdirectory the header files are located. for instance:
+//   core/future => util/backtrace => core/sstring.
+//
+// one way to address this circular dependency problem by breaking some
+// subsystems into smaller pieces at the expense of creasomg the complexity
+// level of the module structure. as each partition has
+// - its own source file
+// - an entry in CMakeLists.txt
+// - one or more cross partition import / export clause when it is used / exposed
+//
+// a simpler alternative is to put all headers into a the same purview of
+// the "seastar" module. but this slows down the build speed of Seastar itself,
+// as each time when we modify any of the header file, the whole module is
+// recompiled. but this should fine at this moment, as the majority Seastar
+// developers are not supposed to build Seastar as a C++ module, which is, in
+// general, built for a single time to be consumed by Seastar applications.
+
+module;
+
+// put all headers not provided by this module into the global module fragment
+// to prevent attachment to the module
+
+#include <array>
+#include <algorithm>
+#include <atomic>
+#include <bitset>
+#include <cassert>
+#include <chrono>
+#include <concepts>
+#include <coroutine>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <filesystem>
+#include <functional>
+#include <future>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <memory_resource>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <queue>
+#include <random>
+#include <regex>
+#include <source_location>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <tuple>
+#include <typeindex>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <boost/container/small_vector.hpp>
+#include <boost/container/static_vector.hpp>
+#include <boost/endian/conversion.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/parent_from_member.hpp>
+#include <boost/intrusive/slist.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/iterator/counting_iterator.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/lockfree/queue.hpp>
+#include <boost/lockfree/spsc_queue.hpp>
+#include <boost/mpl/for_each.hpp>
+#include <boost/mpl/range_c.hpp>
+#include <boost/next_prior.hpp>
+#include <boost/program_options.hpp>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/irange.hpp>
+#include <boost/thread/barrier.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <xmmintrin.h>
+#endif
+#include <linux/fs.h>
+#include <linux/perf_event.h>
+#include <arpa/inet.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <malloc.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <spawn.h>
+#include <ucontext.h>
+#include <unistd.h>
+#define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
+#include <cryptopp/md5.h>
+
+export module seastar;
+
+#define SEASTAR_COROUTINES_ENABLED
+// include all declaration and definitions to be exported in the the module
+// purview
+#include <seastar/util/std-compat.hh>
+#include <seastar/core/abortable_fifo.hh>
+#include <seastar/core/abort_on_ebadf.hh>
+#include <seastar/core/abort_on_expiry.hh>
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/alien.hh>
+#include <seastar/core/align.hh>
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/array_map.hh>
+#include <seastar/core/bitops.hh>
+#include <seastar/core/bitset-iter.hh>
+#include <seastar/core/byteorder.hh>
+#include <seastar/core/cacheline.hh>
+#include <seastar/core/checked_ptr.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/circular_buffer_fixed_capacity.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/deleter.hh>
+#include <seastar/core/distributed.hh>
+#include <seastar/core/do_with.hh>
+#include <seastar/core/enum.hh>
+#include <seastar/core/exception_hacks.hh>
+#include <seastar/core/execution_stage.hh>
+#include <seastar/core/expiring_fifo.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/file-types.hh>
+#include <seastar/core/fsnotify.hh>
+#include <seastar/core/fsqual.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/idle_cpu_handler.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/iostream-impl.hh>
+#include <seastar/core/io_intent.hh>
+#include <seastar/core/io_queue.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/layered_file.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/make_task.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/map_reduce.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/core/metrics_types.hh>
+#include <seastar/core/pipe.hh>
+#include <seastar/core/polymorphic_temporary_buffer.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/core/preempt.hh>
+#include <seastar/core/prefetch.hh>
+#include <seastar/core/print.hh>
+// #include <seastar/core/prometheus.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/ragel.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/reactor_config.hh>
+#include <seastar/core/relabel_config.hh>
+#include <seastar/core/report_exception.hh>
+#include <seastar/core/resource.hh>
+#include <seastar/core/rwlock.hh>
+#include <seastar/core/scattered_message.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/scheduling_specific.hh>
+#include <seastar/core/scollectd.hh>
+#include <seastar/core/scollectd_api.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/shared_mutex.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/shared_ptr_debug_helper.hh>
+#include <seastar/core/shared_ptr_incomplete.hh>
+#include <seastar/core/simple-stream.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/smp_options.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/stream.hh>
+#include <seastar/core/stall_sampler.hh>
+#include <seastar/core/systemwide_memory_barrier.hh>
+#include <seastar/core/task.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/core/transfer.hh>
+#include <seastar/core/unaligned.hh>
+#include <seastar/core/units.hh>
+#include <seastar/core/vector-data-sink.hh>
+#include <seastar/core/weak_ptr.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/when_any.hh>
+#include <seastar/core/with_scheduling_group.hh>
+#include <seastar/core/with_timeout.hh>
+
+#include <seastar/util/alloc_failure_injector.hh>
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/conversions.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/file.hh>
+#include <seastar/util/log-cli.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/optimized_optional.hh>
+#include <seastar/util/print_safe.hh>
+#include <seastar/util/process.hh>
+#include <seastar/util/read_first_line.hh>
+#include <seastar/util/short_streams.hh>
+
+#include <seastar/net/arp.hh>
+#include <seastar/net/packet.hh>
+#include <seastar/net/api.hh>
+#include <seastar/net/ip_checksum.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/ip.hh>
+#include <seastar/net/ipv4_address.hh>
+#include <seastar/net/native-stack.hh>
+#include <seastar/net/posix-stack.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/net/tcp.hh>
+#include <seastar/net/udp.hh>
+#include <seastar/net/tls.hh>
+
+#include <seastar/http/common.hh>
+#include <seastar/http/client.hh>
+#include <seastar/http/exception.hh>
+#include <seastar/http/file_handler.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/http/json_path.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/http/response_parser.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/routes.hh>
+#include <seastar/http/transformers.hh>
+
+#include <seastar/json/formatter.hh>
+#include <seastar/json/json_elements.hh>
+
+module : private;
+
+#include <seastar/core/internal/read_state.hh>
+#include <seastar/core/internal/buffer_allocator.hh>
+#include <seastar/core/internal/io_intent.hh>
+#include <seastar/core/internal/stall_detector.hh>
+#include <seastar/core/internal/uname.hh>
+
+#include "core/cgroup.hh"
+#include "core/file-impl.hh"
+#include "core/program_options.hh"
+#include "core/reactor_backend.hh"
+#include "core/syscall_result.hh"
+#include "core/thread_pool.hh"
+#include "core/scollectd-impl.hh"
+#include "core/vla.hh"
+
+#include <seastar/util/internal/iovec_utils.hh>
+#include <seastar/util/internal/magic.hh>
+#include <seastar/util/function_input_iterator.hh>
+#include <seastar/util/shared_token_bucket.hh>
+#include <seastar/util/transform_iterator.hh>
+
+#include <seastar/net/dhcp.hh>
+#include <seastar/net/native-stack.hh>
+#include <seastar/net/proxy.hh>
+#include <seastar/net/tcp-stack.hh>
+#include <seastar/net/toeplitz.hh>
+#include <seastar/net/virtio.hh>
+
+#include "net/native-stack-impl.hh"
+
+#include <seastar/http/url.hh>
+#include <seastar/http/internal/content_source.hh>

--- a/src/util/alloc_failure_injector.cc
+++ b/src/util/alloc_failure_injector.cc
@@ -19,10 +19,18 @@
  * Copyright 2017 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cstdint>
+#include <new>
+#include <utility>
+module seastar;
+#else
 #include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/defer.hh>
+#endif
 
 namespace seastar {
 namespace memory {

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -18,19 +18,31 @@
 /*
  * Copyright 2017 ScyllaDB
  */
-#include <seastar/util/backtrace.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
+#include <execinfo.h>
 #include <link.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <algorithm>
+#include <cstddef>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <variant>
+#include <vector>
+#include <boost/container/static_vector.hpp>
 
-#include <errno.h>
-#include <string.h>
-
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/util/backtrace.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
-
+#endif
 
 namespace seastar {
 

--- a/src/util/conversions.cc
+++ b/src/util/conversions.cc
@@ -19,11 +19,20 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#include <seastar/util/conversions.hh>
-#include <seastar/core/print.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cctype>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/util/conversions.hh>
+#include <seastar/core/print.hh>
+#endif
 
 namespace seastar {
 

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -20,13 +20,25 @@
  * Copyright 2020 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <cstdint>
+#include <deque>
+#include <filesystem>
 #include <iostream>
 #include <list>
-#include <deque>
+#include <vector>
+#include <sys/statvfs.h>
 
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/util/file.hh>
+#endif
 
 namespace seastar {
 

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -19,15 +19,40 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
-#include <unistd.h>
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <chrono>
+#include <algorithm>
+
 #include <fmt/core.h>
 #if FMT_VERSION >= 60000
 #include <fmt/chrono.h>
 #include <fmt/color.h>
+#include <fmt/ostream.h>
 #elif FMT_VERSION >= 50000
 #include <fmt/time.h>
 #endif
+#include <boost/any.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/program_options.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <cxxabi.h>
+#include <syslog.h>
+#include <unistd.h>
 
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
 #include <seastar/util/log.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/log-cli.hh>
@@ -37,22 +62,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/print.hh>
 
-#include <boost/any.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <cxxabi.h>
-#include <syslog.h>
-
-#include <iostream>
-#include <map>
-#include <regex>
-#include <string>
-#include <string_view>
-#include <system_error>
-#include <chrono>
-#include <algorithm>
 
 #include "core/program_options.hh"
+#endif
 
 using namespace std::chrono_literals;
 

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -20,12 +20,24 @@
  * Copyright (C) 2022 Kefu Chai ( tchaikov@gmail.com )
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <cassert>
+#include <csignal>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+#include <utility>
+module seastar;
+#else
 #include <seastar/core/fstream.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/process.hh>
+#endif
 
 namespace seastar::experimental {
 

--- a/src/util/program-options.cc
+++ b/src/util/program-options.cc
@@ -20,10 +20,21 @@
  * Copyright (C) 2017 ScyllaDB
  */
 
-#include <seastar/util/program-options.hh>
-#include <seastar/util/log-cli.hh>
+#ifdef SEASTAR_MODULE
+module;
+#endif
 
 #include <regex>
+#include <boost/any.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/program_options.hpp>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/util/program-options.hh>
+#include <seastar/util/log-cli.hh>
+#endif
 
 namespace bpo = boost::program_options;
 

--- a/src/util/read_first_line.cc
+++ b/src/util/read_first_line.cc
@@ -1,5 +1,12 @@
+#ifdef SEASTAR_MODULE
+module;
+#include <filesystem>
+#include <fcntl.h>
+module seastar;
+#else
 #include <seastar/core/posix.hh>
 #include <seastar/util/read_first_line.hh>
+#endif
 
 namespace seastar {
 

--- a/src/util/short_streams.cc
+++ b/src/util/short_streams.cc
@@ -19,9 +19,16 @@
  * Copyright (C) 2021 ScyllaDB
  */
 
+#ifdef SEASTAR_MODULE
+module;
+#include <utility>
+#include <vector>
+module seastar;
+#else
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>
+#endif
 
 namespace seastar {
 


### PR DESCRIPTION
treewide: add C++ modules support

this change brings C++20 modules to seastar.

the C++20 modules support are added for couple reasons:

- allow developer to import Seastar in a more efficient way in
  the sense of compile-time speed, as the compiler does not
  need to compile the headers for every source file including the
  Seastar headers -- the compiler just need to read the precompiled
  module interface, or in Clang's terminology the BMI (Built Module
  Interface) files.
- better encapsulation. without C++20 modules, we just add guards
  around the non-public declaration/definitions in the headers using
  an   "internal" namespace. but developer and compiler at Seastar
  application's side is still able to access them. this is but a
  coding convention. but with C++20 modules, it enforces this with
  different linkages. So only the exported symbols have the external
  linkage, while the internal ones only have the so called,
  module linkage. in other words, the internal symbols are not
  visible from the application. this ensures Seastar applications
  do not access the private symbols even if they are located in the
  public header files

In this change, only a single "seastar" module is exposed. We have
some other alternatives:

- to have one module for each subsystem, like `seastar.core` and
  `seastar.utils`. but due to the circular dependencies between
  these subsystems, without addressing it first, this is leading
  nowhere. also, to have multiple modules would need some
  discussions beforehand, as changing the boundary of each module
  would be a API change, so instead of making decision in the
  preliminary phase of the modularization change.
- to have two modules for experimental and non-experimental APIs.
  this is a more viable and safer direction. we will need to
  implement this in a follow-up change.

For building a single "seastar" module, there are more than one way
to structure the module system. the author of this change
experimented all of them, but they either do not work at all, or
are more complicated than the solution used in this change. All of
the experimented solutions are listed below:

- to build each subsystem as a separate module partition by including
  all headers of individual subsystem in, for instance,
  "seastar-core.cppm", and use an umbrella "seastar.cppm" to import
  and export all these partitions. this would face exactly the same
  problem encountered by one-module-for-each-subsystem due to the
  circular dependencies.
- to build each header file as a separate module partition. and
  let `seastar.cc` to import and export each of these partition.
  this solution is techinically viable.
  the upside of this solution is that
  * we don't have a monolithic `seastar.cc` source file which
    includes all third-party headers by each of these partitions.
    so each partition can manage its own global headers. and
    we don't need to replicate them in `seastar.cc`.
  but the downside is that
  * we need to pay extra attention on the order of `#include`s, so
    the symbols in every partition's global fragment agree,
    compiler would emit error if it believes that any symbol
    has different definition either because it is compiled with
    different macro definition or different compiling options,
    as it would violate ODR.
  * in each header , we would have to export its own partition, and
    import all used partitions in each header, take `abort_fifo.hh`
    for an example, we need follow statements before starting its
    purview:
    ```c++
    export module seastar:core.abortable_fifo;
    import :core.abort_source;
    import :core.chunked_fifo;
    import :util.optimized_optional;
    ```
    quite like how we use the "#include" preprocessor directive in
    C/C++.
- to include all Seastar headers in `seastar.cc` in its global
  fragment, and then expose all public symbols using
  "using public_symbol" in its `export {}` block in its purview.
  the upside is that
  * it has minimum impact to the existing source code. actually,
    this solution does not change the existing source files at
    all. it just *adds* a new `seastar.cc` which consumes the
    public header files.

  the downside is that
  * there are numerous public interfaces in Seastar, it would be
    a pain to replicate them in a separate file, not to mention
    it's error-prone. it's quite easy to forget to add a new
    `using` statement in `seastar.cc` when adding a new public
    symbol.
  * if I recall correctly, I ran into an error where the compiler
    refuse to "friend" a class exposed with `using` in the `export`
    block. so this is deal breaker.
- to include all third-party headers in the global fragment of
  `seastar.cc`, include all Seasetar headers in the purview
  `seastar.cc`, and expose individual symbols in the headers
  where they are originally declared or defined.
  the upside is that
  * we don't need to care about the `export`/`import` dependencies
    between different partitions. as the header and source files
    have access to the whole module by default.
  * the visibility of symbols are managed by their own headers,
    this reduces the burden of maintainers.
  * we don't need to worry about the ODR violations which might
    arise when we include third-party headers in different order
    in different Seastar header.

  the downside is that
  * the long list of third-party headers and macro definitions
    in the single file -- `seastar.cc`. they practically replicate
    the ones in all included Seastar header files.
  * in comparison to the `using` based solution, we have to use
    macros to enable/disable the module related statements in
    header / source files.

One goal of this change is to preserve the backward compatibility
in the sense that existing Seastar application can continue using
Seastar as a plain library without having to switch over to C++20
modules. Since we choose to include all Seastar headers in the
purview of `seastar.cc`, the problem boils down to two sub problems:

- header files included by the module interface unit, i.e., in our
  case, `seastar.cc`
- source files compiled separately as module implementation units.

first, a new macro `SEASTAR_MODULE` is defined when we are building
a C++ module.

when it comes to header files, since all third-party headers are
included in `seastar.cc`'s global fragment, and we don't want to
include them in the module's purview, they should be excluded
when compiling the module. so, if `SEASTAR_MODULE` is defined,
the third-party headers are not included in the header file.

in order to export public symbols in each header file, a set of
macros are introduced to hide the differences between two build
modes: `SEASTAR_MODULE_EXPORT` and `SEASTAR_MODULE_EXPORT_{BEGIN, END}`.
these macros are defined in `util/modules.hh`. when building the
C++20 module, they are defined as the `export` keyword; when building
the regular library, these macro are no-ops. that's why this new
header file is included in every Seastar header now. fortunately,
it's a very smaller one.

in the case of source files, because they are not included by
`seastar.cc`, and they are compiled individually, we need to keep
the used third-party headers in its global fragment. but please
note, the required headers might be more than what we generally
need when compiling the source file to a regular library. because,
unlike the textual inclusion, the source file will not include
the headers previously included by the Seastar headers anymore.
now, the .cc files only have access to the symbols attached "seastar"
module by default. so we need to include them explicity in the
global fragment. that's why a bunch of "new" includes are added
in this change.

in hope to minimize the impact to the existing source code, the
author also experimented another way to insert the module related
statements by preprocessing the all source files using CMake. so,
for instance, it can translate the markers in comments or add
`module;` at the very beginning of a source file. and let the
compiler compile the preprocessed files. this works fine. the
only drawback exhibits itself in the development cycle. when
developer tries to fix a compiling warning / error, he/she always
has to manually go to the original source file, as the compiler
cannot connect the error to the original file. this greatly hurts
developers' experience when building the library as a module.

we have following requirements on the toolchain for building
the C++20 module:

- CMake 3.26: CMake 3.26 has builtin supports for building
  C++ modules with Clang 16.
- Ninja 1.11: it has dyndep feature used by CMake.
- Clang 16: for better support of C++ modules. as the C++ modules
  changes are not backported to Clang 15, we need Clang 16 or up.

GCC does have basic C++20 modules support, see
https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Modules.html. But
for two reason it is not supported

* it still does not support p1689r5 yet. so it cannot provide
  necessary support required by CMake for figuring out the
  inter translation unit dependencies.
* it does not support private module fragment. it is used for
  including the private headers.

also, please note, neither ccache nor distcc now supports C++20
modules at the time of writing.

in addition to the changes in the building system and those
directly related to C++20 module, in this change, we also

* remove the `static` specifier applied to the exported symbols,
  because, otherwise these symbols will have module linkage and
  will not be exported.
* remove the `static` specifier applied to the symbols shared in
  the module. as otherwise, it will only be visible in the same
  translation unit.
* add `extern "C++"` specifier if a symbol is not supposed to be
  exported as part of the module. as the symbols exported by
  module has a different mangling rule. this applies to the
  `new` and `delete` operator defined in `memory.cc`.
* remove `inline` specifier from the symbol attached to the module.
  as per http://eel.is/c++draft/dcl.inline#7, we should otherwise
  define it in the same domain. fortunately, both GCC and Clang don't
  complain after the specifier is dropped when building regular
  library.