### PR TITLE
util: remove unused #include

### DIFF
--- a/src/util/program-options.cc
+++ b/src/util/program-options.cc
@@ -24,7 +24,6 @@
 module;
 #endif
 
-#include <regex>
 #include <boost/any.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/program_options.hpp>


### PR DESCRIPTION
`#include <regex>` in util/program-options.cc was added back in 735dc123f0d86822fdc8562bb3561152c3f11748, where we were using std::regex for parsing map associations, but the function of
`parse_map_associations()` which uses std::regex was moved into util/log.cc.

so let's remove this include from the .cc file.