### PR TITLE
add .cache/.clangd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tags
 .idea/
 .vscode/
 compile_commands.json
+.clangd
+.cache


### PR DESCRIPTION
follow up to #1277

.clangd, .cache dirs is used to store the inferred index by `clangd`.

link to https://github.com/scylladb/seastar/pull/1638#discussion_r1182106709