### PR TITLE
Bringing back Prometheus protobuf support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,28 @@ find_package (SystemTap-SDT)
 # Code generation helpers.
 #
 
+function (seastar_generate_protobuf)
+  set (one_value_args TARGET VAR IN_FILE OUT_DIR)
+  cmake_parse_arguments (args "" "${one_value_args}" "" ${ARGN})
+  get_filename_component (in_file_name ${args_IN_FILE} NAME_WE)
+  get_filename_component (in_file_dir ${args_IN_FILE} DIRECTORY)
+  set (header_out ${args_OUT_DIR}/${in_file_name}.pb.h)
+  set (source_out ${args_OUT_DIR}/${in_file_name}.pb.cc)
+
+  add_custom_command (
+    DEPENDS ${args_IN_FILE}
+    OUTPUT ${header_out} ${source_out}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${args_OUT_DIR}
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE} --cpp_out=${args_OUT_DIR} -I${in_file_dir} ${args_IN_FILE})
+
+  add_custom_target (${args_TARGET}
+    DEPENDS
+      ${header_out}
+      ${source_out})
+
+  set (${args_VAR} ${header_out} ${source_out} PARENT_SCOPE)
+endfunction ()
+
 function (seastar_generate_ragel)
   set (one_value_args TARGET VAR IN_FILE OUT_FILE)
   cmake_parse_arguments (args "" "${one_value_args}" "" ${ARGN})
@@ -470,9 +492,17 @@ seastar_generate_ragel (
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/http/response_parser.rl
   OUT_FILE ${Seastar_GEN_BINARY_DIR}/include/seastar/http/response_parser.hh)
 
+seastar_generate_protobuf (
+  TARGET seastar_proto_metrics2
+  VAR proto_metrics2_files
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/proto/metrics2.proto
+  OUT_DIR ${Seastar_GEN_BINARY_DIR}/src/proto)
+
 add_library (seastar
   ${http_chunk_parsers_file}
   ${http_request_parser_file}
+  ${proto_metrics2_files}
+  ${seastar_dpdk_obj}
   include/seastar/core/abort_source.hh
   include/seastar/core/alien.hh
   include/seastar/core/align.hh
@@ -745,13 +775,15 @@ add_library (Seastar::seastar ALIAS seastar)
 add_dependencies (seastar
   seastar_http_chunk_parsers
   seastar_http_request_parser
-  seastar_http_response_parser)
+  seastar_http_response_parser
+  seastar_proto_metrics2)
 
 target_include_directories (seastar
   PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${Seastar_GEN_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${Seastar_GEN_BINARY_DIR}/src>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -795,6 +827,7 @@ target_link_libraries (seastar
     GnuTLS::gnutls
     StdAtomic::atomic
     lksctp-tools::lksctp-tools
+    protobuf::libprotobuf
     rt::rt
     ucontext::ucontext
     yaml-cpp::yaml-cpp
@@ -1316,6 +1349,7 @@ if (Seastar_INSTALL)
     FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindGnuTLS.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLinuxMembarrier.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindProtobuf.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSanitizers.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSourceLocation.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindStdAtomic.cmake

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -96,6 +96,7 @@ macro (seastar_find_dependencies)
     GnuTLS
     LibUring
     LinuxMembarrier
+    Protobuf
     Sanitizers
     SourceLocation
     StdAtomic
@@ -130,6 +131,8 @@ macro (seastar_find_dependencies)
     VERSION 1.7.3)
   seastar_set_dep_args (GnuTLS REQUIRED
     VERSION 3.3.26)
+  seastar_set_dep_args (Protobuf REQUIRED
+    VERSION 2.5.0)
   seastar_set_dep_args (LibUring
     VERSION 2.0
     OPTION ${Seastar_IO_URING})

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -194,6 +194,14 @@ cooking_ingredient (GnuTLS
     BUILD_COMMAND <DISABLE>
     INSTALL_COMMAND ${make_command} install)
 
+cooking_ingredient (Protobuf
+  REQUIRES zlib
+  EXTERNAL_PROJECT_ARGS
+    URL https://github.com/protocolbuffers/protobuf/releases/download/v21.11//protobuf-cpp-3.21.11.tar.gz
+    URL_MD5 e2cf711edae444bba0da199bc034e031
+  CMAKE_ARGS
+    -Dprotobuf_BUILD_TESTS=OFF)
+
 cooking_ingredient (hwloc
   REQUIRES
     numactl

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -48,7 +48,7 @@ struct config {
 future<> start(httpd::http_server_control& http_server, config ctx);
 
 /// \defgroup add_prometheus_routes adds a /metrics endpoint that returns prometheus metrics
-///    in txt format
+///    both in txt format and in protobuf according to the prometheus spec
 /// @{
 future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx);
 future<> add_prometheus_routes(httpd::http_server& server, config ctx);

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -43,6 +43,7 @@ struct config {
     sstring hostname; //!< hostname is deprecated, use label instead
     std::optional<metrics::label_instance> label; //!< A label that will be added to all metrics, we advice not to use it and set it on the prometheus server
     sstring prefix = "seastar"; //!< a prefix that will be added to metric names
+    bool allow_protobuf = false; // protobuf support is experimental and off by default
 };
 
 future<> start(httpd::http_server_control& http_server, config ctx);

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -175,6 +175,7 @@ arch_packages=(
     make
     meson
     python-pyelftools
+    protobuf
     libtool
     cmake
     yaml-cpp
@@ -221,6 +222,7 @@ opensuse_packages=(
     ragel
     xfsprogs-devel
     yaml-cpp-devel
+    protobuf-devel
     libtool
     stow
     openssl

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -38,7 +38,7 @@ seastar_cflags=${seastar_include_flags} $<JOIN:$<FILTER:$<TARGET_PROPERTY:seasta
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 
 Requires: liblz4 >= 1.7.3
-Requires.private: gnutls >= 3.2.26, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
+Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
 Cflags: ${boost_cflags} ${c_ares_cflags} ${cryptopp_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${numactl_cflags} ${seastar_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${boost_thread_libs} ${c_ares_libs} ${cryptopp_libs} ${fmt_libs}

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -800,19 +800,19 @@ public:
 
     future<std::unique_ptr<http::reply>> handle(const sstring& path,
         std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
-        auto text = is_accept_text(req->get_header("Accept"));
+        auto is_text_format = !_ctx.allow_protobuf || is_accept_text(req->get_header("Accept"));
         sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
         bool show_help = req->get_query_param("__help__") != "false";
         std::function<bool(const mi::labels_type&)> filter = make_filter(*req);
 
-        rep->write_body((text) ? "txt" : "proto", [this, text, metric_family_name, prefix, show_help, filter] (output_stream<char>&& s) {
+        rep->write_body(is_text_format ? "txt" : "proto", [this, is_text_format, metric_family_name, prefix, show_help, filter] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),
-                    [this, text, prefix, &metric_family_name, show_help, filter] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
-                return get_map_value(families).then([&s, &families, this, text, prefix, &metric_family_name, show_help, filter]() mutable {
+                    [this, is_text_format, prefix, &metric_family_name, show_help, filter] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
+                return get_map_value(families).then([&s, &families, this, is_text_format, prefix, &metric_family_name, show_help, filter]() mutable {
                     return do_with(get_range(families, metric_family_name, prefix),
-                            [&s, this, text, show_help, filter](metric_family_range& m) {
-                        return (text) ? write_text_representation(s, _ctx, m, show_help, filter) :
+                            [&s, this, is_text_format, show_help, filter](metric_family_range& m) {
+                        return (is_text_format) ? write_text_representation(s, _ctx, m, show_help, filter) :
                                 write_protobuf_representation(s, _ctx, m);
                     });
                 }).finally([&s] () mutable {

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -20,6 +20,9 @@
  */
 
 #include <seastar/core/prometheus.hh>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include "proto/metrics2.pb.h"
 #include <sstream>
 
 #include <seastar/core/metrics_api.hh>
@@ -38,8 +41,85 @@ namespace seastar {
 extern seastar::logger seastar_logger;
 
 namespace prometheus {
+namespace pm = io::prometheus::client;
 
 namespace mi = metrics::impl;
+
+/**
+ * Taken from an answer in stackoverflow:
+ * http://stackoverflow.com/questions/2340730/are-there-c-equivalents-for-the-protocol-buffers-delimited-i-o-functions-in-ja
+ */
+static bool write_delimited_to(const google::protobuf::MessageLite& message,
+        google::protobuf::io::ZeroCopyOutputStream* rawOutput) {
+    google::protobuf::io::CodedOutputStream output(rawOutput);
+
+#if GOOGLE_PROTOBUF_VERSION >= 3004000
+    const size_t size = message.ByteSizeLong();
+    output.WriteVarint64(size);
+#else
+    const int size = message.ByteSize();
+    output.WriteVarint32(size);
+#endif
+
+    uint8_t* buffer = output.GetDirectBufferForNBytesAndAdvance(size);
+    if (buffer != nullptr) {
+        message.SerializeWithCachedSizesToArray(buffer);
+    } else {
+        message.SerializeWithCachedSizes(&output);
+        if (output.HadError()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static pm::Metric* add_label(pm::Metric* mt, const metrics::impl::metric_id & id, const config& ctx) {
+    mt->mutable_label()->Reserve(id.labels().size() + 1);
+    if (ctx.label) {
+        auto label = mt->add_label();
+        label->set_name(ctx.label->key());
+        label->set_value(ctx.label->value());
+    }
+    for (auto &&i : id.labels()) {
+        auto label = mt->add_label();
+        label->set_name(i.first);
+        label->set_value(i.second);
+    }
+    return mt;
+}
+
+static void fill_metric(pm::MetricFamily& mf, const metrics::impl::metric_value& c,
+        const metrics::impl::metric_id & id, const config& ctx) {
+    switch (c.type()) {
+    case scollectd::data_type::GAUGE:
+        add_label(mf.add_metric(), id, ctx)->mutable_gauge()->set_value(c.d());
+        mf.set_type(pm::MetricType::GAUGE);
+        break;
+    case scollectd::data_type::SUMMARY:
+        [[fallthrough]];
+    case scollectd::data_type::HISTOGRAM:
+    {
+        auto h = c.get_histogram();
+        auto mh = add_label(mf.add_metric(), id,ctx)->mutable_histogram();
+        mh->set_sample_count(h.sample_count);
+        mh->set_sample_sum(h.sample_sum);
+        for (auto b : h.buckets) {
+            auto bc = mh->add_bucket();
+            bc->set_cumulative_count(b.count);
+            bc->set_upper_bound(b.upper_bound);
+        }
+        mf.set_type(pm::MetricType::HISTOGRAM);
+        break;
+    }
+    case scollectd::data_type::REAL_COUNTER:
+        [[fallthrough]];
+    case scollectd::data_type::COUNTER:
+        add_label(mf.add_metric(), id, ctx)->mutable_counter()->set_value(c.ui());
+        mf.set_type(pm::MetricType::COUNTER);
+        break;
+    }
+}
 
 static std::string to_str(seastar::metrics::impl::data_type dt) {
     switch (dt) {
@@ -632,6 +712,38 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
     });
 }
 
+future<> write_protobuf_representation(output_stream<char>& out, const config& ctx, metric_family_range& m) {
+    return do_for_each(m, [&ctx, &out](metric_family& metric_family) mutable {
+        std::string s;
+        google::protobuf::io::StringOutputStream os(&s);
+
+        auto& name = metric_family.name();
+        pm::MetricFamily mtf;
+
+        mtf.set_name(ctx.prefix + "_" + name);
+        mtf.mutable_metric()->Reserve(metric_family.size());
+        metric_family.foreach_metric([&mtf, &ctx](auto value, auto value_info) {
+            fill_metric(mtf, value, value_info.id, ctx);
+        });
+        if (!write_delimited_to(mtf, &os)) {
+            seastar_logger.warn("Failed to write protobuf metrics");
+        }
+        return out.write(s);
+    });
+}
+
+bool is_accept_text(const std::string& accept) {
+    std::vector<std::string> strs;
+    boost::split(strs, accept, boost::is_any_of(","));
+    for (auto i : strs) {
+        boost::trim(i);
+        if (boost::starts_with(i, "application/vnd.google.protobuf;")) {
+            return false;
+        }
+    }
+    return true;
+}
+
 class metrics_handler : public httpd::handler_base  {
     sstring _prefix;
     config _ctx;
@@ -688,18 +800,20 @@ public:
 
     future<std::unique_ptr<http::reply>> handle(const sstring& path,
         std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
+        auto text = is_accept_text(req->get_header("Accept"));
         sstring metric_family_name = req->get_query_param("__name__");
         bool prefix = trim_asterisk(metric_family_name);
         bool show_help = req->get_query_param("__help__") != "false";
         std::function<bool(const mi::labels_type&)> filter = make_filter(*req);
 
-        rep->write_body("txt", [this, metric_family_name, prefix, show_help, filter] (output_stream<char>&& s) {
+        rep->write_body((text) ? "txt" : "proto", [this, text, metric_family_name, prefix, show_help, filter] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),
-                    [this, prefix, &metric_family_name, show_help, filter] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
-                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name, show_help, filter]() mutable {
+                    [this, text, prefix, &metric_family_name, show_help, filter] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
+                return get_map_value(families).then([&s, &families, this, text, prefix, &metric_family_name, show_help, filter]() mutable {
                     return do_with(get_range(families, metric_family_name, prefix),
-                            [&s, this, show_help, filter](metric_family_range& m) {
-                        return write_text_representation(s, _ctx, m, show_help, filter);
+                            [&s, this, text, show_help, filter](metric_family_range& m) {
+                        return (text) ? write_text_representation(s, _ctx, m, show_help, filter) :
+                                write_protobuf_representation(s, _ctx, m);
                     });
                 }).finally([&s] () mutable {
                     return s.close();

--- a/src/http/mime_types.cc
+++ b/src/http/mime_types.cc
@@ -36,6 +36,7 @@ struct mapping {
         { "txt", "text/plain" },
         { "ico", "image/x-icon" },
         { "bin", "application/octet-stream" },
+        { "proto", "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"},
 };
 
 const char* extension_to_type(const sstring& extension)


### PR DESCRIPTION
This PR is based on PR #1518 and includes an additional commit that adds a flag to the Prometheus configuration object disabling protobuf by default.

The original PR #1518  resurrected the protobuf support that was removed in 8ed9771ae98130d5adbccdaea4ecbac738170939.

The motivation is the experimental Prometheus protobuf with native histogram support. After this series, it will be possible to adopt Prometheus protobuf support to the newer feature of the text representation and add Prometheus native histogram support.



