### PR TITLE
build: disable the -Wunused-* warnings for checkheaders

### DIFF
--- a/cmake/CheckHeaders.cmake
+++ b/cmake/CheckHeaders.cmake
@@ -95,18 +95,18 @@ function (seastar_check_self_contained target library)
       PRIVATE ${includes})
   endif ()
 
-  # symbols in header file should always be referenced, but these
-  # are just pure headers, so unused variables should be tolerated.
-  target_compile_options (${check_lib}
-    PRIVATE
-      -Wno-error=unused-const-variable
-      -Wno-error=unused-function
-      -Wno-error=unused-variable)
   get_target_property (compile_options ${library} COMPILE_OPTIONS)
   if (compile_options)
     target_compile_options (${check_lib}
       PRIVATE ${compile_options})
   endif ()
+  # symbols in header file should always be referenced, but these
+  # are just pure headers, so unused variables should be tolerated.
+  target_compile_options (${check_lib}
+    PRIVATE
+      -Wno-unused-const-variable
+      -Wno-unused-function
+      -Wno-unused-variable)
 
   get_target_property (compile_definitions ${library} COMPILE_DEFINITIONS)
   if (compile_definitions)


### PR DESCRIPTION
these warning does not help when checking the self-contain'ness of these headers. actually they are always false alarms, as the way how we check the self-contain'ness of headers is to rename the headers to .cc files and compile them. but the symbols defined by the header are not always used by the header itself. hence there are good chances that the compiler would complain with these -Wunused-* warnings.

in this change, to silence these warnings,

- replace, for instance `-Wno-error=unused-variable` with `-Wno-unused-variable`, to completely disable these warnings.
- pass the options disabling these warning after the ones specified for the target being built. the options for building the target are likely to contain the option to enable these -Wunused-* warnings. if multiple options conflicts the last wins, so we need to put the -Wno-unused* options after them.