### PR TITLE
sstring: format sstring without implicit conversion

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -882,10 +882,14 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
 
 SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
-struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>> : fmt::formatter<std::basic_string_view<char_type>> {
+struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>>
+    : private fmt::formatter<std::basic_string_view<char_type>> {
+    using format_as_t = std::basic_string_view<char_type>;
+    using base = fmt::formatter<format_as_t>;
+    using base::parse;
     template <typename FormatContext>
     auto format(const ::seastar::basic_sstring<char_type, Size, max_size, NulTerminate>& s, FormatContext& ctx) const {
-        return formatter<std::basic_string_view<char_type>>::format(s, ctx);
+        return base::format(format_as_t{s}, ctx);
     }
 };
 


### PR DESCRIPTION
since fmt v10.1.1, it disabled implicitly conversion in quite a few use cases. to be more specific, in fmtlib 10.1.0, it stops converting the first argument passed to
formatter<std::string_view>::format(const std::string_view& s, FormatContext&) to `std::string_view`, even if the parameter can be implicitly converted to `std::string_view`. as the formatter of `std::string_view` is implemented by subclassing its formatter from the builtin basic_string_view's formatter.
so, the existing formatter does not compile any more with fmt v10.1.1 and up.

in this change,

* convert the sstring instance to std::string_view explicitly before formatting it.
* private inherit from fmt::formatter<string_view>. as strictly, speaking, fmt::formatter<sstring> is not a fmt::formatter<std::string_view>
* define helper type alias for better readability.

this change is tested after pointing the `cooking_ingredient (fmt ...)` command to `10.1.1.tar.gz` in cooking_recipe.cmake, and run
```console
$ ./configure.py --mode debug --compiler /usr/bin/clang++ --cook fmt
$ ninja -C build/debug seastar
```

Fixes #1807
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>