### PR TITLE
prometheus.cc: function in foreach_metrics to use const ref

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -588,7 +588,7 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
             found = false;
             metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels);
             bool should_aggregate = !metric_family.metadata().aggregate_labels.empty();
-            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help, &filter](auto value, auto value_info) mutable {
+            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate, show_help, &filter](const mi::metric_value& value, const mi::metric_info& value_info) mutable {
                 s.clear();
                 s.str("");
                 if ((value_info.should_skip_when_empty && value.is_empty()) || !filter(value_info.id.labels())) {


### PR DESCRIPTION
metric_family.foreach_metric passes parameters to the handled function by const ref. The implmentation code used auto, which added an unneeded copy.

This patch changes it to const reference.

Fixes scylladb/scylladb#13929