### PR TITLE
reactor: mark kernel_completion's dtor protected

### DIFF
--- a/include/seastar/core/internal/io_desc.hh
+++ b/include/seastar/core/internal/io_desc.hh
@@ -27,6 +27,10 @@
 namespace seastar {
 
 class kernel_completion {
+protected:
+     kernel_completion() = default;
+     kernel_completion(const kernel_completion&) = default;
+     ~kernel_completion() = default;
 public:
     virtual void complete_with(ssize_t res) = 0;
 };


### PR DESCRIPTION
in 8295335c, in order to silence a warning from compiler, the user-provided dtor of kernel_completion was removed. but the removal exposes the implicitly default-generated dtor as a public member function. this is not intended, as `kernel_completion` should not be deleted directly, as the dtor is not marked virtual, we must always delete it via its derived classes.

to correct this and to address the compile warning previously addressed by 8295335c,

* the dtor is brought back. this addresses the concern of exposing the dtor public.
* the copy ctor is added, so that it is defined explicitly. this addresses the compile warning.
* the default ctor is added, otherwise it is deleted, as we have a user-provided copy ctor now.