### PR TITLE
prometheus: do not qualify return type with const.

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -253,7 +253,7 @@ public:
         return *_name;
     }
 
-    const uint32_t size() const {
+    uint32_t size() const {
         return _size;
     }
 
@@ -366,7 +366,7 @@ public:
         return *_info._name;
     }
 
-    const uint32_t size() const {
+    uint32_t size() const {
         return _info._size;
     }
 


### PR DESCRIPTION
functions return prvalue, so one cannot mutate them. and GCC rightfully points this out:

```
/home/kefu/dev/seastar/src/core/prometheus.cc:256:5: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  256 |     const uint32_t size() const {
      |     ^~~~~
/home/kefu/dev/seastar/src/core/prometheus.cc:369:5: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  369 |     const uint32_t size() const {
      |     ^~~~~
```

in this change, the unnecessary `const` specifiers are removed.