### PR TITLE
reactor: stop _aio_eventfd loop also on shard other than 0

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2408,6 +2408,7 @@ void reactor::at_exit(noncopyable_function<future<> ()> func) {
 
 future<> reactor::run_exit_tasks() {
     _stop_requested.broadcast();
+    _stopping = true;
     stop_aio_eventfd_loop();
     return do_for_each(_exit_funcs.rbegin(), _exit_funcs.rend(), [] (auto& func) {
         return func();


### PR DESCRIPTION
Fixes a regression introduced in f6a2c0125f.

_aio_eventfd loop stops when it's woken up with _stopping set. Thus stop_aio_eventfd_loop(), whose job is to stop the loop, has to be preceded by setting _stopping to true.

In f6a2c0125f the assignment to _stopping was moved to a different place, which accidentally caused it to happen only on shard 0, while it has to happen on all shards.
(Because if it doesn't happen on some shard, this shard will hang on exit.)

Fixes #1610