### PR TITLE
Make make_file_impl() less yielding

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -170,7 +170,7 @@ public:
     friend class reactor;
 };
 
-future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int oflags) noexcept;
+future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int oflags, struct stat st) noexcept;
 
 /// \endcond
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -704,7 +704,7 @@ private:
 
     future<struct stat> fstat(int fd) noexcept;
     future<struct statfs> fstatfs(int fd) noexcept;
-    friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags) noexcept;
+    friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags, struct stat st) noexcept;
 public:
     future<> readable(pollable_fd_state& fd);
     future<> writeable(pollable_fd_state& fd);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -702,7 +702,6 @@ private:
     friend future<typename function_traits<Reducer>::return_type>
         reduce_scheduling_group_specific(Reducer reducer, Initial initial_val, scheduling_group_key key);
 
-    future<struct stat> fstat(int fd) noexcept;
     future<struct statfs> fstatfs(int fd) noexcept;
     friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags, struct stat st) noexcept;
 public:

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1024,84 +1024,85 @@ xfs_concurrency_from_kernel_version() {
 
 future<shared_ptr<file_impl>>
 make_file_impl(int fd, file_open_options options, int flags, struct stat st) noexcept {
-        auto st_dev = st.st_dev;
-
-        if (S_ISBLK(st.st_mode)) {
-            size_t block_size;
-            auto ret = ::ioctl(fd, BLKBSZGET, &block_size);
-            if (ret == -1) {
-                return make_exception_future<shared_ptr<file_impl>>(
-                        std::system_error(errno, std::system_category(), "ioctl(BLKBSZGET) failed"));
-            }
-            return make_ready_future<shared_ptr<file_impl>>(make_shared<blockdev_file_impl>(fd, open_flags(flags), options, st.st_rdev, block_size));
-        } else {
-            if (S_ISDIR(st.st_mode)) {
-                // Directories don't care about block size, so we need not
-                // query it here. Just provide something reasonable.
-                internal::fs_info fsi;
-                fsi.block_size = 4096;
-                fsi.nowait_works = false;
-                return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), options, fsi, st_dev));
-            }
-            static thread_local std::unordered_map<decltype(st_dev), internal::fs_info> s_fstype;
-            future<> get_fs_info = s_fstype.count(st_dev) ? make_ready_future<>() :
-                engine().fstatfs(fd).then([fd, st_dev] (struct statfs sfs) {
-                    internal::fs_info fsi;
-                    fsi.block_size = sfs.f_bsize;
-                    switch (sfs.f_type) {
-                    case internal::fs_magic::xfs:
-                        dioattr da;
-                        if (::ioctl(fd, XFS_IOC_DIOINFO, &da) == 0) {
-                            fsi.dioinfo = std::move(da);
-                        }
-
-                        fsi.append_challenged = true;
-                        static auto xc = xfs_concurrency_from_kernel_version();
-                        fsi.append_concurrency = xc;
-                        fsi.fsync_is_exclusive = true;
-                        fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
-                        break;
-                    case internal::fs_magic::nfs:
-                        fsi.append_challenged = false;
-                        fsi.append_concurrency = 0;
-                        fsi.fsync_is_exclusive = false;
-                        fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
-                        break;
-                    case internal::fs_magic::ext4:
-                        fsi.append_challenged = true;
-                        fsi.append_concurrency = 0;
-                        fsi.fsync_is_exclusive = false;
-                        fsi.nowait_works = internal::kernel_uname().whitelisted({"5.5"});
-                        break;
-                    case internal::fs_magic::btrfs:
-                        fsi.append_challenged = true;
-                        fsi.append_concurrency = 0;
-                        fsi.fsync_is_exclusive = true;
-                        fsi.nowait_works = internal::kernel_uname().whitelisted({"5.9"});
-                        break;
-                    case internal::fs_magic::tmpfs:
-                    case internal::fs_magic::fuse:
-                        fsi.append_challenged = false;
-                        fsi.append_concurrency = 999;
-                        fsi.fsync_is_exclusive = false;
-                        fsi.nowait_works = false;
-                        break;
-                    default:
-                        fsi.append_challenged = true;
-                        fsi.append_concurrency = 0;
-                        fsi.fsync_is_exclusive = true;
-                        fsi.nowait_works = false;
-                    }
-                    s_fstype[st_dev] = std::move(fsi);
-                });
-            return get_fs_info.then([st_dev, fd, flags, options = std::move(options)] () mutable {
-                const internal::fs_info& fsi = s_fstype[st_dev];
-                if (!fsi.append_challenged || options.append_is_unlikely || ((flags & O_ACCMODE) == O_RDONLY)) {
-                    return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
-                }
-                return make_ready_future<shared_ptr<file_impl>>(make_shared<append_challenged_posix_file_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
-            });
+    if (S_ISBLK(st.st_mode)) {
+        size_t block_size;
+        auto ret = ::ioctl(fd, BLKBSZGET, &block_size);
+        if (ret == -1) {
+            return make_exception_future<shared_ptr<file_impl>>(
+                    std::system_error(errno, std::system_category(), "ioctl(BLKBSZGET) failed"));
         }
+        return make_ready_future<shared_ptr<file_impl>>(make_shared<blockdev_file_impl>(fd, open_flags(flags), options, st.st_rdev, block_size));
+    }
+
+    if (S_ISDIR(st.st_mode)) {
+        // Directories don't care about block size, so we need not
+        // query it here. Just provide something reasonable.
+        internal::fs_info fsi;
+        fsi.block_size = 4096;
+        fsi.nowait_works = false;
+        return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), options, fsi, st.st_dev));
+    }
+
+    auto st_dev = st.st_dev;
+    static thread_local std::unordered_map<decltype(st_dev), internal::fs_info> s_fstype;
+
+    future<> get_fs_info = s_fstype.count(st_dev) ? make_ready_future<>() :
+        engine().fstatfs(fd).then([fd, st_dev] (struct statfs sfs) {
+            internal::fs_info fsi;
+            fsi.block_size = sfs.f_bsize;
+            switch (sfs.f_type) {
+            case internal::fs_magic::xfs:
+                dioattr da;
+                if (::ioctl(fd, XFS_IOC_DIOINFO, &da) == 0) {
+                    fsi.dioinfo = std::move(da);
+                }
+
+                fsi.append_challenged = true;
+                static auto xc = xfs_concurrency_from_kernel_version();
+                fsi.append_concurrency = xc;
+                fsi.fsync_is_exclusive = true;
+                fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
+                break;
+            case internal::fs_magic::nfs:
+                fsi.append_challenged = false;
+                fsi.append_concurrency = 0;
+                fsi.fsync_is_exclusive = false;
+                fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
+                break;
+            case internal::fs_magic::ext4:
+                fsi.append_challenged = true;
+                fsi.append_concurrency = 0;
+                fsi.fsync_is_exclusive = false;
+                fsi.nowait_works = internal::kernel_uname().whitelisted({"5.5"});
+                break;
+            case internal::fs_magic::btrfs:
+                fsi.append_challenged = true;
+                fsi.append_concurrency = 0;
+                fsi.fsync_is_exclusive = true;
+                fsi.nowait_works = internal::kernel_uname().whitelisted({"5.9"});
+                break;
+            case internal::fs_magic::tmpfs:
+            case internal::fs_magic::fuse:
+                fsi.append_challenged = false;
+                fsi.append_concurrency = 999;
+                fsi.fsync_is_exclusive = false;
+                fsi.nowait_works = false;
+                break;
+            default:
+                fsi.append_challenged = true;
+                fsi.append_concurrency = 0;
+                fsi.fsync_is_exclusive = true;
+                fsi.nowait_works = false;
+            }
+            s_fstype[st_dev] = std::move(fsi);
+        });
+    return get_fs_info.then([st_dev, fd, flags, options = std::move(options)] () mutable {
+        const internal::fs_info& fsi = s_fstype[st_dev];
+        if (!fsi.append_challenged || options.append_is_unlikely || ((flags & O_ACCMODE) == O_RDONLY)) {
+            return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
+        }
+        return make_ready_future<shared_ptr<file_impl>>(make_shared<append_challenged_posix_file_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
+    });
 }
 
 file::file(seastar::file_handle&& handle) noexcept

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1023,8 +1023,7 @@ xfs_concurrency_from_kernel_version() {
 }
 
 future<shared_ptr<file_impl>>
-make_file_impl(int fd, file_open_options options, int flags) noexcept {
-    return engine().fstat(fd).then([fd, options = std::move(options), flags] (struct stat st) mutable {
+make_file_impl(int fd, file_open_options options, int flags, struct stat st) noexcept {
         auto st_dev = st.st_dev;
 
         if (S_ISBLK(st.st_mode)) {
@@ -1103,7 +1102,6 @@ make_file_impl(int fd, file_open_options options, int flags) noexcept {
                 return make_ready_future<shared_ptr<file_impl>>(make_shared<append_challenged_posix_file_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
             });
         }
-    });
 }
 
 file::file(seastar::file_handle&& handle) noexcept

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2006,18 +2006,6 @@ timespec_to_time_point(const timespec& ts) {
     return std::chrono::system_clock::time_point(d);
 }
 
-future<struct stat>
-reactor::fstat(int fd) noexcept {
-    return _thread_pool->submit<syscall_result_extra<struct stat>>([fd] {
-        struct stat st;
-        auto ret = ::fstat(fd, &st);
-        return wrap_syscall(ret, st);
-    }).then([] (syscall_result_extra<struct stat> ret) {
-        ret.throw_if_error();
-        return make_ready_future<struct stat>(ret.extra);
-    });
-}
-
 future<int>
 reactor::inotify_add_watch(int fd, std::string_view path, uint32_t flags) {
     // Allocating memory for a sstring can throw, hence the futurize_invoke

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1883,7 +1883,7 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
             return wrap_syscall(fd, st);
         }).then([&options, name = std::move(name), &open_flags] (syscall_result_extra<struct stat> sr) {
             sr.throw_fs_exception_if_error("open failed", name);
-            return make_file_impl(sr.result, options, open_flags);
+            return make_file_impl(sr.result, options, open_flags, sr.extra);
         }).then([] (shared_ptr<file_impl> impl) {
             return make_ready_future<file>(std::move(impl));
         });
@@ -2351,7 +2351,7 @@ reactor::open_directory(std::string_view name) noexcept {
             return wrap_syscall(fd, st);
         }).then([name = sstring(name), oflags] (syscall_result_extra<struct stat> sr) {
             sr.throw_fs_exception_if_error("open failed", name);
-            return make_file_impl(sr.result, file_open_options(), oflags);
+            return make_file_impl(sr.result, file_open_options(), oflags, sr.extra);
         }).then([] (shared_ptr<file_impl> file_impl) {
             return make_ready_future<file>(std::move(file_impl));
         });

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1850,9 +1850,11 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
             auto close_fd = defer([fd] () noexcept { ::close(fd); });
             int o_direct_flag = _kernel_page_cache ? 0 : O_DIRECT;
             int r = ::fcntl(fd, F_SETFL, open_flags | o_direct_flag);
-            auto maybe_ret = wrap_syscall<int>(r);  // capture errno (should be EINVAL)
-            if (r == -1  && strict_o_direct && !is_tmpfs(fd)) {
-                return maybe_ret;
+            if (r == -1  && strict_o_direct) {
+                auto maybe_ret = wrap_syscall<int>(r);  // capture errno (should be EINVAL)
+                if (!is_tmpfs(fd)) {
+                    return maybe_ret;
+                }
             }
             if (fd != -1 && options.extent_allocation_size_hint && !_kernel_page_cache) {
                 fsxattr attr = {};


### PR DESCRIPTION
The helper in question makes a file object out of a given file descriptor and options+flags. In order to proceed it first calls `engine().fstat(fd)` to get the file mode and device. The `reactor::fstat()` yields to thread-pool. However, the make_file_impl()'s callers get the file descriptor via thread pool either, so they can call fstat on it instantly thus avoiding second yield