### PR TITLE
Make http client restart requests

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -220,7 +220,14 @@ public:
      * may re-use the sockets on its own
      *
      * \param f -- the factory pointer
+     * \param max_connections -- maximum number of connection a client is allowed to maintain
+     * (both active and cached in pool)
      *
+     * The client uses connections provided by factory to send requests over and receive responses
+     * back. Once request-response cycle is over the connection used for that is kept by a client
+     * in a "pool". Making another http request may then pick up the existing connection from the
+     * pool thus avoiding the extra latency of establishing new connection. Pool may thus accumulate
+     * more than one connection if user sends several requests in parallel.
      */
     explicit client(std::unique_ptr<connection_factory> f, unsigned max_connections = default_max_connections);
 

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -180,11 +180,16 @@ class client {
     using connection_ptr = seastar::shared_ptr<connection>;
 
     future<connection_ptr> get_connection();
+    future<connection_ptr> make_connection();
     future<> put_connection(connection_ptr con);
     future<> shrink_connections();
 
     template <std::invocable<connection&> Fn>
     auto with_connection(Fn&& fn);
+
+    template <typename Fn>
+    requires std::invocable<Fn, connection&>
+    auto with_new_connection(Fn&& fn);
 
 public:
     using reply_handler = noncopyable_function<future<>(const reply&, input_stream<char>&& body)>;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -137,7 +137,12 @@ future<connection::reply_ptr> connection::recv_reply() {
         parser.init();
         return _read_buf.consume(parser).then([this, &parser] {
             if (parser.eof()) {
-                throw std::runtime_error("Invalid response");
+                http_log.trace("Parsing response EOFed");
+                throw std::system_error(ECONNABORTED, std::system_category());
+            }
+            if (parser.failed()) {
+                http_log.trace("Parsing response failed");
+                throw std::runtime_error("Invalid http server response");
             }
 
             auto resp = parser.get_parsed_response();

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -951,6 +951,49 @@ SEASTAR_TEST_CASE(test_client_response_parse_error) {
     });
 }
 
+SEASTAR_TEST_CASE(test_client_retry_request) {
+    return seastar::async([] {
+        loopback_connection_factory lcf(1);
+        auto ss = lcf.get_server_socket();
+        future<> server = ss.accept().then([] (accept_result ar) {
+            return seastar::async([sk = std::move(ar.connection)] () mutable {
+                input_stream<char> in = sk.input();
+                read_simple_http_request(in);
+                output_stream<char> out = sk.output();
+                out.write("HTT").get(); // write incomplete response
+                out.flush().get();
+                out.close().get();
+            });
+        }).then([&ss] {
+            return ss.accept().then([] (accept_result ar) {
+                return seastar::async([sk = std::move(ar.connection)] () mutable {
+                    input_stream<char> in = sk.input();
+                    read_simple_http_request(in);
+                    output_stream<char> out = sk.output();
+                    sstring r200("HTTP/1.1 200 OK\r\nHost: localhost\r\n\r\n");
+                    out.write(r200).get(); // now write complete response
+                    out.flush().get();
+                    out.close().get();
+                });
+            });
+        });
+
+        future<> client = seastar::async([&lcf] {
+            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 2, http::experimental::client::retry_requests::yes);
+            auto req = http::request::make("GET", "test", "/test");
+            bool got_response = false;
+            cln.make_request(std::move(req), [&] (const http::reply& rep, input_stream<char>&& in) {
+                got_response = true;
+                return make_ready_future<>();
+            }, http::reply::status_type::ok).get();
+            cln.close().get();
+            BOOST_REQUIRE(got_response);
+        });
+
+        when_all(std::move(client), std::move(server)).discard_result().get();
+    });
+}
+
 SEASTAR_TEST_CASE(test_100_continue) {
     return seastar::async([] {
         loopback_connection_factory lcf(1);


### PR DESCRIPTION
There's an issue with maintaining keep-alive sockets by http client.

Some prior art first.

The HTTP client uses seastar connections to send requests over and receive responses back. Typically the connection is a TCP socket (or TLS connection which is a wrapper over TCP socket too). Once request-response cycle is over the connection used for that is kept by a client in a "pool". Making another http request may then pick up the existing connection from the pool thus avoiding the extra latency of establishing new connection. Pool may thus accumulate more than one connection if the client user sends several requests in parallel.

```mermaid
flowchart TD
  A[ Start ] --> B{ pool is not empty }
  B -->| y | C[ pop connection from pool ]
  B -->| n | D[ establish new connection ]
  C --> E[ talk to server ]
  D --> E
  E --> F{ got error? }
  F --> | n | G[ push connection to pool ]
  F --> | y | H[ Done ]
  G --> H
```

HTTP servers may sometimes want to terminate the connections it keeps. This can happen in one of several ways.

The "gentle" way is when server adds the "connection: close" header to its response. In that case client would handle the response and will not put the connection back to pool, but instead would just close it. So next request would either pick some other connection from pool or would need to establish a new one.

Less gentle way a server may terminate a connection is by closing it, so the underlying TCP stack would communicate regular TCP FIN-s. On the client side there's connected_socket::wait_input_shutdown() method that returns a future that gets resolved when kernel terminates the connection by peers request. In case client's connection is kept in pool it will be closed and removed from the pool behind the scenes. Next request won't even notice that -- it will either pick some other connection from pool, or will establish a new one.

Sometimes more unpleasant situation happens. It can be either a race or deliberate server's "abort". In the former case, server closes the connection and TCP starts communicating FIN-s in parallel with client picking up a connection for its new request. In that case, even if kernel resolves "input-shutdown" event described above, due to seastar event loop and batch flusher, client would see that the connection is closed _after_ it had picked it from pool and had chance to put some data into it. In the latter case server closes the connection in the middle of reading the request from the client or even in the middle of writing back the response. This is very unlikely, but still happens from time to time.

Having said the above, the problem -- when user calls `client::make_request()` and client steps on the "unpleasant" server-side connection closure, the request making resolves with exception and user has to do something about it. There are two options here -- handle the exception somehow or ask client to make the same request again (restart the request). This PR suggest that the latter choice can be implemented in the HTTP client code. If user doesn't want to restart, it may ask client not to do it, the new API allows for that.

First (a side node) -- to tell the "server closed its socket" from other errors the exception from scoket IO is checked to be the system error with EPIPE or ECONABORTED code in it. EPIPE is reported when it comes from writing the request, ECONABORTED is reported when it comes from reading the response.

Next, there's only one way to replay the request -- client should get new connection somehow and repeat the request-response cycle. There are two options where to get new connection from -- from pool (if it's there) or establish a new one. While experimenting with HTTP client I noticed that picking up connection from pool often results in several "transport exception"-s in a row, as if server was closing connections in batches. So this PR makes a shortcut for restarts it always establishes new connection to server (which, after request-response cycle, is put back into pool normally).

```mermaid
flowchart TD
  A[ Start ] --> B{ pool is not empty }
  B -->| y | C[ pop connection from pool ]
  B -->| n | D[ establish new connection ]
  C --> E[ talk to server ]
  D --> E
  E --> F{ got error? }
  F --> | n | G[ push connection to pool ]
  F --> | y | J{ should restart }
  J --> | n | H[ Done ]
  J --> | y | D
  G --> H
```

And the last, but not least, restart only happens once, because the chance of observing "transport exception" from newly established connection is considered to be low enough not to care. Respectively, if a request is made over new connection (not over a connection from pool) and "transport exception" pops up it's not restarted.