### PR TITLE
build: always quote the ENVIRONMENT with quotes

### DIFF
--- a/apps/memcached/tests/CMakeLists.txt
+++ b/apps/memcached/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (
 set_tests_properties (Seastar.app.memcached.memcached
   PROPERTIES
     TIMEOUT ${Seastar_TEST_TIMEOUT}
-    ENVIRONMENT ${Seastar_TEST_ENVIRONMENT})
+    ENVIRONMENT "${Seastar_TEST_ENVIRONMENT}")
 
 add_executable (app_memcached_test_ascii
   test_ascii_parser.cc)
@@ -74,4 +74,4 @@ add_test (
 set_tests_properties (Seastar.app.memcached.ascii
   PROPERTIES
     TIMEOUT ${Seastar_TEST_TIMEOUT}
-    ENVIRONMENT ${Seastar_TEST_ENVIRONMENT})
+    ENVIRONMENT "${Seastar_TEST_ENVIRONMENT}")


### PR DESCRIPTION
otherwise, if we pass it as it-is, it will be expanded by CMake, and is considered as multiple parameter passed to
`set_tests_properties()` instead of a single one as the argument of after the `ENVIRONMENT` keyword. this change should allow us to add more environmental variables to `Seastar_TEST_ENVIRONMENT` without running into errors like

```
CMake Error at apps/memcached/tests/CMakeLists.txt:74 (set_tests_properties):
  set_tests_properties called with incorrect number of arguments.
```