### PR TITLE
build: reenable -Warray-bound and -Wdeprecated-declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,9 +767,7 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -UNDEBUG
   -Wall
   -Werror
-  -Wimplicit-fallthrough
-  -Wno-array-bounds # Disabled because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93437
-  -Wno-error=deprecated-declarations)
+  -Wimplicit-fallthrough)
 if (NOT BUILD_SHARED_LIBS)
   list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)
 endif ()


### PR DESCRIPTION
-Warray-bound was disabled in bdbce89e, by then we had false alarms from GCC 9, but now that the fix of the false alarm was merged in GCC 10, and GCC 13 was already released. since Seastar supports up to two major releases of GCC, we can safely drop this workaround.

-Wno-error=deprecated-declarations was added in 861da6e3. we wanted to be consistent with the behavior before switching to CMake. but, it would be better to encourage the developer to address the places where the deprecated thing are used when he/she adds the `[[deprecated]]` attribute.

Refs #602
Refs #1813
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>