### PR TITLE
Handle batch flush background error

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -482,6 +482,7 @@ output_stream<CharType>::poll_flush() noexcept {
             f.get();
         } catch (...) {
             _ex = std::current_exception();
+            _fd.on_batch_flush_error();
         }
         // if flush() was called while flushing flush once more
         poll_flush();

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -128,6 +128,8 @@ public:
     future<> put(packet p) override;
     future<> put(temporary_buffer<char> buf) override;
     future<> close() override;
+    bool can_batch_flushes() const noexcept override { return true; }
+    void on_batch_flush_error() noexcept override;
 };
 
 class posix_ap_server_socket_impl : public server_socket_impl {

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -199,6 +199,10 @@ public:
         _conn->close_write();
         return make_ready_future<>();
     }
+    virtual bool can_batch_flushes() const noexcept override { return true; }
+    virtual void on_batch_flush_error() noexcept override {
+        _conn->close_read();
+    }
 };
 
 template <typename Protocol>

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -666,6 +666,10 @@ posix_data_sink_impl::close() {
     return make_ready_future<>();
 }
 
+void posix_data_sink_impl::on_batch_flush_error() noexcept {
+    shutdown_socket_fd(_fd, SHUT_RD);
+}
+
 posix_network_stack::posix_network_stack(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator)
         : _reuseport(engine().posix_reuseport_available()), _allocator(allocator) {
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1815,6 +1815,10 @@ private:
         _session->close();
         return make_ready_future<>();
     }
+    bool can_batch_flushes() const noexcept override { return true; }
+    void on_batch_flush_error() noexcept override {
+        _session->close();
+    }
 };
 
 class server_session : public net::server_socket_impl {


### PR DESCRIPTION
When output_stream::flush() is called with .batch_flushes ON, the flush() itself resolves immediately with ready future. The real flushing happens later when a dedicated poller gets to it. If that real flush resolves with exception the poller just keeps the exception on the stream in the hope that it will later be returned from .write() or .flush() (or .close()).

This hope breaks the RPC-like scenario:

    while (!aborted()) {
        co_await out.send()
        co_await out.flush()
        co_await in.recv()
        co_await handle()
    }

Even if output stream background flush fails some time later the whole loop is not aware of it as it's waiting for different stream.

The proposed fix is to make batch-flush poller "notify" the data sink about background flush error. Existing sockets implementation would then shutdown the socket for reading thus handling the RPC scenario.

Test included.

fixes: #1150
refs: #1141