### PR TITLE
metrics: round and trim integer values

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -211,8 +211,8 @@ metric_value metric_value::operator+(const metric_value& c) {
     return res;
 }
 
-void metric_value::ulong_conversion_error(double d) {
-    throw std::range_error(format("cannot convert double value {} to unsigned long", d));
+void metric_value::ulong_conversion_error(double d, const char* ctype) {
+    seastar_logger.warn("cannot convert double value {} to {}", d, ctype);
 }
 
 metric_definition_impl::metric_definition_impl(


### PR DESCRIPTION
Currently, ulong_conversion_error throws an exception that is unhandled, causing https://github.com/scylladb/scylladb/issues/9793

Instead, just trim the rounded value to the
valid range (either signed or unsigned), the
lround(double) can represent.

Added a unit test to check the trimming bounds,

Fixes #1612