### PR TITLE
core/posix return old behaviour using pthread_attr_setaffinity_np

### DIFF
--- a/cmake/CheckLibc.cmake
+++ b/cmake/CheckLibc.cmake
@@ -29,3 +29,13 @@ if (Strerror_R_Returns_Char_P)
     PRIVATE
       SEASTAR_STRERROR_R_CHAR_P)
 endif ()
+
+include (CheckFunctionExists)
+
+check_function_exists (pthread_attr_setaffinity_np
+  Pthread_Attr_Setaffinity_Np)
+if (Pthread_Attr_Setaffinity_Np)
+  target_compile_definitions (seastar
+    PRIVATE
+    SEASTAR_PTHREAD_ATTR_SETAFFINITY_NP)
+endif ()


### PR DESCRIPTION
if it is present

as noted in the review of: https://github.com/scylladb/seastar/pull/1803/

and the commit
https://github.com/scylladb/seastar/commit/982690e8ead7d8cf30a71746ea0d55ee74f582a5#r1315429863

using the portable version could lead to a performance hit of some instructions running on the wrong core while the affinity was set after creation