### PR TITLE
RPC metrics

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -293,10 +293,6 @@ protected:
     // if it is not ready it means the sink is been closed
     future<bool> _sink_closed_future = make_ready_future<bool>(false);
 
-    size_t outgoing_queue_length() const noexcept {
-        return _outgoing_queue_size;
-    }
-
     void set_negotiated() noexcept;
 
     bool is_stream() const noexcept {
@@ -322,6 +318,10 @@ public:
     }
     connection(const logger& l, void* s, connection_id id = invalid_connection_id) : _logger(l), _serializer(s), _id(id) {}
     virtual ~connection() {}
+    size_t outgoing_queue_length() const noexcept {
+        return _outgoing_queue_size;
+    }
+
     void set_socket(connected_socket&& fd);
     future<> send_negotiation_frame(feature_map features);
     bool error() const noexcept { return _error; }
@@ -490,6 +490,10 @@ public:
     client(const logger& l, void* s, client_options options, socket socket, const socket_address& addr, const socket_address& local = {});
 
     stats get_stats() const;
+    size_t incoming_queue_length() const noexcept {
+        return _outstanding.size();
+    }
+
     auto next_message_id() { return _message_id++; }
     void wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel);
     void wait_timed_out(id_type id);

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -117,6 +117,7 @@ struct client_options {
     ///
     /// \see resource_limits::isolate_connection
     sstring isolation_cookie;
+    sstring metrics_domain = "default";
 };
 
 /// @}
@@ -433,6 +434,24 @@ class client : public rpc::connection, public weakly_referencable<client> {
         };
     };
 
+    class metrics {
+        struct domain;
+
+        using domain_member_hook_t = boost::intrusive::list_member_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
+
+        const client& _c;
+        domain& _domain;
+        domain_member_hook_t _link;
+
+        using domain_list_t = boost::intrusive::list<metrics,
+              boost::intrusive::member_hook<metrics, metrics::domain_member_hook_t, &metrics::_link>,
+              boost::intrusive::constant_time_size<false>>;
+
+    public:
+        metrics(const client&);
+        ~metrics();
+    };
+
     void enqueue_zero_frame();
 public:
     template<typename Reply, typename Func>
@@ -458,6 +477,8 @@ private:
     socket_address _server_addr, _local_addr;
     client_options _options;
     weak_ptr<client> _parent; // for stream clients
+
+    metrics _metrics;
 
 private:
     future<> negotiate_protocol(feature_map map);
@@ -519,6 +540,7 @@ public:
             client_options o = _options;
             o.stream_parent = this->get_connection_id();
             o.send_timeout_data = false;
+            o.metrics_domain += "_stream";
             auto c = make_shared<client>(_logger, _serializer, o, std::move(socket), _server_addr, _local_addr);
             c->_parent = this->weak_from_this();
             c->_is_stream = true;

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -739,7 +739,7 @@ namespace rpc {
 
   stats client::get_stats() const {
       stats res = _stats;
-      res.wait_reply = _outstanding.size();
+      res.wait_reply = incoming_queue_length();
       res.pending = outgoing_queue_length();
       return res;
   }

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -815,6 +815,7 @@ namespace rpc {
 
   struct client::metrics::domain {
       metrics::domain_list_t list;
+      stats dead;
 
       static thread_local std::unordered_map<sstring, domain> all;
       static domain& find_or_create(sstring name);
@@ -839,6 +840,10 @@ namespace rpc {
   }
 
   client::metrics::~metrics() {
+      _domain.dead.replied += _c._stats.replied;
+      _domain.dead.exception_received += _c._stats.exception_received;
+      _domain.dead.sent_messages += _c._stats.sent_messages;
+      _domain.dead.timeout += _c._stats.timeout;
   }
 
   client::client(const logger& l, void* s, client_options ops, socket socket, const socket_address& addr, const socket_address& local)


### PR DESCRIPTION
RPC connections already collect some stats about themselves, but these stats are not registered in metrics layer. There main question here is the granularity of reporting -- per-connection, ~~node~~shard-wide or in groups. The grouping seems the most appropriate way, but RPC layer itself has little glues to how group the sockets, so the groups configuration is up to the application and this PR provides the facilities for such grouping.

refs: #323 