### PR TITLE
reactor: cast enum to int when formatting it

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1243,7 +1243,7 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
 
     for (auto op : required_ops) {
         if (!io_uring_opcode_supported(probe, op)) {
-            maybe_throw(std::runtime_error(fmt::format("required io_uring opcode {} not supported", op)));
+            maybe_throw(std::runtime_error(fmt::format("required io_uring opcode {} not supported", static_cast<int>(op))));
             return std::nullopt;
         }
     }


### PR DESCRIPTION
we start to have FTBFS if compiled with GCC-13.1 and fmtlib v10, like

```
/home/kefu/dev/seastar/build/release/_cooking/stow/fmt/include/fmt/core.h: In instantiation of ‘constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = io_uring_op; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]’:
/home/kefu/dev/seastar/build/release/_cooking/stow/fmt/include/fmt/core.h:2620:22:   required from ‘constexpr fmt::v10::detail::format_string_checker<Char, Args>::format_string_checker(fmt::v10::basic_string_view<Char>) [with Char = char; Args = {io_uring_op}]’
/home/kefu/dev/seastar/src/core/reactor_backend.cc:1246:55:   required from here
/home/kefu/dev/seastar/build/release/_cooking/stow/fmt/include/fmt/core.h:2561:10: error: use of deleted function ‘fmt::v10::formatter<T, Char, Enable>::formatter() [with T = io_uring_op; Char = char; Enable = void]’
 2561 |   return formatter<mapped_type, char_type>().parse(ctx);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/seastar/build/release/_cooking/stow/fmt/include/fmt/core.h:792:3: note: declared here
  792 |   formatter() = delete;
      |   ^~~~~~~~~
```

because, in {fmt} v10, it

> Removed deprecated implicit conversions for enums and conversions
> to primitive types for compatibility with std::format and to
> prevent potential ODR violations.

see https://github.com/fmtlib/fmt/releases/tag/10.0.0.

the document also encourages us to use `format_as()`. as liburing is a C library, `io_uring_op` is defined in the global namespace. we could define `format_as()` in the global namespace, and guard it with `#ifdef SEASTAR_HAVE_URING`, but this complicates the overall structure of this source file. as the caller of the problematic `fmt::format()` is in `seastar` namespace, we have to define the `format_as()` out of this namespace.

so, since we don't need to have a formatter for `io_uring_op` at this moment, we just cast it to `int` to format it, as `int` is always the `underlying_type` of a C enum, and liburing is always a C library.

this should address the FTBFS above.