### PR TITLE
HTTP headers in http_response are now case insensitive

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -39,6 +39,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/modules.hh>
+#include <seastar/util/string_utils.hh>
 
 namespace seastar {
 
@@ -107,7 +108,7 @@ struct reply {
     /**
      * The headers to be included in the reply.
      */
-    std::unordered_map<sstring, sstring> _headers;
+    std::unordered_map<sstring, sstring, seastar::internal::case_insensitive_hash, seastar::internal::case_insensitive_cmp> _headers;
 
     sstring _version;
     /**

--- a/include/seastar/util/string_utils.hh
+++ b/include/seastar/util/string_utils.hh
@@ -1,0 +1,68 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015 Cloudius Systems
+ */
+
+//
+// request.hpp
+// ~~~~~~~~~~~
+//
+// Copyright (c) 2003-2013 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#ifndef SEASTAR_MODULE
+#include <cstring>
+#include <stdio.h>
+#endif
+
+#include <seastar/util/modules.hh>
+#include <seastar/core/sstring.hh>
+
+namespace seastar {
+
+namespace internal {
+
+SEASTAR_MODULE_EXPORT_BEGIN
+//
+// Collection of utilities for working with strings .
+//
+
+struct case_insensitive_cmp {
+    bool operator()(const sstring& s1, const sstring& s2) const {
+        return std::equal(s1.begin(), s1.end(), s2.begin(), s2.end(),
+                [](char a, char b) { return ::tolower(a) == ::tolower(b); });
+    }
+};
+
+struct case_insensitive_hash {
+    size_t operator()(sstring s) const {
+        std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+        return std::hash<sstring>()(s);
+    }
+};
+
+SEASTAR_MODULE_EXPORT_END
+
+}
+
+}

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -33,6 +33,7 @@ module seastar;
 #include <seastar/http/response_parser.hh>
 #include <seastar/http/internal/content_source.hh>
 #include <seastar/util/short_streams.hh>
+#include <seastar/util/string_utils.hh>
 #endif
 
 namespace seastar {
@@ -162,7 +163,7 @@ future<reply> connection::make_request(request req) {
 }
 
 input_stream<char> connection::in(reply& rep) {
-    if (http::request::case_insensitive_cmp()(rep.get_header("Transfer-Encoding"), "chunked")) {
+    if (seastar::internal::case_insensitive_cmp()(rep.get_header("Transfer-Encoding"), "chunked")) {
         return input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(_read_buf, rep.chunk_extensions, rep.trailing_headers)));
     }
 


### PR DESCRIPTION
Previously to this commit only the headers in the http requests were case insensitive. This failed to handled a scenario in which a server returns headers with different cases.
The most impactful case is `content-type` instead of `Content-Type`. In case a server uses lower case, seastar would ignore the content and return an empty reply.

To address this issue the same case-insensitive logic was reused. Move the case_insensitive_cmp/case_insensitive_hash to a utility module.

---------------------------------
As the test suggests, I noticed this issue while working with [uvicorn](https://www.uvicorn.org/), which is a popular web server for python. I noticed that seastar was ignoring the data of the reply. After digging a bit I found that it is caused by the fact that uvicorn uses `content-length` and seastar expected `Content-Length` in a case sensitive way.

Note: According the the HTTP RFC header field names are case insensitive.
[StackOverflow reference](https://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive)

---------------------------------
Note: Since I moved `case_insensitive_cmp/case_insensitive_hash` from `request.hh` to the new `string_utils.hh` I took the license comment from the original file.

@xemul - I noticed that you worked on `http` lately, would love a review :)