### PR TITLE
build: check if libucontext is necessary for using ucontext functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,7 @@ seastar_find_dependencies ()
 
 # Private build dependencies not visible to consumers
 find_package (ragel 6.10 REQUIRED)
+find_package (ucontext REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
@@ -796,6 +797,7 @@ target_link_libraries (seastar
     StdAtomic::atomic
     lksctp-tools::lksctp-tools
     rt::rt
+    ucontext::ucontext
     yaml-cpp::yaml-cpp
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)

--- a/cmake/Finducontext.cmake
+++ b/cmake/Finducontext.cmake
@@ -1,0 +1,51 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2023 Scylladb, Ltd.
+#
+
+# Try to compile without the library first.
+include (CheckFunctionExists)
+check_function_exists (getcontext
+  ucontext_NO_EXPLICIT_LINK)
+
+if (ucontext_NO_EXPLICIT_LINK)
+  set (ucontext_FOUND yes)
+else ()
+  # The `libucontext` library is required.
+  find_package (PkgConfig QUIET REQUIRED)
+  pkg_check_modules (PC_ucontext QUIET ucontext)
+  find_library (ucontext_LIBRARY
+    NAMES ucontext
+    HINTS
+      ${PC_ucontext_LIBDIR}
+      ${PC_ucontext_LIBRARY_DIRS})
+  mark_as_advanced (ucontext_LIBRARY)
+  include (FindPackageHandleStandardArgs)
+  find_package_handle_standard_args (ucontext
+    REQUIRED_VARS ucontext_LIBRARY)
+endif ()
+
+if (ucontext_FOUND AND NOT (TARGET ucontext::ucontext))
+  add_library (ucontext::ucontext INTERFACE IMPORTED)
+
+  set_target_properties (ucontext::ucontext
+    PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${ucontext_LIBRARY}")
+endif ()


### PR DESCRIPTION
musl libc does not offer the symbols of getcontext() and friends. it merely provides the header file of `ucontext.h` with the declarations of these functions so that "gcc with dwarf2 unwinding" can be built without errors. these functions were removed from POSIX. fortunately, libucontext provides a portable implementation.

in this change, if the function of `getcontext()` can not be compiled or linked, we fall back to check libucontext, and use it as a fallback.

this should improve portability of Seastar, so it can compile on platforms where glibc is not available.