### PR TITLE
Fix reactor shutdown hang with --poll-aio false

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2427,6 +2427,7 @@ void reactor::stop() {
                 // Stop other cpus asynchronously, signal when done.
                 (void)smp::invoke_on_others(0, [] {
                     engine()._smp->cleanup_cpu();
+                    engine()._stopping = true;
                     return engine().run_exit_tasks().then([] {
                         engine()._stopped = true;
                     });


### PR DESCRIPTION
Prior to f6a2c0125f80d8ef01a8ef89a87b7ce09172ad25 reactor::_stopping was set to true in reactor::run_exit_tasks. The run_exit_tasks method is called from reactor::stop, initially on shard 0, and then again via invoke_on_others(0, ...) so that _stopping is eventually set to true on all shards.

The referenced commit changed this behavior such that _stopping was set to true only on shard 0 at the beginning of reactor::stop, and no longer via reactor::run_exit_tasks. The effect of this change was that reactor::_stopping was no longer set to true on shards other than shard 0.

The _stopping flag plays an important role in shutdown: both sleep_abortable (via reactor::wait_for_stop) and aio_eventfd_loop use the flag to signal a stopping condition. Without this flag being set, reactor::stop will hang when using --smp > 1 and --poll-aio false.

This can be reproduced using:

  demos/hello-world_demo --smp 2 --poll-aio false