### PR TITLE
alien: do not define customized copy ctor

### DIFF
--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -107,7 +107,6 @@ namespace internal {
 struct qs_deleter {
     unsigned count;
     qs_deleter(unsigned n = 0) : count(n) {}
-    qs_deleter(const qs_deleter& d) : count(d.count) {}
     void operator()(message_queue* qs) const;
 };
 


### PR DESCRIPTION
as per the standard

> The generation of the implicitly-defined copy assignment operator is
> deprecated if T has a user-declared destructor or user-declared copy
> constructor.

and GCC rightfully warns us, if `-Wextra` is passed to the compiler:

```
In file included from /home/kefu/dev/seastar/src/core/reactor.cc:118:
/home/kefu/dev/seastar/include/seastar/core/alien.hh:110:5: error: definition of implicit copy assignment operator for 'qs_deleter' is deprecated because it has a user-provided copy constructor [-Werror,-Wdeprecated-copy-with-user-provided-copy]
  110 |     qs_deleter(const qs_deleter& d) : count(d.count) {}
      |     ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:192:15: note: in implicit copy assignment operator for 'seastar::alien::internal::qs_deleter' first required here
  192 |         _M_deleter() = std::forward<_Dp>(__u._M_deleter());
      |                      ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unique_ptr.h:243:61: note: in instantiation of member function 'std::__uniq_ptr_impl<seastar::alien::message_queue, seastar::alien::internal::qs_deleter>::operator=' requested here
  243 |       __uniq_ptr_data& operator=(__uniq_ptr_data&&) = default;
      |                                                             ^
1 error generated.
```

but we do need the copy assignment operator, so let's remove the copy ctor, as it will be default generated by compiler anyway.