### PR TITLE
build: pass -DBOOST_NO_CXX98_FUNCTION_BASE to C++ compiler

### DIFF
--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -45,6 +45,10 @@ endif ()
 
 # This is the minimum version of Boost we need the CMake-bundled `FindBoost.cmake` to know about.
 find_package (Boost ${_seastar_boost_version} MODULE)
+if (BOOST_VERSION_STRING VERSION_LESS 1.81.0)
+  set_target_properties (Boost::boost PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "BOOST_NO_CXX98_FUNCTION_BASE")
+endif ()
 
 # - set _seastar_dep_args_<package> for additional args for find_package().
 #   add REQUIRED if the corresponding option is explicitly enabled, so


### PR DESCRIPTION
std::unary_function was deprecated in C++11, and was removed in C++17. but Boost::container is still using it. libstdc++ keeps it around even compiles with C++20 standard, while libc++ just keeps us away from it when compiling with C++20, and we would have following compiling error:

```
FAILED: CMakeFiles/seastar.dir/src/core/memory.cc.o
/usr/lib64/ccache/clang -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_URING -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/clang-libcxx/gen/include -I/home/kefu/dev/seastar/src -stdlib=libc++ -O3 -DNDEBUG -std=gnu++20 -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Wno-error=unused-result "-Wno-error=#warnings" -UNDEBUG -Wall -Wno-array-bounds -Wno-error=deprecated-declarations -fvisibility=hidden -gz -MD -MT CMakeFiles/seastar.dir/src/core/memory.cc.o -MF CMakeFiles/seastar.dir/src/core/memory.cc.o.d -o CMakeFiles/seastar.dir/src/core/memory.cc.o -c /home/kefu/dev/seastar/src/core/memory.cc
In file included from /home/kefu/dev/seastar/src/core/memory.cc:95:
In file included from /home/kefu/dev/seastar/include/seastar/core/memory.hh:24:
In file included from /home/kefu/dev/seastar/include/seastar/core/resource.hh:34:
In file included from /usr/include/boost/any.hpp:20:
In file included from /usr/include/boost/type_index.hpp:29:
In file included from /usr/include/boost/type_index/stl_type_index.hpp:47:
/usr/include/boost/container_hash/hash.hpp:132:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
  132 |         struct hash_base : std::unary_function<T, std::size_t> {};
      |                            ~~~~~^
/usr/include/c++/v1/__functional/unary_function.h:46:1: note: '__unary_function' declared here
   46 | using __unary_function = __unary_function_keep_layout_base<_Arg, _Result>;
      | ^
1 error generated.
```

this is a bug in Boost, and it was fixed for libstdc++ and libc++ in v1.80.0 and v1.81.0 respectively. but the stable releases of quite a few mainstream distros come with earlier Boost versions, for instance, at the time of writing, Debian bookworm ships 1.74.0, Fedora fc38 boost 1.78.0. so to cater the needs of developers working these distros, we need to define `BOOST_NO_CXX98_FUNCTION_BASE` to prevent Boost from using the deprecated/removed C++ template. see also https://www.boost.org/doc/libs/1_82_0/libs/config/doc/html/boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_describe_features_that_have_been_removed_from_the_standard_

to be on the safe side, and to have a simpler CMake building system, we just check the Boost's version, instead of checking combination of the used C++ standard library and Boost's version.

see also https://github.com/boostorg/container_hash/issues/22