### PR TITLE
sharded: avoid #include <seastar/core/reactor.hh> for run_in_backgrou…

### DIFF
--- a/include/seastar/core/internal/run_in_background.hh
+++ b/include/seastar/core/internal/run_in_background.hh
@@ -1,0 +1,35 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+#pragma once
+
+#include <seastar/core/future.hh>
+
+namespace seastar::internal {
+
+void run_in_background(future<> f);
+
+template <typename Func>
+void run_in_background(Func&& func) {
+    run_in_background(futurize_invoke(std::forward<Func>(func)));
+}
+
+}

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -24,12 +24,12 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/map_reduce.hh>
+#include <seastar/core/internal/run_in_background.hh>
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/util/concepts.hh>
 #include <seastar/util/log.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE
@@ -858,7 +858,7 @@ private:
         // wait for this future.
         auto f = destroy_on(std::move(p), cpu);
         if (!f.available() || f.failed()) {
-            engine().run_in_background(std::move(f));
+            internal::run_in_background(std::move(f));
         }
     }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -143,6 +143,7 @@ module seastar;
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/uname.hh>
 #include <seastar/core/internal/stall_detector.hh>
+#include <seastar/core/internal/run_in_background.hh>
 #include <seastar/net/native-stack.hh>
 #include <seastar/net/packet.hh>
 #include <seastar/net/posix-stack.hh>
@@ -4984,6 +4985,11 @@ std::ostream& operator<<(std::ostream& os, const stall_report& sr) {
 size_t scheduling_group_count() {
     auto b = s_used_scheduling_group_ids_bitmap.load(std::memory_order_relaxed);
     return __builtin_popcountl(b);
+}
+
+void
+run_in_background(future<> f) {
+    engine().run_in_background(std::move(f));
 }
 
 }

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -30,6 +30,12 @@
 
 using namespace seastar;
 
+namespace seastar {
+
+extern logger seastar_logger;
+
+}
+
 SEASTAR_TEST_CASE(make_foreign_ptr_from_lw_shared_ptr) {
     auto p = make_foreign(make_lw_shared<sstring>("foo"));
     BOOST_REQUIRE(p->size() == 3);
@@ -149,7 +155,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
         {}
         ~deferred() {
             seastar_logger.info("~deferred");
-            engine().run_in_background([&done = done, shard = this_shard_id()] {
+            internal::run_in_background([&done = done, shard = this_shard_id()] {
                 return smp::submit_to(0, [&done, shard] {
                     done[shard].set_value(true);
                     done[shard ^ 1].set_value(false);


### PR DESCRIPTION
…nd()

reactor.hh is a heavy header and we should avoid including it, especially in common headers. sharded.hh includes it for the logger and for reactor::run_in_background().

Drop it by forward-declaring seastar_logger and adding a helper internal::run_in_background() which does not need reactor.hh.