### PR TITLE
build: enable -Wdeprecated compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,7 +765,8 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -Wall
   -Werror
   -Wimplicit-fallthrough
-  -Wno-error=deprecated-declarations)
+  -Wdeprecated
+  -Wno-error=deprecated)
 if (NOT BUILD_SHARED_LIBS)
   list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)
 endif ()


### PR DESCRIPTION
so that for instance, we are aware that which pieces of code are

* using deprecated stuff with "deprecated" attribute attached to it
* using deprecated C++ feature

please note, this will enable a bunch of "-Wdeprecated-*" compiler
warning options, which are previously disabled. and these warning
will be taken as errors with the exception of "deprecated-declarations".
These warnings are from the `[[deprecated]]` attribute.

So this change requires us to address all of the other "-Wdeprecated-*"
warnings in Seastar. but this does not force the applications using
Seastar to do the same, as the "-Wdeprecated" option is a private CXX
flag which is only used when compiling Seastar itself.

Fixes #1863
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>