### PR TITLE
net: use designated initialization when appropriate

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -149,7 +149,7 @@ public:
         // do this ourselves, and instead set ares options
         // here, but it seems more error prone (me parsing
         // resolv.conf -> hah!)
-        ares_options a_opts = { 0, };
+        ares_options a_opts = {};
 
         // For now, use the default "fb" query order
         // (set explicitly lest we forget).


### PR DESCRIPTION
GCC encourages us to initialize all fields of a plain C struct,
which does not provide default value(s) for its member variables,
and hence does not have a default constructor.

and it warns us like:
```
/home/kefu/dev/seastar/src/net/dns.cc:152:36: error: missing field 'timeout' initializer [-Werror,-Wmissing-field-initializers]
  152 |         ares_options a_opts = { 0, };
      |                                    ^
1 error generated.
```

and per C++ standard (draft), we can just initialize fields in the order
of their declaration, and zero-initialize the missing fields. see https://eel.is/c++draft/dcl.init#list . which
defines how the fields in an object can be initialized with the
designated initializer, and if the field(s) are not in the list, they
are value-initialized, which is equivalent to zero-initialization in
this case.

so in this change, we use designated initialization to initialize the
C structs instead of initializing them using the form like `{0, }`.