### PR TITLE
Added ability to configure different credentials per HTTP listeners

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -249,7 +249,9 @@ public:
     future<> stop();
     future<> set_routes(std::function<void(routes& r)> fun);
     future<> listen(socket_address addr);
+    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
     future<> listen(socket_address addr, listen_options lo);
+    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
     distributed<http_server>& server();
 };
 SEASTAR_MODULE_EXPORT_END

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -153,6 +153,7 @@ class http_server {
 public:
     routes _routes;
     using connection = seastar::httpd::connection;
+    using server_credentials_ptr = shared_ptr<seastar::tls::server_credentials>;
     explicit http_server(const sstring& name) : _stats(*this, name) {
         _date_format_timer.arm_periodic(1s);
     }
@@ -182,8 +183,8 @@ public:
         }).get();
      *
      */
-    [[deprecated("use listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials)")]]
-    void set_tls_credentials(shared_ptr<seastar::tls::server_credentials> credentials);
+    [[deprecated("use listen(socket_address addr, server_credentials_ptr credentials)")]]
+    void set_tls_credentials(server_credentials_ptr credentials);
 
     size_t get_content_length_limit() const;
 
@@ -193,8 +194,8 @@ public:
 
     void set_content_streaming(bool b);
 
-    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
-    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
+    future<> listen(socket_address addr, server_credentials_ptr credentials);
+    future<> listen(socket_address addr, listen_options lo, server_credentials_ptr credentials);
     future<> listen(socket_address addr, listen_options lo);
     future<> listen(socket_address addr);
     future<> stop();
@@ -249,9 +250,9 @@ public:
     future<> stop();
     future<> set_routes(std::function<void(routes& r)> fun);
     future<> listen(socket_address addr);
-    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
+    future<> listen(socket_address addr, http_server::server_credentials_ptr credentials);
     future<> listen(socket_address addr, listen_options lo);
-    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
+    future<> listen(socket_address addr, listen_options lo, http_server::server_credentials_ptr credentials);
     distributed<http_server>& server();
 };
 SEASTAR_MODULE_EXPORT_END

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -519,8 +519,16 @@ future<> http_server_control::listen(socket_address addr) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address)>(&http_server::listen, addr);
 }
 
+future<> http_server_control::listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, credentials);
+}
+
 future<> http_server_control::listen(socket_address addr, listen_options lo) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options)>(&http_server::listen, addr, lo);
+}
+
+future<> http_server_control::listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, lo, credentials);
 }
 
 distributed<http_server>& http_server_control::server() {

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -224,7 +224,7 @@ future<> connection::read_one() {
         req->_server_address = this->_server_addr;
         req->_client_address = this->_client_addr;
 
-        if (_server._credentials) {
+        if (_tls) {
             req->protocol_name = "https";
         }
         if (_parser.failed()) {
@@ -389,14 +389,27 @@ void http_server::set_content_streaming(bool b) {
     _content_streaming = b;
 }
 
-future<> http_server::listen(socket_address addr, listen_options lo) {
-    if (_credentials) {
-        _listeners.push_back(seastar::tls::listen(_credentials, addr, lo));
+future<> http_server::listen(socket_address addr, listen_options lo,
+            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+    if (listener_credentials) {
+        _listeners.push_back(seastar::tls::listen(listener_credentials, addr, lo));
     } else {
         _listeners.push_back(seastar::listen(addr, lo));
     }
-    return do_accepts(_listeners.size() - 1);
+    return do_accepts(_listeners.size() - 1, listener_credentials != nullptr);
 }
+
+future<> http_server::listen(socket_address addr, listen_options lo) {
+    return listen(addr, lo, _credentials);
+}
+
+future<> http_server::listen(socket_address addr,
+            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+    listen_options lo;
+    lo.reuse_address = true;
+    return listen(addr, lo, listener_credentials);
+}
+
 future<> http_server::listen(socket_address addr) {
     listen_options lo;
     lo.reuse_address = true;
@@ -414,22 +427,26 @@ future<> http_server::stop() {
 }
 
 // FIXME: This could return void
-future<> http_server::do_accepts(int which) {
-    (void)try_with_gate(_task_gate, [this, which] {
-        return keep_doing([this, which] {
-            return try_with_gate(_task_gate, [this, which] {
-                return do_accept_one(which);
+future<> http_server::do_accepts(int which, bool tls) {
+    (void)try_with_gate(_task_gate, [this, which, tls] {
+        return keep_doing([this, which, tls] {
+            return try_with_gate(_task_gate, [this, which, tls] {
+                return do_accept_one(which, tls);
             });
         }).handle_exception_type([](const gate_closed_exception& e) {});
     }).handle_exception_type([](const gate_closed_exception& e) {});
     return make_ready_future<>();
 }
 
-future<> http_server::do_accept_one(int which) {
-    return _listeners[which].accept().then([this] (accept_result ar) mutable {
+future<> http_server::do_accepts(int which){
+    return do_accepts(which, _credentials != nullptr);
+}
+
+future<> http_server::do_accept_one(int which, bool tls) {
+    return _listeners[which].accept().then([this, tls] (accept_result ar) mutable {
         auto local_address = ar.connection.local_address();
-        auto conn = std::make_unique<connection>(*this,
-            std::move(ar.connection), std::move(ar.remote_address), std::move(local_address));
+        auto conn = std::make_unique<connection>(*this, std::move(ar.connection),
+                std::move(ar.remote_address), std::move(local_address), tls);
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().handle_exception([conn = std::move(conn)] (std::exception_ptr ex) {
                 hlogger.error("request error: {}", ex);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -369,7 +369,7 @@ future<bool> connection::generate_reply(std::unique_ptr<http::request> req) {
     });
 }
 
-void http_server::set_tls_credentials(shared_ptr<seastar::tls::server_credentials> credentials) {
+void http_server::set_tls_credentials(server_credentials_ptr credentials) {
     _credentials = credentials;
 }
 
@@ -389,8 +389,8 @@ void http_server::set_content_streaming(bool b) {
     _content_streaming = b;
 }
 
-future<> http_server::listen(socket_address addr, listen_options lo,
-            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+future<> http_server::listen(socket_address addr, listen_options lo, 
+            server_credentials_ptr listener_credentials) {
     if (listener_credentials) {
         _listeners.push_back(seastar::tls::listen(listener_credentials, addr, lo));
     } else {
@@ -404,7 +404,7 @@ future<> http_server::listen(socket_address addr, listen_options lo) {
 }
 
 future<> http_server::listen(socket_address addr,
-            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+            server_credentials_ptr listener_credentials) {
     listen_options lo;
     lo.reuse_address = true;
     return listen(addr, lo, listener_credentials);
@@ -519,16 +519,16 @@ future<> http_server_control::listen(socket_address addr) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address)>(&http_server::listen, addr);
 }
 
-future<> http_server_control::listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, credentials);
+future<> http_server_control::listen(socket_address addr, http_server::server_credentials_ptr credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, http_server::server_credentials_ptr)>(&http_server::listen, addr, credentials);
 }
 
 future<> http_server_control::listen(socket_address addr, listen_options lo) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options)>(&http_server::listen, addr, lo);
 }
 
-future<> http_server_control::listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, lo, credentials);
+future<> http_server_control::listen(socket_address addr, listen_options lo, http_server::server_credentials_ptr credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, http_server::server_credentials_ptr)>(&http_server::listen, addr, lo, credentials);
 }
 
 distributed<http_server>& http_server_control::server() {


### PR DESCRIPTION
For some deployments it may be required to configure different set of
credentials for different http server listeners. Added ability to
set/override default http server credentials with listener specific set
of credentials.