### PR TITLE
[cmake] portable build: only link with rt where it's available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,7 +795,7 @@ target_link_libraries (seastar
     GnuTLS::gnutls
     StdAtomic::atomic
     lksctp-tools::lksctp-tools
-    rt::rt
+    $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt::rt>
     yaml-cpp::yaml-cpp
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)


### PR DESCRIPTION
This PR is in support of https://github.com/ceph/ceph/pull/52629