### PR TITLE
build: error out if find_program() fails

### DIFF
--- a/cmake/Findragel.cmake
+++ b/cmake/Findragel.cmake
@@ -23,6 +23,9 @@
 find_program (
   ragel_RAGEL_EXECUTABLE
   ragel)
+if (NOT ragel_RAGEL_EXECUTABLE)
+  message (FATAL_ERROR "ragel is required for processing .rl source files!")
+endif ()
 
 mark_as_advanced (ragel_RAGEL_EXECUTABLE)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,7 @@
 find_program (Seastar_DOXYGEN_EXECUTABLE doxygen)
+if (NOT Seastar_DOXYGEN_EXECUTABLE)
+  message (FATAL_ERROR "doxgen is required for building document!")
+endif ()
 
 configure_file (
   ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -525,6 +525,9 @@ function(seastar_add_certgen name)
   )
 
   find_program(OPENSSL openssl)
+  if (NOT OPENSSL)
+    message(FATAL_ERROR "openssl is required for performing tests!")
+  endif ()
 
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}"
     COMMAND ${OPENSSL} genpkey -quiet -out ${CERT_PRIVKEY} -algorithm ${CERT_ALG} ${CERT_ALG_OPTS}
@@ -617,6 +620,9 @@ endfunction(seastar_sign_cert)
 
 function(seastar_gen_mtls_certs)
   find_program(OPENSSL openssl)
+  if (NOT OPENSSL)
+    message (FATAL_ERROR "openssl is required for performing tests!")
+  endif ()
 
   # create a CA cert
   set(cert_ca "mtls_ca")


### PR DESCRIPTION
the programs being found are always required, so it would be better to error out than moving on and ending with an obscure error message. `find_programe()` does support the `REQUIRED` parameter, but it was introduced by CMake 3.18, while our minimum required CMake version is 3.13. so let's check it manually at this moment.