### PR TITLE
http, json, net: define default-generated copy ctor for polymorphic types

### DIFF
--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -40,7 +40,11 @@ typedef const http::request& const_req;
  *
  */
 class handler_base {
+protected:
+    handler_base() = default;
+    handler_base(const handler_base&) = default;
 public:
+    virtual ~handler_base() = default;
     /**
      * All handlers should implement this method.
      *  It fill the reply according to the request.
@@ -51,7 +55,6 @@ public:
     virtual future<std::unique_ptr<http::reply> > handle(const sstring& path,
             std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) = 0;
 
-    virtual ~handler_base() = default;
 
     /**
      * Add a mandatory parameter

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -50,7 +50,7 @@ SEASTAR_MODULE_EXPORT_BEGIN
  * this is not a valid object
  */
 class json_base_element {
-public:
+protected:
     /**
      * The constructors
      */
@@ -58,8 +58,17 @@ public:
             : _mandatory(false), _set(false) {
     }
 
-    virtual ~json_base_element() = default;
+    json_base_element(const json_base_element& o) noexcept = default;
+    json_base_element& operator=(const json_base_element& o) noexcept {
+        // Names and mandatory are never changed after creation
+        _set = o._set;
+        return *this;
+    }
 
+    json_base_element(json_base_element&&) = delete;
+    json_base_element& operator=(json_base_element&&) = delete;
+public:
+    virtual ~json_base_element() = default;
     /**
      * Check if it's a mandatory parameter
      * and if it's set.
@@ -68,12 +77,6 @@ public:
      */
     virtual bool is_verify() noexcept {
         return !(_mandatory && !_set);
-    }
-
-    json_base_element& operator=(const json_base_element& o) noexcept {
-        // Names and mandatory are never changed after creation
-        _set = o._set;
-        return *this;
     }
 
     /**

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -82,8 +82,11 @@ public:
 };
 
 class network_interface_impl {
-public:
+protected:
+    network_interface_impl() = default;
+    network_interface_impl(const network_interface_impl&) = default;
     virtual ~network_interface_impl() {}
+public:
     virtual uint32_t index() const = 0;
     virtual uint32_t mtu() const = 0;
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -115,9 +115,13 @@ namespace tls {
     };
 
     class abstract_credentials {
-    public:
+    protected:
+        abstract_credentials() = default;
+        abstract_credentials(const abstract_credentials&) = default;
+        abstract_credentials& operator=(abstract_credentials&) = default;
+        abstract_credentials& operator=(abstract_credentials&&) = default;
         virtual ~abstract_credentials() {};
-
+    public:
         virtual void set_x509_trust(const blob&, x509_crt_format) = 0;
         virtual void set_x509_crl(const blob&, x509_crt_format) = 0;
         virtual void set_x509_key(const blob& cert, const blob& key, x509_crt_format) = 0;


### PR DESCRIPTION
handler_base and json_base_element serve as the base class of polymorphic classes. their copy constructors and assignment operator can be misused by external users -- those who are not its derived classes. also, because we have to define a virtual destructor for these two base classes, clang rightfully complains like:

```
In file included from /home/kefu/dev/seastar/src/http/api_docs.cc:22:
In file included from /home/kefu/dev/seastar/include/seastar/http/api_docs.hh:23:
/home/kefu/dev/seastar/include/seastar/json/json_elements.hh:61:13: warning: definition of implicit copy constructor for 'json_base_element' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
    virtual ~json_base_element() = default;
            ^
/home/kefu/dev/seastar/include/seastar/json/json_elements.hh:99:7: note: in implicit copy constructor for 'seastar::json::json_base_element' first required here
class json_element : public json_base_element {
      ^
/home/kefu/dev/seastar/include/seastar/http/api_docs.hh:83:11: note: in implicit copy constructor for 'seastar::json::json_element<std::basic_string<char>>' first required here
        : apiVersion{e.apiVersion}
          ^
1 warning generated.
```

as the implicit copy constructor is dangerous as explained above.

so, let's

* mark all the copy constructors and assignment operators as "protected", because they are not supposed to be part of the public interface of the base class. this offers us a smaller and safer public interface.
* mark those who will not never used "delete". this explains our intention better.
* define the previously implicit copy constructor so it is not implicit generated anymore. this silences the warning above.

Refs #1863
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>