### PR TITLE
test: add fixture support to seastar::testing

### DIFF
--- a/include/seastar/testing/seastar_test.hh
+++ b/include/seastar/testing/seastar_test.hh
@@ -53,7 +53,7 @@ public:
         return _test_file;
     }
     static const std::string& get_name();
-    virtual future<> run_test_case() const = 0;
+    virtual future<> run_test_case() = 0;
     void run();
 };
 

--- a/include/seastar/testing/test_case.hh
+++ b/include/seastar/testing/test_case.hh
@@ -33,14 +33,14 @@
 #define SEASTAR_TEST_CASE_WITH_DECO(name, decorators)               \
     struct name : public seastar::testing::seastar_test {           \
         using seastar::testing::seastar_test::seastar_test;         \
-        seastar::future<> run_test_case() const override;           \
+        seastar::future<> run_test_case() override;                 \
     };                                                              \
     static const name name ## _instance(                            \
         #name,                                                      \
         __FILE__,                                                   \
         __LINE__,                                                   \
         decorators); /* NOLINT(cert-err58-cpp) */                   \
-    seastar::future<> name::run_test_case() const
+    seastar::future<> name::run_test_case()
 
 #define SEASTAR_TEST_CASE_WITHOUT_DECO(name)                        \
     SEASTAR_TEST_CASE_WITH_DECO(                                    \

--- a/include/seastar/testing/test_case.hh
+++ b/include/seastar/testing/test_case.hh
@@ -29,6 +29,7 @@
 #include <seastar/core/future.hh>
 
 #include <seastar/testing/seastar_test.hh>
+#include <utility>
 
 #define SEASTAR_TEST_CASE_WITH_DECO(name, decorators)               \
     struct name : public seastar::testing::seastar_test {           \
@@ -53,4 +54,77 @@
             BOOST_PP_EQUAL(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 1), \
             SEASTAR_TEST_CASE_WITHOUT_DECO,                         \
             SEASTAR_TEST_CASE_WITH_DECO),                           \
+        __VA_ARGS__)
+
+namespace seastar::testing::internal {
+    template<typename T, typename = void>
+    struct has_setup : std::false_type {};
+    template<typename T>
+    struct has_setup<T, std::void_t<decltype(std::declval<T>().setup())>> : std::true_type {};
+    template<typename T>
+    seastar::future<> setup_conditional(T& t) {
+        if constexpr(has_setup<T>::value) {
+            return t.setup();
+        }
+        return seastar::make_ready_future();
+    }
+
+    template<typename T, typename = void>
+    struct has_teardown : std::false_type {};
+    template<typename T>
+    struct has_teardown<T, std::void_t<decltype(std::declval<T>().teardown())>> : std::true_type {};
+    template<typename T>
+    seastar::future<> teardown_conditional(T& t) {
+        if constexpr(has_setup<T>::value) {
+            return t.teardown();
+        }
+        return seastar::make_ready_future();
+    }
+}
+
+#define SEASTAR_FIXTURE_TEST_CASE_WITH_DECO(name, F, decorators)        \
+    struct name : public seastar::testing::seastar_test,                \
+                  private F {                                           \
+        using seastar::testing::seastar_test::seastar_test;             \
+        seastar::future<> run_test_case() override;                     \
+    private:                                                            \
+        seastar::future<> do_run_test_case() const;                     \
+    };                                                                  \
+    static const name name ## _instance(                                \
+        #name,                                                          \
+        __FILE__,                                                       \
+        __LINE__,                                                       \
+        decorators); /* NOLINT(cert-err58-cpp) */                       \
+    seastar::future<> name::run_test_case() {                           \
+        BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture ctor");       \
+        BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture setup");      \
+        /* seastar_test does not have  adefault ctor,  */               \
+        /* but setup_conditional needs to construct the fixture  */     \
+        /* to check if setup() is available, so cast it to F */         \
+        F& fixture = *this;                                             \
+        return testing::internal::setup_conditional(fixture).then([this] { \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" test entry");     \
+            return do_run_test_case();                                  \
+        }).finally([this] {                                             \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture teardown"); \
+            F& fixture = *this;                                         \
+            return testing::internal::teardown_conditional(fixture);    \
+        });                                                             \
+        BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture dtor");       \
+        return seastar::make_ready_future();                            \
+    }                                                                   \
+    seastar::future<> name::do_run_test_case() const
+
+
+#define SEASTAR_FIXTURE_TEST_CASE_WITHOUT_DECO(name, F)             \
+    SEASTAR_FIXTURE_TEST_CASE_WITH_DECO(                            \
+        name, F,                                                    \
+        boost::unit_test::decorator::collector_t::instance())
+
+#define SEASTAR_FIXTURE_TEST_CASE(...)                              \
+    SEASTAR_TEST_INVOKE(                                            \
+        BOOST_PP_IIF(                                               \
+            BOOST_PP_EQUAL(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 2), \
+            SEASTAR_FIXTURE_TEST_CASE_WITHOUT_DECO,                 \
+            SEASTAR_FIXTURE_TEST_CASE_WITH_DECO),                   \
         __VA_ARGS__)

--- a/include/seastar/testing/thread_test_case.hh
+++ b/include/seastar/testing/thread_test_case.hh
@@ -60,3 +60,47 @@
             SEASTAR_THREAD_TEST_CASE_WITHOUT_DECO,                  \
             SEASTAR_THREAD_TEST_CASE_WITH_DECO),                    \
         __VA_ARGS__)
+
+#define SEASTAR_THREAD_FIXTURE_TEST_CASE_WITH_DECO(name, F, decorators) \
+    struct name : public seastar::testing::seastar_test, public F {     \
+        using seastar::testing::seastar_test::seastar_test;             \
+        seastar::future<> run_test_case() override;                     \
+    private:                                                            \
+        void do_run_test_case() const;                                  \
+    };                                                                  \
+    static const name name ## _instance(                                \
+        #name,                                                          \
+        __FILE__,                                                       \
+        __LINE__,                                                       \
+        decorators); /* NOLINT(cert-err58-cpp) */                       \
+    seastar::future<> name::run_test_case() {                           \
+        return seastar::async([this] {                                  \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture ctor");   \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture setup");  \
+            /* seastar_test does not have a default ctor,  */           \
+            /* but setup_conditional needs to construct the fixture  */ \
+            /* to check if setup() is available, so cast it to F */     \
+            F& fixture = *this;                                         \
+            boost::unit_test::setup_conditional(fixture);               \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" test entry");     \
+            do_run_test_case();                                         \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture teardown"); \
+            boost::unit_test::teardown_conditional(fixture);            \
+            BOOST_TEST_CHECKPOINT('"' << #name << "\" fixture dtor");   \
+        });                                                             \
+    }                                                                   \
+    void name::do_run_test_case() const                                 \
+
+
+#define SEASTAR_THREAD_FIXTURE_TEST_CASE_WITHOUT_DECO(name, F)      \
+    SEASTAR_THREAD_FIXTURE_TEST_CASE_WITH_DECO(                     \
+        name, F,                                                    \
+        boost::unit_test::decorator::collector_t::instance())
+
+#define SEASTAR_THREAD_FIXTURE_TEST_CASE(...)                       \
+    SEASTAR_TEST_INVOKE(                                            \
+        BOOST_PP_IIF(                                               \
+            BOOST_PP_EQUAL(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 2), \
+            SEASTAR_THREAD_FIXTURE_TEST_CASE_WITHOUT_DECO,          \
+            SEASTAR_THREAD_FIXTURE_TEST_CASE_WITH_DECO),            \
+        __VA_ARGS__)

--- a/include/seastar/testing/thread_test_case.hh
+++ b/include/seastar/testing/thread_test_case.hh
@@ -34,7 +34,7 @@
 #define SEASTAR_THREAD_TEST_CASE_WITH_DECO(name, decorators) \
     struct name : public seastar::testing::seastar_test {    \
         using seastar::testing::seastar_test::seastar_test;  \
-        seastar::future<> run_test_case() const override {   \
+        seastar::future<> run_test_case() override {         \
             return seastar::async([this] {                   \
                 do_run_test_case();                          \
             });                                              \

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -173,7 +173,7 @@ SEASTAR_TEST_CASE(test_thread_custom_stack_size) {
 #if defined(SEASTAR_THREAD_STACK_GUARDS) && defined(__x86_64__) && !defined(SEASTAR_ASAN_ENABLED)
 struct test_thread_custom_stack_size_failure : public seastar::testing::seastar_test {
     using seastar::testing::seastar_test::seastar_test;
-    seastar::future<> run_test_case() const override;
+    seastar::future<> run_test_case() override;
 };
 
 static test_thread_custom_stack_size_failure test_thread_custom_stack_size_failure_instance(
@@ -213,7 +213,7 @@ static void bypass_stack_guard(int sig, siginfo_t* si, void* ctx) {
 
 // This test will fail with a regular stack size, because we only probe
 // around 10KiB of data, and the stack guard resides after 128'th KiB.
-seastar::future<> test_thread_custom_stack_size_failure::run_test_case() const {
+seastar::future<> test_thread_custom_stack_size_failure::run_test_case() {
     if (RUNNING_ON_VALGRIND) {
         return make_ready_future<>();
     }


### PR DESCRIPTION
before this change, because of the missing support of test fixture,
some tests in scylladb are using lambdas or homebrew test helper
class for hosting the helpers and for creating the test fixture,
so they can be shared in a test case or across test cases. this
hurts the readability. the better practice would be to have smaller
tests which share the same fixture explicitly.

so, in this change, 

* the `const` specifier is removed from `seastar_test::run_test_case()`
* two more macros are added so tests can be defined with fixtures:
  - SEASTAR_FIXTURE_TEST_CASE
  - SEASTAR_THREAD_FIXTURE_TEST_CASE
* tls_test.cc is updated to use `SEASTAR_THREAD_FIXTURE_TEST_CASE`
