### PR TITLE
Enable all deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,8 +765,7 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -Wall
   -Werror
   -Wimplicit-fallthrough
-  -Wdeprecated
-  -Wno-error=deprecated)
+  -Wdeprecated)
 if (NOT BUILD_SHARED_LIBS)
   list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)
 endif ()

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -76,6 +76,10 @@ private:
     // the base for queue waiters. looks complicated, but this is
     // to make it transparent once we add non-promise based nodes
     struct waiter : public boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
+        waiter() = default;
+        waiter(waiter&&) = default;
+        waiter(const waiter&) = delete;
+        waiter& operator=(const waiter&) = delete;
         virtual ~waiter() = default;
         void timeout() noexcept;
 

--- a/include/seastar/core/internal/io_desc.hh
+++ b/include/seastar/core/internal/io_desc.hh
@@ -29,7 +29,8 @@ namespace seastar {
 class kernel_completion {
 protected:
      kernel_completion() = default;
-     kernel_completion(const kernel_completion&) = default;
+     kernel_completion(kernel_completion&&) = default;
+     kernel_completion& operator=(kernel_completion&&) = default;
      ~kernel_completion() = default;
 public:
     virtual void complete_with(ssize_t res) = 0;

--- a/include/seastar/http/file_handler.hh
+++ b/include/seastar/http/file_handler.hh
@@ -51,7 +51,8 @@ public:
      */
     virtual output_stream<char> transform(std::unique_ptr<http::request> req,
             const sstring& extension, output_stream<char>&& s) = 0;
-
+    file_transformer() = default;
+    file_transformer(file_transformer&&) = default;
     virtual ~file_transformer() = default;
 };
 

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -194,6 +194,9 @@ public:
 
 class jsonable {
 public:
+    jsonable() = default;
+    jsonable(const jsonable&) = default;
+    jsonable& operator=(const jsonable&) = default;
     virtual ~jsonable() = default;
     /**
      * create a foramted string of the object.

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -52,6 +52,9 @@ public:
 
 class socket_impl {
 public:
+    socket_impl() = default;
+    socket_impl(const socket_impl&) = delete;
+    socket_impl(socket_impl&&) = default;
     virtual ~socket_impl() {}
     virtual future<connected_socket> connect(socket_address sa, socket_address local, transport proto = transport::TCP) = 0;
     virtual void set_reuseaddr(bool reuseaddr) = 0;

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -143,6 +143,8 @@ private:
 public:
     tasktrace() = default;
     tasktrace(simple_backtrace main, vector_type prev, size_t prev_hash, scheduling_group sg) noexcept;
+    tasktrace(const tasktrace&) = default;
+    tasktrace& operator=(const tasktrace&) = default;
     ~tasktrace();
 
     size_t hash() const noexcept { return _hash; }

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -135,6 +135,8 @@ SEASTAR_TEST_CASE(test_map_reduce) {
 SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -148,6 +150,9 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct reduce {
         long& res;
         bool destroyed = false;
+        reduce(long& result)
+            : res{result} {}
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -174,6 +179,8 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -186,6 +193,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     };
     struct reduce {
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -208,6 +217,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
 SEASTAR_TEST_CASE(test_map_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -709,6 +709,8 @@ SEASTAR_TEST_CASE(test_map_reduce_tuple) {
 SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -722,6 +724,9 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
     struct reduce {
         long& res;
         bool destroyed = false;
+        reduce(long& result)
+            : res{result} {}
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -745,6 +750,8 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -757,6 +764,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     };
     struct reduce {
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             destroyed = true;
         }
@@ -776,6 +785,8 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
 SEASTAR_TEST_CASE(test_map_reduce1_lifetime) {
     struct map {
         bool destroyed = false;
+        map() = default;
+        map(const map&) = default;
         ~map() {
             destroyed = true;
         }
@@ -789,6 +800,8 @@ SEASTAR_TEST_CASE(test_map_reduce1_lifetime) {
     struct reduce {
         long res = 0;
         bool destroyed = false;
+        reduce() = default;
+        reduce(const reduce&) = default;
         ~reduce() {
             BOOST_TEST_MESSAGE("~reduce()");
             destroyed = true;

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -258,6 +258,7 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
         scheduling_group _sg;
     public:
         scheduling_group_destroyer(scheduling_group sg) : _sg(sg) {}
+        scheduling_group_destroyer(const scheduling_group_destroyer&) = default;
         ~scheduling_group_destroyer() {
             destroy_scheduling_group(_sg).get();
         }


### PR DESCRIPTION
this pull request includes following PRs:

- [x] #1867
- [ ] #1871
- [x] #1872

and on top of them, it drops the `-Wno-error=deprecated` compiler option to verify that all deprecated warnings are addressed by the included PRs.