### PR TITLE
util: add formatter using IEC/SI units

### DIFF
--- a/include/seastar/util/conversions.hh
+++ b/include/seastar/util/conversions.hh
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <string_view>
 #include <vector>
+#include <fmt/format.h>
 #endif
 #include <seastar/util/modules.hh>
 
@@ -49,6 +50,13 @@ namespace seastar {
 SEASTAR_MODULE_EXPORT
 size_t parse_memory_size(std::string_view s);
 
+class data_size {
+    const size_t _value;
+    friend struct fmt::formatter<seastar::data_size>;
+public:
+    data_size(size_t value) : _value{value} {}
+};
+
 static inline std::vector<char> string2vector(std::string_view str) {
     auto v = std::vector<char>(str.begin(), str.end());
     v.push_back('\0');
@@ -56,3 +64,38 @@ static inline std::vector<char> string2vector(std::string_view str) {
 }
 
 }
+
+// print data_size using IEC or SI unit annotation
+// usage:
+//   fmt::print("{}", 10'024); // prints "10Ki"
+//   fmt::print("{:i}b", 42); // prints "42b"
+//   fmt::print("{:i}B", 10'024); // prints "10KiB", IEC unit is used
+//   fmt::print("{:s}B", 10'000); // prints "10kB", SI unit is used
+SEASTAR_MODULE_EXPORT
+template <>
+struct fmt::formatter<seastar::data_size> {
+    enum class prefix_type {
+        SI,
+        IEC,
+    };
+    prefix_type _prefix = prefix_type::IEC;
+    constexpr auto parse(format_parse_context& ctx) {
+        auto it = ctx.begin();
+        auto end = ctx.end();
+        if (it != end) {
+            if (*it == 's') {
+                _prefix = prefix_type::SI;
+                ++it;
+            } else if (*it == 'i') {
+                _prefix = prefix_type::IEC;
+                ++it;
+            }
+        }
+        if (it != end && *it != '}') {
+            ctx.on_error("invalid format");
+        }
+        return it;
+    }
+    template <typename FormatContext>
+    auto format(const seastar::data_size size, FormatContext& ctx) const -> decltype(ctx.out());
+};

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -273,6 +273,9 @@ seastar_add_test (connect
 seastar_add_test (content_source
   SOURCES content_source_test.cc)
 
+seastar_add_test (conversion
+  SOURCES conversion_test.cc)
+
 seastar_add_test (coroutines
   SOURCES coroutines_test.cc)
 

--- a/tests/unit/conversion_test.cc
+++ b/tests/unit/conversion_test.cc
@@ -1,0 +1,68 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright 2023 ScyllaDB
+ */
+#define BOOST_TEST_MODULE util
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/core/units.hh>
+#include <seastar/util/conversions.hh>
+
+using namespace seastar;
+
+BOOST_AUTO_TEST_CASE(format_iec) {
+    struct {
+        size_t n;
+        std::string_view formatted;
+    } sizes[] = {
+       {0, "0"},
+       {42, "42"},
+       {10_KiB, "10Ki"},
+       {10_MiB, "10Mi"},
+       {10_GiB, "10Gi"},
+       {10_TiB, "10Ti"},
+       {10'000_TiB, "10000Ti"},
+    };
+    for (auto [n, expected] : sizes) {
+        std::string actual;
+        fmt::format_to(std::back_inserter(actual), "{:i}", data_size{n});
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(format_si) {
+    struct {
+        size_t n;
+        std::string_view formatted;
+    } sizes[] = {
+       {0ULL, "0"},
+       {42ULL, "42"},
+       {10'000ULL, "10k"},
+       {10'000'000ULL, "10M"},
+       {10'000'000'000ULL, "10G"},
+       {10'000'000'000'000ULL, "10T"},
+       {10'000'000'000'000'000ULL, "10000T"},
+    };
+    for (auto [n, expected] : sizes) {
+        std::string actual;
+        fmt::format_to(std::back_inserter(actual), "{:s}", data_size{n});
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}


### PR DESCRIPTION
to ease the printing the size of information content, like the bandwidth and size of file. a data_size type and its formatter is defined.