### PR TITLE
metrics: do not define defaulted copy assignment operator

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -341,8 +341,6 @@ public:
             : u(d), _type(t) {
     }
 
-    metric_value& operator=(const metric_value& c) = default;
-
     metric_value& operator+=(const metric_value& c) {
         *this = *this + c;
         return *this;


### PR DESCRIPTION
a defaulted operator=() defined explicitly is still considered a user-declared copy assignment operator. and the C++ standard marks the default-generated copy constructor deprecated if the type has a user-declared copy assignment operator. so, for the similar reason of 31106bc76e9800eca5ee77acc9bda2c86f6aacb1, we should drop this definition. otherwise, we'd be using the deprecated copy constructor:

```
/home/kefu/dev/seastar/include/seastar/core/metrics.hh:344:19: error: definition of implicit copy constructor for 'metric_value' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
  344 |     metric_value& operator=(const metric_value& c) = default;
      |                   ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/stl_pair.h:317:35: note: in implicit copy constructor for 'seastar::metrics::impl::metric_value' first required here
  317 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y))
      |                                          ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/stl_construct.h:97:39: note: in instantiation of function template specialization 'std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>::pair<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
   97 |     { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
      |                                       ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/alloc_traits.h:539:9: note: in instantiation of function template specialization 'std::construct_at<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
  539 |           std::construct_at(__p, std::forward<_Args>(__args)...);
      |                ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/hashtable_policy.h:2004:27: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, true>>>::construct<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
 2004 |             __node_alloc_traits::construct(_M_node_allocator(),
      |                                  ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/hashtable.h:307:19: note: in instantiation of function template specialization 'std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, true>>>::_M_allocate_node<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
  307 |             _M_node(__h->_M_allocate_node(std::forward<_Args>(__args)...))
      |                          ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/hashtable.h:2072:15: note: in instantiation of function template specialization 'std::_Hashtable<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, std::allocator<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>>, std::__detail::_Select1st, std::equal_to<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>>, std::hash<seastar::metrics::impl::labels_type>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>>::_Scoped_node::_Scoped_node<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
 2072 |         _Scoped_node __node { this, std::forward<_Args>(__args)...  };
      |                      ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/hashtable.h:961:11: note: in instantiation of function template specialization 'std::_Hashtable<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, std::allocator<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>>, std::__detail::_Select1st, std::equal_to<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>>, std::hash<seastar::metrics::impl::labels_type>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>>::_M_emplace<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
  961 |         { return _M_emplace(__unique_keys{}, std::forward<_Args>(__args)...); }
      |                  ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/unordered_map.h:396:16: note: in instantiation of function template specialization 'std::_Hashtable<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>, std::allocator<std::pair<const std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>>, std::__detail::_Select1st, std::equal_to<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>>, std::hash<seastar::metrics::impl::labels_type>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>>::emplace<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
  396 |         { return _M_h.emplace(std::forward<_Args>(__args)...); }
      |                       ^
/home/kefu/dev/seastar/src/core/prometheus.cc:553:21: note: in instantiation of function template specialization 'std::unordered_map<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, seastar::metrics::impl::metric_value>::emplace<std::map<seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>, const seastar::metrics::impl::metric_value &>' requested here
  553 |             _values.emplace(std::move(labels), m);
      |                     ^
1 error generated.
```