### PR TITLE
Slowdown IO scheduler based on dispatched/completed ratio

### DIFF
--- a/doc/io-scheduler.md
+++ b/doc/io-scheduler.md
@@ -1,0 +1,117 @@
+IO scheduler uses rate-limiter to throttle the amount of data it dispatches into the disk.
+
+# Basic math
+
+The scheduler's main equation that models the disk behavior is
+
+$$ \frac {bandwidth_r} {bandwidth_{r_{max}}} +
+   \frac {bandwidth_w} {bandwidth_{w_{max}}} +
+   \frac {iops_r} {iops_{r_{max}}} +
+   \frac {iops_w} {iops_{w_{max}}} \le 1.0 $$
+
+Let's say that
+
+$$ m_b = \frac {bandwidth_{r_{max}}} {bandwidth_{w_{max}}} \ \ m_o = \frac {iops_{r_{max}}} {iops_{w_{max}}} $$
+
+Since
+
+$$ bandwidth_x = \frac {d}{dt} bytes_x \ \ iops_x = \frac {d}{dt} ios_x $$
+
+The main equation turns into
+
+$$ \frac {d}{dt} \( \frac {bytes_r + m_b \times bytes_w} {bandwidth_{r_{max}}} + \frac {ios_r + m_o \times ios_w} {iops_{r_{max}}} \) \le 1.0 $$
+
+Requests are asigned a 2d value of _{1, bytes}_ for reads and _{m<sub>o</sub>, m<sub>b</sub> * bytes}_ for writes called "tickets"
+
+The "normalization" operation is defined as
+
+$$ N(ticket) = \frac {ticket_0}{iops_{r_{max}}} + \frac {ticket_1}{bandwidth_{r_{max}}} $$
+
+With that the main equation turns into 
+
+$$ \frac {d}{dt} \sum_{ticket} N(ticket) \le 1.0 $$
+
+The time-derivative limitation is then implemented with the token bucket algorithm
+
+# Token bucket
+
+The algorithm creates token bucket with the refill rate of _1.0_ and each request wants to carry the fractional token value of _tokens = N(ticket)_ with _ticket_ defined above
+
+The bucket additionally requires the _limit_ parameter which is the maximum number of tokens the bucket may hold. This value is calculated using the _io_latency_goal_ parameter, to be the amount of tokens accumulated for the _io_latency_goal_ duration
+
+# Slowing down the flow
+
+Let's assume we need to reduce the rate of request run-time. This means that we want to
+
+$$ \frac {d}{dt} \( \frac {bytes_r + m_b \times bytes_w} {bandwidth_{r_{max}} \times \alpha} + \frac {ios_r + m_o \times ios_w} {iops_{r_{max}} \times \beta} \) \le 1.0 \ \  \alpha \le 1.0 \ \beta \le 1.0 $$
+
+There are many ways of selecting which of IOPS or bandwidth to reduce, the "general" slowing down may assume that
+
+$$ \alpha = \beta = \frac {1}{\gamma} , \ \ \ \gamma \ge 1.0 $$
+
+The main equation then turns into
+
+$$ \frac {d}{dt} \sum_{ticket} \gamma \times N(ticket) \le 1.0 $$
+
+which in turn means, that we can just multiply the request cost (in tokens) by some number above 1.0
+
+# Detecting the slowdown
+
+Let's say that
+
+_d<sub>i</sub>_ -- the amount of requests dispatched at tick _i_
+_p<sub>i</sub>_ -- the amount of requests processed by disk at tick _i_
+_c<sub>i</sub>_ -- the amount of requests completed by reactor loop at tick _i_
+
+We can observe _d<sub>i</sub>_ and _c<sub>i</sub>_ in the dispatcher, but _not_ the _p<sub>i</sub>_, because we don't have direct access to disks' queues
+
+After _n_ ticks we have 
+
+_D<sub>n</sub>_ -- total amount of requests dispatched, 
+_P<sub>n</sub>_ -- total amount of requests processed, 
+_C<sub>n</sub>_ -- total amount of requests completed, 
+
+$$ D_n = \sum_{i=0}^n d_i $$
+
+$$ P_n = \sum_{i=0}^n p_i $$
+
+$$ C_n = \sum_{i=0}^n c_i $$
+
+* Disk cannot process more than it was dispatched, but it can process less "accumulating" a queue
+
+$$ d_i \ge p_i   \Rightarrow  D_n \ge P_n$$
+
+* Reactor cannot complete more than it was processed by disk either
+
+$$ p_i \ge c_i \Rightarrow P_n \ge C_n $$
+
+
+Note that _D<sub>n</sub> > P<sub>n</sub>_  means that disk is falling behind. Our goal is to make sure the disk doesn't do it and doesn't accumulate the queue, i.e. _D<sub>n</sub> = P<sub>n</sub>_, but we cannot observe _P<sub>n</sub>_ directly, only _C<sub>n</sub>_.
+
+Next
+
+$$ D_n - P_n = Qd_n \ge 0 $$
+
+$$ P_n - C_n = Qc_n \ge 0 $$
+
+$$ D_n - C_N = Qd_n + Qc_n \ge 0 $$
+
+_Qd<sub>n</sub>_ is the queue accumulated in disk. We try to avoid it. _Qc<sub>n</sub>_ is the accumulated delta between processed (by disk) and completed (by reactor) requests. We cannot reliably say that it goes to zero over time, because there's always some unknown amount of processed but not yet completed requests. So the above formula contains two unknowns and we cannot solve it. Let's try the other way
+
+$$ \frac {D_n} {P_n} = Rd_n \ge 1 $$
+
+$$ \frac {P_n} {C_n} = Rc_n \ge 1 $$
+
+$$ \frac {D_n} {C_n} = Rd_n \times Rc_n \ge 1 $$
+
+_Rd<sub>n</sub>_ is the ratio of dispatched to processed requests. If it's 1, we're OK, if it's greater, disk is accumulating the queue, we try to avoid it. _Rc<sub>n</sub>_ is the ratio between processed (by disk) and completed (by reactor) requests. It has a not immediately apparent, but very pretty property
+
+$$ \lim_{n\to\infty} Rc_n = \lim_{n\to\infty} \frac {P_n} {C_n} = \lim_{n\to\infty} \frac {C_n + Qc_n} { C_n} = \lim_{n\to\infty} \(1 +  \frac {Qc_n} {C_n} \) = 1 + \lim_{n\to\infty} \frac {Qc_n} {C_n}$$
+
+The _Qc<sub>n</sub>_ doesn't grow over time. It's non-zero, but it's upper bound by some value. Respectively
+
+$$ \lim_{n\to\infty} Rc_n = 1 $$
+
+$$ \lim_{n\to\infty} \frac {D_n} {C_n} = \lim_{n\to\infty} \( Rd_n \times Rc_n \) =  \lim_{n\to\infty} Rd_n  $$
+
+IOW -- we can say if the disk is accumulating the queue or not by observing the dispatched-to-completed (to _completed_, not _processed_) over a long enough time 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -191,7 +191,7 @@ public:
 
     static constexpr float fixed_point_factor = float(1 << 24);
     using rate_resolution = std::milli;
-    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::yes>;
+    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::no>;
 
 private:
 
@@ -255,7 +255,6 @@ public:
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
     capacity_t grab_capacity(capacity_t cap) noexcept;
     clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
-    void release_capacity(capacity_t cap) noexcept;
     void replenish_capacity(clock_type::time_point now) noexcept;
     void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -393,6 +393,10 @@ public:
         return _group.tokens_capacity(tokens);
     }
 
+    capacity_t maximum_capacity() const noexcept {
+        return _group.maximum_capacity();
+    }
+
     /// Queue the entry \c ent through this class' \ref fair_queue
     ///
     /// The user of this interface is supposed to call \ref notify_requests_finished when the

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -114,6 +114,8 @@ private:
     // decoupling and is temporary
     size_t _queued_requests = 0;
     size_t _requests_executing = 0;
+    uint64_t _requests_dispatched = 0;
+    uint64_t _requests_completed = 0;
 public:
 
     using clock_type = std::chrono::steady_clock;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -157,6 +157,7 @@ public:
         size_t block_count_limit_min = 1;
         unsigned flow_ratio_ticks = 100;
         double flow_ratio_ema_factor = 0.95;
+        double flow_ratio_backpressure_threshold = 1.1;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -126,6 +126,7 @@ private:
 
     void update_flow_ratio() noexcept;
 
+    metrics::metric_groups _metric_groups;
 public:
 
     using clock_type = std::chrono::steady_clock;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -204,6 +204,8 @@ public:
     ~io_group();
     struct priority_class_data;
 
+    std::chrono::duration<double> io_latency_goal() const noexcept;
+
 private:
     friend class io_queue;
     friend struct ::io_queue_for_tests;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -69,6 +69,14 @@ struct reactor_options : public program_options::option_group {
     ///
     /// Default: 1.5 * task_quota_ms value
     program_options::value<double> io_latency_goal_ms;
+    /// \bried Dispatch rate to completion rate ratio threshold
+    ///
+    /// Describes the worst ratio at which seastar reactor is allowed to delay
+    /// IO requests completion. If exceeded, the scheduler will consider it's
+    /// disk that's the reason for completion slow-down and will scale down
+    ///
+    /// Default: 1.1
+    program_options::value<double> io_flow_ratio_threshold;
     /// \brief Maximum number of task backlog to allow.
     ///
     /// When the number of tasks grow above this, we stop polling (e.g. I/O)

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -123,10 +123,6 @@ auto fair_group::grab_capacity(capacity_t cap) noexcept -> capacity_t {
     return _token_bucket.grab(cap);
 }
 
-void fair_group::release_capacity(capacity_t cap) noexcept {
-    _token_bucket.release(cap);
-}
-
 void fair_group::replenish_capacity(clock_type::time_point now) noexcept {
     _token_bucket.replenish(now);
 }
@@ -261,10 +257,6 @@ auto fair_queue::grab_pending_capacity(const fair_queue_entry& ent) noexcept -> 
         return grab_result::cant_preempt;
     }
 
-    if (cap < _pending->cap) {
-        _group.release_capacity(_pending->cap - cap); // FIXME -- replenish right at once?
-    }
-
     _pending.reset();
     return grab_result::grabbed;
 }
@@ -330,7 +322,6 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
 }
 
 void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
-    _group.release_capacity(cap);
 }
 
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -539,6 +539,7 @@ const fair_group& get_fair_group(const io_queue& ioq, unsigned stream) {
 void
 io_queue::complete_request(io_desc_read_write& desc) noexcept {
     _requests_executing--;
+    _requests_completed++;
     _streams[desc.stream()].notify_request_finished(desc.capacity());
 }
 
@@ -1008,6 +1009,7 @@ void io_queue::poll_io_queue() {
 void io_queue::submit_request(io_desc_read_write* desc, internal::io_request req) noexcept {
     _queued_requests--;
     _requests_executing++;
+    _requests_dispatched++;
     _sink.submit(desc, std::move(req));
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -579,6 +579,16 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
         _streams.emplace_back(*_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
     }
     _flow_ratio_update.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(group->io_latency_goal() * cfg.flow_ratio_ticks));
+
+    namespace sm = seastar::metrics;
+    auto owner_l = sm::shard_label(this_shard_id());
+    auto mnt_l = sm::label("mountpoint")(mountpoint());
+    auto group_l = sm::label("iogroup")(to_sstring(_group->_allocated_on));
+    _metric_groups.add_group("io_queue", {
+        sm::make_gauge("flow_ratio", [this] { return _flow_ratio; },
+                sm::description("Ratio of dispatch rate to completion rate. Is expected to be 1.0+ growing larger on reactor stalls or (!) disk problems"),
+                { owner_l, mnt_l, group_l }),
+    });
 }
 
 fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {


### PR DESCRIPTION
There are three places where IO dispatch loop is throttled

  * self-throttling with token bucket according to math model
  * per-shard one-tick threshold
  * 2-bucket approach when tokens are replenished only after they are released from disk

This PR removes the last one, because it leads to self-slowdown in case of reactor stalls. This back-link was introduced to catch the case when the disk suddenly slows down to stop dispatched to over-load it with requests, but effectively this back-link measures not the real disk dispatch rate, but the disk+kernel+reactor dispatch rate. Despite the "kernel" part is tiny, the reactor part can grow large triggering the self slow-down effect.

Here's some math.

Let's assume that a some point scheduler dispatched N_d requests. It means that it was able to grab N_d tokens in T_d duration, the rate of dispatch is R_d = N_d/T_d. The requests are to be completed by the reactor next tick. Let's assume it takes T_c time until reactor gets there and it completes N_c requests. The rate of completion is thus R_c = N_c/T_c. Apparently, N_c <= N_d, because kernel cannot complete more requests that it was queued.

In case reactor experiences a stall during the completion tick, T_c > T_d and since N_c <= N_d consequentially N_d/T_d > N_c/T_c. In case reactor doesn't stall, the number of requests that will complete N_c = N_d/T_d * T_c, because this is how dispatch rate is defined. This is equivalent to N_c/T_c = N_d/T_d.

Finally: R_d >= R_c i.e. the dispatch rate is equal of greater than the completion rate where the "equal" part is less likely and is only if reactor clockworks and doesn't stall.

The mentioned back-link makes sure that R_d <= R_c, coupled with the stalls (even the small ones) this drives the R_d down each tick, causing the R_c to go down as well, then again.

The removed fuse is replaced with the flow-monitor based on dispatch-to-completion rate. Normally, the number of requests dispatched for a certain duration divided by the number of requests completed for the same duration must be 1.0. Otherwise that would mean that requests accumulate in disk. However, this ratio cannot be such immediately and in the longer run it tends to be slightly greater that 1.0, because if reactor polls kernel for IO completions more often, it won't get more requests that it was dispatched. But even a small delay in polling would make Nr_completed / duration less because of the larger denominator value.

Having said that, the new backlink is based on the flow-ratio. When the "average" value of dispatched/completed rates exceeds some threshold (configurable, 1.5 by default) the "cost" of individual requests increases thus reducing the dispatch rate.

The main difference from the current implementation is that the new backlink is not "immediate". The averaging is the exponential moving average filter with 100ms updates and 0.95 smoothing factor. Current backlink is immediate in a sense that delay to deliver a completion immediately slows down the next tick dispatch thus accumulating spontaneous reactor micro-stalls.

This can be reproduced by the test introduced in #1724 . It's not (yet) in the PR, but making the tokens release loop artificially release ~1% more tokens fixes this case, which also supports the theory of reduced completion rate being the culprit. BTW, it cannot be the fix, because the ... over-release factor is not constant and it's hard to calculate it.

fixes: #1641 
refs: #1311 
refs: #1492 (*) in fact, _this_ is the metrics that correlates with the flow ratio to grow above 1.0, but this metrics is sort of look at quota-violation from the IO angle
refs: #1774 this PR has attached metrics screenshots demonstrating the effect on stressed scylla