### PR TITLE
scripts: addr2line: allow specifying kallsyms path

### DIFF
--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -317,6 +317,13 @@ There are three operational modes:
         nargs='*',
         help='Addresses to parse')
 
+    cmdline_parser.add_argument(
+        '--kallsyms',
+        type=str,
+        metavar='KALLSYMS',
+        default='/proc/kallsyms',
+        help='Alternative path for kallsyms file to resolve kernel addresses')
+
     args = cmdline_parser.parse_args()
 
     if args.addresses and args.file:
@@ -334,6 +341,7 @@ There are three operational modes:
             lines = sys.stdin
 
     with BacktraceResolver(executable=args.executable,
+                           kallsyms=args.kallsyms,
                            before_lines=args.before,
                            context_re=args.match,
                            verbose=args.verbose,


### PR DESCRIPTION
Often, addr2line will be run on a machine other than the one that experienced the stalls. Allow for that by adding a command-line parameter for kallsyms path. It still defaults to /proc/kallsyms.