### PR TITLE
tests: always wait for promise

### DIFF
--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1567,7 +1567,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_metric_domains) {
     client_opt.metrics_domain = "dom2";
     auto p2 = rpc_test_env<>::do_with_thread(rpc_test_config(), client_opt, [&] (auto& env, auto& cln) { do_one_echo(env, cln, 2); });
     auto p3 = rpc_test_env<>::do_with_thread(rpc_test_config(), client_opt, [&] (auto& env, auto& cln) { do_one_echo(env, cln, 5); });
-    when_all(std::move(p1), std::move(p2)).discard_result().get();
+    when_all(std::move(p1), std::move(p2), std::move(p3)).discard_result().get();
 
     auto get_metrics = [] (std::string name, std::string domain) -> int {
         const auto& values = seastar::metrics::impl::get_value_map();


### PR DESCRIPTION
in 24c6111c, we introduced a new test in rpc_test.cc, and it creates a future, which is never waited. so, when the reactor tears down, it clears it smp_message_queue, which could contain the unresolved promise(s) associated with this future if they are not resolved yet, but the way how
`promise_base::clear()` clears its state is to schedule its pending task. so at that moment, the engine is not functional anymore, and its `_task_queues` is empty. hence we have segfault in the dtor of `engine` randomly when running
`test_rpc_metric_domains` test in `rpc_test`.

in this change, the promise is waited, as it is a part of the test -- we take it into account when comparing the "rpc_client_sent_messages" in "dom2".

please note, -Wunused compiler option is not able to identify this problem.

Fixes #1868
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>