### PR TITLE
shared_token_bucket: Make duration->tokens conversion more solid

### DIFF
--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -150,8 +150,8 @@ public:
             : _replenish_rate(std::min(rate, max_rate))
             , _replenish_limit(limit)
             , _replenish_threshold(std::clamp(threshold, (T)1, limit))
-            // pretend it was replenished yesterday to spot overflows early
-            , _replenished(Clock::now() - std::chrono::hours(add_replenish_iffset ? 24 : 0))
+            // pretend it was replenished max_delta ago to spot overflows early
+            , _replenished(Clock::now() - std::chrono::hours(add_replenish_iffset ? 1 : 0))
             , _rovers(_replenish_limit)
     {}
 
@@ -174,7 +174,10 @@ public:
         auto extra = accumulated_in(delta);
 
         if (extra >= _replenish_threshold) {
-            if (!_replenished.compare_exchange_weak(ts, ts + delta)) {
+            // accumulated_in() might have lost or accumulated some replenisher
+            // time due to rounding floating-point delta to integer tokens
+            auto real_delta = std::chrono::duration_cast<decltype(delta)>(duration_for(extra));
+            if (!_replenished.compare_exchange_weak(ts, ts + real_delta)) {
                 return; // next time or another shard
             }
 


### PR DESCRIPTION
The t.b. should be replenished from time to time. When replenishing happens it calcualtes the duration between now and last replenishment and converts it to the amount of gained tokens. Since duration is a floating point number and tokens are integers, the convertion may lose some precision, e.g. over a time the bucket mush accumulate 2.718 tokens, but it can only accumulate 2 or 3. Current code rounds the floating point result to integer in the hope that rounding errors compenate each other on average.

However, if the assumption doesn't hold, those deviation may accumulate resulting in wrong replenishing rate. This effects is additionally compensated by the minimal amount of tokens to replenish (called threshold), but it still exists.

There's a simple yet robust fix to that. With the integer number of tokens at hand convert it back to the duration it _had_ to be to get this exact amount of tokens and update the "last time replenished" with the corrected duration.

refs: #1641

One thing to keep in mind is that on start token bucket sets its "last replenished" timestamp to be 24 hours in the past. This is done to make the very first replenish "overflow" and be capped somehow. This capping plays badly with this change, as is re-evaluates the real-delta to be at most max_delta which is just 1 hour, not ~24 hours as it should be.

Thus, the replenisher keeps its "last replenished" timestamp in the past for too long thus giving short loads a burst that greatly exceeds the default-configured one (10Mb/s for io-queue classes)