### PR TITLE
build: reenable -Warray-bound compiling option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,7 +768,6 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -Wall
   -Werror
   -Wimplicit-fallthrough
-  -Wno-array-bounds # Disabled because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93437
   -Wno-error=deprecated-declarations)
 if (NOT BUILD_SHARED_LIBS)
   list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)


### PR DESCRIPTION
-Warray-bound was disabled in bdbce89e, by then we had false alarms from GCC 9, but now that the fix of the false alarm was merged in GCC 10, and GCC 13 was already released. since Seastar supports up to two major releases of GCC, we can safely drop this workaround.