### PR TITLE
metrics: change metadata vector to chunked_fifo

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -29,6 +29,8 @@
 #include <boost/functional/hash.hpp>
 #endif
 
+#include <deque>
+
 /*!
  * \file metrics_api.hh
  * \brief header file for metric API layer (like prometheus or collectd)
@@ -322,7 +324,7 @@ public:
 
 using value_map = std::map<sstring, metric_family>;
 
-using metric_metadata_vector = std::vector<metric_info>;
+using metric_metadata_fifo = std::deque<metric_info>;
 
 /*!
  * \brief holds a metric family metadata
@@ -333,7 +335,7 @@ using metric_metadata_vector = std::vector<metric_info>;
  */
 struct metric_family_metadata {
     metric_family_info mf;
-    metric_metadata_vector metrics;
+    metric_metadata_fifo metrics;
 };
 
 using value_vector = std::vector<metric_value>;
@@ -355,7 +357,7 @@ class impl {
     bool _dirty = true;
     shared_ptr<metric_metadata> _metadata;
     std::set<sstring> _labels;
-    std::vector<std::vector<metric_function>> _current_metrics;
+    std::vector<std::deque<metric_function>> _current_metrics;
     std::vector<relabel_config> _relabel_configs;
 public:
     value_map& get_value_map() {
@@ -380,7 +382,7 @@ public:
 
     shared_ptr<metric_metadata> metadata();
 
-    std::vector<std::vector<metric_function>>& functions();
+    std::vector<std::deque<metric_function>>& functions();
 
     void update_metrics_if_needed();
 

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -340,7 +340,7 @@ struct metric_family_metadata {
 
 using value_vector = std::vector<metric_value>;
 using metric_metadata = std::vector<metric_family_metadata>;
-using metric_values = std::vector<value_vector>;
+using metric_values = std::deque<value_vector>;
 
 struct values_copy {
     shared_ptr<metric_metadata> metadata;

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -366,7 +366,6 @@ foreign_ptr<values_reference> get_values() {
     auto& mv = res.values;
     res.metadata = get_local_impl()->metadata();
     auto & functions = get_local_impl()->functions();
-    mv.reserve(functions.size());
     for (auto&& i : functions) {
         value_vector values;
         values.reserve(i.size());

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -399,7 +399,7 @@ void impl::update_metrics_if_needed() {
         _current_metrics.resize(_value_map.size());
         size_t i = 0;
         for (auto&& mf : _value_map) {
-            metric_metadata_vector metrics;
+            metric_metadata_fifo metrics;
             _current_metrics[i].clear();
             for (auto&& m : mf.second) {
                 if (m.second && m.second->is_enabled()) {
@@ -426,7 +426,7 @@ shared_ptr<metric_metadata> impl::metadata() {
     return _metadata;
 }
 
-std::vector<std::vector<metric_function>>& impl::functions() {
+std::vector<std::deque<metric_function>>& impl::functions() {
     update_metrics_if_needed();
     return _current_metrics;
 }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -392,7 +392,7 @@ public:
             // does not exist, because everything is sorted by metric family name, this is fine.
             if (metadata.mf.name == name()) {
                 const mi::value_vector& values = metric_family->values[pos_in_metric_per_shard];
-                const mi::metric_metadata_vector& metrics_metadata = metadata.metrics;
+                const mi::metric_metadata_fifo& metrics_metadata = metadata.metrics;
                 for (auto&& vm : boost::combine(values, metrics_metadata)) {
                     auto& value = boost::get<0>(vm);
                     auto& metric_metadata = boost::get<1>(vm);

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -412,7 +412,7 @@ void impl::arm() {
 void impl::run() {
     typedef size_t metric_family_id;
     typedef seastar::metrics::impl::value_vector::iterator value_iterator;
-    typedef seastar::metrics::impl::metric_metadata_vector::iterator metadata_iterator;
+    typedef seastar::metrics::impl::metric_metadata_fifo::iterator metadata_iterator;
     typedef std::tuple<metric_family_id, metadata_iterator, value_iterator, type_id, cpwriter> context;
 
     auto ctxt = make_lw_shared<context>();


### PR DESCRIPTION
Upon resizing, a std::vector will allocate a large piece of contiguous memory which may become fragmented over time. This can lead to oversized allocations on the metadata vector occurring at the call to vector.emplace_back():

```cpp
void impl::update_metrics_if_needed() {
if (_dirty) {
   _metadata = ::seastar::make_shared<metric_metadata>();

   auto mt_ref = ::seastar::make_shared<metric_metadata>();
   auto &mt = *(mt_ref.get());
   mt.reserve(_value_map.size());
   _current_metrics.resize(_value_map.size());
   size_t i = 0;
   for (auto&& mf : _value_map) {
       metric_metadata_vector metrics;
       _current_metrics[i].clear();
       for (auto&& m : mf.second) {
           if (m.second && m.second->is_enabled()) {
               metrics.emplace_back(m.second->info()); // Backtrace shows overalloc occurs here
               _current_metrics[i].emplace_back(m.second->get_function());
           }
       }
       if (!metrics.empty()) {
           mt.emplace_back(metric_family_metadata{mf.second.info(), std::move(metrics)});
           i++;
       }
   }
   _current_metrics.resize(i);
   _metadata = mt_ref;
   _dirty = false;
}
}
```

Therefore, this PR switches the metadata vector with a chunked_fifo.

Fixes: https://github.com/scylladb/seastar/issues/1844

Changes from force-push `d8662a3`:
- Split the patches into two commits
- Add more explanation to why `chunked_fifo::basic_iterator` needs a default ctor

Changes from force-push `55d6663`:
- Reduce more potential overallocs in member `_current_metrics` by switching `std::vector<std::vector<metric_function>>` to `std::vector<chunked_fifo<metric_function>>`
- Reduce more potential overallocs in `values_copy::values` by changing `metrics_values` to a `std::deque` 

Changes from force-push `be869b7`:
- Commit https://github.com/scylladb/seastar/commit/3e9321cb46d30adf0d12ff24e401d718e619de0b added a default ctor to `chunked_fifo::basic_iterator`, so this force-push dropped the commit in this patch that added the same default ctor.

Changes from force-push `8a06f57`:
- Changed `chunked_fifo` to a `std::deque`