### PR TITLE
shared_token_bucket: Fix duration_for() underflow

### DIFF
--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -200,7 +200,7 @@ public:
     // Estimated time to process the given amount of tokens
     // (peer of accumulated_in helper)
     rate_resolution duration_for(T tokens) const noexcept {
-        return rate_resolution(tokens / _replenish_rate);
+        return rate_resolution(double(tokens) / _replenish_rate);
     }
 
     T rate() const noexcept { return _replenish_rate; }


### PR DESCRIPTION
This helper calculates the duration that it takes to replenish the specified amount of tokens. When the number of provided tokens is less than than the configured rate the integer division gives zero result which immediatelly converts to empty duration. That's not correct, the duration type is double and can be calculated with more precision.

Typically users of token bucket call this method when they see a deficiency after grabbing a token. In that case they sleep or arm a timer for the provided duration and then call replenish() on the bucket. If the deficiency is small and the calculated duration is zero so the caller doesn't sleep. This leads to unneeded busy-looping around the token bucket.

Another consequence of not sleeping on small deficiency is that replenish() converts time delta to tokens potentially losing precision (delta is floating point, tokens are integers). The conversion rounds the fractional tokens in a hope that rounding happens in both directions and compensates each other on average. This might not be the case when caller doesn't sleep and calls replenish() with tiny durations in between -- rounding goes upper-bound more often than lower-bound thus resulting in higher rate than needed.

refs: #1641