### PR TITLE
TLS: support for extracting certificate subject alt names from client certs

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -387,6 +387,25 @@ namespace tls {
      * If the socket is not a TLS socket an exception will be thrown.
     */
     future<std::vector<subject_alt_name>> get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types = {});
+
+    std::ostream& operator<<(std::ostream&, const subject_alt_name::value_type&);
+    std::ostream& operator<<(std::ostream&, const subject_alt_name&);
+
+    /**
+     * Alt name to string. 
+     * Note: because naming of alternative names is inconsistent between tools,
+     * and because openssl is probably more popular when creating certs anyway,
+     * this routine will be inconsistent with both gnutls and openssl (though more
+     * in line with the latter) and name the constants as follows:
+     * 
+     * dnsname: "DNS"
+     * rfc822name: "EMAIL"
+     * uri: "URI"
+     * ipaddress "IP"
+     * othername: "OTHERNAME"
+     * dn: "DIRNAME"
+    */
+    std::ostream& operator<<(std::ostream&, subject_alt_name_type);
 }
 }
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1912,4 +1912,27 @@ future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connect
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
 }
 
+std::ostream& tls::operator<<(std::ostream& os, subject_alt_name_type type) {
+    switch (type) {
+        case subject_alt_name_type::dnsname: os << "DNS"; break;
+        case subject_alt_name_type::rfc822name: os << "EMAIL"; break;
+        case subject_alt_name_type::uri: os << "URI"; break;
+        case subject_alt_name_type::ipaddress: os << "IP"; break;
+        case subject_alt_name_type::othername: os << "OTHERNAME"; break;
+        case subject_alt_name_type::dn: os << "DIRNAME"; break;
+        default: break;
+    }
+    return os;
+}
+
+std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name::value_type& v) {
+    std::visit([&](auto& vv) { os << vv; }, v);
+    return os;
+}
+
+std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
+    return os << a.type << "=" << a.value;
+}
+
+
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -488,6 +488,18 @@ function(seastar_add_certgen name)
   if (NOT CERT_EMAIL)
     set(CERT_EMAIL postmaster@${CERT_DOMAIN})
   endif()
+  if (NOT CERT_ALT_EMAIL_1)
+    set(CERT_ALT_EMAIL_1 alt1@${CERT_DOMAIN})
+  endif()
+  if (NOT CERT_ALT_EMAIL_2)
+    set(CERT_ALT_EMAIL_2 alt2@${CERT_DOMAIN})
+  endif()
+  if (NOT CERT_ALT_IP_1)
+    set(CERT_ALT_IP_1 127.0.0.1)
+  endif()
+  if (NOT CERT_ALT_DNS)
+    set(CERT_ALT_DNS ${CERT_COMMON})
+  endif()
   if (NOT CERT_WIDTH)
     set(CERT_WIDTH 4096)
   endif()
@@ -520,7 +532,7 @@ function(seastar_add_certgen name)
   )
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"
     COMMAND ${OPENSSL} req -new -key ${CERT_PRIVKEY} -out ${CERT_REQ} -config ${CERT_NAME}.cfg
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -530,13 +542,14 @@ function(seastar_add_certgen name)
   )
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}"
     COMMAND ${OPENSSL} req -x509 -new -nodes -key ${CERT_CAPRIVKEY} -days ${CERT_DAYS} -config ${CERT_NAME}.cfg -out ${CERT_CAROOT}
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAPRIVKEY}"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAPRIVKEY}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
+  
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT}"
-    COMMAND ${OPENSSL} x509 -req -in ${CERT_REQ} -CA ${CERT_CAROOT} -CAkey ${CERT_CAPRIVKEY} -CAcreateserial -out ${CERT_CERT} -days ${CERT_DAYS}
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"  "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}"
+    COMMAND ${OPENSSL} x509 -req -in ${CERT_REQ} -CA ${CERT_CAROOT} -CAkey ${CERT_CAPRIVKEY} -CAcreateserial -out ${CERT_CERT} -days ${CERT_DAYS} -extensions req_ext -extfile ${CERT_NAME}.cfg
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"  "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 

--- a/tests/unit/cert.cfg.in
+++ b/tests/unit/cert.cfg.in
@@ -21,3 +21,6 @@ basicConstraints = CA:true
 # Extensions to add to a certificate request
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[req_ext]
+subjectAltName=email:@CERT_ALT_EMAIL_1@,email:@CERT_ALT_EMAIL_2@,IP:@CERT_ALT_IP_1@,DNS:@CERT_ALT_DNS@


### PR DESCRIPTION
Fixes #1628
    
Subject alt name info can contain more extensive and detailed info on a connecting client. Add interface to allow querying this from a connected socket.

Initially we don't include this in accept-sequence auth verification, though we maybe should include it as an option.