### PR TITLE
io_queue: do not dereference moved-away shared pointer

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -578,7 +578,7 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     } else {
         _streams.emplace_back(*_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
     }
-    _flow_ratio_update.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(group->io_latency_goal() * cfg.flow_ratio_ticks));
+    _flow_ratio_update.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(_group->io_latency_goal() * cfg.flow_ratio_ticks));
 
     namespace sm = seastar::metrics;
     auto owner_l = sm::shard_label(this_shard_id());


### PR DESCRIPTION
in dd6b20d484, we introduced flow monitor. in that commit, we reference the `io_group` parameter after moving away from it. this breaks the test when ASan is enabled. and more importantly, this introduced a bug where a null pointer can be always dereferenced.

the seastar applications are now aborting when dereferecing a null pointer:

```
/home/kefu/dev/seastar/src/core/io_queue.cc:581:98: runtime error: member call on null pointer of type 'seastar::io_group'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/kefu/dev/seastar/src/core/io_queue.cc:581:98 in
Aborting on shard 0.
```

in this change, instead of dereferencing the moved-away pointer,
we deference the member variable instead. it is the destination of
the `std::move()`, so it should be valid.

Refs dd6b20d484
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>