### PR TITLE
http/client: Introduce unexpected_status_error for client requests

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -149,6 +149,16 @@ private:
     }
 };
 
+/**
+ * Client-side exception to report unexpected server reply status
+ */
+class unexpected_status_error : public base_exception {
+public:
+    unexpected_status_error(reply::status_type st)
+        : base_exception("Unexpected reply status", st)
+    {}
+};
+
 SEASTAR_MODULE_EXPORT_END
 }
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -240,14 +240,14 @@ future<> client::make_request(request req, reply_handler handle, reply::status_t
         return con.make_request(std::move(req)).then([&con, expected, handle = std::move(handle)] (reply rep) mutable {
             if (rep._status != expected) {
                 if (!http_log.is_enabled(log_level::debug)) {
-                    return make_exception_future<>(std::runtime_error(format("request finished with {}", rep._status)));
+                    return make_exception_future<>(httpd::unexpected_status_error(rep._status));
                 }
 
                 return do_with(std::move(rep), [&con] (auto& rep) mutable {
                     return do_with(con.in(rep), [&rep] (auto& in) mutable {
                         return util::read_entire_stream_contiguous(in).then([&rep] (auto message) {
                             http_log.debug("request finished with {}: {}", rep._status, message);
-                            return make_exception_future<>(std::runtime_error(format("request finished with {}", rep._status)));
+                            return make_exception_future<>(httpd::unexpected_status_error(rep._status));
                         });
                     });
                 });


### PR DESCRIPTION
When calling http::client::make_request() one of the argument is what status from server is expected. When server sends back some other status the call resolves with exceptional future carrying std::runtime_error.

Callers would benefit from the ability to tell unexpected-status exceptions from any other errors.