### PR TITLE
reactor, linux-aio: print value of aio-max-nr on error

### DIFF
--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -39,6 +39,7 @@ module seastar;
 #else
 #include <seastar/core/linux-aio.hh>
 #include <seastar/core/print.hh>
+#include <seastar/util/read_first_line.hh>
 #endif
 
 namespace seastar {
@@ -171,7 +172,8 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
     if (r < 0) {
         char buf[1024];
         char *msg = strerror_r(errno, buf, sizeof(buf));
-        throw std::runtime_error(fmt::format("Could not setup Async I/O: {}. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application", msg));
+        auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
+        throw std::runtime_error(fmt::format("Could not setup Async I/O: {}. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr ({}). Try increasing that number or reducing the amount of logical CPUs available for your application", aio_max_nr, msg));
     }
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4171,7 +4171,7 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
     auto network_iocbs_old = network_iocbs;
 
     if (available_aio < requested_aio) {
-        seastar_logger.warn("Requested AIO slots too large, please increase request capacity in /proc/sys/fs/aio-max-nr. available:{} requested:{}", available_aio, requested_aio);
+        seastar_logger.warn("Requested AIO slots too large, please increase request capacity in /proc/sys/fs/aio-max-nr. configured:{} available:{} requested:{}", aio_max_nr, available_aio, requested_aio);
         if (available_aio >= requested_aio_other + smp::count) { // at least one queue for each shard
             network_iocbs = (available_aio - requested_aio_other) / smp::count;
             seastar_logger.warn("max-networking-io-control-blocks adjusted from {} to {}, since AIO slots are unavailable", network_iocbs_old, network_iocbs);


### PR DESCRIPTION
To help debug cases where aio-max-nr is not enough.