### PR TITLE
file: call close() without the syscall thread

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -318,17 +318,16 @@ posix_file_impl::close() noexcept {
             return make_ready_future<syscall_result<int>>(wrap_syscall<int>(::close(fd)));
         }();
     } else {
-    // TODO: fix the indent
-    closed = [fd] () noexcept {
-        try {
-            return engine()._thread_pool->submit<syscall_result<int>>([fd] {
-                return wrap_syscall<int>(::close(fd));
-            });
-        } catch (...) {
-            report_exception("Running ::close() in reactor thread, submission failed with exception", std::current_exception());
-            return make_ready_future<syscall_result<int>>(wrap_syscall<int>(::close(fd)));
-        }
-    }();
+        closed = [fd] () noexcept {
+            try {
+                return engine()._thread_pool->submit<syscall_result<int>>([fd] {
+                    return wrap_syscall<int>(::close(fd));
+                });
+            } catch (...) {
+                report_exception("Running ::close() in reactor thread, submission failed with exception", std::current_exception());
+                return make_ready_future<syscall_result<int>>(wrap_syscall<int>(::close(fd)));
+            }
+        }();
     }
     return closed.then([] (syscall_result<int> sr) {
       try {


### PR DESCRIPTION
file: call close() without the syscall thread

the close() system call

1. flushes the data if any
2. reclaims the fd

so far, most popular local filesystems do not implement
the "flush" op, but quite a few network filesystems
and layered filesystems implement it. for instance, cifs,
f2fs, fuse, nfs implement the "flush" op. so to be on the
safe side, let's call close() in reactor only when the
file is opened read-only. presumably, the fs implementation
mutate the its state only if the file is opened in writeable
flag enabled. this behavior is confirmed after auditing
all filesystems with flush op in linux v6.3.

Fixes #1689
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>