### PR TITLE
Limit the number of http client opened connections

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -236,6 +236,22 @@ public:
      * Client must be closed before destruction unconditionally
      */
     future<> close();
+
+    /**
+     * \brief Returns the total number of connections
+     */
+
+    unsigned connections_nr() const noexcept {
+        return _nr_connections;
+    }
+
+    /**
+     * \brief Returns the number of idle connections
+     */
+
+    unsigned idle_connections_nr() const noexcept {
+        return _pool.size();
+    }
 };
 
 } // experimental namespace

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -158,9 +158,14 @@ public:
  */
 
 class client {
+    friend class http::internal::client_ref;
     using connections_list_t = bi::list<connection, bi::member_hook<connection, typename connection::hook_t, &connection::_hook>, bi::constant_time_size<false>>;
+    static constexpr unsigned default_max_connections = 100;
 
     std::unique_ptr<connection_factory> _new_connections;
+    unsigned _nr_connections = 0;
+    const unsigned _max_connections;
+    condition_variable _wait_con;
     connections_list_t _pool;
 
     using connection_ptr = seastar::shared_ptr<connection>;
@@ -208,7 +213,7 @@ public:
      * \param f -- the factory pointer
      *
      */
-    explicit client(std::unique_ptr<connection_factory> f);
+    explicit client(std::unique_ptr<connection_factory> f, unsigned max_connections = default_max_connections);
 
     /**
      * \brief Send the request and handle the response

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -164,7 +164,7 @@ class client {
 
     std::unique_ptr<connection_factory> _new_connections;
     unsigned _nr_connections = 0;
-    const unsigned _max_connections;
+    unsigned _max_connections;
     condition_variable _wait_con;
     connections_list_t _pool;
 
@@ -172,6 +172,7 @@ class client {
 
     future<connection_ptr> get_connection();
     future<> put_connection(connection_ptr con, bool can_cache);
+    future<> shrink_connections();
 
     template <typename Fn>
     SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
@@ -229,6 +230,16 @@ public:
      *
      */
     future<> make_request(request req, reply_handler handle, reply::status_type expected = reply::status_type::ok);
+
+    /**
+     * \brief Updates the maximum number of connections a client may have
+     *
+     * If the new limit is less than the amount of connections a client has, they will be
+     * closed. The returned future resolves when all excessive connections get closed
+     *
+     * \param nr -- the new limit on the number of connections
+     */
+    future<> set_maximum_connections(unsigned nr);
 
     /**
      * \brief Closes the client


### PR DESCRIPTION
In its current shape http::client generates as many connections as it takes to serve all make_request() calls. Eventually the connections settle in the client's internal pool from which client re-uses them, but whenever the pool is empty the new connection is made.

This set allows configuring the limit on the total number of connections -- both active and idle (in pool) -- a client may have. If the pool is empty but there are too many active connections, the new one isn't spawned, instead the caller waits for active one to either get back into the pool, or to get closed.

Also on top of it two stats calls are added to return total number of connections and the amount of idling ones.