### PR TITLE
code: Use std::is_invocable_r_v instead of InvokeReturns

### DIFF
--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -255,7 +255,7 @@ public:
     /// \return a future that becomes ready when \ref signal() is called
     ///         If the condition variable was \ref broken(), may contain an exception.
     template<typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     future<> wait(Pred&& pred) noexcept {
         return do_until(std::forward<Pred>(pred), [this] {
             return wait();
@@ -272,7 +272,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is reached will return \ref condition_variable_timed_out exception.
     template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration, typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     future<> wait(std::chrono::time_point<Clock, Duration> timeout, Pred&& pred) noexcept {
         return do_until(std::forward<Pred>(pred), [this, timeout] {
             return wait(timeout);
@@ -289,7 +289,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is passed will return \ref condition_variable_timed_out exception.
     template<typename Rep, typename Period, typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     future<> wait(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return wait(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }
@@ -340,7 +340,7 @@ public:
     /// \return a future that becomes ready when \ref signal() is called
     ///         If the condition variable was \ref broken(), may contain an exception.
     template<typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     auto when(Pred&& pred) noexcept {
         return predicate_awaiter<Pred, awaiter>{std::forward<Pred>(pred), when()};
     }
@@ -356,7 +356,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is reached will return \ref condition_variable_timed_out exception.
     template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration, typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     auto when(std::chrono::time_point<Clock, Duration> timeout, Pred&& pred) noexcept {
         return predicate_awaiter<Pred, timeout_awaiter<Clock, Duration>>{std::forward<Pred>(pred), when(timeout)};
     }
@@ -372,7 +372,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is passed will return \ref condition_variable_timed_out exception.
     template<typename Rep, typename Period, typename Pred>
-    SEASTAR_CONCEPT( requires seastar::InvokeReturns<Pred, bool> )
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     auto when(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return when(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1043,6 +1043,7 @@ concept CanApplyTuple
         { std::apply(func, std::get<0>(std::move(wrapped_val))) };
     };
 
+// Deprecated, use std::is_invocable_r_v
 template <typename Func, typename Return, typename... T>
 concept InvokeReturns = requires (Func f, T... args) {
     { f(std::forward<T>(args)...) } -> std::same_as<Return>;
@@ -1692,10 +1693,10 @@ public:
     /// successful value; Because handle_exception() is used here on a
     /// future<>, the handler function does not need to return anything.
     template <typename Func>
-    SEASTAR_CONCEPT( requires ::seastar::InvokeReturns<Func, future<T>, std::exception_ptr>
-                    || (std::tuple_size_v<tuple_type> == 0 && ::seastar::InvokeReturns<Func, void, std::exception_ptr>)
-                    || (std::tuple_size_v<tuple_type> == 1 && ::seastar::InvokeReturns<Func, T, std::exception_ptr>)
-                    || (std::tuple_size_v<tuple_type> > 1 && ::seastar::InvokeReturns<Func, tuple_type, std::exception_ptr>)
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<future<T> ,Func, std::exception_ptr>
+                    || (std::tuple_size_v<tuple_type> == 0 && std::is_invocable_r_v<void, Func, std::exception_ptr>)
+                    || (std::tuple_size_v<tuple_type> == 1 && std::is_invocable_r_v<T, Func, std::exception_ptr>)
+                    || (std::tuple_size_v<tuple_type> > 1 && std::is_invocable_r_v<tuple_type ,Func, std::exception_ptr>)
     )
     future<T> handle_exception(Func&& func) noexcept {
         return then_wrapped([func = std::forward<Func>(func)]

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -116,7 +116,7 @@ future<> repeat(AsyncAction& action) noexcept = delete;
 /// \return a ready future if we stopped successfully, or a failed future if
 ///         a call to to \c action failed.
 template<typename AsyncAction>
-SEASTAR_CONCEPT( requires seastar::InvokeReturns<AsyncAction, stop_iteration> || seastar::InvokeReturns<AsyncAction, future<stop_iteration>> )
+SEASTAR_CONCEPT( requires std::is_invocable_r_v<stop_iteration, AsyncAction> || std::is_invocable_r_v<future<stop_iteration>, AsyncAction> )
 inline
 future<> repeat(AsyncAction&& action) noexcept {
     using futurator = futurize<std::invoke_result_t<AsyncAction>>;
@@ -334,7 +334,7 @@ public:
 /// \return a ready future if we stopped successfully, or a failed future if
 ///         a call to to \c action or a call to \c stop_cond failed.
 template<typename AsyncAction, typename StopCondition>
-SEASTAR_CONCEPT( requires seastar::InvokeReturns<StopCondition, bool> && seastar::InvokeReturns<AsyncAction, future<>> )
+SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, StopCondition> && std::is_invocable_r_v<future<>, AsyncAction> )
 inline
 future<> do_until(StopCondition stop_cond, AsyncAction action) noexcept {
     using namespace internal;
@@ -370,7 +370,7 @@ future<> do_until(StopCondition stop_cond, AsyncAction action) noexcept {
 ///        that becomes ready when you wish it to be called again.
 /// \return a future<> that will resolve to the first failure of \c action
 template<typename AsyncAction>
-SEASTAR_CONCEPT( requires seastar::InvokeReturns<AsyncAction, future<>> )
+SEASTAR_CONCEPT( requires std::is_invocable_r_v<future<>, AsyncAction> )
 inline
 future<> keep_doing(AsyncAction action) noexcept {
     return repeat([action = std::move(action)] () mutable {


### PR DESCRIPTION
The std:: one is available since C++17, which is now minimal for
seastar, so the seastar:: one can be replaced