### PR TITLE
circleci: update the image to CircleCI "standard" image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         description: mode to build and test with
         type: string
     machine:
-      image:  ubuntu-2004:202201-02
+      image:  ubuntu-2204:2023.04.2
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
see https://circleci.com/developer/images?imageType=machine, and update the tag to the latest tag. see
https://circleci.com/developer/machine/image/ubuntu-2204 . despite that we only use the circleci's image for running docker container, it'd always be desirable to use the "standard" image which is armed with a more recent docker runtime and linux kernel.