### PR TITLE
net,rpc: Turn on batch-flushes for RPC sockets only

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -165,6 +165,10 @@ struct session_dn {
     sstring issuer;
 };
 
+namespace internal {
+struct socket_output_stream_options : public output_stream_options {};
+};
+
 /// A TCP (or other stream-based protocol) connection.
 ///
 /// A \c connected_socket represents a full-duplex stream between
@@ -257,6 +261,9 @@ public:
     ///
     /// \see poll(2) about POLLRDHUP for more details
     future<> wait_input_shutdown();
+
+    /// @private
+    output_stream<char> output(internal::socket_output_stream_options, size_t buffer_size = 8192);
 };
 /// @}
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -101,9 +101,10 @@ input_stream<char> connected_socket::input(connected_socket_input_stream_config 
 }
 
 output_stream<char> connected_socket::output(size_t buffer_size) {
-    output_stream_options opts;
-    opts.batch_flushes = true;
-    // TODO: allow user to determine buffer size etc
+    return output(internal::socket_output_stream_options{}, buffer_size);
+}
+
+output_stream<char> connected_socket::output(internal::socket_output_stream_options opts, size_t buffer_size) {
     return output_stream<char>(_csi->sink(), buffer_size, opts);
 }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -203,7 +203,9 @@ namespace rpc {
       }
       _fd = std::move(fd);
       _read_buf =_fd.input();
-      _write_buf = _fd.output();
+      internal::socket_output_stream_options opts;
+      opts.batch_flushes = true;
+      _write_buf = _fd.output(opts);
       _connected = true;
   }
 


### PR DESCRIPTION
When calling connected_socket::output() it unconditionally turns on batch flushes for the created output_stream. However, it's only meaningful for RPC sockets whose users may put several independent messages into it and wait for responce.

Contrary to this http client sockets work in pure ping-pong model -- send request, wait for reply. For those turning batch-flush makes things worse, because waiting for the reply is guaranteed not to get one until the upcoming reactor tick and batch-flush poller loop. This is 2x worse when 'continue:' header is in use, because sending a request involves flushing the request in the middle and waiting for the server confirmation to continue.

The proposal is to make batch-flush OFF by default and teach RPC layer to configure its socket's output stream with it explicitly.