### PR TITLE
reactor: epoll backend: initialize _highres_timer_pending

### DIFF
--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -230,7 +230,7 @@ public:
 // using mechanisms like timerfd, signalfd and eventfd respectively.
 class reactor_backend_epoll : public reactor_backend {
     reactor& _r;
-    std::atomic<bool> _highres_timer_pending;
+    std::atomic<bool> _highres_timer_pending = {};
     std::thread _task_quota_timer_thread;
     ::itimerspec _steady_clock_timer_deadline = {};
     // These two timers are used for high resolution timer<>s, one for


### PR DESCRIPTION
The variable is subject to a race condiotion and can be read before use.

This is a benign race; in the worst case there can be a single false-positive in the lifetime of the reactor, and the false positive's impact is a few wasted cycles trying to expire a highres timer where in fact none are ready. In addition it's in the epoll backend that noone uses.

However, it occasionally fails some debug mode tests that have strict ubsan checks, so it's worth fixing.