### PR TITLE
treewide: explicitly define ctor and assignment operator

### DIFF
--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -76,6 +76,10 @@ private:
     // the base for queue waiters. looks complicated, but this is
     // to make it transparent once we add non-promise based nodes
     struct waiter : public boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
+        waiter() = default;
+        waiter(waiter&&) = default;
+        waiter(const waiter&) = delete;
+        waiter& operator=(const waiter&) = delete;
         virtual ~waiter() = default;
         void timeout() noexcept;
 

--- a/include/seastar/core/internal/io_desc.hh
+++ b/include/seastar/core/internal/io_desc.hh
@@ -29,7 +29,8 @@ namespace seastar {
 class kernel_completion {
 protected:
      kernel_completion() = default;
-     kernel_completion(const kernel_completion&) = default;
+     kernel_completion(kernel_completion&&) = default;
+     kernel_completion& operator=(kernel_completion&&) = default;
      ~kernel_completion() = default;
 public:
     virtual void complete_with(ssize_t res) = 0;

--- a/include/seastar/http/file_handler.hh
+++ b/include/seastar/http/file_handler.hh
@@ -51,7 +51,8 @@ public:
      */
     virtual output_stream<char> transform(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s) = 0;
-
+    file_transformer() = default;
+    file_transformer(file_transformer&&) = default;
     virtual ~file_transformer() = default;
 };
 

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -194,6 +194,9 @@ public:
 
 class jsonable {
 public:
+    jsonable() = default;
+    jsonable(const jsonable&) = default;
+    jsonable& operator=(const jsonable&) = default;
     virtual ~jsonable() = default;
     /**
      * create a foramted string of the object.

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -52,6 +52,9 @@ public:
 
 class socket_impl {
 public:
+    socket_impl() = default;
+    socket_impl(const socket_impl&) = delete;
+    socket_impl(socket_impl&&) = default;
     virtual ~socket_impl() {}
     virtual future<connected_socket> connect(socket_address sa, socket_address local, transport proto = transport::TCP) = 0;
     virtual void set_reuseaddr(bool reuseaddr) = 0;

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -143,6 +143,8 @@ private:
 public:
     tasktrace() = default;
     tasktrace(simple_backtrace main, vector_type prev, size_t prev_hash, scheduling_group sg) noexcept;
+    tasktrace(const tasktrace&) = default;
+    tasktrace& operator=(const tasktrace&) = default;
     ~tasktrace();
 
     size_t hash() const noexcept { return _hash; }

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -135,6 +135,8 @@ SEASTAR_TEST_CASE(test_map_reduce) {
 SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -148,6 +150,9 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct reduce {
         long& res;
         bool destroyed = false;
+        reduce(long& result)
+            : res{result} {}
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -174,6 +179,8 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -186,6 +193,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     };
     struct reduce {
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -208,6 +217,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
 SEASTAR_TEST_CASE(test_map_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -709,6 +709,8 @@ SEASTAR_TEST_CASE(test_map_reduce_tuple) {
 SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -722,6 +724,9 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct reduce {
         long& res;
         bool destroyed = false;
+        reduce(long& result)
+            : res{result} {}
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -745,6 +750,8 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -757,6 +764,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     };
     struct reduce {
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -776,6 +785,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce1_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -789,6 +800,8 @@ SEASTAR_TEST_CASE(test_map_reduce1_lifetime) {
     struct reduce {
         long res = 0;
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             BOOST_TEST_MESSAGE("~reduce()");
             destroyed = true;

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -258,6 +258,7 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
         scheduling_group _sg;
     public:
         scheduling_group_destroyer(scheduling_group sg) : _sg(sg) {}
+        scheduling_group_destroyer(const scheduling_group_destroyer&) = default;
         ~scheduling_group_destroyer() {
             destroy_scheduling_group(_sg).get();
         }


### PR DESCRIPTION
there are quite a few places where we define a base class with virtual destructor so that we can destroy the instances of its derived classes via a pointer to the base class. despite that the destructor is marked "default", compiler still considers it as a user-provided destructor. so the related guardrails defined by the C++ standard apply: the implicit copy assignment operator and the implicit copy constructor are deprecated for these base classes, because they are considered dangerous. the idea is: now that developer customizes the way how the instance is teared down, the way how the instance is copied/assigned is very likely to be customized as well. see
https://eel.is/c++draft/depr.impldec

to make our intention explicit and to assure the compiler that we are satisified with the default-generated copy constructor and assignement operator, we need to define them explicitly.

but if we define the user-provided copy constructor by "default"ing it explicitly, we prevent the compiler from creating the implicitly default-generated default constructor. so we have to define the default constructor as well, otherwise the derived classes would have trouble to get a default constructor.

this change fixes the leftover of

- 2148122db8f2d5a3b9749500e1442bd16bf09303
- eb3d703a36948af9ea28668fb1f4dc7f23e846a8

this change should address the warning like:
```
include/seastar/util/backtrace.hh:146:5: error: definition of implicit copy assignment operator for 'tasktrace' is deprecated because it has a user-provided destructor [-Werror,-Wdeprecated-copy-with-user-provided-dtor]
    ~tasktrace();
    ^
/home/circleci/project/src/core/memory.cc:858:30: note: in implicit copy assignment operator for 'seastar::tasktrace' first required here
    new_alloc_site.backtrace = get_backtrace();
                             ^
```
and
```
include/seastar/util/backtrace.hh:147:5: error: definition of implicit copy constructor for 'tasktrace' is deprecated because it has a user-provided destructor [-Werror,-Wdeprecated-copy-with-user-provided-dtor]
    ~tasktrace();
    ^
/home/circleci/project/src/core/memory.cc:187:8: note: in implicit copy constructor for 'seastar::tasktrace' first required here
struct allocation_site {
       ^
```

Refs #1868
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>