### PR TITLE
chunked_fifo: let incremetal operator return iterator not basic_iterator

### DIFF
--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -27,9 +27,18 @@
 #include <stdlib.h>
 #include <chrono>
 #include <deque>
+#include <iterator>
+#if __has_include(<version>)
+#include <version>
+#endif
 #include <seastar/core/circular_buffer.hh>
 
 using namespace seastar;
+
+#ifdef __cpp_lib_concepts
+static_assert(std::weakly_incrementable<chunked_fifo<int>::iterator>);
+static_assert(std::weakly_incrementable<chunked_fifo<int>::const_iterator>);
+#endif
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_small) {
     // Check all the methods of chunked_fifo but with a trivial type (int) and

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -24,20 +24,29 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/circular_buffer.hh>
 #include <stdlib.h>
 #include <chrono>
 #include <deque>
 #include <iterator>
+#if __has_include(<ranges>)
+#include <ranges>
+#endif
 #if __has_include(<version>)
 #include <version>
 #endif
-#include <seastar/core/circular_buffer.hh>
 
 using namespace seastar;
 
 #ifdef __cpp_lib_concepts
 static_assert(std::weakly_incrementable<chunked_fifo<int>::iterator>);
 static_assert(std::weakly_incrementable<chunked_fifo<int>::const_iterator>);
+static_assert(std::sentinel_for<chunked_fifo<int>::iterator, chunked_fifo<int>::iterator>);
+static_assert(std::sentinel_for<chunked_fifo<int>::const_iterator, chunked_fifo<int>::const_iterator>);
+#endif
+
+#ifdef __cpp_lib_ranges
+static_assert(std::ranges::range<chunked_fifo<const int>>);
 #endif
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_small) {


### PR DESCRIPTION
a proper iterator's operator++(int) should return an instance of this iterator, and  operator++() should return a reference of this iterator. but chunked_fifo::iterator and chunked_fifo::const_iterator's incremental operator returns basic_iterator<U>. this is not quite right in the sense of the behavior of a proper iterator's interface.

so, in this change, instead of inheriting from the `basic_iterator`, we just define the `iterator` and `const_iterator` as the instantiation of this template.

Fixes #1793
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>