### PR TITLE
fix compilation for musl

### DIFF
--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -28,7 +28,10 @@
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE
+#if __has_include(<execinfo.h>)
 #include <execinfo.h>
+#define HAVE_EXECINFO
+#endif
 #include <iosfwd>
 #include <memory>
 #include <variant>
@@ -59,6 +62,7 @@ frame decorate(uintptr_t addr) noexcept;
 SEASTAR_MODULE_EXPORT
 template<typename Func>
 void backtrace(Func&& func) noexcept(noexcept(func(frame()))) {
+#ifdef HAVE_EXECINFO
     constexpr size_t max_backtrace = 100;
     void* buffer[max_backtrace];
     int n = ::backtrace(buffer, max_backtrace);
@@ -66,6 +70,10 @@ void backtrace(Func&& func) noexcept(noexcept(func(frame()))) {
         auto ip = reinterpret_cast<uintptr_t>(buffer[i]);
         func(decorate(ip - 1));
     }
+#else
+// Not implemented yet
+#define SEASTAR_BACKTRACE_UNIMPLEMENTED
+#endif
 }
 
 // Represents a call stack of a single thread.

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -382,9 +382,13 @@ posix_file_impl::list_directory(std::function<future<> (directory_entry de)> nex
     // instead.
 
     // From getdents(2):
+    // check for 64-bit inode number
+    static_assert(sizeof(ino_t) == 8, "large file support not enabled");
+    static_assert(sizeof(off_t) == 8, "large file support not enabled");
+
     struct linux_dirent64 {
-        ino64_t        d_ino;    /* 64-bit inode number */
-        off64_t        d_off;    /* 64-bit offset to next structure */
+        ino_t          d_ino;    /* 64-bit inode number */
+        off_t          d_off;    /* 64-bit offset to next structure */
         unsigned short d_reclen; /* Size of this dirent */
         unsigned char  d_type;   /* File type */
         char           d_name[]; /* Filename (null-terminated) */

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -22,7 +22,6 @@
 module;
 #endif
 
-#include <execinfo.h>
 #include <link.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -200,9 +200,11 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {
         log_msg << std::current_exception();
     }
 
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
     auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)";
     std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
     BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
@@ -217,9 +219,11 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
         }
     }
 
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
     auto regex_str = "std::_Nested_exception<unknown_obj>.*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)";
     std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
     BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
@@ -240,10 +244,12 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
         }
     }
 
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
     auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)"
             " \\(while cleaning up after unknown_obj\\)";
     std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
     BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_logging) {
@@ -264,8 +270,10 @@ BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_loggin
         }
     }
 
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
     auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)"
             " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)\\)";
     std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
     BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+#endif
 }

--- a/tests/unit/unwind_test.cc
+++ b/tests/unit/unwind_test.cc
@@ -50,12 +50,14 @@ BOOST_AUTO_TEST_CASE(test_signal_mask_is_preserved_on_unwinding) {
         // ignore
     }
 
-    // Check backtrace()
+    // Check backtrace() if execinfo.h is present
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
     {
         size_t count = 0;
         backtrace([&count] (auto) { ++count; });
         BOOST_REQUIRE(count > 0);
     }
+#endif
 
     {
         sigset_t mask2;


### PR DESCRIPTION
musl lacks execinfo.h
lfs64 definitions are now deprecated and will be removed in the next release of musl

Fixes #1743