### PR TITLE
build, process: avoid using stdout or stderr as C++ identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1033,6 +1033,18 @@ if (Seastar_DEBUG_SHARED_PTR IN_LIST True_STRING_VALUES OR
       SEASTAR_DEBUG_SHARED_PTR)
 endif ()
 
+include (CheckCXXSourceCompiles)
+file (READ ${CMAKE_CURRENT_LIST_DIR}/cmake/code_tests/stdout_test.cc _stdout_test_code)
+check_cxx_source_compiles ("${_stdout_test_code}" Stdout_Can_Be_Used_As_Identifier)
+if (Stdout_Can_Be_Used_As_Identifier)
+  # "stdout" is defined as a macro by the C++ standard, so we cannot assume
+  # that the macro is always expanded into an identifier which can be re-used
+  # to name a enumerator in the declaration of an enumeration.
+  target_compile_definitions (seastar
+    PUBLIC
+      SEASTAR_LOGGER_TYPE_STDOUT)
+endif ()
+
 set (Seastar_STACK_GUARD_MODES "Debug" "Sanitize" "Dev")
 if ((Seastar_STACK_GUARDS STREQUAL "ON") OR
     ((Seastar_STACK_GUARDS STREQUAL "DEFAULT") AND

--- a/cmake/code_tests/stdout_test.cc
+++ b/cmake/code_tests/stdout_test.cc
@@ -1,0 +1,8 @@
+#include <cstdio>
+
+enum class logger_type {
+  stdout,
+  stderr,
+};
+
+int main() {}

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -504,8 +504,12 @@ enum class logger_timestamp_style {
 /// \brief Output stream to use for logging.
 enum class logger_ostream_type {
     none,
-    stdout,
-    stderr,
+#ifdef SEASTAR_LOGGER_TYPE_STDOUT
+    stdout __attribute__ ((deprecated ("use cout instead"))) = 1,
+    stderr __attribute__ ((deprecated ("use cerr instead"))) = 2,
+#endif
+    cout = 1,
+    cerr = 2,
 };
 
 struct logging_settings final {
@@ -515,7 +519,7 @@ struct logging_settings final {
     bool syslog_enabled;
     bool with_color;
     logger_timestamp_style stdout_timestamp_style = logger_timestamp_style::real;
-    logger_ostream_type logger_ostream = logger_ostream_type::stderr;
+    logger_ostream_type logger_ostream = logger_ostream_type::cerr;
 };
 
 /// Shortcut for configuring the logging system all at once.

--- a/include/seastar/util/process.hh
+++ b/include/seastar/util/process.hh
@@ -74,13 +74,13 @@ class process {
     /// \returns a \c process instance representing the spawned subprocess
     static future<process> spawn(const std::filesystem::path& pathname);
 public:
-    process(create_tag, pid_t pid, file_desc&& stdin, file_desc&& stdout, file_desc&& stderr);
+    process(create_tag, pid_t pid, file_desc&& cin, file_desc&& cout, file_desc&& cerr);
     /// Return an writable stream which provides input from the child process
-    output_stream<char> stdin();
+    output_stream<char> cin();
     /// Return an writable stream which provides stdout output from the child process
-    input_stream<char> stdout();
+    input_stream<char> cout();
     /// Return an writable stream which provides stderr output from the child process
-    input_stream<char> stderr();
+    input_stream<char> cerr();
     struct wait_exited {
         int exit_code;
     };

--- a/src/core/program_options.cc
+++ b/src/core/program_options.cc
@@ -74,8 +74,8 @@ const char* to_string(logger_timestamp_style val) {
 const char* to_string(logger_ostream_type val) {
     switch (val) {
         case logger_ostream_type::none: return "none";
-        case logger_ostream_type::stdout: return "stdout";
-        case logger_ostream_type::stderr: return "stderr";
+        case logger_ostream_type::cout: return "stdout";
+        case logger_ostream_type::cerr: return "stderr";
     }
     std::abort();
 }
@@ -121,9 +121,9 @@ logger_ostream_type from_string(const std::string& val, boost::type<logger_ostre
     if (val == "none") {
         return logger_ostream_type::none;
     } else if (val == "stdout") {
-        return logger_ostream_type::stdout;
+        return logger_ostream_type::cout;
     } else if (val == "stderr") {
-        return logger_ostream_type::stderr;
+        return logger_ostream_type::cerr;
     }
     throw std::runtime_error(fmt::format("Invalid value for enum logger_ostream_type: {}", val));
 }

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -212,10 +212,10 @@ void validate(boost::any& v,
         v = logger_ostream_type::none;
         return;
     } else if (s == "stdout") {
-        v = logger_ostream_type::stdout;
+        v = logger_ostream_type::cout;
         return;
     } else if (s == "stderr") {
-        v = logger_ostream_type::stderr;
+        v = logger_ostream_type::cerr;
         return;
     }
     throw validation_error(validation_error::invalid_option_value);
@@ -224,8 +224,8 @@ void validate(boost::any& v,
 std::ostream& operator<<(std::ostream& os, logger_ostream_type lot) {
     switch (lot) {
     case logger_ostream_type::none: return os << "none";
-    case logger_ostream_type::stdout: return os << "stdout";
-    case logger_ostream_type::stderr: return os << "stderr";
+    case logger_ostream_type::cout: return os << "stdout";
+    case logger_ostream_type::cerr: return os << "stderr";
     default: abort();
     }
     return os;
@@ -492,11 +492,11 @@ void apply_logging_settings(const logging_settings& s) {
     case logger_ostream_type::none:
         logger::set_ostream_enabled(false);
         break;
-    case logger_ostream_type::stdout:
+    case logger_ostream_type::cout:
         logger::set_ostream(std::cout);
         logger::set_ostream_enabled(true);
         break;
-    case logger_ostream_type::stderr:
+    case logger_ostream_type::cerr:
         logger::set_ostream(std::cerr);
         logger::set_ostream_enabled(true);
         break;
@@ -588,7 +588,7 @@ options::options(program_options::option_group* parent_group)
     , logger_stdout_timestamps(*this, "logger-stdout-timestamps", logger_timestamp_style::real,
                     "Select timestamp style for stdout logs: none|boot|real")
     , log_to_stdout(*this, "log-to-stdout", true, "Send log output to output stream, as selected by --logger-ostream-type")
-    , logger_ostream_type(*this, "logger-ostream-type", logger_ostream_type::stderr,
+    , logger_ostream_type(*this, "logger-ostream-type", logger_ostream_type::cerr,
             "Send log output to: none|stdout|stderr")
     , log_to_syslog(*this, "log-to-syslog", false, "Send log output to syslog.")
     , log_with_color(*this, "log-with-color", isatty(STDOUT_FILENO), "Print colored tag prefix in log message written to ostream")

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -108,11 +108,11 @@ public:
 };
 }
 
-process::process(create_tag, pid_t pid, file_desc&& stdin, file_desc&& stdout, file_desc&& stderr)
+process::process(create_tag, pid_t pid, file_desc&& cin, file_desc&& cout, file_desc&& cerr)
     : _pid(pid)
-    , _stdin(std::move(stdin))
-    , _stdout(std::move(stdout))
-    , _stderr(std::move(stderr)) {}
+    , _stdin(std::move(cin))
+    , _stdout(std::move(cout))
+    , _stderr(std::move(cerr)) {}
 
 future<process::wait_status> process::wait() {
     return engine().waitpid(_pid).then([] (int wstatus) -> wait_status {
@@ -146,15 +146,15 @@ future<process> process::spawn(const std::filesystem::path& pathname) {
     return spawn(pathname, {{pathname.native()}, {}});
 }
 
-output_stream<char> process::stdin() {
+output_stream<char> process::cin() {
     return output_stream<char>(data_sink(pipe_data_sink_impl::from_fd(std::move(_stdin))));
 }
 
-input_stream<char> process::stdout() {
+input_stream<char> process::cout() {
     return input_stream<char>(data_source(pipe_data_source_impl::from_fd(std::move(_stdout))));
 }
 
-input_stream<char> process::stderr() {
+input_stream<char> process::cerr() {
     return input_stream<char>(data_source(pipe_data_source_impl::from_fd(std::move(_stderr))));
 }
 

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -241,7 +241,7 @@ class https_server {
             std::string line;
         };
         auto reader = ::make_shared<consumer>();
-        process.stdout().consume(*reader).get();
+        process.cout().consume(*reader).get();
         return std::stoul(reader->line);
     }
 


### PR DESCRIPTION
musl libc defines `stdout` like
```c++
#define stdout (stdout)
```
while glibc defines `stdout` like
```c++
#define stdout stdout
```
the same applies to `stderr`. both these definitions comply to the the C++ standard, but we reuse `stdout` and `stderr` when defining an `enum class` or when defining a member function . so, for instance, after preprocessing, the definition from musl libc is expanded into
```c++
enum class logger_ostream_type {
  none,
  (stdout),
  (stderr),
};
```
which does not compile. so, in order to be more standard compliant, and does not rely on a specific libc implementation, while preserve the backward compatibility. let's check if `stdout` and `stderr` can be used as an identifier. also, since `stdout` and `stderr` are required to be defined as macros by the standard library. let's mark them deprecated in hope to remove them in a future version in favor of `cout` and `cerr` which are guranteed to be valid identifiers by the C++ standard.

but as the `[[deprecated]]` specifier cannnot be applied to a certain enumerator, let's use the ` __attribute__ ((deprecated...))` instead. fortunately, it is supported by both Clang and GCC.

this should address one of the FTBFS with musl libc.