### PR TITLE
build: use target_compile_definitions() for adding -D...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,7 +866,8 @@ if (MaybeUninitialized_FOUND)
 endif ()
 
 if (Seastar_SSTRING)
-  target_compile_options (seastar PUBLIC -DSEASTAR_SSTRING)
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_SSTRING)
 endif ()
 
 if (LinuxMembarrier_FOUND)


### PR DESCRIPTION
instead of using `target_compile_options()` use the dedicated command for adding compiling definition when compiling C/C++ sources. for better maintainability. for instance, we can find all -D.. options be searching for `target_compile_definitions()`, and more consistent this way.