### PR TITLE
file: s/(void)/()/ in function's parameter list

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -148,8 +148,8 @@ public:
     }
 #endif
 
-    virtual future<> flush(void) = 0;
-    virtual future<struct stat> stat(void) = 0;
+    virtual future<> flush() = 0;
+    virtual future<struct stat> stat() = 0;
     virtual future<> truncate(uint64_t length) = 0;
     virtual future<> discard(uint64_t offset, uint64_t length) = 0;
     virtual future<int> ioctl(uint64_t cmd, void* argp) noexcept;
@@ -157,7 +157,7 @@ public:
     virtual future<int> fcntl(int op, uintptr_t arg) noexcept;
     virtual future<int> fcntl_short(int op, uintptr_t arg) noexcept;
     virtual future<> allocate(uint64_t position, uint64_t length) = 0;
-    virtual future<uint64_t> size(void) = 0;
+    virtual future<uint64_t> size() = 0;
     virtual future<> close() = 0;
     virtual std::unique_ptr<file_handle_impl> dup();
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) = 0;

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -89,8 +89,8 @@ protected:
             bool nowait_works);
 public:
     virtual ~posix_file_impl() override;
-    future<> flush(void) noexcept override;
-    future<struct stat> stat(void) noexcept override;
+    future<> flush() noexcept override;
+    future<struct stat> stat() noexcept override;
     future<> truncate(uint64_t length) noexcept override;
     future<> discard(uint64_t offset, uint64_t length) noexcept override;
     future<int> ioctl(uint64_t cmd, void* argp) noexcept override;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -180,7 +180,7 @@ posix_file_impl::posix_file_impl(int fd, open_flags f, std::atomic<unsigned>* re
 }
 
 future<>
-posix_file_impl::flush(void) noexcept {
+posix_file_impl::flush() noexcept {
     if ((_open_flags & open_flags::dsync) != open_flags{}) {
         return make_ready_future<>();
     }
@@ -322,7 +322,7 @@ posix_file_impl::close() noexcept {
 }
 
 future<uint64_t>
-blockdev_file_impl::size(void) noexcept {
+blockdev_file_impl::size() noexcept {
     return engine()._thread_pool->submit<syscall_result_extra<size_t>>([this] {
         uint64_t size;
         int ret = ::ioctl(_fd, BLKGETSIZE64, &size);


### PR DESCRIPTION
according to the C++ standard draft $9.3.4.6 [dcl.fct], see https://eel.is/c++draft/dcl.fct#4 .

> A parameter list consisting of a single unnamed parameter of
> non-dependent type void is equivalent to an empty parameter list.

and the symbol of a C++ function of `int foo(void)` is indeed identical to that of `int foo()`: both of them are `_Z3foov`. so, there is no need to keep the void parameter in the parameter list. this is a good practice in the C language though, the `void` in the parameter sends the message explicitly that: there is no parameters here.