### PR TITLE
memcached: do not used deprecated API

### DIFF
--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1373,7 +1373,7 @@ public:
     void start() {
         listen_options lo;
         lo.reuse_address = true;
-        _listener = seastar::server_socket(seastar::listen(make_ipv4_address({_port}), lo));
+        _listener = make_lw_shared<seastar::server_socket>(seastar::listen(make_ipv4_address({_port}), lo));
         // Run in the background until eof has reached on the input connection.
         _task = keep_doing([this] {
             return _listener->accept().then([this] (accept_result ar) mutable {


### PR DESCRIPTION
in 8038c131b7c953319dd69d045c7c5b71d34a6018, lw_shared_ptr operator=(T&&) was deprecated. but since we don't build apps when performing CI or general testing. this caller was not updated in that very change.

when compiling the whole tree, this deprecated warning was identified. so let's fix it.