### PR TITLE
Cleanup RPC request/response frames maintenance

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -463,8 +463,6 @@ private:
     future<> negotiate_protocol(feature_map map);
     void negotiate(feature_map server_features);
     future<std::tuple<int64_t, std::optional<rcv_buf>>>
-    read_response_frame(input_stream<char>& in);
-    future<std::tuple<int64_t, std::optional<rcv_buf>>>
     read_response_frame_compressed(input_stream<char>& in);
 public:
     /**

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -305,7 +305,7 @@ protected:
 
     snd_buf compress(snd_buf buf);
     future<> send_buffer(snd_buf buf);
-
+    future<> send(snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr);
     future<> send_entry(outgoing_entry& d);
     future<> stop_send_loop(std::exception_ptr ex);
     future<std::optional<rcv_buf>>  read_stream_frame_compressed(input_stream<char>& in);
@@ -324,9 +324,6 @@ public:
     virtual ~connection() {}
     void set_socket(connected_socket&& fd);
     future<> send_negotiation_frame(feature_map features);
-    // functions below are public because they are used by external heavily templated functions
-    // and I am not smart enough to know how to define them as friends
-    future<> send(snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr);
     bool error() const noexcept { return _error; }
     void abort();
     future<> stop() noexcept;
@@ -538,6 +535,8 @@ public:
     future<sink<Out...>> make_stream_sink() {
         return make_stream_sink<Serializer, Out...>(make_socket());
     }
+
+    future<> request(uint64_t type, int64_t id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr);
 };
 
 class protocol_base;

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -554,7 +554,7 @@ public:
         connection_id _parent_id = invalid_connection_id;
         std::optional<isolation_config> _isolation_config;
     private:
-        future<> negotiate_protocol(input_stream<char>& in);
+        future<> negotiate_protocol();
         future<std::tuple<std::optional<uint64_t>, uint64_t, int64_t, std::optional<rcv_buf>>>
         read_request_frame_compressed(input_stream<char>& in);
         future<feature_map> negotiate(feature_map requested);

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -460,7 +460,7 @@ private:
     weak_ptr<client> _parent; // for stream clients
 
 private:
-    future<> negotiate_protocol(input_stream<char>& in);
+    future<> negotiate_protocol(feature_map map);
     void negotiate(feature_map server_features);
     future<std::tuple<int64_t, std::optional<rcv_buf>>>
     read_response_frame(input_stream<char>& in);

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -451,6 +451,9 @@ relative_timeout_to_absolute(rpc_clock_type::duration relative) {
     return now + std::min(relative, rpc_clock_type::time_point::max() - now);
 }
 
+// Refer to struct request_frame for more details
+static constexpr size_t request_frame_headroom = 28;
+
 // Returns lambda that can be used to send rpc messages.
 // The lambda gets client connection and rpc parameters as arguments, marshalls them sends
 // to a server and waits for a reply. After receiving reply it unmarshalls it and signal completion
@@ -468,7 +471,7 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
 
             // send message
             auto msg_id = dst.next_message_id();
-            snd_buf data = marshall(dst.template serializer<Serializer>(), 28, args...);
+            snd_buf data = marshall(dst.template serializer<Serializer>(), request_frame_headroom, args...);
 
             // prepare reply handler, if return type is now_wait_type this does nothing, since no reply will be sent
             using wait = wait_signature_t<Ret>;

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -938,8 +938,8 @@ namespace rpc {
   }
 
   future<>
-  server::connection::negotiate_protocol(input_stream<char>& in) {
-      return receive_negotiation_frame(*this, in).then([this] (feature_map requested_features) {
+  server::connection::negotiate_protocol() {
+      return receive_negotiation_frame(*this, _read_buf).then([this] (feature_map requested_features) {
           return negotiate(std::move(requested_features)).then([this] (feature_map returned_features) {
               return send_negotiation_frame(std::move(returned_features));
           });
@@ -1026,7 +1026,7 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
 }
 
   future<> server::connection::process() {
-      return negotiate_protocol(_read_buf).then([this] () mutable {
+      return negotiate_protocol().then([this] () mutable {
         auto sg = _isolation_config ? _isolation_config->sched_group : current_scheduling_group();
         return with_scheduling_group(sg, [this] {
           set_negotiated();

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -588,6 +588,15 @@ namespace rpc {
       return it->second;
   }
 
+  future<> client::request(uint64_t type, int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel) {
+      static_assert(snd_buf::chunk_size >= 28, "send buffer chunk size is too small");
+      auto p = buf.front().get_write() + 8; // 8 extra bytes for expiration timer
+      write_le<uint64_t>(p, type);
+      write_le<int64_t>(p + 8, msg_id);
+      write_le<uint32_t>(p + 16, buf.size - 28);
+      return send(std::move(buf), timeout, cancel);
+  }
+
   void
   client::negotiate(feature_map provided) {
       // record features returned here

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -654,11 +654,6 @@ namespace rpc {
 
 
   future<response_frame::header_and_buffer_type>
-  client::read_response_frame(input_stream<char>& in) {
-      return read_frame<response_frame>(_server_addr, in);
-  }
-
-  future<response_frame::header_and_buffer_type>
   client::read_response_frame_compressed(input_stream<char>& in) {
       return read_frame_compressed<response_frame>(_server_addr, _compressor, in);
   }


### PR DESCRIPTION
The RPC request/response encoding/decoding code uses a bunch of magic hard-coded constants denoting sizes of request/response headers. The PR main intent is to replace them with named constants and respective math and checks around it.

While at it -- drop unused method and keep negotiation steps in one method.