### PR TITLE
coroutine: Add a necessary include in seastar/core/generator.hh

### DIFF
--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cassert>
+#include <coroutine>
 #include <optional>
 #include <utility>
 #include <seastar/core/future.hh>


### PR DESCRIPTION
The types used in the header file rely on types from \<coroutine>, but that header does not seem to be included.