### PR TITLE
smp: warn if --memory parameter is not supported

### DIFF
--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -95,6 +95,8 @@ struct smp_options : public program_options::option_group {
     /// * \ref reactor_options::heapprof
     /// * \ref reactor_options::abort_on_seastar_bad_alloc
     /// * \ref reactor_options::dump_memory_diagnostics_on_alloc_failure_kind
+    /// \note Unused when seastar was compiled without the custom allocator support.
+    /// The options above won't be applied in this case either.
     seastar::memory_allocator memory_allocator = memory_allocator::seastar;
 
     /// \cond internal

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4213,6 +4213,9 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
     std::vector<reactor*> reactors(smp::count);
     if (smp_opts.memory) {
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+        seastar_logger.warn("Seastar compiled with default allocator, --memory option won't take effect");
+#endif
         rc.total_memory = parse_memory_size(smp_opts.memory.get_value());
 #ifdef SEASTAR_HAVE_DPDK
         if (smp_opts.hugepages &&


### PR DESCRIPTION
This parameter is ignored if `SEASTAR_DEFAULT_ALLOCATOR` build option is set. For Scylla this is true for debug builds to enable `ASAN` allocator. There was no clear indication that it was not applied before, which could cause misunderstanding and wasted time during development.

`--memory` is one of the options in `smp_options` and `reactor_options` which won't have effect if Seastar allocator was not compiled in. We emit a warning only for --`memory` since other options are
way less common and impactful.

Fixes: #1691