### PR TITLE
sstring: use char_traits<char>::compare() when possible

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -103,7 +103,15 @@ class basic_sstring {
     char_type* str() noexcept {
         return is_internal() ? u.internal.str : u.external.str;
     }
-
+    static constexpr int compare_chars(const char_type* s1, const char_type* s2, size_t n) {
+        if constexpr (std::is_signed_v<char_type> == std::is_signed_v<char>) {
+            return std::char_traits<char>::compare(reinterpret_cast<const char*>(s1),
+                                                   reinterpret_cast<const char*>(s2),
+                                                   n);
+        } else {
+            return traits_type::compare(s1, s2, n);
+        }
+    }
 public:
     using value_type = char_type;
     using traits_type = std::char_traits<char_type>;
@@ -526,7 +534,7 @@ public:
         }
     }
     int compare(std::basic_string_view<char_type, traits_type> x) const noexcept {
-        auto n = traits_type::compare(begin(), x.begin(), std::min(size(), x.size()));
+        auto n = compare_chars(begin(), x.begin(), std::min(size(), x.size()));
         if (n != 0) {
             return n;
         }
@@ -545,7 +553,7 @@ public:
         }
 
         sz = std::min(size() - pos, sz);
-        auto n = traits_type::compare(begin() + pos, x.begin(), std::min(sz, x.size()));
+        auto n = compare_chars(begin() + pos, x.begin(), std::min(sz, x.size()));
         if (n != 0) {
             return n;
         }

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -79,3 +79,6 @@ seastar_add_test (smp_submit_to
 
 seastar_add_test (coroutine
   SOURCES coroutine_perf.cc)
+
+seastar_add_test (sstring
+  SOURCES sstring_perf.cc)

--- a/tests/perf/sstring_perf.cc
+++ b/tests/perf/sstring_perf.cc
@@ -1,0 +1,59 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB Ltd.
+ */
+
+#include <algorithm>
+#include <climits>
+#include <random>
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/core/sstring.hh>
+
+class random_bytes {
+protected:
+    // sometimes, we use basic_sstring<int8_t> to represent a byte array
+    using char_type = int8_t;
+    using string_t = basic_sstring<char_type, uint32_t, 31, false>;
+    string_t _s1 = random_string();
+    string_t _s2 = random_string();
+    // assuming it's the typical length of a byte string
+    static constexpr size_t size = 30;
+private:
+    static string_t random_string() {
+        // generate the data with random bits, so compiler does not optimize
+        // the comparision with constant propagation.
+        using random_bytes_engine =
+            std::independent_bits_engine<std::default_random_engine,
+                                         CHAR_BIT,
+                                         unsigned char>;
+        random_bytes_engine rng;
+        rng.seed(time(nullptr));
+        string_t s{string_t::initialized_later{}, size};
+        std::generate(std::begin(s), std::end(s), std::ref(rng));
+        return s;
+    }
+public:
+    random_bytes() = default;
+};
+
+PERF_TEST_F(random_bytes, compare) {
+    auto r = _s1.compare(_s2);
+    perf_tests::do_not_optimize(r);
+}


### PR DESCRIPTION
C++ standard library specializes char_traits<char_type>
for all builtin char types. see
http://eel.is/c++draft/char.traits.specializations.general

and it's found that both libstdc++ and libc++ uses memcmp()
and wmemcmp to implement the specialization of
char_traits<char_type>::compare(), where char_type is char,
wchar_t and char8_t for better performance.

but in our typical use cases of basic_sstring, in addition to
using seastar::sstring, we also use seastar::basic_sstring<int8_t,..>
to present a string of bytes. but if int8_t is not an alias of
char or char8_t, the performance of comparison degrades
dramatically, as libstdc++ and libc++ would fall back to the
loop-based implementation in this case.

so, in this change, instead of calling char_traits<char_type>::compare()
directly, we check if the char_type's signness is identical to that
of `char`, and cast to the matched one for better performance.

before/after this change:

| test | iterations |median | mad | min | max | allocs | tasks | inst |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| random_strings.compare | 67727389 | 14.406ns | 0.110ns | 13.301ns | 14.671ns | 0.000 | 0.000 | 266.0 |
| random_strings.compare | 436572368 | 2.216ns | 0.013ns | 2.199ns | 2.239ns | 0.000 | 0.000 | 54.0 |

with clang-17, CMAKE_BUILD_TYPE=RelWithDebInfo.