### PR TITLE
sstring: inherit publicly from string_view formatter

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -880,13 +880,15 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
 
 #if FMT_VERSION >= 90000
 
+// Due to https://github.com/llvm/llvm-project/issues/68849, we inherit
+// from formatter<string_view> publicly rather than privately
+
 SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>>
-    : private fmt::formatter<std::basic_string_view<char_type>> {
+    : public fmt::formatter<std::basic_string_view<char_type>> {
     using format_as_t = std::basic_string_view<char_type>;
     using base = fmt::formatter<format_as_t>;
-    using base::parse;
     template <typename FormatContext>
     auto format(const ::seastar::basic_sstring<char_type, Size, max_size, NulTerminate>& s, FormatContext& ctx) const {
         return base::format(format_as_t{s}, ctx);

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -24,6 +24,8 @@
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/sstring.hh>
 #include <list>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 
 using namespace std::literals;
 using namespace seastar;
@@ -306,3 +308,16 @@ BOOST_AUTO_TEST_CASE(test_compares_left_hand_not_string) {
     BOOST_REQUIRE(std::string("a") < sstring("b"));
 #endif
 }
+
+#if FMT_VERSION >= 90000
+
+BOOST_AUTO_TEST_CASE(test_fmt) {
+#if FMT_VERSION >= 100000   // formatting of std::optional was introduced in fmt 10
+    // https://github.com/llvm/llvm-project/issues/68849
+    std::ignore = fmt::format("{}", std::optional(sstring{"hello"}));
+#endif
+    std::vector<sstring> strings;
+    std::ignore = fmt::format("{}", strings);
+}
+
+#endif


### PR DESCRIPTION
fmt 10 detects if a formatter provides some method (set_debug_format()),
but the detection fails if the method is private and compilation breaks
on clang [1].

Work around the clang bug by inheriting publicly.

[1] https://github.com/llvm/llvm-project/issues/68849

A test case reproducing the problem is included (thanks
Kefu Chai <kefu.chai@scylladb.com>).