### PR TITLE
net: udp_channel: integrate AF_UNIX support to the POSIX stack

### DIFF
--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -871,7 +871,14 @@ public:
     posix_datagram(const socket_address& src, const socket_address& dst, packet p) : _src(src), _dst(dst), _p(std::move(p)) {}
     virtual socket_address get_src() override { return _src; }
     virtual socket_address get_dst() override { return _dst; }
-    virtual uint16_t get_dst_port() override { return _dst.port(); }
+    virtual uint16_t get_dst_port() override {
+        if (_dst.family() != AF_INET && _dst.family() != AF_INET6) {
+            std::stringstream ss;
+            ss << _dst;
+            throw std::runtime_error(format("get_dst_port() called on non-IP address: %s", ss.str()));
+        }
+        return _dst.port();
+    }
     virtual packet& get_data() override { return _p; }
 };
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -747,6 +747,9 @@ private:
             }
         }
 
+        recv_ctx(const recv_ctx&) = delete;
+        recv_ctx(recv_ctx&&) = delete;
+
         void prepare() {
             _buffer = new char[MAX_DATAGRAM_SIZE];
             _iov.iov_base = _buffer;
@@ -764,6 +767,9 @@ private:
             _hdr.msg_name = &_dst.u.sa;
             _hdr.msg_namelen = _dst.addr_length;
         }
+
+        send_ctx(const send_ctx&) = delete;
+        send_ctx(send_ctx&&) = delete;
 
         void prepare(const socket_address& dst, packet p) {
             _dst = dst;


### PR DESCRIPTION
`posix_udp_channel`'s constructor assumed that its local address parameter will always be from `AF_INET`/ `AF_INET6` (`AF_UNSPECIFIED` gets converted to `AF_INET`). To support creating `AF_UNIX` udp_channels, additional checks were added before making inet specific calls in channel's constructor.

To get the information about local address, `posix_udp_channel` uses ancillary data residing in `struct msghdr`'s `msg_control`, `msg_controllen` fields. Their use was limited to inet only. Additionally, destination address returned by `udp_channel::receive` does not depend completely on the ancillary data, a fallback is provided for families other than inet.

`bind()` invoked in `posix_udp_channel`'s constructor body now receives the true address length - this is needed as unix domain addresses have no fixed width (in contrast to inet), and are not necessarily null-terminated.

Ref: https://github.com/scylladb/seastar/issues/1798