### PR TITLE
Keep capacity on fair_queue_entry

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -66,15 +66,10 @@ int main(int ac, char** av) {
 
                             out << YAML::Key << "fair_queue" << YAML::BeginMap;
                             out << YAML::Key << "capacities" << YAML::BeginMap;
-                            auto request_io_capacity = [&ioq] (internal::io_direction_and_length dnl) {
-                                auto stream = ioq.request_stream(dnl);
-                                auto ticket = internal::make_ticket(dnl, ioq.get_config());
-                                return internal::get_fair_group(ioq, stream).ticket_capacity(ticket);
-                            };
                             for (size_t sz = 512; sz <= 128 * 1024; sz <<= 1) {
                                 out << YAML::Key << sz << YAML::BeginMap;
-                                out << YAML::Key << "read" << YAML::Value << request_io_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, sz));
-                                out << YAML::Key << "write" << YAML::Value << request_io_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, sz));
+                                out << YAML::Key << "read" << YAML::Value << ioq.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, sz));
+                                out << YAML::Key << "write" << YAML::Value << ioq.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, sz));
                                 out << YAML::EndMap;
                             }
                             out << YAML::EndMap;

--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -75,7 +75,6 @@ int main(int ac, char** av) {
                             out << YAML::EndMap;
 
                             const auto& fg = internal::get_fair_group(ioq, internal::io_direction_and_length::write_idx);
-                            out << YAML::Key << "cost_capacity" << YAML::Value << format("{}", fg.cost_capacity());
                             out << YAML::Key << "per_tick_grab_threshold" << YAML::Value << fg.per_tick_grab_threshold();
 
                             const auto& tb = fg.token_bucket();

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -243,11 +243,10 @@ public:
          * must accept those as large as the latter pair (but it can accept
          * even larger values, of course)
          */
-        unsigned limit_min_weight = 0;
-        unsigned limit_min_size = 0;
         unsigned long weight_rate;
         unsigned long size_rate;
         double min_tokens = 0.0;
+        double limit_min_tokens = 0.0;
         float rate_factor = 1.0;
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -214,7 +214,6 @@ private:
      * into more tokens in the bucket.
      */
 
-    const fair_queue_ticket _cost_capacity;
     token_bucket_t _token_bucket;
     const capacity_t _per_tick_threshold;
 
@@ -243,8 +242,6 @@ public:
          * must accept those as large as the latter pair (but it can accept
          * even larger values, of course)
          */
-        unsigned long weight_rate;
-        unsigned long size_rate;
         double min_tokens = 0.0;
         double limit_min_tokens = 0.0;
         float rate_factor = 1.0;
@@ -254,7 +251,6 @@ public:
     explicit fair_group(config cfg, unsigned nr_queues);
     fair_group(fair_group&&) = delete;
 
-    fair_queue_ticket cost_capacity() const noexcept { return _cost_capacity; }
     capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
     capacity_t grab_capacity(capacity_t cap) noexcept;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -103,8 +103,11 @@ public:
 /// @{
 
 class fair_queue_entry {
+public:
+    using capacity_t = fair_queue_ticket;
     friend class fair_queue;
 
+private:
     fair_queue_ticket _ticket;
     bi::slist_member_hook<> _hook;
 
@@ -116,7 +119,7 @@ public:
             bi::cache_last<true>,
             bi::member_hook<fair_queue_entry, bi::slist_member_hook<>, &fair_queue_entry::_hook>>;
 
-    fair_queue_ticket ticket() const noexcept { return _ticket; }
+    fair_queue_ticket capacity() const noexcept { return _ticket; }
 };
 
 /// \brief Group of queues class
@@ -397,7 +400,7 @@ public:
 
     /// Notifies that ont request finished
     /// \param desc an instance of \c fair_queue_ticket structure describing the request that just finished.
-    void notify_request_finished(fair_queue_ticket desc) noexcept;
+    void notify_request_finished(fair_queue_entry::capacity_t cap) noexcept;
     void notify_request_cancelled(fair_queue_entry& ent) noexcept;
 
     /// Try to execute new requests if there is capacity left in the queue.

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -243,12 +243,11 @@ public:
          * must accept those as large as the latter pair (but it can accept
          * even larger values, of course)
          */
-        unsigned min_weight = 0;
-        unsigned min_size = 0;
         unsigned limit_min_weight = 0;
         unsigned limit_min_size = 0;
         unsigned long weight_rate;
         unsigned long size_rate;
+        double min_tokens = 0.0;
         float rate_factor = 1.0;
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -225,6 +225,11 @@ public:
         return (double)cap / fixed_point_factor / token_bucket_t::rate_cast(std::chrono::seconds(1)).count();
     }
 
+    // Convert floating-point tokens into the token bucket capacity
+    static capacity_t tokens_capacity(double tokens) noexcept {
+        return tokens * token_bucket_t::rate_cast(std::chrono::seconds(1)).count() * fixed_point_factor;
+    }
+
     auto capacity_duration(capacity_t cap) const noexcept {
         return _token_bucket.duration_for(cap);
     }
@@ -394,6 +399,10 @@ public:
 
     capacity_t ticket_capacity(fair_queue_ticket ticket) const noexcept {
         return _group.ticket_capacity(ticket);
+    }
+
+    capacity_t tokens_capacity(double tokens) const noexcept {
+        return _group.tokens_capacity(tokens);
     }
 
     /// Queue the entry \c ent through this class' \ref fair_queue

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -264,7 +264,6 @@ public:
     void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
 
     capacity_t capacity_deficiency(capacity_t from) const noexcept;
-    capacity_t ticket_capacity(fair_queue_ticket ticket) const noexcept;
 
     std::chrono::duration<double> rate_limit_duration() const noexcept {
         std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
@@ -394,10 +393,6 @@ public:
 
     /// \return the amount of resources (weight, size) currently executing
     fair_queue_ticket resources_currently_executing() const;
-
-    capacity_t ticket_capacity(fair_queue_ticket ticket) const noexcept {
-        return _group.ticket_capacity(ticket);
-    }
 
     capacity_t tokens_capacity(double tokens) const noexcept {
         return _group.tokens_capacity(tokens);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -174,6 +174,7 @@ public:
     void poll_io_queue();
 
     clock_type::time_point next_pending_aio() const noexcept;
+    fair_queue_entry::capacity_t request_capacity(internal::io_direction_and_length dnl) const noexcept;
 
     sstring mountpoint() const;
     dev_t dev_id() const noexcept;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -233,7 +233,7 @@ inline dev_t io_queue::dev_id() const noexcept {
 }
 
 namespace internal {
-fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept;
+double request_tokens(io_direction_and_length dnl, const io_queue::config& cfg) noexcept;
 }
 
 }

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -103,15 +103,12 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
 }
 
 fair_group::fair_group(config cfg, unsigned nr_queues)
-        : _cost_capacity(cfg.weight_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count(), cfg.size_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count())
-        , _token_bucket(cfg.rate_factor * fixed_point_factor,
+        : _token_bucket(cfg.rate_factor * fixed_point_factor,
                         std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
                         tokens_capacity(cfg.min_tokens)
                        )
         , _per_tick_threshold(_token_bucket.limit() / nr_queues)
 {
-    assert(_cost_capacity.is_non_zero());
-
     if (cfg.rate_factor * fixed_point_factor > _token_bucket.max_rate) {
         throw std::runtime_error("Fair-group rate_factor is too large");
     }

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -148,10 +148,6 @@ auto fair_group::capacity_deficiency(capacity_t from) const noexcept -> capacity
     return _token_bucket.deficiency(from);
 }
 
-auto fair_group::ticket_capacity(fair_queue_ticket t) const noexcept -> capacity_t {
-    return t.normalize(_cost_capacity) * fixed_point_factor;
-}
-
 // Priority class, to be used with a given fair_queue
 class fair_queue::priority_class_data {
     friend class fair_queue;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -106,7 +106,7 @@ fair_group::fair_group(config cfg, unsigned nr_queues)
         : _cost_capacity(cfg.weight_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count(), cfg.size_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count())
         , _token_bucket(cfg.rate_factor * fixed_point_factor,
                         std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), ticket_capacity(fair_queue_ticket(cfg.limit_min_weight, cfg.limit_min_size))),
-                        ticket_capacity(fair_queue_ticket(cfg.min_weight, cfg.min_size))
+                        tokens_capacity(cfg.min_tokens)
                        )
         , _per_tick_threshold(_token_bucket.limit() / nr_queues)
 {
@@ -116,7 +116,7 @@ fair_group::fair_group(config cfg, unsigned nr_queues)
         throw std::runtime_error("Fair-group rate_factor is too large");
     }
 
-    if (ticket_capacity(fair_queue_ticket(cfg.min_weight, cfg.min_size)) > _token_bucket.threshold()) {
+    if (tokens_capacity(cfg.min_tokens) > _token_bucket.threshold()) {
         throw std::runtime_error("Fair-group replenisher limit is lower than threshold");
     }
 }

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -337,9 +337,9 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
     _resources_queued += ent._ticket;
 }
 
-void fair_queue::notify_request_finished(fair_queue_ticket desc) noexcept {
-    _resources_executing -= desc;
-    _group.release_capacity(_group.ticket_capacity(desc));
+void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
+    _resources_executing -= cap;
+    _group.release_capacity(_group.ticket_capacity(cap));
 }
 
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -105,7 +105,7 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
 fair_group::fair_group(config cfg, unsigned nr_queues)
         : _cost_capacity(cfg.weight_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count(), cfg.size_rate / token_bucket_t::rate_cast(std::chrono::seconds(1)).count())
         , _token_bucket(cfg.rate_factor * fixed_point_factor,
-                        std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), ticket_capacity(fair_queue_ticket(cfg.limit_min_weight, cfg.limit_min_size))),
+                        std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
                         tokens_capacity(cfg.min_tokens)
                        )
         , _per_tick_threshold(_token_bucket.limit() / nr_queues)

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -567,8 +567,9 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
 fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {
     fair_group::config cfg;
     cfg.label = fmt::format("io-queue-{}", qcfg.devid);
-    cfg.min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    cfg.min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
+    double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
+    double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
+    cfg.min_tokens = min_weight / qcfg.req_count_rate + min_size / qcfg.blocks_count_rate;
     cfg.limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     cfg.limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
     cfg.weight_rate = qcfg.req_count_rate;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -573,8 +573,6 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
     double limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     double limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
     cfg.limit_min_tokens = limit_min_weight / qcfg.req_count_rate + limit_min_size / qcfg.blocks_count_rate;
-    cfg.weight_rate = qcfg.req_count_rate;
-    cfg.size_rate = qcfg.blocks_count_rate;
     cfg.rate_factor = qcfg.rate_factor;
     cfg.rate_limit_duration = qcfg.rate_limit_duration;
     return cfg;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -570,8 +570,9 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
     double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
     cfg.min_tokens = min_weight / qcfg.req_count_rate + min_size / qcfg.blocks_count_rate;
-    cfg.limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    cfg.limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
+    double limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
+    double limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
+    cfg.limit_min_tokens = limit_min_weight / qcfg.req_count_rate + limit_min_size / qcfg.blocks_count_rate;
     cfg.weight_rate = qcfg.req_count_rate;
     cfg.size_rate = qcfg.blocks_count_rate;
     cfg.rate_factor = qcfg.rate_factor;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -903,7 +903,7 @@ future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direc
         // First time will hit here, and then we create the class. It is important
         // that we create the shared pointer in the same shard it will be used at later.
         auto& pclass = find_or_create_class(pc);
-        auto cap = internal::make_ticket(dnl, get_config());
+        auto cap = _streams[request_stream(dnl)].ticket_capacity(internal::make_ticket(dnl, get_config()));
         auto queued_req = std::make_unique<queued_io_request>(std::move(req), *this, cap, pclass, std::move(dnl), std::move(iovs));
         auto fut = queued_req->get_future();
         if (intent != nullptr) {

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -103,7 +103,7 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto cap = fair_queue_ticket(1, 1);
+            auto cap = local.queue(loc).ticket_capacity(fair_queue_ticket(1, 1));
             auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
                 local.queue(loc).notify_request_finished(cap);

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -66,8 +66,8 @@ struct local_fq_entry {
     std::function<void()> submit;
 
     template <typename Func>
-    local_fq_entry(fair_queue_ticket ticket, Func&& f)
-        : ent(ticket)
+    local_fq_entry(fair_queue_entry::capacity_t cap, Func&& f)
+        : ent(cap)
         , submit(std::move(f)) {}
 };
 
@@ -103,10 +103,10 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto ticket = fair_queue_ticket(1, 1);
-            auto req = std::make_unique<local_fq_entry>(ticket, [&local, loc, ticket] {
+            auto cap = fair_queue_ticket(1, 1);
+            auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
-                local.queue(loc).notify_request_finished(ticket);
+                local.queue(loc).notify_request_finished(cap);
             });
             local.queue(loc).queue(cid, req->ent);
             req.release();

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -103,7 +103,7 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto cap = local.queue(loc).ticket_capacity(fair_queue_ticket(1, 1));
+            auto cap = local.queue(loc).tokens_capacity(double(1) / std::numeric_limits<int>::max() + double(1) / std::numeric_limits<int>::max());
             auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
                 local.queue(loc).notify_request_finished(cap);

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -39,8 +39,6 @@ struct local_fq_and_class {
 
     static fair_group::config fg_config() {
         fair_group::config cfg;
-        cfg.weight_rate = std::numeric_limits<int>::max();
-        cfg.size_rate = std::numeric_limits<int>::max();
         return cfg;
     }
 
@@ -81,8 +79,6 @@ struct perf_fair_queue {
 
     static fair_group::config fg_config() {
         fair_group::config cfg;
-        cfg.weight_rate = std::numeric_limits<int>::max();
-        cfg.size_rate = std::numeric_limits<int>::max();
         return cfg;
     }
 

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -64,8 +64,6 @@ class test_env {
 
     static fair_group::config fg_config(unsigned cap) {
         fair_group::config cfg;
-        cfg.weight_rate = 1'000'000;
-        cfg.size_rate = std::numeric_limits<int>::max();
         cfg.rate_limit_duration = std::chrono::microseconds(cap);
         return cfg;
     }

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -133,7 +133,7 @@ public:
 
     void do_op(fair_queue::class_id id, unsigned weight) {
         unsigned index = id;
-        auto cap = fair_queue_ticket(weight, 0);
+        auto cap = _fq.ticket_capacity(fair_queue_ticket(weight, 0));
         auto req = std::make_unique<request>(cap, index, [this, index] (request& req) mutable noexcept {
             try {
                 _inflight.push_back(std::move(req));

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -42,8 +42,8 @@ struct request {
     unsigned index;
 
     template <typename Func>
-    request(unsigned weight, unsigned index, Func&& h)
-        : fqent(fair_queue_ticket(weight, 0))
+    request(fair_queue_ticket ticket, unsigned index, Func&& h)
+        : fqent(ticket)
         , handle(std::move(h))
         , index(index)
     {}
@@ -133,7 +133,8 @@ public:
 
     void do_op(fair_queue::class_id id, unsigned weight) {
         unsigned index = id;
-        auto req = std::make_unique<request>(weight, index, [this, index] (request& req) mutable noexcept {
+        auto ticket = fair_queue_ticket(weight, 0);
+        auto req = std::make_unique<request>(ticket, index, [this, index] (request& req) mutable noexcept {
             try {
                 _inflight.push_back(std::move(req));
             } catch (...) {

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -133,7 +133,7 @@ public:
 
     void do_op(fair_queue::class_id id, unsigned weight) {
         unsigned index = id;
-        auto cap = _fq.ticket_capacity(fair_queue_ticket(weight, 0));
+        auto cap = _fq.tokens_capacity(double(weight) / 1'000'000);
         auto req = std::make_unique<request>(cap, index, [this, index] (request& req) mutable noexcept {
             try {
                 _inflight.push_back(std::move(req));


### PR DESCRIPTION
Current implementation of fair-queue uses two distinct data types to "measure" a request -- tickets and capacities. The former is a 2d value that represents request weight and size and the latter is a fixed-point number that represents the request cost that's used by cross-classes balancing and capacity throttling. The capacity is calculated from the ticket each time f.q. needs to know the entry's capacity, which is not very efficient.

Other than generating extra CPU waste, this detail makes it hard to auto-adjust the dispatch rate. This is because the entry's (and a entry represents an IO request) capacity is its ticket normalized by the capacity "cost" ticket. If the queue needs to lower or increase the dispatch rate, it has two options: re-configure the token bucket, or change the "cost" value so that each request becomes more weighty or lighter. The 2nd option is not possible now, because the "cost" dispatch-time and the "cost" completion-time cannot differ. This patch fixes it by pinning the entry's cost construction time, so the rate can be altered at any time.

Tested with:
- test.py
- comparing ioinfo output for unconfigured and iotune-configured disk (capacities changed tiny bit due to rounding shifts)
- stressing scylla build with this set applied