### PR TITLE
Print more IO info with ioinfo app

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -55,6 +55,8 @@ int main(int ac, char** av) {
                             auto& ioq = engine().get_io_queue(st.st_dev);
                             auto& cfg = ioq.get_config();
 
+                            out << YAML::Key << "io_latency_goal_ms" << YAML::Value <<
+                                    std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(cfg.rate_limit_duration).count();
                             out << YAML::Key << "io_queue" << YAML::BeginMap;
                             out << YAML::Key << "req_count_rate" << YAML::Value << cfg.req_count_rate;
                             out << YAML::Key << "blocks_count_rate" << YAML::Value << cfg.blocks_count_rate;

--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -61,6 +61,22 @@ int main(int ac, char** av) {
                             out << YAML::Key << "disk_req_write_to_read_multiplier" << YAML::Value << cfg.disk_req_write_to_read_multiplier;
                             out << YAML::Key << "disk_blocks_write_to_read_multiplier" << YAML::Value << cfg.disk_blocks_write_to_read_multiplier;
                             out << YAML::EndMap;
+
+                            out << YAML::Key << "fair_queue" << YAML::BeginMap;
+                            out << YAML::Key << "capacities" << YAML::BeginMap;
+                            auto request_io_capacity = [&ioq] (internal::io_direction_and_length dnl) {
+                                auto stream = ioq.request_stream(dnl);
+                                auto ticket = internal::make_ticket(dnl, ioq.get_config());
+                                return internal::get_fair_group(ioq, stream).ticket_capacity(ticket);
+                            };
+                            for (size_t sz = 512; sz <= 128 * 1024; sz <<= 1) {
+                                out << YAML::Key << sz << YAML::BeginMap;
+                                out << YAML::Key << "read" << YAML::Value << request_io_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, sz));
+                                out << YAML::Key << "write" << YAML::Value << request_io_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, sz));
+                                out << YAML::EndMap;
+                            }
+                            out << YAML::EndMap;
+                            out << YAML::EndMap;
                         });
                     });
                 });

--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -76,6 +76,18 @@ int main(int ac, char** av) {
                                 out << YAML::EndMap;
                             }
                             out << YAML::EndMap;
+
+                            const auto& fg = internal::get_fair_group(ioq, internal::io_direction_and_length::write_idx);
+                            out << YAML::Key << "cost_capacity" << YAML::Value << format("{}", fg.cost_capacity());
+                            out << YAML::Key << "per_tick_grab_threshold" << YAML::Value << fg.per_tick_grab_threshold();
+
+                            const auto& tb = fg.token_bucket();
+                            out << YAML::Key << "token_bucket" << YAML::BeginMap;
+                            out << YAML::Key << "limit" << YAML::Value << tb.limit();
+                            out << YAML::Key << "rate" << YAML::Value << tb.rate();
+                            out << YAML::Key << "threshold" << YAML::Value << tb.threshold();
+                            out << YAML::EndMap;
+
                             out << YAML::EndMap;
                         });
                     });

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -261,6 +261,8 @@ public:
         std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
         return std::chrono::duration_cast<std::chrono::duration<double>>(dur);
     }
+
+    const token_bucket_t& token_bucket() const noexcept { return _token_bucket; }
 };
 
 /// \brief Fair queuing class

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -40,6 +40,11 @@ struct io_queue_for_tests;
 
 namespace seastar {
 
+class io_queue;
+namespace internal {
+const fair_group& get_fair_group(const io_queue& ioq, unsigned stream);
+}
+
 #if SEASTAR_API_LEVEL < 7
 SEASTAR_MODULE_EXPORT
 class io_priority_class;
@@ -97,6 +102,8 @@ private:
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;
+    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
     future<size_t> queue_one_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
@@ -199,6 +206,7 @@ public:
 private:
     friend class io_queue;
     friend struct ::io_queue_for_tests;
+    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
     const io_queue::config _config;
     size_t _max_request_length[2];

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -223,4 +223,8 @@ inline dev_t io_queue::dev_id() const noexcept {
     return get_config().devid;
 }
 
+namespace internal {
+fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept;
+}
+
 }

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -111,8 +111,6 @@ fair_group::fair_group(config cfg, unsigned nr_queues)
         , _per_tick_threshold(_token_bucket.limit() / nr_queues)
 {
     assert(_cost_capacity.is_non_zero());
-    seastar_logger.info("Created fair group {} for {} queues, capacity rate {}, limit {}, rate {} (factor {}), threshold {}, per tick grab {}", cfg.label, nr_queues,
-            _cost_capacity, _token_bucket.limit(), _token_bucket.rate(), cfg.rate_factor, _token_bucket.threshold(), _per_tick_threshold);
 
     if (cfg.rate_factor * fixed_point_factor > _token_bucket.max_rate) {
         throw std::runtime_error("Fair-group rate_factor is too large");

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -580,7 +580,7 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
 
 static void maybe_warn_latency_goal_auto_adjust(const fair_group& fg, const io_queue::config& cfg) noexcept {
     auto goal = fg.rate_limit_duration();
-    auto lvl = goal > 1.1 * cfg.rate_limit_duration ? log_level::warn : log_level::info;
+    auto lvl = goal > 1.1 * cfg.rate_limit_duration ? log_level::warn : log_level::debug;
     seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, cfg.devid);
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -64,8 +64,6 @@ using io_direction_and_length = internal::io_direction_and_length;
 static constexpr auto io_direction_read = io_direction_and_length::read_idx;
 static constexpr auto io_direction_write = io_direction_and_length::write_idx;
 
-static fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept;
-
 struct default_io_exception_factory {
     static auto cancelled() {
         return cancelled_error();
@@ -291,7 +289,7 @@ public:
         : io_request(std::move(req))
         , _ioq(q)
         , _stream(_ioq.request_stream(dnl))
-        , _fq_entry(make_ticket(dnl, _ioq.get_config()))
+        , _fq_entry(internal::make_ticket(dnl, _ioq.get_config()))
         , _desc(std::make_unique<io_desc_read_write>(_ioq, pc, _stream, dnl, _fq_entry.ticket(), std::move(iovs)))
     {
     }
@@ -624,7 +622,7 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
         auto g_idx = _config.duplex ? idx : 0;
         auto max_cap = _fgs[g_idx]->maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
-            auto ticket = make_ticket(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
+            auto ticket = internal::make_ticket(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
             auto cap = _fgs[g_idx]->ticket_capacity(ticket);
             if (cap > max_cap) {
                 if (shift == 0) {
@@ -893,7 +891,7 @@ stream_id io_queue::request_stream(io_direction_and_length dnl) const noexcept {
     return get_config().duplex ? dnl.rw_idx() : 0;
 }
 
-fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
+fair_queue_ticket internal::make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
     struct {
         unsigned weight;
         unsigned size;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -530,6 +530,10 @@ sstring io_request::opname() const {
     std::abort();
 }
 
+const fair_group& get_fair_group(const io_queue& ioq, unsigned stream) {
+    return *(ioq._group->_fgs[stream]);
+}
+
 } // internal namespace
 
 void


### PR DESCRIPTION
On start reactor and io-queue do some math calculating IO-queue's configuration. For the ease of debugging all this math was printed into log with info level. Now it's more-or-less stable and predictable, so the printing can be dropped not to make too many noise into logs. To still have the ability to get the math results there's ioinfo app out there that's extended by this PR to print all internal IO scheduler configuration

fixes: #1428