### PR TITLE
deleter: Delete move and copy constructors

### DIFF
--- a/include/seastar/core/deleter.hh
+++ b/include/seastar/core/deleter.hh
@@ -193,6 +193,8 @@ SEASTAR_MODULE_EXPORT_END
 struct free_deleter_impl final : deleter::impl {
     void* obj;
     free_deleter_impl(void* obj) : impl(deleter()), obj(obj) {}
+    free_deleter_impl(const free_deleter_impl&) = delete;
+    free_deleter_impl(free_deleter_impl&&) = delete;
     virtual ~free_deleter_impl() override { std::free(obj); }
 };
 /// \endcond


### PR DESCRIPTION
It looks like this small helper object has them defaulted which likely leads to double ::free() of memory. It doesn't happen yet, but it's better to be on the safer side.