### PR TITLE
build: pass target name to seastar_check_self_contained

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1183,7 +1183,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Dev")
   add_custom_target (checkheaders)
   foreach (lib seastar seastar_testing seastar_perf_testing)
     if (TARGET ${lib})
-      seastar_check_self_contained (${lib}
+      seastar_check_self_contained (checkheaders ${lib}
         INCLUDE "\\.hh$"
         # impl.hh headers are internal implementations of .hh, so they are not
         # compilable. let's exclude them from the files to be checked.

--- a/cmake/CheckHeaders.cmake
+++ b/cmake/CheckHeaders.cmake
@@ -67,6 +67,11 @@ function (seastar_check_self_contained target library)
     list (APPEND srcs "${src}")
   endforeach ()
 
+  if (NOT srcs)
+    # library's SOURCES does not contain any header
+    return ()
+  endif ()
+
   set (check_lib "${target}-${library}")
   add_library (${check_lib} EXCLUDE_FROM_ALL)
   target_sources (${check_lib}

--- a/cmake/CheckHeaders.cmake
+++ b/cmake/CheckHeaders.cmake
@@ -28,7 +28,7 @@
 # for performing a similar check. see
 # https://cmake.org/cmake/help/latest/prop_tgt/LANG_INCLUDE_WHAT_YOU_USE.html
 
-function (seastar_check_self_contained library)
+function (seastar_check_self_contained target library)
   cmake_parse_arguments (
     parsed_args
     ""
@@ -50,7 +50,7 @@ function (seastar_check_self_contained library)
     endif ()
     get_filename_component (file_dir ${fn} DIRECTORY)
     list (APPEND includes "${file_dir}")
-    set (src_dir "${CMAKE_BINARY_DIR}/checkheaders/${file_dir}")
+    set (src_dir "${CMAKE_BINARY_DIR}/${target}/${file_dir}")
     file (MAKE_DIRECTORY "${src_dir}")
     get_filename_component (file_name ${fn} NAME)
     set (src "${src_dir}/${file_name}.cc")
@@ -67,7 +67,7 @@ function (seastar_check_self_contained library)
     list (APPEND srcs "${src}")
   endforeach ()
 
-  set (check_lib "checkheaders-${library}")
+  set (check_lib "${target}-${library}")
   add_library (${check_lib} EXCLUDE_FROM_ALL)
   target_sources (${check_lib}
     PRIVATE ${srcs})
@@ -109,5 +109,5 @@ function (seastar_check_self_contained library)
       PRIVATE ${compile_definitions})
   endif ()
 
-  add_dependencies (checkheaders ${check_lib})
+  add_dependencies (${target} ${check_lib})
 endfunction ()


### PR DESCRIPTION
instead of hard-wiring the target for "checkheaders" to "checkheaders", pass the target name as a parameter. also, this change does not add a header check helper target if the specified library target does not contain any headers.

this allows us to reuse the `seastar_check_self_contained()` function in the parent project.