### PR TITLE
http/api_docs: copy in api_docs's copy constructor

### DIFF
--- a/include/seastar/http/api_docs.hh
+++ b/include/seastar/http/api_docs.hh
@@ -80,10 +80,10 @@ struct api_docs : public json::json_base {
         register_params();
     }
     api_docs(const api_docs & e)
-      : json::json_base()
+        : apiVersion{e.apiVersion}
+        , swaggerVersion{e.swaggerVersion}
+        , apis{e.apis}
     {
-        apiVersion = "0.0.1";
-        swaggerVersion = "1.2";
         register_params();
     }
     template<class T>


### PR DESCRIPTION
instead of hardwiring the apiVersion and swaggerVersion, we'd better copy it from the the copied instance. also, it be more correct to copy the "apis", which is the most important thing held by an "api_docs".

this issue was spotted when auditing the code. as typically, we don't use `api_docs` directly. instead, we use `api_registry_builder`, which in general, registers the pointer to a newly created `api_registry` to the specified `routes` instance. so we don't really copy an `api_docs`.

but this fix is still an improvement in the sense of correctness.