### PR TITLE
circular_buffer_fixed_capacity_test: enable randomize test to reverse

### DIFF
--- a/tests/unit/circular_buffer_fixed_capacity_test.cc
+++ b/tests/unit/circular_buffer_fixed_capacity_test.cc
@@ -106,7 +106,7 @@ using deque = std::deque<int>;
 
 BOOST_AUTO_TEST_CASE(test_random_walk) {
     auto rand = std::default_random_engine();
-    auto op_gen = std::uniform_int_distribution<unsigned>(0, 6);
+    auto op_gen = std::uniform_int_distribution<unsigned>(0, 7);
     deque d;
     cb16_t c;
     for (auto i = 0; i != 1000000; ++i) {
@@ -164,6 +164,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
         case 7:
             boost::reverse(c);
             boost::reverse(d);
+            break;
         default:
             abort();
         }


### PR DESCRIPTION
before this change, the randomized test accepts a RNG which generates numbers in the range of [0, 6], and translate the generated numbers to corresponding operations, then apply them to the `std::deque` and `circular_buffer_fixed_capacity<>` under test.

it seems that we intent to support numbers in the range of [0, 7], as we also handle 7, and reverse the dequeu and buffer respectively. but we failed generate 7 with the RNG.

so, in this change,

* enlarge the maximum value of of the uniform distribution from 6 to 7
* do not fallthrough in the "case 7" block, otherwise the test will abort() at seeing "7" generated from RNG.

this change should improve the coverage of the test. and enable us to pass `-Wimplicit-fallthrough` command line option to the compiler for better compile-time check.