### PR TITLE
rpc: add zstd streaming compressor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,7 @@ add_library (seastar
   include/seastar/net/virtio.hh
   include/seastar/rpc/lz4_compressor.hh
   include/seastar/rpc/lz4_fragmented_compressor.hh
+  include/seastar/rpc/zstd_streaming_compressor.hh
   include/seastar/rpc/multi_algo_compressor_factory.hh
   include/seastar/rpc/rpc.hh
   include/seastar/rpc/rpc_impl.hh
@@ -731,6 +732,7 @@ add_library (seastar
   src/net/virtio.cc
   src/rpc/lz4_compressor.cc
   src/rpc/lz4_fragmented_compressor.cc
+  src/rpc/zstd_streaming_compressor.cc
   src/rpc/rpc.cc
   src/util/alloc_failure_injector.cc
   src/util/backtrace.cc
@@ -786,6 +788,7 @@ target_link_libraries (seastar
     cryptopp::cryptopp
     fmt::fmt
     lz4::lz4
+    zstd::zstd
     SourceLocation::source_location
   PRIVATE
     ${CMAKE_DL_LIBS}

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,0 +1,65 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2023 Scylladb, Ltd.
+#
+
+find_package (PkgConfig REQUIRED)
+
+pkg_search_module (PC_zstd QUIET libzstd)
+
+find_library (zstd_LIBRARY
+  NAMES zstd
+  HINTS
+    ${PC_zstd_LIBDIR}
+    ${PC_zstd_LIBRARY_DIRS})
+
+find_path (zstd_INCLUDE_DIR
+  NAMES zstd.h
+  HINTS
+    ${PC_zstd_INCLUDEDIR}
+    ${PC_zstd_INCLUDE_DIRS})
+
+mark_as_advanced (
+  zstd_LIBRARY
+  zstd_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (zstd
+  REQUIRED_VARS
+    zstd_LIBRARY
+    zstd_INCLUDE_DIR
+  VERSION_VAR PC_zstd_VERSION)
+
+if (zstd_FOUND)
+  set (CMAKE_REQUIRED_LIBRARIES ${zstd_LIBRARY})
+
+  set (zstd_LIBRARIES ${zstd_LIBRARY})
+  set (zstd_INCLUDE_DIRS ${zstd_INCLUDE_DIR})
+
+  if (NOT (TARGET zstd::zstd))
+    add_library (zstd::zstd UNKNOWN IMPORTED)
+
+    set_target_properties (zstd::zstd
+      PROPERTIES
+        IMPORTED_LOCATION ${zstd_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${zstd_INCLUDE_DIRS})
+  endif ()
+endif ()

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -88,6 +88,7 @@ macro (seastar_find_dependencies)
     dpdk # No version information published.
     fmt
     lz4
+    zstd
     # Private and private/public dependencies.
     GnuTLS
     LibUring
@@ -124,6 +125,8 @@ macro (seastar_find_dependencies)
     VERSION 5.0.0)
   seastar_set_dep_args (lz4 REQUIRED
     VERSION 1.7.3)
+  seastar_set_dep_args (zstd REQUIRED
+    VERSION 1.5.4)
   seastar_set_dep_args (GnuTLS REQUIRED
     VERSION 3.3.26)
   seastar_set_dep_args (LibUring

--- a/include/seastar/rpc/zstd_streaming_compressor.hh
+++ b/include/seastar/rpc/zstd_streaming_compressor.hh
@@ -1,0 +1,72 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 Scylladb, Ltd.
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include <seastar/rpc/rpc_types.hh>
+#include <zstd.h>
+
+namespace seastar {
+namespace rpc {
+
+struct zstd_cstream_deleter {
+    void operator()(ZSTD_CStream* stream) const noexcept {
+        ZSTD_freeCStream(stream);
+    }
+};
+
+struct zstd_dstream_deleter {
+    void operator()(ZSTD_DStream* stream) const noexcept {
+        ZSTD_freeDStream(stream);
+    }
+};
+
+class zstd_streaming_compressor final : public compressor {
+    std::unique_ptr<ZSTD_CStream, zstd_cstream_deleter> _cstream;
+    std::unique_ptr<ZSTD_DStream, zstd_dstream_deleter> _dstream;
+    void check_zstd(size_t ret, const char* text) {
+        if (ZSTD_isError(ret)) {
+            throw std::runtime_error(fmt::format("{} error: {}", text, ZSTD_getErrorName(ret)));
+        }
+    }
+public:
+    zstd_streaming_compressor()
+        : _cstream(ZSTD_createCStream())
+        , _dstream(ZSTD_createDStream())
+    {
+        check_zstd(ZSTD_initCStream(_cstream.get(), 1), "ZSTD_initCStream(.., 1)");
+        check_zstd(ZSTD_CCtx_setParameter(_cstream.get(), ZSTD_c_windowLog, 16), "ZSTD_CCtx_setParameter(.., ZSTD_c_windowLog, 16)");
+        check_zstd(ZSTD_initDStream(_dstream.get()), "ZSTD_initDStream");
+    }
+    class factory final : public rpc::compressor::factory {
+    public:
+        virtual const sstring& supported() const override;
+        virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override;
+    };
+public:
+    virtual snd_buf compress(size_t head_space, snd_buf data) override;
+    virtual rcv_buf decompress(rcv_buf data) override;
+    sstring name() const override;
+};
+
+}
+}

--- a/src/rpc/zstd_streaming_compressor.cc
+++ b/src/rpc/zstd_streaming_compressor.cc
@@ -1,0 +1,207 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 Scylladb, Ltd.
+ */
+
+#include <seastar/core/byteorder.hh>
+#include <seastar/rpc/zstd_streaming_compressor.hh>
+
+namespace seastar {
+namespace rpc {
+
+sstring zstd_streaming_compressor::name() const {
+    return factory{}.supported();
+}
+
+const sstring& zstd_streaming_compressor::factory::supported() const {
+    const static sstring name = "ZSTD_STREAMING";
+    return name;
+}
+
+std::unique_ptr<rpc::compressor> zstd_streaming_compressor::factory::negotiate(sstring feature, bool is_server) const {
+    return feature == supported() ? std::make_unique<zstd_streaming_compressor>() : nullptr;
+}
+
+constexpr size_t chunk_size = snd_buf::chunk_size;
+
+snd_buf zstd_streaming_compressor::compress(size_t head_space, snd_buf data) {
+    const auto size = data.size;
+    auto src = std::get_if<temporary_buffer<char>>(&data.bufs);
+    if (!src) {
+        src = std::get<std::vector<temporary_buffer<char>>>(data.bufs).data();
+    }
+
+    std::vector<temporary_buffer<char>> dst_buffers;
+    constexpr size_t header_size = 4;
+    dst_buffers.emplace_back(std::max<size_t>(head_space + header_size, chunk_size));
+    char* const header = dst_buffers.back().get_write() + head_space;
+
+    size_t size_left = size;
+    size_left -= src->size();
+    size_t size_compressed = 0;
+
+    ZSTD_inBuffer inbuf;
+    ZSTD_outBuffer outbuf;
+
+    inbuf.src = src->get();
+    inbuf.size = src->size();
+    inbuf.pos = 0;
+
+    outbuf.dst = dst_buffers.back().get_write();
+    outbuf.size = dst_buffers.back().size();
+    outbuf.pos = head_space + header_size;
+
+    if (size > 0) {
+        while (true) {
+            if (size_left && inbuf.pos == inbuf.size) {
+                ++src;
+                size_left -= src->size();
+                inbuf.src = src->get();
+                inbuf.size = src->size();
+                inbuf.pos = 0;
+                continue;
+            }
+            if (outbuf.pos == outbuf.size) {
+                size_compressed += outbuf.pos;
+                dst_buffers.emplace_back(chunk_size);
+                outbuf.dst = dst_buffers.back().get_write();
+                outbuf.size = dst_buffers.back().size();
+                outbuf.pos = 0;
+                continue;
+            }
+            size_t ret = ZSTD_compressStream2(_cstream.get(), &outbuf, &inbuf, static_cast<ZSTD_EndDirective>(!size_left));
+            check_zstd(ret, "ZSTD_compressStream2");
+            if (!size_left && inbuf.pos == inbuf.size && ret == 0) {
+                break;
+            }
+        }
+    }
+    size_compressed += outbuf.pos;
+    dst_buffers.back().trim(outbuf.pos);
+
+    write_le<uint32_t>(header, size);
+
+    // If messages are small, the chunk_size per message might be too big.
+    // Let's pay some cycles to shrink the underlying allocation to fit,
+    // to avoid problems with that overhead.
+    dst_buffers.back() = dst_buffers.back().clone();
+    if (dst_buffers.size() == 1) {
+        return snd_buf(std::move(dst_buffers.front()));
+    }
+    return snd_buf(std::move(dst_buffers), size_compressed);
+}
+
+rcv_buf zstd_streaming_compressor::decompress(rcv_buf data) {
+    const auto size = data.size;
+    if (size < 4) {
+        return rcv_buf();
+    }
+
+    auto src = std::get_if<temporary_buffer<char>>(&data.bufs);
+    if (!src) {
+        src = std::get<std::vector<temporary_buffer<char>>>(data.bufs).data();
+    }
+
+    size_t size_left = size;
+    size_left -= src->size();
+    size_t size_decompressed = 0;
+
+    constexpr size_t header_size = 4;
+    char header[header_size];
+
+    ZSTD_inBuffer inbuf;
+    ZSTD_outBuffer outbuf;
+
+    inbuf.src = src->get();
+    inbuf.size = src->size();
+    inbuf.pos = 0;
+
+    outbuf.dst = std::data(header);
+    outbuf.size = std::size(header);
+    outbuf.pos = 0;
+
+    while (outbuf.pos != outbuf.size) {
+        if (size_left && inbuf.pos == inbuf.size) {
+            ++src;
+            size_left -= src->size();
+            inbuf.src = src->get();
+            inbuf.size = src->size();
+            inbuf.pos = 0;
+            continue;
+        }
+        size_t n = std::min(outbuf.size - outbuf.pos, inbuf.size - inbuf.pos);
+        memcpy(static_cast<char*>(outbuf.dst) + outbuf.pos, static_cast<const char*>(inbuf.src) + inbuf.pos, n);
+        outbuf.pos += n;
+        inbuf.pos += n;
+    }
+
+    const size_t expected_size_decompressed = read_le<uint32_t>(header);
+
+    std::vector<temporary_buffer<char>> dst_buffers;
+    dst_buffers.emplace_back(std::min<size_t>(expected_size_decompressed - size_decompressed, chunk_size));
+    outbuf.dst = dst_buffers.back().get_write();
+    outbuf.size = dst_buffers.back().size();
+    outbuf.pos = 0;
+
+    if (size - header_size > 0) {
+        while (true) {
+            if (size_left && inbuf.pos == inbuf.size) {
+                ++src;
+                size_left -= src->size();
+                inbuf.src = src->get();
+                inbuf.size = src->size();
+                inbuf.pos = 0;
+                continue;
+            }
+            if (outbuf.pos == outbuf.size) {
+                size_decompressed += outbuf.pos;
+                // The blessed check that the decompressor finished its work is `outbuf.pos < outbuf.size`.
+                // To perform that check, we have to give the decompressor at least one extra byte of output space.
+                // Hence `+ 1`.
+                dst_buffers.emplace_back(std::min<size_t>(expected_size_decompressed - size_decompressed + 1, chunk_size));
+                outbuf.dst = dst_buffers.back().get_write();
+                outbuf.size = dst_buffers.back().size();
+                outbuf.pos = 0;
+                continue;
+            }
+            size_t ret = ZSTD_decompressStream(_dstream.get(), &outbuf, &inbuf);
+            check_zstd(ret, "ZSTD_decompressStream");
+            if (!size_left // No more input chunks.
+                && inbuf.pos == inbuf.size // No more data in the last input chunk.
+                && (outbuf.pos < outbuf.size // No more data in decompressor's internal buffers.
+                    || outbuf.pos + size_decompressed > expected_size_decompressed) // The decompressed message is bigger than promised.
+            ) {
+                break;
+            }
+        }
+    }
+    size_decompressed += outbuf.pos;
+    dst_buffers.back().trim(outbuf.pos);
+    if (size_decompressed != expected_size_decompressed) {
+        throw std::runtime_error(fmt::format("ZSTD decompressed frame size {} doesn't match pledged size {}", size_decompressed, expected_size_decompressed));
+    }
+
+    if (dst_buffers.size() == 1) {
+        return rcv_buf(std::move(dst_buffers.front()));
+    }
+    return rcv_buf(std::move(dst_buffers), size_decompressed);
+}
+
+}
+}


### PR DESCRIPTION
TODO:

- Add zstd to seastar dependencies.
- Check that exceptions in the constructor of the compressor are handled properly.

Considerations:

With window size 16 (chosen in this patch), zstd will be able to backreference 64 kiB into the past, at the cost of ~521 kiB per compressor and 413 kiB per decompresor, which adds up to 1 MiB per connection which uses this compression.
(Note: since these are separate allocations now, it really adds up to 1.5 MiB due to separate rounding. But we can fix that, if we want).

This can add up to a great overhead with a large number of RPC connections. Users of seastar should consider enabling it selectively, only for the most voluminous connections.