### PR TITLE
Fix -Wunused-variable warnings

### DIFF
--- a/include/seastar/net/arp.hh
+++ b/include/seastar/net/arp.hh
@@ -47,7 +47,12 @@ public:
     arp_for_protocol(arp& a, uint16_t proto_num);
     virtual ~arp_for_protocol();
     virtual future<> received(packet p) = 0;
-    virtual bool forward(forward_hash& out_hash_data, packet& p, size_t off) { return false; }
+    virtual bool forward(forward_hash& out_hash_data, packet& p, size_t off) {
+      std::ignore = out_hash_data;
+      std::ignore = p;
+      std::ignore = off;
+      return false;
+    }
 };
 
 class arp {

--- a/include/seastar/net/ethernet.hh
+++ b/include/seastar/net/ethernet.hh
@@ -46,7 +46,7 @@ struct ethernet_address {
     std::array<uint8_t, 6> mac;
 
     template <typename Adjuster>
-    void adjust_endianness(Adjuster a) noexcept {}
+    void adjust_endianness(Adjuster) noexcept {}
 
     static ethernet_address read(const char* p) noexcept {
         ethernet_address ea;

--- a/include/seastar/net/ip.hh
+++ b/include/seastar/net/ip.hh
@@ -96,7 +96,12 @@ class ip_protocol {
 public:
     virtual ~ip_protocol() {}
     virtual void received(packet p, ipv4_address from, ipv4_address to) = 0;
-    virtual bool forward(forward_hash& out_hash_data, packet& p, size_t off) { return true; }
+    virtual bool forward(forward_hash& out_hash_data, packet& p, size_t off) {
+      std::ignore = out_hash_data;
+      std::ignore = p;
+      std::ignore = off;
+      return true;
+    }
 };
 
 template <typename InetTraits>


### PR DESCRIPTION
unused params in net::ethernet_address::adjust_endianess,
net::arp_protocol::forward and net::ip_protocol::forward trigger -Wunused-parameter 

This PR fixes this by either removing the name of the parameter or by void-casting