### PR TITLE
smp: reference correct variable when fetch_or()

### DIFF
--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -216,7 +216,7 @@ internal::memory_prefaulter::work(std::vector<memory::internal::memory_range>& r
 #else
         // atomic_ref would be better, but alas C++20 only
         auto p1 = reinterpret_cast<volatile std::atomic<char>*>(p);
-        p->fetch_or(0, std::memory_order_relaxed);
+        p1->fetch_or(0, std::memory_order_relaxed);
 #endif
     };
     while (!_stop_request.load(std::memory_order_relaxed) && !ranges.empty()) {


### PR DESCRIPTION
we are supposed to call `p1->fetch_or()` but ended up using `p->fetch_or()`, where `p` is a plain pointer. this issue has not been reported until we started to build Seastar on architecture not amd64 or aarch64.

Fixes #1815
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>