### PR TITLE
exception_hacks: Change guard check order to work around static init …

### DIFF
--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -116,7 +116,7 @@ extern "C"
 [[gnu::used]]
 [[gnu::no_sanitize_address]]
 int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data) {
-    if (!seastar::local_engine || !seastar::phdrs_cache) {
+    if (!seastar::phdrs_cache || !seastar::local_engine) {
         // Cache is not yet populated, pass through to original function
         return seastar::dl_iterate_phdr_org()(callback, data);
     }


### PR DESCRIPTION
…fail

Fixes #1626

Found whilst debugging; In the dl_iterate_phdr override we check one module static var and one external __thread variable. The latter is dependent on tls resolving working. Apparently, if one angers the linker gods enough, the init sequence for ASAN (woho) can happen such that we actually call here before this tls resolve call actually works. Crash boom sigsegv.

Very simple fix is to just change the order of the checks to check the module local var first, since this is simple, non-auto-inited, and again, module-local.