### PR TITLE
linux-aio: better error handling when io_setup() fails

### DIFF
--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -172,8 +172,16 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
     if (r < 0) {
         char buf[1024];
         char *msg = strerror_r(errno, buf, sizeof(buf));
-        auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
-        throw std::runtime_error(fmt::format("Could not setup Async I/O: {}. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr ({}). Try increasing that number or reducing the amount of logical CPUs available for your application", msg, aio_max_nr));
+        if (errno == EAGAIN) {
+            auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
+            throw std::runtime_error(
+                fmt::format("Could not setup Async I/O: {}. "
+                            "The required nr_event ({}) exceeds the limit of request capacity in /proc/sys/fs/aio-max-nr ({}). "
+                            "Try increasing that number or reducing the amount of logical CPUs available for your application",
+                            msg, nr, aio_max_nr));
+        } else {
+            throw std::runtime_error(fmt::format("Could not setup Async I/O: {}", msg));
+        }
     }
 }
 

--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -173,7 +173,7 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
         char buf[1024];
         char *msg = strerror_r(errno, buf, sizeof(buf));
         auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
-        throw std::runtime_error(fmt::format("Could not setup Async I/O: {}. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr ({}). Try increasing that number or reducing the amount of logical CPUs available for your application", aio_max_nr, msg));
+        throw std::runtime_error(fmt::format("Could not setup Async I/O: {}. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr ({}). Try increasing that number or reducing the amount of logical CPUs available for your application", msg, aio_max_nr));
     }
 }
 


### PR DESCRIPTION
we can raise exception with more accurate error message according to `errno`. so in this series, let's fill `std::runtime_error` with the more specific error message.