### PR TITLE
Fix compilation for non glibc platforms like alpine using musl libc

### DIFF
--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -33,6 +33,7 @@ module;
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <valgrind/valgrind.h>
+#include <features.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -171,7 +172,11 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
     auto r = io_setup(nr, io_context);
     if (r < 0) {
         char buf[1024];
-        char *msg = strerror_r(errno, buf, sizeof(buf));
+#ifdef __GLIBC__
+        const char *msg = strerror_r(errno, buf, sizeof(buf));
+#else
+        const char *msg = strerror_r(errno, buf, sizeof(buf)) ? "unknown error" : buf;
+#endif
         if (errno == EAGAIN) {
             auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
             throw std::runtime_error(

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -69,6 +69,7 @@ module;
 #include <boost/container/static_vector.hpp>
 
 #include <dlfcn.h>
+#include <features.h>
 
 #ifndef SEASTAR_DEFAULT_ALLOCATOR
 #include <new>
@@ -1608,7 +1609,11 @@ configure(std::vector<resource::memory> m, bool mbind,
 
             if (r == -1) {
                 char err[1000] = {};
-                char *msg = strerror_r(errno, err, sizeof(err));
+#ifdef __GLIBC__
+                const char *msg = strerror_r(errno, err, sizeof(err));
+#else
+                const char *msg = strerror_r(errno, err, sizeof(err)) ? "unknown error" : buf;
+#endif
                 std::cerr << "WARNING: unable to mbind shard memory; performance may suffer: "
                         << msg << std::endl;
             }

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -122,15 +122,15 @@ posix_thread::posix_thread(attr a, std::function<void ()> func)
     }
 #endif
 
-    if (a._affinity) {
-        auto& cpuset = *a._affinity;
-        pthread_attr_setaffinity_np(&pa, sizeof(cpuset), &cpuset);
-    }
-
     r = pthread_create(&_pthread, &pa,
                 &posix_thread::start_routine, _func.get());
     if (r) {
         throw std::system_error(r, std::system_category());
+    }
+
+    if (a._affinity) {
+        auto& cpuset = *a._affinity;
+        pthread_setaffinity_np(_pthread, sizeof(cpuset), &cpuset);
     }
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -48,7 +48,7 @@ module;
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/eventfd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/thread/barrier.hpp>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1950,7 +1950,7 @@ reactor::chmod(std::string_view name, file_permissions permissions) noexcept {
     });
 }
 
-directory_entry_type stat_to_entry_type(__mode_t type) {
+directory_entry_type stat_to_entry_type(mode_t type) {
     if (S_ISDIR(type)) {
         return directory_entry_type::directory;
     }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1176,7 +1176,10 @@ cpu_stall_detector_posix_timer::cpu_stall_detector_posix_timer(cpu_stall_detecto
     struct sigevent sev = {};
     sev.sigev_notify = SIGEV_THREAD_ID;
     sev.sigev_signo = signal_number();
-    sev._sigev_un._tid = syscall(SYS_gettid);
+#ifndef sigev_notify_thread_id
+#define sigev_notify_thread_id _sigev_un._tid
+#endif
+    sev.sigev_notify_thread_id = syscall(SYS_gettid);
     int err = timer_create(CLOCK_THREAD_CPUTIME_ID, &sev, &_timer);
     if (err) {
         throw std::system_error(std::error_code(err, std::system_category()));

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -32,7 +32,7 @@ module;
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/epoll.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/syscall.h>
 #include <sys/resource.h>
 #include <boost/container/small_vector.hpp>

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -30,7 +30,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
 #include <sys/mman.h>
-#include <sys/signal.h>
+#include <signal.h>
 
 #include <valgrind/valgrind.h>
 


### PR DESCRIPTION
Currently seastar fails to compile on non glibc platforms like ones using musl libc due to the use of some internal glibc macros and glibc extensions of functions, so change to portable ones or perform checks to make sure the correct one is used for the target platform.

These changes include:
Changing includes of sys/poll.h and sys/signal.h to the posix location without sys
Replacing the internal __mode_t with mode_t
Fix strerror_r usage which was a glibc specific extension
Use pthread_setaffinity_np instead of pthread_attr_setaffinity_np
Access sigevent.sigev_notify_thread_id with a macro