### PR TITLE
Add alternate method for file system detection

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -88,6 +88,9 @@ enum class fs_type {
     btrfs,
     hfs,
     tmpfs,
+
+    first_type = other,
+    last_type = tmpfs   // sentinels for iteration
 };
 
 // Access flags for files/directories

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -871,3 +871,7 @@ std::ostream& operator<<(std::ostream&, fs_type fs);
 SEASTAR_MODULE_EXPORT_END
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<seastar::fs_type> : fmt::ostream_formatter {};
+#endif

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -866,6 +866,8 @@ public:
     }
 };
 
+std::ostream& operator<<(std::ostream&, fs_type fs);
+
 SEASTAR_MODULE_EXPORT_END
 
 }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -547,6 +547,7 @@ public:
         return file_accessible(pathname, access_flags::exists);
     }
     future<fs_type> file_system_at(std::string_view pathname) noexcept;
+    future<fs_type> file_system_at_from_mounts(std::string_view pathname) noexcept;
     future<struct statvfs> statvfs(std::string_view pathname) noexcept;
     future<> remove_file(std::string_view pathname) noexcept;
     future<> rename_file(std::string_view old_pathname, std::string_view new_pathname) noexcept;

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -387,8 +387,26 @@ future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
 /// Return information about the filesystem where a file is located.
 ///
-/// \param name name of the file to inspect
-future<fs_type> file_system_at(std::string_view name) noexcept;
+/// This method examines the superblock magic number and will detect
+/// ext3 and ext4 as ext2.
+///
+/// \param path path to the file to inspect
+future<fs_type> file_system_at(std::string_view path) noexcept;
+
+/// Return information about the filesystem where a file is located.
+///
+/// This method parses /proc/mounts and is able to disambiguate among
+/// ext2, ext3 and ext4, but it is slower, will fail if /proc/mounts is
+/// not available, etc.
+///
+/// The file must exist and an exceptional future is returned otherwise.
+///
+/// Most other failures such as missing /proc/mounts, failure to parse
+/// /proc/mounts, failure to find path in any mount, etc result in a 
+/// return value of fs_type::other.
+///
+/// \param path name of the file to inspect
+future<fs_type> file_system_at_from_mounts(std::string_view path) noexcept;
 
 /// Return space available to unprivileged users in filesystem where a file is located, in bytes.
 ///

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1367,4 +1367,30 @@ future<file> open_directory(std::string_view name) noexcept {
     return engine().open_directory(name);
 }
 
+std::ostream& operator<<(std::ostream& os, fs_type fs) {
+    os << [fs]() {
+        switch (fs) {
+        case fs_type::other:
+            return "other";
+        case fs_type::xfs:
+            return "xfs";
+        case fs_type::ext2:
+            return "ext2";
+        case fs_type::ext3:
+            return "ext3";
+        case fs_type::ext4:
+            return "ext4";
+        case fs_type::btrfs:
+            return "btrfs";
+        case fs_type::hfs:
+            return "hfs";
+        case fs_type::tmpfs:
+            return "tmpfs";
+        };
+        return "bad_enum";
+    }();
+
+    return os;
+}
+
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2280,8 +2280,8 @@ reactor::file_system_at(std::string_view pathname) noexcept {
             static std::unordered_map<long int, fs_type> type_mapper = {
                 { internal::fs_magic::xfs, fs_type::xfs },
                 { internal::fs_magic::ext2, fs_type::ext2 },
-                { internal::fs_magic::ext3, fs_type::ext3 },
-                { internal::fs_magic::ext4, fs_type::ext4 },
+                // ext3 and ext4 are always detected as ext2 by this method as they
+                // share the same superblock magic
                 { internal::fs_magic::btrfs, fs_type::btrfs },
                 { internal::fs_magic::hfs, fs_type::hfs },
                 { internal::fs_magic::tmpfs, fs_type::tmpfs },

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -116,6 +116,10 @@ future<fs_type> file_system_at(std::string_view name) noexcept {
     return engine().file_system_at(name);
 }
 
+future<fs_type> file_system_at_from_mounts(std::string_view name) noexcept {
+    return engine().file_system_at_from_mounts(name);
+}
+
 future<uint64_t> fs_avail(std::string_view name) noexcept {
     return engine().statvfs(name).then([] (struct statvfs st) {
         return make_ready_future<uint64_t>(st.f_bavail * st.f_frsize);

--- a/tests/manual/test_detect_fs_type.sh
+++ b/tests/manual/test_detect_fs_type.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# sets up the mounts needed for file_utils_test::test_detect_fs_type
+# and runs the test, cleans up the mounts
+
+set -euo pipefail
+
+echo "BASE=${BASE:=$(mktemp --tmpdir -d fs_test.XXXXXX)}"
+echo "BUILD_DIR=${BUILD_DIR=$(dirname "$0")/../../build/dev}"
+echo "FS_SIZE=${FS_SIZE:=16M}" # ext3 filesystems smaller than about 8M tend to identify as ext2
+
+fs_list=(ext2 ext3 ext4 xfs)
+
+TEST_PATH="$BUILD_DIR/tests/unit/file_utils_test"
+if [[ ! -e "$TEST_PATH" ]]; then
+  echo "Test does not exist, did you build? Expected path: $TEST_PATH"
+  exit 1
+fi
+
+unmount_all() {
+  for fs in "${fs_list[@]}"; do
+    if mountpoint "$BASE/mnt/$fs" > /dev/null; then
+      sudo umount "$BASE/mnt/$fs"
+    fi
+  done
+}
+
+mkdir -p "$BASE/data" "$BASE/sym0" "$BASE/sym1"
+
+# create and format the data files we'll use to loop-mount the file systems
+for fs in "${fs_list[@]}"; do
+  DF="$BASE/data/$fs.data"
+  echo "Creating $fs file system inside $DF"
+  truncate -s 0 "$DF"
+  truncate -s "$FS_SIZE" "$DF"
+  "mkfs.$fs" "$DF"
+  mkdir -p "$BASE/mnt/$fs"
+  sudo mount -t "$fs" -o loop "$DF" "$BASE/mnt/$fs"
+  sudo chown "$USER:$USER" "$BASE/mnt/$fs"
+  mkdir -p "$BASE/mnt/$fs/dir1/dir2"
+  ln -s "$BASE/mnt/$fs" "$BASE/sym0/$fs" # symlink directly to mount
+  ln -s "$BASE/mnt/$fs/dir1" "$BASE/sym1/$fs" # symlink to a dir inside mount
+done
+
+# run test
+test_result=0
+TEST_DETECT_FS_TYPE_ROOT=$BASE "$TEST_PATH" -t test_detect_fs_type --log_level=all || test_result=$?
+
+# clean up
+unmount_all
+rm -rf "${BASE:?}/mnt" "${BASE:?}/data" "${BASE:?}/sym0" "${BASE:?}/sym1"
+rmdir "$BASE"
+
+echo "All mounts cleaned."
+
+if [[ $test_result -eq 0 ]]; then
+  echo "TEST PASSED"
+else
+  echo "TEST FAILED (rc=$test_result), see above"
+fi
+
+
+
+
+
+


### PR DESCRIPTION
This attempts to resolve #251 by adding an alternative detection method which parses `/proc/mounts` rather than relying on superblock magic checks (as suggested in 251).

I did not modify the existing method, since I'm not entirely sure how robust this method is: rather it is added as an alternative method with the same API.