### PR TITLE
install-dependencies.sh: re-add protobuf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2022-11-29 "$@"' > run; chmod +x run
+      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2023-08-13 "$@"' > run; chmod +x run
       - run:
           command: |
             ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >>

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -57,6 +57,8 @@ debian_packages=(
     doxygen
     openssl
     pkg-config
+    libprotobuf-dev
+    protobuf-compiler
 )
 
 # seastar doesn't directly depend on these packages. They are
@@ -92,6 +94,8 @@ redhat_packages=(
     fmt-devel
     boost-devel
     valgrind-devel
+    protobuf-devel
+    protobuf-compiler
     "${transitive[@]}"
 )
 


### PR DESCRIPTION
In preparation for re-introducing protobuf support to Prometheus, add the supporting libraries and compiler to the dependencies.

The testing toolchain is regenerated.