### PR TITLE
build: build ingredients using user-specified C compiler

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -186,7 +186,6 @@ def configure_mode(mode):
 
     TRANSLATED_ARGS = [
         '-DCMAKE_BUILD_TYPE={}'.format(MODE_TO_CMAKE_BUILD_TYPE[mode]),
-        '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_CXX_STANDARD={}'.format(args.cpp_standard),
         '-DCMAKE_INSTALL_PREFIX={}'.format(args.install_prefix),
@@ -220,6 +219,9 @@ def configure_mode(mode):
 
     # Generate a new build by pointing to the source directory.
     if ingredients_to_cook:
+        # the C compiler is only used when building ingredients.
+        TRANSLATED_ARGS.append(f'-DCMAKE_C_COMPILER={args.cc}')
+
         # We need to use cmake-cooking for some dependencies.
         inclusion_arguments = []
 

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -323,7 +323,9 @@ cooking_ingredient (liburing
   EXTERNAL_PROJECT_ARGS
     URL https://github.com/axboe/liburing/archive/liburing-2.1.tar.gz
     URL_MD5 78f13d9861b334b9a9ca0d12cf2a6d3c
-    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND
+      ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+      <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
     BUILD_COMMAND <DISABLE>
     BUILD_BYPRODUCTS "<SOURCE_DIR>/src/liburing.a"
     BUILD_IN_SOURCE ON

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -271,7 +271,7 @@ cooking_ingredient (cryptopp
     INSTALL_COMMAND
       ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} install-lib PREFIX=<INSTALL_DIR>)
 
-
+include(CMakeDetermineCCompiler)
 if(CMAKE_C_COMPILER_ID STREQUAL GNU)
   set(dpdk_toolchain "gcc")
 elseif(CMAKE_C_COMPILER_ID STREQUAL Clang)
@@ -301,6 +301,7 @@ set (dpdk_args
   "EXTRA_CFLAGS=${dpdk_extra_cflags}"
   O=<BINARY_DIR>
   DESTDIR=<INSTALL_DIR>
+  CC=${CMAKE_C_COMPILER}
   T=${dpdk_quadruple})
 
 cooking_ingredient (dpdk

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -272,12 +272,23 @@ cooking_ingredient (cryptopp
       ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${make_command} install-lib PREFIX=<INSTALL_DIR>)
 
 
+if(CMAKE_C_COMPILER_ID STREQUAL GNU)
+  set(dpdk_toolchain "gcc")
+elseif(CMAKE_C_COMPILER_ID STREQUAL Clang)
+  set(dpdk_toolchain "clang")
+elseif(CMAKE_C_COMPILER_ID STREQUAL Intel)
+  set(dpdk_toolchain "icc")
+else()
+  message(FATAL_ERROR "not able to build DPDK: "
+    "unknown compiler \"${CMAKE_C_COMPILER_ID}\"")
+endif()
+
 # Use the "native" profile that DPDK defines in `dpdk/config`, but in `dpdk_configure.cmake` we override
 # CONFIG_RTE_MACHINE with `Seastar_DPDK_MACHINE`.
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  set (dpdk_quadruple arm64-armv8a-linuxapp-gcc)
+  set (dpdk_quadruple arm64-armv8a-linuxapp-${dpdk_toolchain})
 else()
-  set (dpdk_quadruple ${CMAKE_SYSTEM_PROCESSOR}-native-linuxapp-gcc)
+  set (dpdk_quadruple ${CMAKE_SYSTEM_PROCESSOR}-native-linuxapp-${dpdk_toolchain})
 endif()
 
 # gcc 10 defaults to -fno-common, which dpdk is not prepared for


### PR DESCRIPTION
in this series, instead of using the default C compiler, we build liburing and DPDK using user-specified C compiler. this has two benefits:

1. be more consistent on fulfill user's configuration
2. silence the warning of 
    ```
    CMake Warning:
      Manually-specified variables were not used by the project:
    
        CMAKE_C_COMPILER
    ```
    it could be misleading sometimes, most of the times, it's just annoying.