### PR TITLE
shared_token_bucket: Make duration->tokens conversion more solid

### DIFF
--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -173,7 +173,10 @@ public:
         auto extra = accumulated_in(delta);
 
         if (extra >= _replenish_threshold) {
-            if (!_replenished.compare_exchange_weak(ts, ts + delta)) {
+            // accumulated_in() might have lost or accumulated some replenisher
+            // time due to rounding floating-point delta to integer tokens
+            auto real_delta = std::chrono::duration_cast<decltype(delta)>(duration_for(extra));
+            if (!_replenished.compare_exchange_weak(ts, ts + real_delta)) {
                 return; // next time or another shard
             }
 


### PR DESCRIPTION
The t.b. should be replenished from time to time. When replenishing happens it calcualtes the duration between now and last replenishment and converts it to the amount of gained tokens. Since duration is a floating point number and tokens are integers, the convertion may lose some precision, e.g. over a time the bucket mush accumulate 2.718 tokens, but it can only accumulate 2 or 3. Current code rounds the floating point result to integer in the hope that rounding errors compenate each other on average.

However, if the assumption doesn't hold, those deviation may accumulate resulting in wrong replenishing rate. This effects is additionally compensated by the minimal amount of tokens to replenish (called threshold), but it still exists.

There's a simple yet robust fix to that. With the integer number of tokens at hand convert it back to the duration it _had_ to be to get this exact amount of tokens and update the "last time replenished" with the corrected duration.

refs: #1641