### PR TITLE
build: use new behavior defined by CMP0127

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,11 @@ list (APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_BINARY_DIR})
 
 cmake_policy (SET CMP0090 NEW)
-if (POLICY CMP0135)
-  cmake_policy (SET CMP0135 NEW)
-endif ()
+foreach (policy CMP0127 CMP0135)
+  if (POLICY ${policy})
+    cmake_policy (SET ${policy} NEW)
+  endif ()
+endforeach ()
 
 include (Cooking OPTIONAL)
 


### PR DESCRIPTION
the CMake policy of CMP0127 defines the behavior
of `cmake_dependent_option()`. this policy was introduced by CMake 3.22, and our minimal required CMake version is 3.13, so we need to conditionalize it.

the new behavior allows us to use nested paren groups, while the old behavior does not. but our use cases is very simple and works with the new behavior and old one. so, to silence the warnings emitted by CMake v3.22 and up, let's explicitly set the policy. to simplify the code, let's use a loop and always use the NEW behavior.

```
CMake Warning (dev) at /usr/share/cmake-3.24/Modules/CMakeDependentOption.cmake:89 (message):
  Policy CMP0127 is not set: cmake_dependent_option() supports full Condition
  Syntax.  Run "cmake --help-policy CMP0127" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
Call Stack (most recent call first):
  CMakeLists.txt:153 (cmake_dependent_option)
This warning is for project developers.  Use -Wno-dev to suppress it
```