### PR TITLE
build: detect glibc features using CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,17 +1021,7 @@ if (Seastar_DEBUG_SHARED_PTR IN_LIST True_STRING_VALUES OR
       SEASTAR_DEBUG_SHARED_PTR)
 endif ()
 
-include (CheckCXXSourceCompiles)
-file (READ ${CMAKE_CURRENT_LIST_DIR}/cmake/code_tests/stdout_test.cc _stdout_test_code)
-check_cxx_source_compiles ("${_stdout_test_code}" Stdout_Can_Be_Used_As_Identifier)
-if (Stdout_Can_Be_Used_As_Identifier)
-  # "stdout" is defined as a macro by the C++ standard, so we cannot assume
-  # that the macro is always expanded into an identifier which can be re-used
-  # to name a enumerator in the declaration of an enumeration.
-  target_compile_definitions (seastar
-    PUBLIC
-      SEASTAR_LOGGER_TYPE_STDOUT)
-endif ()
+include (CheckLibc)
 
 set (Seastar_STACK_GUARD_MODES "Debug" "Sanitize" "Dev")
 if ((Seastar_STACK_GUARDS STREQUAL "ON") OR

--- a/cmake/CheckLibc.cmake
+++ b/cmake/CheckLibc.cmake
@@ -1,0 +1,14 @@
+# check for the bits in different standard C library implementations we
+# care about
+
+include (CheckCXXSourceCompiles)
+file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/stdout_test.cc _stdout_test_code)
+check_cxx_source_compiles ("${_stdout_test_code}" Stdout_Can_Be_Used_As_Identifier)
+if (Stdout_Can_Be_Used_As_Identifier)
+  # "stdout" is defined as a macro by the C++ standard, so we cannot assume
+  # that the macro is always expanded into an identifier which can be re-used
+  # to name a enumerator in the declaration of an enumeration.
+  target_compile_definitions (seastar
+    PUBLIC
+      SEASTAR_LOGGER_TYPE_STDOUT)
+endif ()

--- a/cmake/CheckLibc.cmake
+++ b/cmake/CheckLibc.cmake
@@ -12,3 +12,20 @@ if (Stdout_Can_Be_Used_As_Identifier)
     PUBLIC
       SEASTAR_LOGGER_TYPE_STDOUT)
 endif ()
+
+check_cxx_source_compiles ("
+#include <string.h>
+
+int main() {
+    char buf;
+    char* a = strerror_r(1, &buf, 0);
+    static_cast<void>(a);
+}"
+  Strerror_R_Returns_Char_P)
+if (Strerror_R_Returns_Char_P)
+  # define SEASTAR_STRERROR_R_CHAR_P if strerror_r() is GNU-specific version,
+  # which returns a "char*" not "int".
+  target_compile_definitions (seastar
+    PRIVATE
+      SEASTAR_STRERROR_R_CHAR_P)
+endif ()

--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -33,7 +33,6 @@ module;
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <valgrind/valgrind.h>
-#include <features.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -172,7 +171,7 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
     auto r = io_setup(nr, io_context);
     if (r < 0) {
         char buf[1024];
-#ifdef __GLIBC__
+#ifdef SEASTAR_STRERROR_R_CHAR_P
         const char *msg = strerror_r(errno, buf, sizeof(buf));
 #else
         const char *msg = strerror_r(errno, buf, sizeof(buf)) ? "unknown error" : buf;

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -69,7 +69,6 @@ module;
 #include <boost/container/static_vector.hpp>
 
 #include <dlfcn.h>
-#include <features.h>
 
 #ifndef SEASTAR_DEFAULT_ALLOCATOR
 #include <new>
@@ -1609,7 +1608,7 @@ configure(std::vector<resource::memory> m, bool mbind,
 
             if (r == -1) {
                 char err[1000] = {};
-#ifdef __GLIBC__
+#ifdef SEASTAR_STRERROR_R_CHAR_P
                 const char *msg = strerror_r(errno, err, sizeof(err));
 #else
                 const char *msg = strerror_r(errno, err, sizeof(err)) ? "unknown error" : buf;


### PR DESCRIPTION
in this series, instead of checking `__GLIBC__` macro for some glibc specific behavior, we check the behavior directly using CMake. this should improve the maintainability.