### PR TITLE
util: file: drop unnecessary include of reactor.hh

### DIFF
--- a/include/seastar/util/file.hh
+++ b/include/seastar/util/file.hh
@@ -26,7 +26,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/modules.hh>


### PR DESCRIPTION
Reduce compile time and recompilations.