### PR TITLE
Make sure http client doesn't change request while sending

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -129,7 +129,7 @@ private:
     future<reply_ptr> do_make_request(request rq);
     void setup_request(request& rq);
     future<> send_request_head(const request& rq);
-    future<reply_ptr> maybe_wait_for_continue(request& req);
+    future<reply_ptr> maybe_wait_for_continue(const request& req);
     future<> write_body(request& rq);
     future<reply_ptr> recv_reply();
 };

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -127,6 +127,7 @@ public:
 
 private:
     future<reply_ptr> do_make_request(request rq);
+    void setup_request(request& rq);
     future<> send_request_head(request& rq);
     future<reply_ptr> maybe_wait_for_continue(request& req);
     future<> write_body(request& rq);

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -128,7 +128,7 @@ public:
 private:
     future<reply_ptr> do_make_request(request rq);
     void setup_request(request& rq);
-    future<> send_request_head(request& rq);
+    future<> send_request_head(const request& rq);
     future<reply_ptr> maybe_wait_for_continue(request& req);
     future<> write_body(request& rq);
     future<reply_ptr> recv_reply();

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -130,7 +130,7 @@ private:
     void setup_request(request& rq);
     future<> send_request_head(const request& rq);
     future<reply_ptr> maybe_wait_for_continue(const request& req);
-    future<> write_body(request& rq);
+    future<> write_body(const request& rq);
     future<reply_ptr> recv_reply();
 };
 

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -259,7 +259,7 @@ struct request {
 private:
     void add_param(const std::string_view& param);
     sstring request_line() const;
-    future<> write_request_headers(output_stream<char>& out);
+    future<> write_request_headers(output_stream<char>& out) const;
     friend class experimental::connection;
 };
 

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -60,6 +60,7 @@ struct request {
     sstring _version;
     ctclass content_type_class;
     size_t content_length = 0;
+    size_t _bytes_written = 0;
     std::unordered_map<sstring, sstring, seastar::internal::case_insensitive_hash, seastar::internal::case_insensitive_cmp> _headers;
     std::unordered_map<sstring, sstring> query_parameters;
     httpd::parameters param;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -60,7 +60,7 @@ struct request {
     sstring _version;
     ctclass content_type_class;
     size_t content_length = 0;
-    size_t _bytes_written = 0;
+    mutable size_t _bytes_written = 0;
     std::unordered_map<sstring, sstring, seastar::internal::case_insensitive_hash, seastar::internal::case_insensitive_cmp> _headers;
     std::unordered_map<sstring, sstring> query_parameters;
     httpd::parameters param;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -115,7 +115,7 @@ void connection::setup_request(request& req) {
     }
 }
 
-future<> connection::send_request_head(request& req) {
+future<> connection::send_request_head(const request& req) {
     return _write_buf.write(req.request_line()).then([this, &req] {
         return req.write_request_headers(_write_buf).then([this] {
             return _write_buf.write("\r\n", 2);

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -87,7 +87,7 @@ future<> connection::write_body(request& req) {
     }
 }
 
-future<connection::reply_ptr> connection::maybe_wait_for_continue(request& req) {
+future<connection::reply_ptr> connection::maybe_wait_for_continue(const request& req) {
     if (req.get_header("Expect") == "") {
         return make_ready_future<reply_ptr>(nullptr);
     }

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -65,7 +65,7 @@ connection::connection(connected_socket&& fd, internal::client_ref cr)
 {
 }
 
-future<> connection::write_body(request& req) {
+future<> connection::write_body(const request& req) {
     if (req.body_writer) {
         if (req.content_length != 0) {
             req._bytes_written = req.content_length;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -103,7 +103,7 @@ future<connection::reply_ptr> connection::maybe_wait_for_continue(request& req) 
     });
 }
 
-future<> connection::send_request_head(request& req) {
+void connection::setup_request(request& req) {
     if (req._version.empty()) {
         req._version = "1.1";
     }
@@ -113,7 +113,9 @@ future<> connection::send_request_head(request& req) {
         }
         req._headers["Content-Length"] = to_sstring(req.content_length);
     }
+}
 
+future<> connection::send_request_head(request& req) {
     return _write_buf.write(req.request_line()).then([this, &req] {
         return req.write_request_headers(_write_buf).then([this] {
             return _write_buf.write("\r\n", 2);
@@ -143,6 +145,7 @@ future<connection::reply_ptr> connection::recv_reply() {
 
 future<connection::reply_ptr> connection::do_make_request(request req) {
     return do_with(std::move(req), [this] (auto& req) {
+        setup_request(req);
         return send_request_head(req).then([this, &req] {
             return maybe_wait_for_continue(req).then([this, &req] (reply_ptr cont) {
                 if (cont) {

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -57,7 +57,7 @@ sstring request::request_line() const {
 }
 
 // FIXME -- generalize with reply::write_request_headers
-future<> request::write_request_headers(output_stream<char>& out) {
+future<> request::write_request_headers(output_stream<char>& out) const {
     return do_for_each(_headers, [&out] (auto& h) {
         return out.write(h.first + ": " + h.second + "\r\n");
     });


### PR DESCRIPTION
The confidence comes from marking the request reference const throughout the sending methods. There are only two places that are allowed to change the request, and after this patch they become explicit and, thus, controllable.

refs: #1847 (this pr is prerequisite for that one)
fixes: scylladb/scylladb#15509