### PR TITLE
make chunked_fifo a regular range

### DIFF
--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -149,6 +149,7 @@ private:
         size_t _item_index = 0;
 
     protected:
+        inline basic_iterator() = default;
         inline explicit basic_iterator(chunk* c) noexcept;
         inline basic_iterator(chunk* c, size_t item_index) noexcept;
 

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -31,12 +31,16 @@
 #include <version>
 #endif
 #include <seastar/core/circular_buffer.hh>
+#include <ranges>
 
 using namespace seastar;
 
 #ifdef __cpp_lib_concepts
 static_assert(std::weakly_incrementable<chunked_fifo<int>::iterator>);
 static_assert(std::weakly_incrementable<chunked_fifo<int>::const_iterator>);
+static_assert(std::sentinel_for<chunked_fifo<int>::iterator, chunked_fifo<int>::iterator>);
+static_assert(std::sentinel_for<chunked_fifo<int>::const_iterator, chunked_fifo<int>::const_iterator>);
+static_assert(std::ranges::range<chunked_fifo<const int>>);
 #endif
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_small) {

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -27,9 +27,17 @@
 #include <stdlib.h>
 #include <chrono>
 #include <deque>
+#if __has_include(<version>)
+#include <version>
+#endif
 #include <seastar/core/circular_buffer.hh>
 
 using namespace seastar;
+
+#ifdef __cpp_lib_concepts
+static_assert(std::weakly_incrementable<chunked_fifo<int>::iterator>);
+static_assert(std::weakly_incrementable<chunked_fifo<int>::const_iterator>);
+#endif
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_small) {
     // Check all the methods of chunked_fifo but with a trivial type (int) and


### PR DESCRIPTION
this Pr modifies chunked_fifo::basic_iterator to make chunked_fifo a range,
and makes `static_assert(std::ranges::range<chunked_fifo<int>>);` compile.

logically there are two changes to accomplish this
1. make operator++ return the correct type by using CRTP
2. make basic_iterator default constructible, needed for the end iterator

The unit tests are static_assert on the specific issues

Fixes https://github.com/scylladb/seastar/issues/1793