### PR TITLE
util: print_safe: fix hex print functions

### DIFF
--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -89,14 +89,14 @@ char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
 template<typename Integral>
 SEASTAR_CONCEPT( requires std::integral<Integral> )
 void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
-    convert_hex_safe<'0'>(buf, bufsz, n);
+    convert_hex_safe<Integral, '0'>(buf, bufsz, n);
 }
 
 // Prints zero-padded hexadecimal representation of an integer to stderr.
 // For example, print_zero_padded_hex_safe(uint16_t(12)) prints "000c".
 // Async-signal safe.
 template<typename Integral>
-SEASTAR_CONCEPT ( requires std::signed_integral<Integral> )
+SEASTAR_CONCEPT ( requires std::unsigned_integral<Integral> )
 void print_zero_padded_hex_safe(Integral n) noexcept {
     char buf[sizeof(n) * 2];
     convert_zero_padded_hex_safe(buf, sizeof(buf), n);


### PR DESCRIPTION
print_zero_padded_hex_safe was never supposed to be for signed integers. The concept was accidentally changed from std::integral to std::signed_integral instead of std::unsigned_integral in a recent refactor in 274f22a8c53c472feb1d110409a80d66df15b101. Fix that.

convert_zero_padded_hex_safe is using a non-existent one-argument variant of convert_hex_safe. Fix that.