### PR TITLE
rpc: Fix client-side stream registration race

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -519,6 +519,9 @@ public:
             c->_parent = this->weak_from_this();
             c->_is_stream = true;
             return c->await_connection().then([c, this] {
+                if (_error) {
+                    throw closed_error();
+                }
                 xshard_connection_ptr s = make_lw_shared(make_foreign(static_pointer_cast<rpc::connection>(c)));
                 this->register_stream(c->get_connection_id(), s);
                 return sink<Out...>(make_shared<sink_impl<Serializer, Out...>>(std::move(s)));


### PR DESCRIPTION
Client-side stream socket is made by client::make_stream_sink() call. The stream creation consists of

- wait for "this" to finish negotiation
- make new client (this issues connect() and negotiation in the background)
- wait for the new socket negotiation to finish
- .then([] { register new socket to "this" socket })

The last step is racy. After the new socket negotiation succeeds the parent socket (called "this" above) may receive "peer closed" from the kernel and start demolishing the client. The latter means aborting all streams, that happens in one non-preemptive and non-waiting loop. So in case the new stream wasn't _yet_ registered, it won't be aborted and will wait for the server-side stream to terminate (which also may never happen, see #1732)