### PR TITLE
loop: Fix iterator_range_estimate_vector_capacity for random iters

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -503,17 +503,14 @@ struct has_iterator_category<T, std::void_t<typename std::iterator_traits<T>::it
 template <typename Iterator, typename Sentinel, typename IteratorCategory>
 inline
 size_t
-iterator_range_estimate_vector_capacity(Iterator const&, Sentinel const&, IteratorCategory) {
+iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, IteratorCategory) {
+    // May be linear time below random_access_iterator_tag, but still better than reallocation
+    if constexpr (std::is_base_of<std::forward_iterator_tag, IteratorCategory>::value) {
+        return std::distance(begin, end);
+    }
+
     // For InputIterators we can't estimate needed capacity
     return 0;
-}
-
-template <typename Iterator, typename Sentinel>
-inline
-size_t
-iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, std::forward_iterator_tag) {
-    // May be linear time below random_access_iterator_tag, but still better than reallocation
-    return std::distance(begin, end);
 }
 
 } // namespace internal

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -19,8 +19,12 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
+#include "seastar/core/loop.hh"
+#include <boost/test/tools/old/interface.hpp>
 #include <cstddef>
 #include <exception>
+#include <forward_list>
+#include <iterator>
 #include <seastar/testing/test_case.hh>
 
 #include <seastar/core/reactor.hh>
@@ -506,6 +510,21 @@ SEASTAR_TEST_CASE(test_when_all_iterator_range) {
         BOOST_REQUIRE(std::all_of(ret.begin(), ret.end(), [] (auto& f) { return f.available(); }));
         BOOST_REQUIRE(std::all_of(ret.begin(), ret.end(), [&ret] (auto& f) { return f.get0() == size_t(&f - ret.data()); }));
     });
+}
+
+template<typename Container>
+void test_iterator_range_estimate() {
+    using iter_traits = std::iterator_traits<typename Container::iterator>;
+    Container container{1,2,3};
+
+    BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
+        container.begin(), container.end(), typename iter_traits::iterator_category{}), 3);
+}
+
+BOOST_AUTO_TEST_CASE(test_iterator_range_estimate_vector_capacity) {
+    test_iterator_range_estimate<std::vector<int>>();
+    test_iterator_range_estimate<std::list<int>>();
+    test_iterator_range_estimate<std::forward_list<int>>();
 }
 
 // helper function for when_any tests


### PR DESCRIPTION
The implementation uses tag dispatch to call out to `std::distance` for
forward iterators and below.

However this doesn't work as expected for random iterators. They will
actually get dispatched to the default template version.

Hence, functions that use `iterator_range_estimate_vector_capacity`
don't pre-reserve anything for `std::vector` or similar classes.

This causes lots of reallocations when using `seastar::when_all` or
similar.

Change the implementation to also call out to std::distance for derived
types.