### PR TITLE
Cleanup class metrics::registered_metrics

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -210,14 +210,13 @@ public:
 
 class impl;
 
-class registered_metric {
+class registered_metric final {
     metric_info _info;
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
     registered_metric(metric_id id, metric_function f, bool enabled=true, skip_when_empty skip=skip_when_empty::no);
-    virtual ~registered_metric() {}
-    virtual metric_value operator()() const {
+    metric_value operator()() const {
         return _f();
     }
 

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -240,7 +240,7 @@ public:
     metric_info& info() {
         return _info;
    }
-    metric_function& get_function() {
+    const metric_function& get_function() const {
         return _f;
     }
 };

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -216,9 +216,6 @@ class registered_metric final {
     shared_ptr<impl> _impl;
 public:
     registered_metric(metric_id id, metric_function f, bool enabled=true, skip_when_empty skip=skip_when_empty::no);
-    metric_value operator()() const {
-        return _f();
-    }
 
     bool is_enabled() const {
         return _info.enabled;

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -582,7 +582,7 @@ std::vector<collectd_value> get_collectd_value(
         const scollectd::type_instance_id& id) {
     std::vector<collectd_value> vals;
     const seastar::metrics::impl::registered_metric& val = *get_register(id);
-    vals.push_back(val());
+    vals.push_back(val.get_function()());
     return vals;
 }
 


### PR DESCRIPTION
It had changed since it was first introduced and can be brushed up a little bit:

- make it non-virtual class
- mark value-function getter const
- remove now unused operator()