### PR TITLE
exception_hacks: fix sanitization of dl_iterate_phdr_org in debug mode

### DIFF
--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -73,13 +73,15 @@ module seastar;
 namespace seastar {
 using dl_iterate_fn = int (*) (int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data);
 
-[[gnu::no_sanitize_address]]
+// once it was a lambda, [[gnu::no_sanitize_address]] did not help in debug.
+static dl_iterate_fn dl_iterate_phdr_org_assert() {
+    auto org = (dl_iterate_fn)dlsym (RTLD_NEXT, "dl_iterate_phdr");
+    assert(org);
+    return org;
+}
+
 static dl_iterate_fn dl_iterate_phdr_org() {
-    static dl_iterate_fn org = [] {
-        auto org = (dl_iterate_fn)dlsym (RTLD_NEXT, "dl_iterate_phdr");
-        assert(org);
-        return org;
-    }();
+    static dl_iterate_fn org = dl_iterate_phdr_org_assert();
     return org;
 }
 


### PR DESCRIPTION
This is to fix SEGFAULTS (/demos) for Debug builds with ASAN.

A fix for ffdaceed0 Rafael Ávila de Espíndola from 2019-06-11 10:41:26 -0700:

Use of [[gnu::no_sanitize_address]] attribute does not work for the statically evaluated closure:

    [] {
        auto org = (dl_iterate_fn)dlsym (RTLD_NEXT, "dl_iterate_phdr");
        assert(org);
        return org;
    }()

The code was segfaulting with ASAN in Debug builds at:

Dump of assembler code for function operator()() const:

       0x00007fffee93b9c2 <+0>:	push   rbp
       0x00007fffee93b9c3 <+1>:	mov    rbp,rsp
       0x00007fffee93b9c6 <+4>:	push   r14
       0x00007fffee93b9c8 <+6>:	push   r13
       0x00007fffee93b9ca <+8>:	push   r12
       0x00007fffee93b9cc <+10>:	push   rbx
       0x00007fffee93b9cd <+11>:	sub    rsp,0x70
       0x00007fffee93b9d1 <+15>:	mov    QWORD PTR [rbp-0x88],rdi
       0x00007fffee93b9d8 <+22>:	lea    rbx,[rbp-0x80]
       ...
       0x00007fffee93b9fd <+59>:	lea    rax,[rbx+0x60]
       0x00007fffee93ba01 <+63>:	mov    r12,rax
       0x00007fffee93ba04 <+66>:	mov    QWORD PTR [rbx],0x41b58ab3
       ...
       0x00007fffee93ba21 <+95>:	mov    r13,rbx
       0x00007fffee93ba24 <+98>:	shr    r13,0x3
    => R13: 0x00000FFFFFFFFAF4
    => 0x00007fffee93ba28 <+102>:	mov    DWORD PTR [r13+0x7fff8000],0xf1f1f1f1
       0x00007fffee93ba33 <+113>:	mov    DWORD PTR [r13+0x7fff8004],0xf3f3f300

arch, gcc version 13.1.1 20230429 (GCC)

I don't remember what kind of process I need to go through to test it.
This at least works for me for Debug, Dev and Release.