### PR TITLE
build: append JOB_POOLS definition instead of setting it

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -526,9 +526,6 @@ function(seastar_add_certgen name)
 
   find_program(OPENSSL openssl)
 
-  # Some openssl commands read and write the serial number file (.srl). These can't be executed in parallel.
-  set_property(GLOBAL PROPERTY JOB_POOLS openssl_serial=1)
-
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}"
     COMMAND ${OPENSSL} genpkey -quiet -out ${CERT_PRIVKEY} -algorithm ${CERT_ALG} ${CERT_ALG_OPTS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -568,6 +565,9 @@ function(seastar_gen_mtls_certs)
   set(EXTENSION "subjectAltName = IP:127.0.0.1")
   set(CLIENT1_SUBJECT "/C=GB/ST=London/L=London/O=Redpanda Data/OU=Core/CN=client1.org")
   set(CLIENT2_SUBJECT "/C=GB/ST=London/L=London/O=Redpanda Data/OU=Core/CN=client2.org")
+
+  # Some openssl commands read and write the serial number file (.srl). These can't be executed in parallel.
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS openssl_serial=1)
 
   add_custom_command(OUTPUT mtls_ca.key
     COMMAND ${OPENSSL} ecparam -name prime256v1 -genkey -noout -out mtls_ca.key


### PR DESCRIPTION
in 18f43a0c7b148765853f47d3f5d562f53efe832e, a job definition is added for serialization the calls to openssl commands. it sets the global property named "JOB_POOL". assuming we have a parent project which uses Seastar. if:

- it is also using CMake and include Seastar as a subdirectory in its CMake building system, and
- it is also using "JOB_POOL", and
- it sets this variable before Seastar does. this variable's value will be overwritten by Seastar. and all of the targets using the pool(s) defined by it won't be able to find the defined pool(s) anymore.

the typical error message would look like

```
CMake Error:
  Running

   '/home/kefu/.local/bin/ninja' '-C' '/home/kefu/dev/scylladb/build/cmake-test' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:1360: unknown pool name 'link_pool'
```

where CMake is able to create the building system. but ninja is not able to find the definition of the pool.

so, in order to address this problem, in this changes

1. move the command which sets the JOB_POOLS property closer to where this pool is used.
2. instead of setting the property, add "openssl_serial=1" to to it. so the existing value of this property is not overwritten.

since `seastar_gen_mtls_certs()` is only called once, and is not supposed to be reused. we don't need to worry about failures like:

```
   ninja: error: CMakeFiles/rules.ninja:26: duplicate pool 'openssl_serial'
```