### PR TITLE
sstring, util: do not define constexpr static out-of-line

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -703,8 +703,6 @@ public:
         return std::basic_string_view<char_type>(str(), size());
     }
 };
-template <typename char_type, typename Size, Size max_size, bool NulTerminate>
-constexpr Size basic_sstring<char_type, Size, max_size, NulTerminate>::npos;
 
 namespace internal {
 template <class T> struct is_sstring : std::false_type {};

--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -2147,18 +2147,6 @@ void tcp<InetTraits>::connection::shutdown_connect() {
 }
 
 template <typename InetTraits>
-constexpr uint16_t tcp<InetTraits>::tcb::_max_nr_retransmit;
-
-template <typename InetTraits>
-constexpr std::chrono::milliseconds tcp<InetTraits>::tcb::_rto_min;
-
-template <typename InetTraits>
-constexpr std::chrono::milliseconds tcp<InetTraits>::tcb::_rto_max;
-
-template <typename InetTraits>
-constexpr std::chrono::milliseconds tcp<InetTraits>::tcb::_rto_clk_granularity;
-
-template <typename InetTraits>
 typename tcp<InetTraits>::tcb::isn_secret tcp<InetTraits>::tcb::_isn_secret;
 
 }

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -222,9 +222,6 @@ public:
 
 
 template <typename Ret, typename... Args, bool Noexcept>
-constexpr typename noncopyable_function<Ret (Args...) noexcept(Noexcept)>::vtable noncopyable_function<Ret (Args...) noexcept(Noexcept)>::_s_empty_vtable;
-
-template <typename Ret, typename... Args, bool Noexcept>
 template <typename Func>
 const typename noncopyable_function<Ret (Args...) noexcept(Noexcept)>::vtable noncopyable_function<Ret (Args...) noexcept(Noexcept)>::direct_vtable_for<Func>::s_vtable
         = noncopyable_function<Ret (Args...) noexcept(Noexcept)>::direct_vtable_for<Func>::make_vtable();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -616,9 +616,6 @@ using namespace internal::linux_abi;
 
 std::atomic<manual_clock::rep> manual_clock::_now;
 
-constexpr unsigned reactor::max_queues;
-constexpr unsigned reactor::max_aio_per_queue;
-
 // Base version where this works; some filesystems were only fixed later, so
 // this value is mixed in with filesystem-provided values later.
 bool aio_nowait_supported = internal::kernel_uname().whitelisted({"4.13"});

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -48,10 +48,6 @@ ipv4_address::ipv4_address(const std::string& addr) {
     ip = static_cast<uint32_t>(std::move(ipv4).to_ulong());
 }
 
-constexpr std::chrono::seconds ipv4::_frag_timeout;
-constexpr uint32_t ipv4::_frag_low_thresh;
-constexpr uint32_t ipv4::_frag_high_thresh;
-
 ipv4::ipv4(interface* netif)
     : _netif(netif)
     , _global_arp(netif)

--- a/src/net/packet.cc
+++ b/src/net/packet.cc
@@ -47,9 +47,6 @@ namespace net {
 
 static_assert(std::is_nothrow_move_constructible_v<packet>);
 
-constexpr size_t packet::internal_data_size;
-constexpr size_t packet::default_nr_frags;
-
 void packet::linearize(size_t at_frag, size_t desired_size) {
     _impl->unuse_internal_data();
     size_t nr_frags = 0;

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -114,11 +114,6 @@ public:
     }
 };
 
-// in cpp 14 declaration of static variables is mandatory even
-// though the assignment took place inside the class declaration
-// - no inline static variables (like in Cpp17).
-constexpr size_t reusable_buffer::chunk_size;
-
 static thread_local reusable_buffer reusable_buffer_compressed_data;
 static thread_local reusable_buffer reusable_buffer_decompressed_data;
 static thread_local size_t buffer_use_count = 0;

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -40,8 +40,6 @@ namespace rpc {
 
   no_wait_type no_wait;
 
-  constexpr size_t snd_buf::chunk_size;
-
   snd_buf::snd_buf(size_t size_) : size(size_) {
       if (size <= chunk_size) {
           bufs = temporary_buffer<char>(size);


### PR DESCRIPTION
it was deprecated in C++17, see
https://eel.is/c++draft/depr.static.constexpr, so let's just keep the inline definition.

this silences the following warning from the Clang compiler:
```
FAILED: CMakeFiles/seastar.dir/src/core/memory.cc.o
/home/kefu/.local/bin/clang++ -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -Dseastar_EXPORTS -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/debug/gen/include -I/home/kefu/dev/seastar/src -isystem /home/kefu/dev/seastar/build/debug/_cooking/installed/include -g -std=gnu++20 -fPIC -U_FORTIFY_SOURCE -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -UNDEBUG -Wall -Werror -Wdeprecated -Wimplicit-fallthrough -gz -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT CMakeFiles/seastar.dir/src/core/memory.cc.o -MF CMakeFiles/seastar.dir/src/core/memory.cc.o.d -o CMakeFiles/seastar.dir/src/core/memory.cc.o -c /home/kefu/dev/seastar/src/core/memory.cc
In file included from /home/kefu/dev/seastar/src/core/memory.cc:96:
In file included from /home/kefu/dev/seastar/include/seastar/core/print.hh:24:
/home/kefu/dev/seastar/include/seastar/core/sstring.hh:707:72: error: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Werror,-Wdeprecated]
constexpr Size basic_sstring<char_type, Size, max_size, NulTerminate>::npos;
                                                                       ^
```

Refs #1863
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>