### PR TITLE
reactor: use s/::free()/::io_uring_free_probe()/

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1239,7 +1239,7 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
         maybe_throw(std::runtime_error("unable to create io_uring probe"));
         return std::nullopt;
     }
-    auto free_probe = defer([&] () noexcept { ::free(probe); });
+    auto free_probe = defer([&] () noexcept { ::io_uring_free_probe(probe); });
 
     for (auto op : required_ops) {
         if (!io_uring_opcode_supported(probe, op)) {


### PR DESCRIPTION
use ::io_uring_free_probe() instead of ::free() to free the memory chunk pointed by `probe`. io_uring allocates the memory chunk by itself. so there are chances that the precompiled liburing is using the vanilla malloc from the libc, while we free the memory chunk using the overridden version which works with the customized allocator.

in other words, we cannot assume which malloc() was used. in this change, ::io_uring_free_probe() is used, as this function is provided by liburing, so we can ensure that the free() used by it always matches with the malloc() called by io_uring_get_probe_ring().

this should address the issue reported by ASan when the tree is compiled with liburing 2.4, like:

AddressSanitizer: attempting free on address which was not malloc()-ed

Fixes #1692