### PR TITLE
http/client: pass tls_options to tls::connect()

### DIFF
--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -208,7 +208,7 @@ public:
     {
     }
     virtual future<connected_socket> make() override {
-        return tls::connect(_creds, _addr, _host);
+        return tls::connect(_creds, _addr, tls::tls_options{.server_name = _host});
     }
 };
 


### PR DESCRIPTION
in e7e51612, we moved the `server_name` into `tls_options`, and deprecated the overloads of `tls::connect()` which accept `server_name` in favor of the ones which accept `tls::tls_options`. but we failed to update the caller of the deprecated function in src/htpp/client.cc.

to use the new API and to address the deprecation warning, let's update this caller as well.