### PR TITLE
reactor: Move add_to_flush_poller() to internal namespace

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -408,7 +408,9 @@ output_stream<CharType>::slow_write(const char_type* buf, size_t n) noexcept {
   }
 }
 
+namespace internal {
 void add_to_flush_poller(output_stream<char>& x) noexcept;
+}
 
 template <typename CharType>
 future<> output_stream<CharType>::do_flush() noexcept {
@@ -439,7 +441,7 @@ output_stream<CharType>::flush() noexcept {
         } else {
             _flush = true;
             if (!_in_batch) {
-                add_to_flush_poller(*this);
+                internal::add_to_flush_poller(*this);
                 _in_batch = promise<>();
             }
         }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -674,7 +674,7 @@ private:
     friend class smp_message_queue;
     friend class internal::poller;
     friend class scheduling_group;
-    friend void add_to_flush_poller(output_stream<char>& os) noexcept;
+    friend void internal::add_to_flush_poller(output_stream<char>& os) noexcept;
     friend void seastar::internal::increase_thrown_exceptions_counter() noexcept;
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
     friend void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4718,10 +4718,6 @@ future<> later() noexcept {
     return check_for_io_immediately();
 }
 
-void add_to_flush_poller(output_stream<char>& os) noexcept {
-    engine()._flush_batching.push_back(os);
-}
-
 steady_clock_type::duration reactor::total_idle_time() {
     return _total_idle;
 }
@@ -5003,6 +4999,10 @@ rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_short
 }
 
 namespace internal {
+
+void add_to_flush_poller(output_stream<char>& os) noexcept {
+    engine()._flush_batching.push_back(os);
+}
 
 inline
 sched_clock::duration


### PR DESCRIPTION
Not the part of public API at all