### PR TITLE
build: enable systemtap only if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,7 @@ find_package (ragel 6.10 REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
+find_package (SystemTap-SDT)
 
 #
 # Code generation helpers.
@@ -998,6 +999,13 @@ if (Seastar_NUMA)
 
   target_link_libraries (seastar
     PRIVATE numactl::numactl)
+endif ()
+
+if (SystemTap-SDT_FOUND)
+  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_SYSTEMTAP_SDT)
+
+  target_link_libraries (seastar
+    PRIVATE SystemTap::SDT)
 endif ()
 
 seastar_supports_flag ("-Werror=unused-result" ErrorUnused_FOUND)

--- a/cmake/FindSystemTap-SDT.cmake
+++ b/cmake/FindSystemTap-SDT.cmake
@@ -1,0 +1,39 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2023 Scylladb, Ltd.
+#
+
+find_path (SystemTap-SDT_INCLUDE_DIR
+  NAMES sys/sdt.h)
+
+mark_as_advanced (
+  SystemTap-SDT_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (SystemTap-SDT
+  REQUIRED_VARS SystemTap-SDT_INCLUDE_DIR)
+
+if (NOT TARGET SystemTap::SDT)
+  add_library (SystemTap::SDT INTERFACE IMPORTED)
+  set_target_properties (SystemTap::SDT
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${SystemTap-SDT_INCLUDE_DIR})
+endif ()

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -95,7 +95,11 @@ module;
 #include <sys/mman.h>
 #include <sys/utsname.h>
 #include <linux/falloc.h>
+#ifdef SEASTAR_HAVE_SYSTEMTAP_SDT
 #include <sys/sdt.h>
+#else
+#define STAP_PROBE(provider, name)
+#endif
 
 #ifdef HAVE_OSV
 #include <osv/newpoll.hh>


### PR DESCRIPTION
systemtap is not available in musl libc. and we should detect at the configure time.

in this change, we check for the existence of `sys/sdt.h`, and define a placeholder for `STAP_PROBE()` macro if the header is not available.

Fixes #557
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>