### PR TITLE
Support ccache in ./configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -70,6 +70,8 @@ arg_parser.add_argument('--compiler', action = 'store', dest = 'cxx', default = 
                         help = 'C++ compiler path')
 arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc',
                         help = 'C compiler path (for bundled libraries such as dpdk)')
+arg_parser.add_argument('--ccache', nargs='?', const='ccache', default='', metavar='CCACHE_BINARY_PATH',
+                        help = 'Use ccache to cache compilation (and optionally provide a path to ccache binary)')
 arg_parser.add_argument('--c++-standard', action='store', dest='cpp_standard', default='',
                         help='C++ standard to build with [default: %(default)s]')
 arg_parser.add_argument('--cook', action='append', dest='cook', default=[],
@@ -189,6 +191,7 @@ def configure_mode(mode):
         '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_CXX_STANDARD={}'.format(args.cpp_standard),
+        '-DCMAKE_CXX_COMPILER_LAUNCHER={}'.format(args.ccache),
         '-DCMAKE_INSTALL_PREFIX={}'.format(args.install_prefix),
         '-DCMAKE_EXPORT_COMPILE_COMMANDS={}'.format('yes' if args.cc_json else 'no'),
         '-DBUILD_SHARED_LIBS={}'.format('yes' if mode in ('debug', 'dev') else 'no'),


### PR DESCRIPTION
By passing --ccache to configure.py, the CMAKE_C_COMPILER_LAUCHER (and equivalent CXX property) will be set to ccache, so that ccache will be used to cache the compilation results.