### PR TITLE
tls_test: abort_accept() after getting server socket

### DIFF
--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -410,9 +410,8 @@ SEASTAR_TEST_CASE(test_abort_accept_after_handshake) {
         b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
 
         auto c = tls::connect(b.build_certificate_credentials(), addr).get0();
-        server.abort_accept(); // should not affect the socket we got.
-
         auto s = sa.get0();
+        server.abort_accept(); // should not affect the socket we got.
         auto out = c.output();
         auto in = s.connection.input();
 


### PR DESCRIPTION
before this change, we get the `accept_result` after calling `abort_accept()`, but there is chance that the event from the fd which is registered for accept event is not fired yet, and the fd is closed, so what we get is an errno of EINVAL because `shutdown(fd, SHUT_RD)` is called. so `sa.get0()` throws a `system_error` instead of the `accept_result`.

this does not happen if the backend is `linux-aio`. but it surfaces occasionally when the io_uring backend is used.

Fixes #1532
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>