### PR TITLE
http/exception: s/<TAB>/    /

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -137,9 +137,9 @@ public:
     }
 
     json_exception(std::exception_ptr e) {
-	std::ostringstream exception_description;
-	exception_description << e;
-	set(exception_description.str(), http::reply::status_type::internal_server_error);
+        std::ostringstream exception_description;
+        exception_description << e;
+        set(exception_description.str(), http::reply::status_type::internal_server_error);
     }
 private:
     void set(const std::string& msg, http::reply::status_type code) {


### PR DESCRIPTION
per coding-style.md, we use spaces only. so trade tabs for spaces.