### PR TITLE
tls: Optionally skip client EOF wait

### DIFF
--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -89,11 +89,11 @@ int main(int ac, char** av) {
             return net::dns::get_host_by_name(addr).then([=](net::hostent e) {
                 ipv4_addr ia(e.addr_list.front(), port);
 
-                sstring name;
+                tls::tls_options options;
                 if (check) {
-                    name = server_name.empty() ? e.names.front() : server_name;
+                    options.server_name = server_name.empty() ? e.names.front() : server_name;
                 }
-                return tls::connect(certs, ia, name).then([=](::connected_socket s) {
+                return tls::connect(certs, ia, options).then([=](::connected_socket s) {
                     auto strms = ::make_lw_shared<streams>(std::move(s));
                     auto range = boost::irange(size_t(0), i);
                     return do_for_each(range, [=](auto) {

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -309,6 +309,8 @@ namespace tls {
     struct tls_options {
         /// \brief whether to wait for EOF from server on session termination
         bool wait_for_eof_on_shutdown = true;
+        /// \brief server name to be used for the SNI TLS extension
+        sstring server_name = {};
     };
 
     /**
@@ -317,11 +319,28 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name = {});
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name);
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name);
+    /// @}
+
+    /**
+     * Creates a TLS client connection using the default network stack and the
+     * supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, tls_options option = {});
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, tls_options options = {});
     /// @}
 
     /**
@@ -330,10 +349,38 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name);
+    /// @}
+
+    /**
+     * Creates a socket through which a TLS client connection can be created,
+     * using the default network stack and the supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, tls_options options = {});
+    /// @}
+
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
+     */
+    /// @{
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name);
+    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 
     /**
@@ -342,8 +389,7 @@ namespace tls {
      * \param options Optional additional session configuration
      */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
-    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, tls_options options = {});
     /// @}
 
     /**

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -305,6 +305,12 @@ namespace tls {
         sstring _priority;
     };
 
+    /// TLS configuration options
+    struct tls_options {
+        /// \brief whether to wait for EOF from server on session termination
+        bool wait_for_eof_on_shutdown = true;
+    };
+
     /**
      * Creates a TLS client connection using the default network stack and the
      * supplied credentials.
@@ -330,9 +336,13 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /** Wraps an existing connection in SSL/TLS. */
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * \param options Optional additional session configuration
+     */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1001,10 +1001,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
+            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, tls_options options = {})
             : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _output_pending(
+                    _in_sem(1), _out_sem(1), _options(options), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1047,9 +1047,10 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { })
+            connected_socket sock, sstring name = { },
+            tls_options options = {})
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name)) {
+                    std::move(name), options) {
     }
 
     ~session() {
@@ -1467,6 +1468,10 @@ public:
         return wait_for_output();
     }
     future<> wait_for_eof() {
+        if (!_options.wait_for_eof_on_shutdown) {
+            return make_ready_future();
+        }
+
         // read records until we get an eof alert
         // since this call could time out, we must not ac
         return with_semaphore(_in_sem, 1, [this] {
@@ -1685,6 +1690,8 @@ private:
 
     semaphore _in_sem, _out_sem;
 
+    tls_options _options;
+
     bool _eof = false;
     bool _shutdown = false;
     bool _connected = false;
@@ -1889,8 +1896,8 @@ socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
     return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name)));
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, tls_options options) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }


### PR DESCRIPTION
This commit extends the `tls::wrap_client` interface with an optional param which indicates to the sessions that it should not wait for an EOF after sending the BYE message.

Badly behaved servers will not send the expected EOF message. Clients that call `wait_input_shutdown` on the connected socket will hang for 10 seconds in that case (the tls session `close` method spawns a background fiber with a 10s hardcoded timeout). I've tested this against the wacky server with both Seastar's experimental HTTP client and Redpanda's own HTTP client and the result was the same.

The previous default behaviour has been preserved and clients should always wait for EOF if the intend to re-use the connection.