### PR TITLE
shared_ptr: deprecate lw_shared_ptr operator=(T&&)

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -343,6 +343,7 @@ public:
     lw_shared_ptr& operator=(std::nullptr_t) noexcept {
         return *this = lw_shared_ptr();
     }
+    [[deprecated("call make_lw_shared<> and assign the result instead")]]
     lw_shared_ptr& operator=(T&& x) noexcept {
         this->~lw_shared_ptr();
         new (this) lw_shared_ptr(make_lw_shared<T>(std::move(x)));


### PR DESCRIPTION
unlike std::shared_ptr, seastar::shared_ptr allows us to move a
value into a shared_ptr with operator=(). the corresponding change in
seastar was introduced by
https://github.com/scylladb/seastar/commit/319ae0b530107dce510c27f45d21b4ad696ef07d. despite that this helper is convenient, it is confusing. as the behavior of a shared_ptr should look like a pointer instead the value pointed by  it. and this could be error-prune, because a developer could by accident write something like:
```c++
p = std::string();
```
and expect that the value pointed by `p` is cleared. and all copies of this shared_ptr are updated accordingly. what he/she really wants is:
```c++
*p = std::string();
```
but the code compiles. while the outcome of the statement is that the destructor `p` is called, and `p` now points to a new instance of string with a new address. the copies of this instance of shared_ptr still hold the old value.

apparently, this behavior is not expected.

so let's deprecate this operator and remove it in future.

Fixes #1621
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>