### PR TITLE
Slowdown IO scheduler based on dispatched/completed ratio

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -188,7 +188,7 @@ public:
 
     static constexpr float fixed_point_factor = float(1 << 24);
     using rate_resolution = std::milli;
-    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::yes>;
+    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::no>;
 
 private:
 
@@ -252,7 +252,6 @@ public:
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
     capacity_t grab_capacity(capacity_t cap) noexcept;
     clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
-    void release_capacity(capacity_t cap) noexcept;
     void replenish_capacity(clock_type::time_point now) noexcept;
     void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -390,6 +390,10 @@ public:
         return _group.tokens_capacity(tokens);
     }
 
+    capacity_t maximum_capacity() const noexcept {
+        return _group.maximum_capacity();
+    }
+
     /// Queue the entry \c ent through this class' \ref fair_queue
     ///
     /// The user of this interface is supposed to call \ref notify_requests_finished when the

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -114,6 +114,12 @@ private:
     // decoupling and is temporary
     size_t _queued_requests = 0;
     size_t _requests_executing = 0;
+    uint64_t _requests_dispatched = 0;
+    uint64_t _requests_completed = 0;
+    struct flow_monitor;
+    std::unique_ptr<flow_monitor> _flow_mon;
+
+    metrics::metric_groups _metric_groups;
 public:
 
     using clock_type = std::chrono::steady_clock;
@@ -142,6 +148,8 @@ public:
         float rate_factor = 1.0;
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
         size_t block_count_limit_min = 1;
+        std::chrono::milliseconds flow_monitor_period = std::chrono::milliseconds(100);
+        double flow_ratio_ema_factor = 0.95;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -150,6 +150,7 @@ public:
         size_t block_count_limit_min = 1;
         std::chrono::milliseconds flow_monitor_period = std::chrono::milliseconds(100);
         double flow_ratio_ema_factor = 0.95;
+        double flow_ratio_backpressure_threshold = 1.5;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -69,6 +69,14 @@ struct reactor_options : public program_options::option_group {
     ///
     /// Default: 1.5 * task_quota_ms value
     program_options::value<double> io_latency_goal_ms;
+    /// \bried Dispatch rate to completion rate ratio threshold
+    ///
+    /// Describes the worst ratio at which seastar reactor is allowed to delay
+    /// IO requests completion. If exceeded, the scheduler will consider it's
+    /// disk that's the reason for completion slow-down and will scale down
+    ///
+    /// Default: 1.5
+    program_options::value<double> io_flow_ratio_threshold;
     /// \brief Maximum number of task backlog to allow.
     ///
     /// When the number of tasks grow above this, we stop polling (e.g. I/O)

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -123,10 +123,6 @@ auto fair_group::grab_capacity(capacity_t cap) noexcept -> capacity_t {
     return _token_bucket.grab(cap);
 }
 
-void fair_group::release_capacity(capacity_t cap) noexcept {
-    _token_bucket.release(cap);
-}
-
 void fair_group::replenish_capacity(clock_type::time_point now) noexcept {
     _token_bucket.replenish(now);
 }
@@ -261,10 +257,6 @@ auto fair_queue::grab_pending_capacity(const fair_queue_entry& ent) noexcept -> 
         return grab_result::cant_preempt;
     }
 
-    if (cap < _pending->cap) {
-        _group.release_capacity(_pending->cap - cap); // FIXME -- replenish right at once?
-    }
-
     _pending.reset();
     return grab_result::grabbed;
 }
@@ -330,7 +322,6 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
 }
 
 void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
-    _group.release_capacity(cap);
 }
 
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -947,7 +947,16 @@ double internal::request_tokens(io_direction_and_length dnl, const io_queue::con
 }
 
 fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length dnl) const noexcept {
-    return _streams[request_stream(dnl)].tokens_capacity(internal::request_tokens(dnl, get_config()));
+    const auto& cfg = get_config();
+    auto tokens = internal::request_tokens(dnl, cfg);
+    if (_flow_mon->flow_ratio <= cfg.flow_ratio_backpressure_threshold) {
+        return _streams[request_stream(dnl)].tokens_capacity(tokens);
+    }
+
+    auto stream = request_stream(dnl);
+    auto cap = _streams[stream].tokens_capacity(tokens * _flow_mon->flow_ratio);
+    auto max_cap = _streams[stream].maximum_capacity();
+    return std::min(cap, max_cap);
 }
 
 io_queue::request_limits io_queue::get_request_limits() const noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -64,8 +64,6 @@ using io_direction_and_length = internal::io_direction_and_length;
 static constexpr auto io_direction_read = io_direction_and_length::read_idx;
 static constexpr auto io_direction_write = io_direction_and_length::write_idx;
 
-static fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept;
-
 struct default_io_exception_factory {
     static auto cancelled() {
         return cancelled_error();
@@ -222,21 +220,21 @@ class io_desc_read_write final : public io_completion {
     io_queue::clock_type::time_point _ts;
     const stream_id _stream;
     const io_direction_and_length _dnl;
-    const fair_queue_ticket _fq_ticket;
+    const fair_queue_entry::capacity_t _fq_capacity;
     promise<size_t> _pr;
     iovec_keeper _iovs;
 
 public:
-    io_desc_read_write(io_queue& ioq, io_queue::priority_class_data& pc, stream_id stream, io_direction_and_length dnl, fair_queue_ticket ticket, iovec_keeper iovs)
+    io_desc_read_write(io_queue& ioq, io_queue::priority_class_data& pc, stream_id stream, io_direction_and_length dnl, fair_queue_entry::capacity_t cap, iovec_keeper iovs)
         : _ioq(ioq)
         , _pclass(pc)
         , _ts(io_queue::clock_type::now())
         , _stream(stream)
         , _dnl(dnl)
-        , _fq_ticket(ticket)
+        , _fq_capacity(cap)
         , _iovs(std::move(iovs))
     {
-        io_log.trace("dev {} : req {} queue  len {} ticket {}", _ioq.dev_id(), fmt::ptr(this), _dnl.length(), _fq_ticket);
+        io_log.trace("dev {} : req {} queue  len {} capacity {}", _ioq.dev_id(), fmt::ptr(this), _dnl.length(), _fq_capacity);
     }
 
     virtual void set_exception(std::exception_ptr eptr) noexcept override {
@@ -273,7 +271,7 @@ public:
         return _pr.get_future();
     }
 
-    fair_queue_ticket ticket() const noexcept { return _fq_ticket; }
+    fair_queue_entry::capacity_t capacity() const noexcept { return _fq_capacity; }
     stream_id stream() const noexcept { return _stream; }
 };
 
@@ -287,12 +285,12 @@ class queued_io_request : private internal::io_request {
     bool is_cancelled() const noexcept { return !_desc; }
 
 public:
-    queued_io_request(internal::io_request req, io_queue& q, io_queue::priority_class_data& pc, io_direction_and_length dnl, iovec_keeper iovs)
+    queued_io_request(internal::io_request req, io_queue& q, fair_queue_entry::capacity_t cap, io_queue::priority_class_data& pc, io_direction_and_length dnl, iovec_keeper iovs)
         : io_request(std::move(req))
         , _ioq(q)
         , _stream(_ioq.request_stream(dnl))
-        , _fq_entry(make_ticket(dnl, _ioq.get_config()))
-        , _desc(std::make_unique<io_desc_read_write>(_ioq, pc, _stream, dnl, _fq_entry.ticket(), std::move(iovs)))
+        , _fq_entry(cap)
+        , _desc(std::make_unique<io_desc_read_write>(_ioq, pc, _stream, dnl, cap, std::move(iovs)))
     {
     }
 
@@ -532,12 +530,16 @@ sstring io_request::opname() const {
     std::abort();
 }
 
+const fair_group& get_fair_group(const io_queue& ioq, unsigned stream) {
+    return *(ioq._group->_fgs[stream]);
+}
+
 } // internal namespace
 
 void
 io_queue::complete_request(io_desc_read_write& desc) noexcept {
     _requests_executing--;
-    _streams[desc.stream()].notify_request_finished(desc.ticket());
+    _streams[desc.stream()].notify_request_finished(desc.capacity());
 }
 
 fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring label) {
@@ -560,35 +562,17 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     } else {
         _streams.emplace_back(*_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
     }
-
-    if (this_shard_id() == 0) {
-        sstring caps_str;
-        for (size_t sz = 512; sz <= 128 * 1024; sz <<= 1) {
-            caps_str += fmt::format(" {}:", sz);
-            if (sz <= _group->_max_request_length[io_direction_read]) {
-                caps_str += fmt::format("{}", _group->_fgs[0]->ticket_capacity(make_ticket(io_direction_and_length(io_direction_read, sz), get_config())));
-            } else {
-                caps_str += "X";
-            }
-            if (sz <= _group->_max_request_length[io_direction_write]) {
-                caps_str += fmt::format(":{}", _group->_fgs[0]->ticket_capacity(make_ticket(io_direction_and_length(io_direction_write, sz), get_config())));
-            } else {
-                caps_str += ":X";
-            }
-        }
-        seastar_logger.info("Created io queue dev({}) capacities:{}", get_config().devid, caps_str);
-    }
 }
 
 fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {
     fair_group::config cfg;
     cfg.label = fmt::format("io-queue-{}", qcfg.devid);
-    cfg.min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    cfg.min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
-    cfg.limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    cfg.limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
-    cfg.weight_rate = qcfg.req_count_rate;
-    cfg.size_rate = qcfg.blocks_count_rate;
+    double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
+    double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
+    cfg.min_tokens = min_weight / qcfg.req_count_rate + min_size / qcfg.blocks_count_rate;
+    double limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
+    double limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
+    cfg.limit_min_tokens = limit_min_weight / qcfg.req_count_rate + limit_min_size / qcfg.blocks_count_rate;
     cfg.rate_factor = qcfg.rate_factor;
     cfg.rate_limit_duration = qcfg.rate_limit_duration;
     return cfg;
@@ -596,7 +580,7 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
 
 static void maybe_warn_latency_goal_auto_adjust(const fair_group& fg, const io_queue::config& cfg) noexcept {
     auto goal = fg.rate_limit_duration();
-    auto lvl = goal > 1.1 * cfg.rate_limit_duration ? log_level::warn : log_level::info;
+    auto lvl = goal > 1.1 * cfg.rate_limit_duration ? log_level::warn : log_level::debug;
     seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, cfg.devid);
 }
 
@@ -624,8 +608,8 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
         auto g_idx = _config.duplex ? idx : 0;
         auto max_cap = _fgs[g_idx]->maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
-            auto ticket = make_ticket(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
-            auto cap = _fgs[g_idx]->ticket_capacity(ticket);
+            auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
+            auto cap = _fgs[g_idx]->tokens_capacity(tokens);
             if (cap > max_cap) {
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");
@@ -638,11 +622,6 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
 
     update_max_size(io_direction_write);
     update_max_size(io_direction_read);
-
-    seastar_logger.info("Created io group dev({}), length limit {}:{}, rate {}:{}", _config.devid,
-            _max_request_length[io_direction_read],
-            _max_request_length[io_direction_write],
-            _config.req_count_rate, _config.blocks_count_rate);
 }
 
 io_group::~io_group() {
@@ -893,7 +872,7 @@ stream_id io_queue::request_stream(io_direction_and_length dnl) const noexcept {
     return get_config().duplex ? dnl.rw_idx() : 0;
 }
 
-fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
+double internal::request_tokens(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
     struct {
         unsigned weight;
         unsigned size;
@@ -909,7 +888,12 @@ fair_queue_ticket make_ticket(io_direction_and_length dnl, const io_queue::confi
     };
 
     const auto& m = mult[dnl.rw_idx()];
-    return fair_queue_ticket(m.weight, m.size * (dnl.length() >> io_queue::block_size_shift));
+
+    return double(m.weight) / cfg.req_count_rate + double(m.size) * (dnl.length() >> io_queue::block_size_shift) / cfg.blocks_count_rate;
+}
+
+fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length dnl) const noexcept {
+    return _streams[request_stream(dnl)].tokens_capacity(internal::request_tokens(dnl, get_config()));
 }
 
 io_queue::request_limits io_queue::get_request_limits() const noexcept {
@@ -924,7 +908,8 @@ future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direc
         // First time will hit here, and then we create the class. It is important
         // that we create the shared pointer in the same shard it will be used at later.
         auto& pclass = find_or_create_class(pc);
-        auto queued_req = std::make_unique<queued_io_request>(std::move(req), *this, pclass, std::move(dnl), std::move(iovs));
+        auto cap = request_capacity(dnl);
+        auto queued_req = std::make_unique<queued_io_request>(std::move(req), *this, cap, pclass, std::move(dnl), std::move(iovs));
         auto fut = queued_req->get_future();
         if (intent != nullptr) {
             auto& cq = intent->find_or_create_cancellable_queue(dev_id(), pc.id());
@@ -1032,7 +1017,7 @@ void io_queue::cancel_request(queued_io_request& req) noexcept {
 }
 
 void io_queue::complete_cancelled_request(queued_io_request& req) noexcept {
-    _streams[req.stream()].notify_request_finished(req.queue_entry().ticket());
+    _streams[req.stream()].notify_request_finished(req.queue_entry().capacity());
 }
 
 io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3814,6 +3814,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                 "busy-poll for disk I/O (reduces latency and increases throughput)")
     , task_quota_ms(*this, "task-quota-ms", 0.5, "Max time (ms) between polls")
     , io_latency_goal_ms(*this, "io-latency-goal-ms", {}, "Max time (ms) io operations must take (1.5 * task-quota-ms if not set)")
+    , io_flow_ratio_threshold(*this, "io-flow-rate-threshold", 1.5, "Dispatch rate to completion rate threshold")
     , max_task_backlog(*this, "max-task-backlog", 1000, "Maximum number of task backlog to allow; above this we ignore I/O")
     , blocked_reactor_notify_ms(*this, "blocked-reactor-notify-ms", 25, "threshold in miliseconds over which the reactor is considered blocked if no progress is made")
     , blocked_reactor_reports_per_minute(*this, "blocked-reactor-reports-per-minute", 5, "Maximum number of backtraces reported by stall detector per minute")
@@ -4042,6 +4043,7 @@ private:
     unsigned _num_io_groups = 0;
     std::unordered_map<dev_t, mountpoint_params> _mountpoints;
     std::chrono::duration<double> _latency_goal;
+    double _flow_ratio_backpressure_threshold;
 
 public:
     uint64_t per_io_group(uint64_t qty, unsigned nr_groups) const noexcept {
@@ -4064,6 +4066,8 @@ public:
         seastar_logger.debug("smp::count: {}", smp::count);
         _latency_goal = std::chrono::duration_cast<std::chrono::duration<double>>(latency_goal_opt(reactor_opts) * 1ms);
         seastar_logger.debug("latency_goal: {}", latency_goal().count());
+        _flow_ratio_backpressure_threshold = reactor_opts.io_flow_ratio_threshold.get_value();
+        seastar_logger.debug("flow-ratio threshold: {}", _flow_ratio_backpressure_threshold);
 
         if (smp_opts.num_io_groups) {
             _num_io_groups = smp_opts.num_io_groups.get_value();
@@ -4148,6 +4152,7 @@ public:
         cfg.duplex = p.duplex;
         cfg.rate_factor = p.rate_factor;
         cfg.rate_limit_duration = latency_goal();
+        cfg.flow_ratio_backpressure_threshold = _flow_ratio_backpressure_threshold;
         // Block count limit should not be less than the minimal IO size on the device
         // On the other hand, even this is not good enough -- in the worst case the
         // scheduler will self-tune to allow for the single 64k request, while it would

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -39,8 +39,6 @@ struct local_fq_and_class {
 
     static fair_group::config fg_config() {
         fair_group::config cfg;
-        cfg.weight_rate = std::numeric_limits<int>::max();
-        cfg.size_rate = std::numeric_limits<int>::max();
         return cfg;
     }
 
@@ -66,8 +64,8 @@ struct local_fq_entry {
     std::function<void()> submit;
 
     template <typename Func>
-    local_fq_entry(unsigned weight, unsigned index, Func&& f)
-        : ent(seastar::fair_queue_ticket(weight, index))
+    local_fq_entry(fair_queue_entry::capacity_t cap, Func&& f)
+        : ent(cap)
         , submit(std::move(f)) {}
 };
 
@@ -81,8 +79,6 @@ struct perf_fair_queue {
 
     static fair_group::config fg_config() {
         fair_group::config cfg;
-        cfg.weight_rate = std::numeric_limits<int>::max();
-        cfg.size_rate = std::numeric_limits<int>::max();
         return cfg;
     }
 
@@ -103,9 +99,10 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto req = std::make_unique<local_fq_entry>(1, 1, [&local, loc] {
+            auto cap = local.queue(loc).tokens_capacity(double(1) / std::numeric_limits<int>::max() + double(1) / std::numeric_limits<int>::max());
+            auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
-                local.queue(loc).notify_request_finished(seastar::fair_queue_ticket{1, 1});
+                local.queue(loc).notify_request_finished(cap);
             });
             local.queue(loc).queue(cid, req->ent);
             req.release();


### PR DESCRIPTION
The essence of the PR is last commit (b24ff95fd895e08f7efd77e79c7054a03da4d9b6). It also contains PRs #1766, #1773 and #1754 it depends on

As described in #1766, current attempt to make IO queue slowdown if disk cannot keep up with the load is problematic. The main problem is that the backlink relies on requests completions arriving in a timely manner thus replenishing tokens into the bucket. It doesn't work well, because the case when "disk is overloaded and delays completion of requests" is     indistinguishable from "reactor is overloaded and cannot poll completions in a timely manner". As a result, lowering the rate of  dispatch on softly stalling reactor doesn't necessarily help making the disk more happy. Reactor would continue delaying completions and the  backling would drop the rate even further.

This PR makes the backlink based on dispatch-to-completion rate. Normally, the number of requests dispatched for a certain duration divided by the number of requests completed for the same duration must be 1.0. Otherwise that would mean that requests accumulate in disk. However, this ratio cannot be such immediately and in the longer run it tends to be slightly greater that 1.0, because if reactor polls kernel for IO completions more often, it won't get _more_ requests that it was dispatched. But even a small delay in polling would make Nr_completed / duration _less_ because of the larger denominator value.

Having said that, the backlink is based on the flow-ratio intruduced in #1766 . When the "average" value of dispatched/completed rates exceeds some threshold (configurable, 1.5 by default) the "cost" of individual requests increases thus reducing the dispatch rate.

The main difference from the current implementation is that the new backlink is not "immediate". The averaging is the exponential moving average filter with 100ms updates and 0.95 smoothing factor. Current backlink is immediate in a sense that delay to deliver a completion immediately slows down the next tick dispatch thus accumulating spontaneous reactor micro-stalls.