### PR TITLE
app-template: add support to specify seastar.conf

### DIFF
--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -117,6 +117,17 @@ const app_template::seastar_options& app_template::options() const {
 
 app_template::configuration_reader app_template::get_default_configuration_reader() {
     return [this] (bpo::variables_map& configuration) {
+        auto seastar_conf = std::getenv("SEASTAR_CONF");
+        if (seastar_conf) {
+            std::ifstream ifs {std::string(seastar_conf)};
+            if (ifs) {
+                bpo::store(bpo::parse_config_file(ifs, _opts_conf_file), configuration);
+            } else {
+                seastar_logger.error("Failed to open {}", seastar_conf);
+                _exit(1);
+            }
+            return;
+        }
         auto home = std::getenv("HOME");
         if (home) {
             std::ifstream ifs(std::string(home) + "/.config/seastar/seastar.conf");


### PR DESCRIPTION
On Scylla, we want to use seastar.conf to store configured parameters from setup scripts, but we do not want to place it under ~/.config/seastar, we want to use /etc instead.
Let's add SEASTAR_CONF_FILE environment variable to specify the file path.

Related scylladb/scylladb#14674