### PR TITLE
memory: use `err` for the error string

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1611,7 +1611,7 @@ configure(std::vector<resource::memory> m, bool mbind,
 #ifdef SEASTAR_STRERROR_R_CHAR_P
                 const char *msg = strerror_r(errno, err, sizeof(err));
 #else
-                const char *msg = strerror_r(errno, err, sizeof(err)) ? "unknown error" : buf;
+                const char *msg = strerror_r(errno, err, sizeof(err)) ? "unknown error" : err;
 #endif
                 std::cerr << "WARNING: unable to mbind shard memory; performance may suffer: "
                         << msg << std::endl;


### PR DESCRIPTION
in cf0c3ee0df1d64bb6e162d5b47edbba53c62215d, we detected for the GNU variant of `strerror_r()` and falled back to the XSI variant if the GNU version was not available. but we failed to handle the case where `strerror_r()` succeeds in the XSI branch -- we should use the buffer passed to `strerror_r()` for the returned `msg`. and `buf` is not defined there. it was a copy-pasta error.

in this change, the error is corrected by s/err/buf/