### PR TITLE
Proactively close non-keepalive http connections

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -76,6 +76,10 @@ class connection : public enable_shared_from_this<connection> {
     hook_t _hook;
     future<> _closed;
     internal::client_ref _ref;
+    // Client sends HTTP-1.1 version and assumes the server is 1.1-compatible
+    // too and thus the connection will be persistent by default. If the server
+    // responds with older version, this flag will be dropped (see recv_reply())
+    bool _persistent = true;
 
 public:
     /**
@@ -175,7 +179,7 @@ class client {
     using connection_ptr = seastar::shared_ptr<connection>;
 
     future<connection_ptr> get_connection();
-    future<> put_connection(connection_ptr con, bool can_cache);
+    future<> put_connection(connection_ptr con);
     future<> shrink_connections();
 
     template <typename Fn>

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -133,7 +133,7 @@ future<connection::reply_ptr> connection::recv_reply() {
             auto resp = parser.get_parsed_response();
             sstring length_header = resp->get_header("Content-Length");
             resp->content_length = strtol(length_header.c_str(), nullptr, 10);
-            if (resp->_version != "1.1") {
+            if ((resp->_version != "1.1") || seastar::internal::case_insensitive_cmp()(resp->get_header("Connection"), "close")) {
                 _persistent = false;
             }
             return make_ready_future<reply_ptr>(std::move(resp));


### PR DESCRIPTION
Some (spoiler: AWS S3) http servers may send back the `Connection: close` header indicating that its going to close the connection after sending back the response. Not handling it is problematic for http client due to batch-flushes being explicitly used.

After client handles such a response, it will put back the connection into the pool. In case there's another request to be served, the same connection will be taken back and the request will be sent. However, write()-ing the request into the connection and even flush()-ing it won't report back _any_ exception because the batch-flush is turned on on socket by default. So the fact that the server had already closed the connection will only be found out at the attempt to read back and parse the response. Although in this case the client must re-connect and re-send the request, that's too late already. Even if the request object itself can be preserved, there's no guarantee that the body writer is able to "restart" and write the body again.

So the best that can be done here is to note that there's the `Connection: close` header in the response and not caching the connection in pool after it. This gracefully handles the typical scenario when AWS S3 server decides to stop keep-alive-ing a connection.