### PR TITLE
httpd: Added server and client addresses to request structure

### DIFF
--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -295,6 +295,12 @@ public:
         throw_system_error_on(r == -1, "getsockname");
         return addr;
     }
+    socket_address get_remote_address() {
+        socket_address addr;
+        auto r = ::getpeername(_fd, &addr.u.sa, &addr.addr_length);
+        throw_system_error_on(r == -1, "getpeername");
+        return addr;
+    }
     void listen(int backlog) {
         auto fd = ::listen(_fd, backlog);
         throw_system_error_on(fd == -1, "listen");

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -76,6 +76,8 @@ class connection : public boost::intrusive::list_base_hook<> {
     connected_socket _fd;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
+    socket_address _client_addr;
+    socket_address _server_addr;
     static constexpr size_t limit = 4096;
     using tmp_buf = temporary_buffer<char>;
     http_request_parser _parser;
@@ -89,8 +91,22 @@ public:
     connection(http_server& server, connected_socket&& fd,
             socket_address) : connection(server, std::move(fd)) {}
     connection(http_server& server, connected_socket&& fd)
-            : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
-                    _fd.output()) {
+            : _server(server)
+            , _fd(std::move(fd))
+            , _read_buf(_fd.input())
+            , _write_buf(_fd.output())
+            , _client_addr(_fd.remote_address())
+            , _server_addr(_fd.local_address()) {
+        on_new_connection();
+    }
+    connection(http_server& server, connected_socket&& fd,
+            socket_address client_addr, socket_address server_addr)
+            : _server(server)
+            , _fd(std::move(fd))
+            , _read_buf(_fd.input())
+            , _write_buf(_fd.output())
+            , _client_addr(std::move(client_addr))
+            , _server_addr(std::move(server_addr)) {
         on_new_connection();
     }
     ~connection();

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -37,6 +37,7 @@
 #include <strings.h>
 #include <seastar/http/common.hh>
 #include <seastar/http/mime_types.hh>
+#include <seastar/net/socket_defs.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/string_utils.hh>
 
@@ -55,6 +56,8 @@ struct request {
             other, multipart, app_x_www_urlencoded,
     };
 
+    socket_address _client_address;
+    socket_address _server_address;
     sstring _method;
     sstring _url;
     sstring _version;
@@ -74,6 +77,22 @@ struct request {
     std::unordered_map<sstring, sstring> chunk_extensions;
     sstring protocol_name = "http";
     noncopyable_function<future<>(output_stream<char>&&)> body_writer; // for client
+
+    /**
+     * Get the address of the client that generated the request
+     * @return The address of the client that generated the request
+     */
+    const socket_address & get_client_address() const {
+        return _client_address;
+    }
+
+    /**
+     * Get the address of the server that handled the request
+     * @return The address of the server that handled the request
+     */
+    const socket_address & get_server_address() const {
+        return _server_address;
+    }
 
     /**
      * Search for the first header of a given name

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -224,6 +224,8 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const;
     /// Local address of the socket
     socket_address local_address() const noexcept;
+    /// Remote address of the socket
+    socket_address remote_address() const noexcept;
 
     /// Disables output to the socket.
     ///

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -47,6 +47,7 @@ public:
     virtual void set_sockopt(int level, int optname, const void* data, size_t len) = 0;
     virtual int get_sockopt(int level, int optname, void* data, size_t len) const = 0;
     virtual socket_address local_address() const noexcept = 0;
+    virtual socket_address remote_address() const noexcept = 0;
     virtual future<> wait_input_shutdown() = 0;
 };
 

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -107,6 +107,7 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const override;
     void set_sockopt(int level, int optname, const void* data, size_t len) override;
     socket_address local_address() const noexcept override;
+    socket_address remote_address() const noexcept override;
     virtual future<> wait_input_shutdown() override;
 };
 
@@ -272,6 +273,11 @@ int native_connected_socket_impl<Protocol>::get_sockopt(int level, int optname, 
 template<typename Protocol>
 socket_address native_connected_socket_impl<Protocol>::local_address() const noexcept {
     return {_conn->local_ip(), _conn->local_port()};
+}
+
+template<typename Protocol>
+socket_address native_connected_socket_impl<Protocol>::remote_address() const noexcept {
+    return {_conn->foreign_ip(), _conn->foreign_port()};
 }
 
 template <typename Protocol>

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -107,6 +107,9 @@ public:
     virtual socket_address local_address(file_desc& _fd) const {
         return _fd.get_address();
     }
+    virtual socket_address remote_address(file_desc& _fd) const {
+        return _fd.get_remote_address();
+    }
 };
 
 thread_local posix_ap_server_socket_impl::sockets_map_t posix_ap_server_socket_impl::sockets{};
@@ -280,6 +283,9 @@ public:
     }
     socket_address local_address() const noexcept override {
         return _ops->local_address(_fd.get_file_desc());
+    }
+    socket_address remote_address() const noexcept override {
+        return _ops->remote_address(_fd.get_file_desc());
     }
     future<> wait_input_shutdown() override {
         return _fd.poll_rdhup();

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -150,6 +150,10 @@ socket_address connected_socket::local_address() const noexcept {
     return _csi->local_address();
 }
 
+socket_address connected_socket::remote_address() const noexcept {
+    return _csi->remote_address();
+}
+
 void connected_socket::shutdown_output() {
     _csi->shutdown_output();
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1771,6 +1771,9 @@ public:
     socket_address local_address() const noexcept override {
         return _session->socket().local_address();
     }
+    socket_address remote_address() const noexcept override {
+        return _session->socket().remote_address();
+    }
     future<std::optional<session_dn>> get_distinguished_name() {
         return _session->get_distinguished_name();
     }

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -204,6 +204,10 @@ public:
         // dummy
         return {};
     }
+    socket_address remote_address() const noexcept override {
+        // dummy
+        return {};
+    }
     future<> wait_input_shutdown() override {
         return _rx->wait_input_shutdown();
     }


### PR DESCRIPTION
Adds the client and servers network address information to the `seastar::http::request` structure and populates it when it is created.

Fixes: #1850 