### PR TITLE
rpc: Make server._proto a reference

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -597,7 +597,7 @@ public:
         future<> deregister_this_stream();
     };
 private:
-    protocol_base* _proto;
+    protocol_base& _proto;
     server_socket _ss;
     resource_limits _limits;
     rpc_semaphore _resources_available;


### PR DESCRIPTION
Now it's a pointer, but it's non-nullptr all the time and never changes