### PR TITLE
tls: Return EPIPE exception when writing to shutdown socket

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1362,7 +1362,7 @@ public:
             return make_exception_future<>(_error);
         }
         if (_shutdown) {
-            return make_exception_future<>(std::system_error(ENOTCONN, std::system_category()));
+            return make_exception_future<>(std::system_error(EPIPE, std::system_category()));
         }
         if (!_connected) {
             return handshake().then([this, p = std::move(p)]() mutable {


### PR DESCRIPTION
If writing to a socket that was shutdown, Linux kernel returns back EPIPE errno. This should be the case for the TLS socket as well, not the ENOTCON, which means "socket was never connected" instead.

refs: scylladb/scylladb#15462