### PR TITLE
core: undefine fallthrough to fix compilation error

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -43,6 +43,13 @@ module;
 #include <unistd.h>
 #include <fcntl.h>
 #include <xfs/linux.h>
+/*
+ * With package xfsprogs-devel >= 5.14.1, `fallthrough` has defined to
+ * fix compilation warning in header <xfs/linux.h>,
+ * (see: https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=df9c7d8d8f3ed0785ed83e7fd0c7ddc92cbfbe15)
+ * There is a confliction with c++ keyword `fallthrough`, so undefine fallthrough here.
+ */
+#undef fallthrough   
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -72,6 +72,13 @@ module;
 #include <sys/ioctl.h>
 #include <linux/perf_event.h>
 #include <xfs/linux.h>
+/*
+ * With package xfsprogs-devel >= 5.14.1, `fallthrough` has defined to
+ * fix compilation warning in header <xfs/linux.h>,
+ * (see: https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=df9c7d8d8f3ed0785ed83e7fd0c7ddc92cbfbe15)
+ * There is a confliction with c++ keyword `fallthrough`, so undefine fallthrough here.
+ */
+#undef fallthrough
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min


### PR DESCRIPTION
With package xfsprogs-devel >= 5.14.1, `fallthrough` has defined to fix compilation warning in header <xfs/linux.h>,
(see: https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=df9c7d8d8f3ed0785ed83e7fd0c7ddc92cbfbe15) There is a confliction with c++ keyword `fallthrough`, hence compilation error occurs like:
```
FAILED: CMakeFiles/seastar.dir/src/core/file.cc.o
/usr/bin/g++ -DFMT_LOCALE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BROKEN_SOURCE_LOCATION -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -I/home/seastar/include -I/home/seastar/build/release/gen/include -I/home/seastar/src -O2 -g -DNDEBUG -U_FORTIFY_SOURCE -Wno-maybe-uninitialized -DSEASTAR_SSTRING -Wno-error=unused-result -UNDEBUG -Wall -Werror -Wno-array-bounds -Wno-error=deprecated-declarations -fvisibility=hidden -gz -std=gnu++2a -MD -MT CMakeFiles/seastar.dir/src/core/file.cc.o -MF CMakeFiles/seastar.dir/src/core/file.cc.o.d -o CMakeFiles/seastar.dir/src/core/file.cc.o -c /home/seastar/src/core/file.cc
In file included from /usr/include/fmt/format.h:44,
                 from /usr/include/fmt/ostream.h:13,
                 from /home/seastar/include/seastar/core/sstring.hh:41,
                 from /home/seastar/include/seastar/core/scheduling.hh:29,
                 from /home/seastar/include/seastar/core/task.hh:24,
                 from /home/seastar/include/seastar/core/future.hh:36,
                 from /home/seastar/include/seastar/core/timer.hh:24,
                 from /home/seastar/include/seastar/core/condition-variable.hh:31,
                 from /home/seastar/include/seastar/core/reactor.hh:28,
                 from /home/seastar/src/core/file.cc:55:
/usr/include/fmt/core.h:188:42: error: missing ')' after "__has_attribute"
  188 | #elif FMT_HAS_CPP17_ATTRIBUTE(fallthrough) || \
      |                                          ^
/usr/include/fmt/core.h:188:31: error: missing binary operator before token "("
  188 | #elif FMT_HAS_CPP17_ATTRIBUTE(fallthrough) || \
      |                               ^~~~~~~~~~~
In file included from /home/seastar/src/core/file.cc:45:
/usr/include/boost/container/detail/copy_move_algo.hpp: In function ‘typename boost::move_detail::enable_if_c<(boost::container::dtl::is_memtransfer_copy_assignable<F, G>::value && true), void>::type boost::container::deep_swap_alloc_n(Allocator&, F, std::size_t, G, std::size_t)’:
/usr/include/boost/container/detail/copy_move_algo.hpp:1093:10: error: ‘__fallthrough__’ was not declared in this scope; did you mean ‘fallthrough’?
 1093 |          BOOST_FALLTHROUGH;
      |          ^~~~~~~~~~~~~~~~~
```
so undefine macro `fallthrough` to fix compilation error.