### PR TITLE
websocket: print logging message before handle_ping()

### DIFF
--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -300,8 +300,8 @@ future<> connection::read_one() {
                      */
                     return close(true);
                 case opcodes::PING:
-                    return handle_ping();
                     wlogger.debug("Received ping frame.");
+                    return handle_ping();
                 case opcodes::PONG:
                     wlogger.debug("Received pong frame.");
                     return handle_pong();


### PR DESCRIPTION
before this change, we have following warning if the tree is compiled with `-Werror=implicit-fallthrough`

```
/home/circleci/project/src/websocket/server.cc: In lambda function:
/home/circleci/project/src/websocket/server.cc:304:34: error: this statement may fall through [-Werror=implicit-fallthrough=]
  304 |                     wlogger.debug("Received ping frame.");
      |                     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```

and `wlogger.debug("Received ping frame.");` is dead code which is not reachable. so in order to silence the warning, and to print out the logging message. let's transpose these two statements.