### PR TITLE
Warn if RPC server handlers are not exiting fast enough during stopping time

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -610,6 +610,7 @@ private:
     server_options _options;
     bool _shutdown = false;
     uint64_t _next_client_id = 1;
+    uint32_t _handlers_running = 0;
 
 public:
     server(protocol_base* proto, const socket_address& addr, resource_limits memory_limit = resource_limits());
@@ -653,6 +654,10 @@ public:
     gate& reply_gate() {
         return _reply_gate;
     }
+
+    void handler_enter() noexcept { _handlers_running++; }
+    void handler_leave() noexcept { _handlers_running--; }
+
     friend connection;
     friend client;
 };

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -610,7 +610,10 @@ private:
     server_options _options;
     bool _shutdown = false;
     uint64_t _next_client_id = 1;
+    timer<lowres_clock> _stop_watchdog;
     uint32_t _handlers_running = 0;
+
+    void warn_stuck_handler();
 
 public:
     server(protocol_base* proto, const socket_address& addr, resource_limits memory_limit = resource_limits());

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -675,6 +675,7 @@ protected:
 
     virtual rpc_handler* get_handler(uint64_t msg_id) = 0;
     virtual void put_handler(rpc_handler*) = 0;
+    virtual void with_handlers(noncopyable_function<void(uint64_t, const rpc_handler&)>) const = 0;
 };
 
 /// \addtogroup rpc
@@ -913,6 +914,12 @@ public:
     }
 
 private:
+    void with_handlers(noncopyable_function<void(uint64_t, const rpc_handler&)> fn) const override {
+        for (const auto& h : _handlers) {
+            fn(uint64_t(h.first), h.second);
+        }
+    }
+
     rpc_handler* get_handler(uint64_t msg_id) override;
     void put_handler(rpc_handler*) override;
 


### PR DESCRIPTION
When rpc::server stops it kicks accept abort, stops connections and waits for all of them to resolve relevant stopping futures. One of the stopping promises is that the `_reply_gate` is closed. Inside this gate server runs responses to messages, but also the gate enter-exit spans over the message handler callback to resolve.

While all the kicked-and-waited stuff is internal to RPC, handlers are external and seastar has no way to ensure they finish in a timely manner, it can only assume that. The PR is supposed to facilitate debugging this assumption by counting handler callback entrances and exits (i.e. future resolutions) and warn in server stop doesn't finish within a minute printing the number of currently not-exited handlers.

Stuck server.stop() with zero running handlers is still an internal issue to result.