### PR TITLE
Make http client restart requests (backoff-retry)

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -166,6 +166,10 @@ public:
  */
 
 class client {
+public:
+    using reply_handler = noncopyable_function<future<>(const reply&, input_stream<char>&& body)>;
+
+private:
     friend class http::internal::client_ref;
     using connections_list_t = bi::list<connection, bi::member_hook<connection, typename connection::hook_t, &connection::_hook>, bi::constant_time_size<false>>;
     static constexpr unsigned default_max_connections = 100;
@@ -187,8 +191,9 @@ class client {
     SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
     auto with_connection(Fn&& fn);
 
+    future<> do_make_request(request req, reply_handler handle, reply::status_type expected);
+
 public:
-    using reply_handler = noncopyable_function<future<>(const reply&, input_stream<char>&& body)>;
     /**
      * \brief Construct a simple client
      *

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -191,7 +191,7 @@ private:
     SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
     auto with_connection(Fn&& fn);
 
-    future<> do_make_request(request& req, reply_handler handle, reply::status_type expected);
+    future<> do_make_request(request& req, reply_handler& handle, reply::status_type expected);
 
 public:
     /**

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -126,7 +126,7 @@ public:
     future<> close();
 
 private:
-    future<reply_ptr> do_make_request(request rq);
+    future<reply_ptr> do_make_request(request& rq);
     void setup_request(request& rq);
     future<> send_request_head(const request& rq);
     future<reply_ptr> maybe_wait_for_continue(const request& req);
@@ -191,7 +191,7 @@ private:
     SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
     auto with_connection(Fn&& fn);
 
-    future<> do_make_request(request req, reply_handler handle, reply::status_type expected);
+    future<> do_make_request(request& req, reply_handler handle, reply::status_type expected);
 
 public:
     /**

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -149,28 +149,28 @@ future<connection::reply_ptr> connection::recv_reply() {
 }
 
 future<connection::reply_ptr> connection::do_make_request(request& req) {
-        setup_request(req);
-        return send_request_head(req).then([this, &req] {
-            return maybe_wait_for_continue(req).then([this, &req] (reply_ptr cont) {
-                if (cont) {
-                    return make_ready_future<reply_ptr>(std::move(cont));
-                }
+    setup_request(req);
+    return send_request_head(req).then([this, &req] {
+        return maybe_wait_for_continue(req).then([this, &req] (reply_ptr cont) {
+            if (cont) {
+                return make_ready_future<reply_ptr>(std::move(cont));
+            }
 
-                return write_body(req).then([this] {
-                    return _write_buf.flush().then([this] {
-                        return recv_reply();
-                    });
+            return write_body(req).then([this] {
+                return _write_buf.flush().then([this] {
+                    return recv_reply();
                 });
             });
         });
+    });
 }
 
 future<reply> connection::make_request(request req) {
-  return do_with(std::move(req), [this] (auto& req) {
-    return do_make_request(req).then([] (reply_ptr rep) {
-        return make_ready_future<reply>(std::move(*rep));
+    return do_with(std::move(req), [this] (auto& req) {
+        return do_make_request(req).then([] (reply_ptr rep) {
+            return make_ready_future<reply>(std::move(*rep));
+        });
     });
-  });
 }
 
 input_stream<char> connection::in(reply& rep) {

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -129,7 +129,12 @@ future<connection::reply_ptr> connection::recv_reply() {
         parser.init();
         return _read_buf.consume(parser).then([this, &parser] {
             if (parser.eof()) {
-                throw std::runtime_error("Invalid response");
+                http_log.trace("Parsing responce EOFed");
+                throw std::system_error(ECONNABORTED, std::system_category());
+            }
+            if (parser.failed()) {
+                http_log.trace("Parsing responce failed");
+                throw std::runtime_error("Invalid http server response");
             }
 
             auto resp = parser.get_parsed_response();

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -308,6 +308,10 @@ auto client::with_connection(Fn&& fn) {
 }
 
 future<> client::make_request(request req, reply_handler handle, reply::status_type expected) {
+    return do_make_request(std::move(req), std::move(handle), expected);
+}
+
+future<> client::do_make_request(request req, reply_handler handle, reply::status_type expected) {
     return with_connection([req = std::move(req), handle = std::move(handle), expected] (connection& con) mutable {
         return con.do_make_request(std::move(req)).then([&con, expected, handle = std::move(handle)] (connection::reply_ptr reply) mutable {
             auto& rep = *reply;


### PR DESCRIPTION
Right now if an http request fails for whatever reason, the exception is propagated back to caller. However, if the failure is due to connection problems, often the only option to handle it is to try the same request again a bit later. This PR adds this ability to the client.

Tested with scylla S3 client over "real" S3 server

closes: #1883 (this PR is another implementation of restarts)