### PR TITLE
memory: diable transparent hugepages if --overprovisioned is specified

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -159,6 +159,7 @@ numa_layout merge(numa_layout one, numa_layout two);
 }
 
 internal::numa_layout configure(std::vector<resource::memory> m, bool mbind,
+        bool transparent_hugepages,
         std::optional<std::string> hugetlbfs_path = {});
 
 // A deprecated alias for set_abort_on_allocation_failure(true).


### PR DESCRIPTION
--overprovisioned (which should really be renamed --overcommitted or --underprovisioned) means that Seastar should sacrifice performance in favor of playing well with other applications on the same system. One such sacrifice can be avoiding transparent hugepages.

Transparent hugepages can waste memory if only part of a hugepage is used, waste kernel CPU time trying to coalesce a huge page, and make it harder to swap.

Be more friendly by avoiding transparent hugepages when --overprovisioned is specified. This is a little complicated since we allocate memory before we know whether --overprovisioned is specified or not (even before main() runs). Since it's only a small amount of memory, conservatively (from the performance point of view) assume we want transparent hugepages, and back down and undo if it later turns out we don't.

I verified with strace that madvise() calls happen as expected.

Ref scylladb/scylladb#15095.