### PR TITLE
Add file::list_directory() that co_yields entries

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -78,6 +78,24 @@ enum class directory_entry_type {
     socket,
 };
 
+namespace internal::linux_abi {
+
+// From getdents(2):
+// check for 64-bit inode number
+static_assert(sizeof(ino_t) == 8, "large file support not enabled");
+static_assert(sizeof(off_t) == 8, "large file support not enabled");
+
+// From getdents(2):
+struct linux_dirent64 {
+    ino64_t        d_ino;    /* 64-bit inode number */
+    off64_t        d_off;    /* 64-bit offset to next structure */
+    unsigned short d_reclen; /* Size of this dirent */
+    unsigned char  d_type;   /* File type */
+    char           d_name[]; /* Filename (null-terminated) */
+};
+
+} // internal::linux_abi namespace
+
 /// Enumeration describing the type of a particular filesystem
 enum class fs_type {
     other,

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -173,9 +173,7 @@ public:
     virtual std::unique_ptr<file_handle_impl> dup();
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) = 0;
 #ifdef SEASTAR_COROUTINES_ENABLED
-    virtual coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory() {
-        throw std::runtime_error("not implemented");
-    }
+    virtual coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory();
 #endif
 
     friend class reactor;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -553,6 +553,8 @@ public:
     future<> link_file(std::string_view oldpath, std::string_view newpath) noexcept;
     future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
+    future<size_t> read_directory(int fd, char* buffer, size_t buffer_size);
+
     future<int> inotify_add_watch(int fd, std::string_view path, uint32_t flags);
 
     future<std::tuple<file_desc, file_desc>> make_pipe();

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -104,6 +104,9 @@ public:
     virtual future<> close() noexcept override;
     virtual std::unique_ptr<seastar::file_handle_impl> dup() override;
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) override;
+#ifdef SEASTAR_COROUTINES_ENABLED
+    virtual coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory() override;
+#endif
 
 #if SEASTAR_API_LEVEL >= 7
     virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept override = 0;


### PR DESCRIPTION
Current implementation of list_directory() requires a callback function that's called with entries. That's not very convenient for coroutines-enabled code. E.g. Scylla has the convenience emulation of this approach, see scylladb/scylladb@207174c6927