### PR TITLE
http: do not use req.content_length as both input parameter

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -33,9 +33,10 @@ namespace seastar {
 namespace http {
 namespace internal {
 output_stream<char> make_http_chunked_output_stream(output_stream<char>& out);
-// The len parameter defines the maximum number of bytes to be written. After the
-// stream is closed, the len is updated with the actual number of bytes written.
-output_stream<char> make_http_content_length_output_stream(output_stream<char>& out, size_t& len);
+// @param total_len defines the maximum number of bytes to be written.
+// @param bytes_written after the stream is closed, it is updated with the
+//        actual number of bytes written.
+output_stream<char> make_http_content_length_output_stream(output_stream<char>& out, size_t total_len, size_t& bytes_written);
 } // internal namespace
 } // http namespace
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -68,8 +68,7 @@ connection::connection(connected_socket&& fd, internal::client_ref cr)
 future<> connection::write_body(const request& req) {
     if (req.body_writer) {
         if (req.content_length != 0) {
-            req._bytes_written = req.content_length;
-            return req.body_writer(internal::make_http_content_length_output_stream(_write_buf, req._bytes_written)).then([&req] {
+            return req.body_writer(internal::make_http_content_length_output_stream(_write_buf, req.content_length, req._bytes_written)).then([&req] {
                 if (req.content_length == req._bytes_written) {
                     return make_ready_future<>();
                 } else {


### PR DESCRIPTION
before this change, req.content_length is used as both input and output parameter. but it would be clearer if we only use it for tracking the progress of writing the content.