### PR TITLE
reactor: do not define dtor of kernel_completion

### DIFF
--- a/include/seastar/core/internal/io_desc.hh
+++ b/include/seastar/core/internal/io_desc.hh
@@ -27,8 +27,6 @@
 namespace seastar {
 
 class kernel_completion {
-protected:
-    ~kernel_completion() = default;
 public:
     virtual void complete_with(ssize_t res) = 0;
 };


### PR DESCRIPTION
there is no need to define its destructor explicitly. if we want to prevent applications from instantiate this class, it already has a pure virtual member function, so this never happens.

this silences the warning like:
```
[19/85] Building CXX object CMakeFiles/seastar.dir/src/core/reactor_backend.cc.o
In file included from /home/kefu/dev/seastar/src/core/reactor_backend.cc:51:
In file included from /home/kefu/dev/seastar/src/core/reactor_backend.hh:26:
In file included from /home/kefu/dev/seastar/include/seastar/core/internal/pollable_fd.hh:26:
/home/kefu/dev/seastar/include/seastar/core/internal/io_desc.hh:31:5: warning: definition of implicit copy assignment operator for 'kernel_completion' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
    ~kernel_completion() = default;
    ^
/home/kefu/dev/seastar/src/core/reactor_backend.cc:70:7: note: in implicit copy assignment operator for 'seastar::kernel_completion' first required here
class pollable_fd_state_completion : public kernel_completion {
      ^
/home/kefu/dev/seastar/src/core/reactor_backend.cc:611:15: note: in implicit move assignment operator for 'seastar::pollable_fd_state_completion' first required here
        *desc = pollable_fd_state_completion{};
              ^
1 warning generated.
```

Refs #1863
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>