### PR TITLE
sstring: add comparison operators where the left-hand-side isn't an sstring

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -673,6 +673,23 @@ operator<<(std::basic_ostream<char_type, char_traits>& os,
     return os.write(s.begin(), s.size());
 }
 
+#if __cpp_lib_three_way_comparison
+
+template <typename char_type, typename size_type, size_type max_size>
+std::strong_ordering
+operator<=>(const char_type* s1, const basic_sstring<char_type, size_type, max_size>& s2) {
+    return std::basic_string_view<char_type>(s1) <=> std::basic_string_view<char_type>(s2);
+}
+
+template <typename string_view_like, typename char_type, typename size_type, size_type max_size>
+SEASTAR_CONCEPT(requires std::convertible_to<std::basic_string_view<char_type>, string_view_like>)
+std::strong_ordering
+operator<=>(const string_view_like& s1, const basic_sstring<char_type, size_type, max_size>& s2) {
+    return std::basic_string_view<char_type>(s1) <=> std::basic_string_view<char_type>(s2);
+}
+
+#endif
+
 template <typename char_type, typename size_type, size_type max_size, bool NulTerminate, typename char_traits>
 inline
 std::basic_istream<char_type, char_traits>&

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -238,3 +238,14 @@ BOOST_AUTO_TEST_CASE(test_resize_and_overwrite) {
         BOOST_CHECK_EQUAL(s, sstring(smaller_size, pattern));
     }
 }
+
+
+#ifdef __cpp_lib_three_way_comparison 
+
+BOOST_AUTO_TEST_CASE(test_compares_left_hand_not_string) {
+    // mostly a compile test for non-sstring left-hand-side
+    BOOST_REQUIRE("a" < sstring("b"));
+    BOOST_REQUIRE(std::string("a") < sstring("b"));
+}
+
+#endif


### PR DESCRIPTION

Clang 15 started to reject (probably with cause) compares where the left-hand-side isn't an sstring.

To avoid forcing people to convert to string_view, add two new three-way comparison operators: one where the left-hand-side is a C string, and one where it's convertible to string_view. This follows std::basic_string.

Since older compilers accept mixed comparions, we don't bother with C++17 support as it's too much bother to implement all six comparison operators.

A unit test is added.