### PR TITLE
iotune: Don't close file that wasn't opened

### DIFF
--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -496,7 +496,7 @@ public:
     }
 
     future<> stop() {
-        return _file.close();
+        return _file ? _file.close() : make_ready_future<>();
     }
 };
 


### PR DESCRIPTION
Calling test_file::close() may happen before create_data_file() managed to assign the _file field (e.g. -- test directory creation failed for whatever reason). In that case closing nullptr file-impl would crash.

refs: scylladb/scylladb#13439