### PR TITLE
Prefault memory when --lock-memory 1 is specified

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -141,7 +141,24 @@ static constexpr size_t huge_page_size =
 #error "Huge page size is not defined for this architecture"
 #endif
 
-void configure(std::vector<resource::memory> m, bool mbind,
+
+namespace internal {
+
+struct memory_range {
+    char* start;
+    char* end;
+    unsigned numa_node_id;
+};
+
+struct numa_layout {
+    std::vector<memory_range> ranges;
+};
+
+numa_layout merge(numa_layout one, numa_layout two);
+
+}
+
+internal::numa_layout configure(std::vector<resource::memory> m, bool mbind,
         std::optional<std::string> hugetlbfs_path = {});
 
 // A deprecated alias for set_abort_on_allocation_failure(true).

--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -44,6 +44,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <optional>
 #endif
 #include "abort_on_ebadf.hh"
 #include <seastar/core/sstring.hh>
@@ -442,8 +443,10 @@ public:
             set(std::forward<Rest>(rest)...);
         }
         void set(stack_size ss) { _stack_size = ss; }
+        void set(cpu_set_t affinity) { _affinity = affinity; }
     private:
         stack_size _stack_size;
+        std::optional<cpu_set_t> _affinity;
         friend class posix_thread;
     };
 };

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -129,6 +129,7 @@ struct cpu {
 struct resources {
     std::vector<cpu> cpus;
     std::unordered_map<dev_t, io_queue_topology> ioq_topology;
+    std::unordered_map<unsigned /* numa node id */, cpuset> numa_node_id_to_cpuset;
 };
 
 resources allocate(configuration& c);

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -122,6 +122,11 @@ posix_thread::posix_thread(attr a, std::function<void ()> func)
     }
 #endif
 
+    if (a._affinity) {
+        auto& cpuset = *a._affinity;
+        pthread_attr_setaffinity_np(&pa, sizeof(cpuset), &cpuset);
+    }
+
     r = pthread_create(&_pthread, &pa,
                 &posix_thread::start_routine, _func.get());
     if (r) {

--- a/src/core/prefault.hh
+++ b/src/core/prefault.hh
@@ -1,0 +1,48 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2023 ScyllaDB
+
+#pragma once
+
+#include <atomic>
+#include <map>
+
+#include <seastar/core/posix.hh>
+#include <seastar/core/resource.hh>
+#include <seastar/core/task.hh>
+#include <seastar/core/memory.hh>
+
+namespace seastar::internal {
+
+// Responsible for pre-faulting in memory so soft page fault latency doesn't impact applications
+class memory_prefaulter {
+    std::atomic<bool> _stop_request = false;
+    std::vector<posix_thread> _worker_threads;
+    // Keep this in object scope to avoid allocating in worker thread
+    std::unordered_map<unsigned, std::vector<memory::internal::memory_range>> _layout_by_node_id;
+public:
+    explicit memory_prefaulter(const resource::resources& res, memory::internal::numa_layout layout);
+    ~memory_prefaulter();
+private:
+    void work(std::vector<memory::internal::memory_range>& ranges, size_t page_size);
+};
+
+
+}
+

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4290,8 +4290,9 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     if (thread_affinity) {
         smp::pin(allocations[0].cpu_id);
     }
+    std::optional<memory::internal::numa_layout> layout;
     if (smp_opts.memory_allocator == memory_allocator::seastar) {
-        memory::configure(allocations[0].mem, mbind, hugepages_path);
+        layout = memory::configure(allocations[0].mem, mbind, hugepages_path);
     }
 
     if (reactor_opts.abort_on_seastar_bad_alloc) {
@@ -4305,6 +4306,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     reactor_config reactor_cfg;
     reactor_cfg.auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm;
     reactor_cfg.max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value());
+
+    std::mutex mtx;
 
 #ifdef SEASTAR_HEAPPROF
     bool heapprof_enabled = reactor_opts.heapprof;
@@ -4391,7 +4394,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     auto smp_tmain = smp::_tmain;
     for (i = 1; i < smp::count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg, &mtx, &layout] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4401,7 +4404,9 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 smp::pin(allocation.cpu_id);
             }
             if (smp_opts.memory_allocator == memory_allocator::seastar) {
-                memory::configure(allocation.mem, mbind, hugepages_path);
+                auto another_layout = memory::configure(allocation.mem, mbind, hugepages_path);
+                auto guard = std::lock_guard(mtx);
+                *layout = memory::internal::merge(std::move(*layout), std::move(another_layout));
             }
             if (heapprof_enabled) {
                 memory::set_heap_profiling_enabled(heapprof_enabled);
@@ -4471,6 +4476,10 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     inited->wait();
 
     engine().configure(reactor_opts);
+
+    if (smp_opts.lock_memory && smp_opts.lock_memory.get_value() && layout && !layout->ranges.empty()) {
+        smp::setup_prefaulter(resources, std::move(*layout));
+    }
 }
 
 bool smp::poll_queues() {


### PR DESCRIPTION
To avoid latency spikes due to page faults on anonymous memory,
we mlockall() all memory. This prevents memory from being swapped out,
but we can still see a latency spike when faulting in the memory the first time
it is touched.

It's rare for this to be a problem, as faulting in an anonymous memory page
on first use is cheap - the kernel just has to zero it. However, things are complicated
by transparent hugepages as the kernel first has to defragment memory. This can
take quite a while, as was observed in [1].

The solution is to launch background threads that will attempt to fault-in the
memory ahead of the application. We need to be careful so that these threads
themselves don't compete with the application and cause latency spikes themselves,
so we take the following steps:
1. We launch just one thread per NUMA node, reducing lock contention
2. We place the threads in the SCHED_IDLE class, so the kernel will favor application threads
3. We let the thread affinity float over the entire NUMA node, so it can find the least contended core

Tested on an old Intel E5 E5-2697. It was able to fault 200GB in 50 cpu seconds
(25 wall-clock seconds) for a rate of 8 GB/s. This shows that even a large-memory application
will be able to fault in memory faster than it will need it.


[1] https://github.com/scylladb/scylladb/issues/8828