### PR TITLE
http/exception: stop using dynamic exception specification

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -43,7 +43,7 @@ public:
             : _msg(msg), _status(status) {
     }
 
-    virtual const char* what() const throw () {
+    virtual const char* what() const noexcept {
         return _msg.c_str();
     }
 


### PR DESCRIPTION
it has been removed since C++14, see
https://eel.is/c++draft/diff.cpp14.except . so let's replace it with `noexcept` as suggested by Clang.

```
In file included from /home/kefu/dev/seastar/src/http/file_handler.cc:39:
/home/kefu/dev/seastar/include/seastar/http/exception.hh:46:38: warning: dynamic exception specifications are deprecated [-Wdeprecated-dynamic-exception-spec]
    virtual const char* what() const throw () {
                                     ^~~~~~~~
/home/kefu/dev/seastar/include/seastar/http/exception.hh:46:38: note: use 'noexcept' instead
    virtual const char* what() const throw () {
                                     ^~~~~~~~
                                     noexcept
1 warning generated.
```