### PR TITLE
app-template: allow reserving -h for the application

### DIFF
--- a/include/seastar/core/app-template.hh
+++ b/include/seastar/core/app-template.hh
@@ -106,6 +106,13 @@ public:
         /// You can adjust the behavior of SIGINT/SIGTERM by installing signal handlers
         /// via reactor::handle_signal().
         bool auto_handle_sigint_sigterm = true;
+        /// \brief Reserve -h for the application
+        ///
+        /// Normally, -h is the short-form for --help.
+        /// Some applications however might want to reserve -h for their own use.
+        /// Set this option to true, to reserve -h for the application. In this
+        /// case, --help will not have a short-form option.
+        bool reserve_dash_h = false;
         /// Configuration options for the reactor.
         reactor_options reactor_opts;
         /// Configuration for the metrics sub-system.

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -85,9 +85,15 @@ app_template::app_template(app_template::seastar_options opts)
         if (!alien::internal::default_instance) {
             alien::internal::default_instance = _alien.get();
         }
-        _app_opts.add_options()
-                ("help,h", "show help message")
-                ;
+        if (opts.reserve_dash_h) {
+            _app_opts.add_options()
+                    ("help", "show help message")
+                    ;
+        } else {
+            _app_opts.add_options()
+                    ("help,h", "show help message")
+                    ;
+        }
         _app_opts.add_options()
                 ("help-seastar", "show help message about seastar options")
                 ;


### PR DESCRIPTION
Normally, -h is the short-form of --help. Some applications however may wish to reserve -h as the short-form of another option. Allow this via a new option: app_template::seastar_options::reserve_dash_h. When set to true, seastar will only register --help, without a short-form.