### PR TITLE
utils/backtrace.hh: make simple_backtrace formattable

### DIFF
--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -173,6 +173,7 @@ struct hash<seastar::tasktrace> {
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::tasktrace> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<seastar::simple_backtrace> : fmt::ostream_formatter {};
 #endif
 
 namespace seastar {


### PR DESCRIPTION
Currently only tasktrace is formattable, add a formatter for simple_backtrace too.