### PR TITLE
[WIP]Http: support for batch unsettings in routes

### DIFF
--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -106,7 +106,9 @@ public:
      * @return it self
      */
     routes& add(match_rule* rule, operation_type type = GET) {
-        _rules[type][_rover++] = rule;
+        _rules[type][_rover] = rule;
+        _rules_batch.emplace_back(std::make_pair(type,_rules[type].find(_rover)));
+        _rover++;
         return *this;
     }
 
@@ -178,6 +180,8 @@ private:
     std::map<rule_cookie, match_rule*> _rules[NUM_OPERATION];
     //default Handler -- for any HTTP Method and Path (/*)
     handler_base* _default_handler = nullptr;
+    std::vector<std::pair<operation_type,std::unordered_map<sstring, handler_base*>::iterator>> _map_batch;
+    std::vector<std::pair<operation_type,std::map<rule_cookie, match_rule*>::iterator>> _rules_batch;
 public:
     using exception_handler_fun = std::function<std::unique_ptr<http::reply>(std::exception_ptr eptr)>;
     using exception_handler_id = size_t;
@@ -235,6 +239,11 @@ public:
      * @return the pointer to the rule
      */
     match_rule* del_cookie(rule_cookie cookie, operation_type type);
+
+    /**
+     * Del rules or matches based on the underlying batch.
+     */
+    void clean_batch();
 };
 
 /**

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -168,11 +168,27 @@ routes& routes::put(operation_type type, const sstring& url, handler_base* handl
     if (it.second == false) {
         throw std::runtime_error(format("Handler for {} already exists.", url));
     }
+    _map_batch.emplace_back(std::make_pair(type,it.first));
     return *this;
 }
 
 match_rule* routes::del_cookie(rule_cookie cookie, operation_type type) {
     return delete_rule_from(type, cookie, _rules);
+}
+
+void routes::clean_batch() {
+    if (!_map_batch.empty()) {
+        for (auto& it : _map_batch) {
+            _map[it.first].erase(it.second);
+        }
+    }
+    if (!_rules_batch.empty()) {
+        for (auto& it : _rules_batch) {
+            _rules[it.first].erase(it.second);
+        }
+    }
+    _map_batch.clear();
+    _rules_batch.clear();
 }
 
 void routes::add_alias(const path_description& old_path, const path_description& new_path) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -164,6 +164,26 @@ SEASTAR_TEST_CASE(test_add_del_cookie)
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_batch_del_cookie)
+{
+    parameters params;
+    routes rts;
+
+    auto* h1 = new handl();
+    rts.put(operation_type::GET, "/hello", h1);
+    auto* h2 = new handl();
+    rts.put(operation_type::GET, "/world", h2);
+    rts.clean_batch();
+    auto res1 = rts.get_handler(operation_type::GET, "/hello", params);
+    httpd::handler_base* nl = nullptr;
+    BOOST_REQUIRE_EQUAL(res1, nl);
+    auto res2 = rts.get_handler(operation_type::GET, "/world", params);
+    BOOST_REQUIRE_EQUAL(res2, nl);
+    delete h1;
+    delete h2;
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_formatter)
 {
     BOOST_REQUIRE_EQUAL(json::formatter::to_json(true), "true");


### PR DESCRIPTION
Closes #1620

for example,
```cpp
 rts.put(GET, "/h1", h1);
 rts.put(GET, "/h2", h2);
 rts.clean_batch();
// then h1,h2 rule is removed.
 rts.put(GET, "/h3", h3);
// then h3 rule is added.
```

in the origin issue(#1620),
>When registering several endpoints one should call several set()-s and then several unset()-s. It's good to have a way to unset() all routes in a mux with the single call.

I don't know if the place needs to use a mutex. Maybe the mutex should be placed in all the routes' set/unset methods. But we observe that it doesn't seem to require a lock to handle route rules from route.h.