### PR TITLE
docker: bump up to clang {16,17} and gcc {12,13}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,6 @@ workflows:
       - build_and_test:
           matrix:
             parameters:
-              compiler: ["clang++-15", "g++-12"]
+              compiler: ["clang++-17", "g++-13"]
               standard: ["20", "17"]
               mode: ["dev", "debug", "release"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:kinetic
+FROM ubuntu:mantic
 RUN apt -y update \
     && apt -y install build-essential \
-    && apt -y install gcc-12 g++-12 gcc-11 g++-11 pandoc \
+    && apt -y install gcc-12 g++-12 gcc-13 g++-13 pandoc \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11 \
-    && apt -y install clang-15 clang-14 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 15 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 15 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 14 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 14
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13 \
+    && apt -y install clang-16 clang-17 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 16 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 16 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 17 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 17
 COPY install-dependencies.sh /tmp/
 RUN bash /tmp/install-dependencies.sh
 CMD /bin/bash


### PR DESCRIPTION
since we only support the latest two major releases of compilers. at the moment of writing, Clang just released v16, and the latest major release of GCC is v13.

so we should install them respectively.

because ubuntu kinetic does not ship clang-16. we need to bump up the base image from ubuntu:kinetic to ubuntu:lunar despite that lunar is not an LTS release. we should use ubuntu 24.04 once it's out.

see also 80969ef9ffc10bb219bd3ef83ab76c2c536de7ec, which bumped the compilers also.