### PR TITLE
reactor: merge pollfn on I/O paths into a single one

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -203,9 +203,7 @@ private:
     class lowres_timer_pollfn;
     class manual_timer_pollfn;
     class epoll_pollfn;
-    class reap_kernel_completions_pollfn;
-    class kernel_submit_work_pollfn;
-    class io_queue_submission_pollfn;
+    class kernel_events_pollfn;
     class syscall_pollfn;
     class execution_stage_pollfn;
     friend class manual_clock;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -379,8 +379,9 @@ private:
     static std::chrono::nanoseconds calculate_poll_time();
     static void block_notifier(int);
     bool flush_pending_aio();
+    bool poll_all_events();
+    bool poll_any_event();
     steady_clock_type::time_point next_pending_aio() const noexcept;
-    bool reap_kernel_completions();
     bool flush_tcp_batches();
     void update_lowres_clocks() noexcept;
     bool do_expire_lowres_timers() noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2784,8 +2784,7 @@ class reactor::kernel_events_pollfn final : public reactor::pollfn {
     // Wake-up the reactor with highres timer when the io-queue
     // decides to delay dispatching until some time point in
     // the future
-    bool _armed = false;
-    timer<> _nearest_wakeup { [this] { _armed = false; } };
+    timer<> _nearest_wakeup { [] { } };
     bool maybe_set_alarm_for_aio() {
         auto next = _r.next_pending_aio();
         auto now = steady_clock_type::now();
@@ -2793,7 +2792,6 @@ class reactor::kernel_events_pollfn final : public reactor::pollfn {
             return false;
         }
         _nearest_wakeup.arm(next);
-        _armed = true;
         return true;
     }
 public:
@@ -2834,9 +2832,8 @@ public:
     }
 
     void exit_interrupt_mode() final {
-        if (_armed) {
+        if (_nearest_wakeup.armed()) {
             _nearest_wakeup.cancel();
-            _armed = false;
         }
     }
 };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1788,10 +1788,7 @@ bool reactor::poll_all_events() {
     bool work = false;
     work |= _backend->reap_kernel_completions();
     work |= flush_pending_aio();
-#ifndef HAVE_OSV
-    work |= _backend->kernel_submit_work();
-#endif
-    work |= _backend->reap_kernel_completions();
+    work |= _backend->submit_and_get_completions();
     return work;
 }
 
@@ -1800,10 +1797,7 @@ bool reactor::poll_any_event() {
         // actually performs work, but triggers no user continuations, so okay
         _backend->reap_kernel_completions() ||
         flush_pending_aio() ||
-#ifndef HAVE_OSV
-        _backend->kernel_submit_work() ||
-#endif
-        _backend->reap_kernel_completions());
+        _backend->submit_and_get_completions());
 }
 
 #if SEASTAR_API_LEVEL < 7

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -534,10 +534,12 @@ bool reactor_backend_aio::reap_kernel_completions() {
     return did_work;
 }
 
-bool reactor_backend_aio::kernel_submit_work() {
+bool reactor_backend_aio::submit_and_get_completions() {
     _hrtimer_poll_completion.maybe_queue(_polling_io);
     bool did_work = _polling_io.flush();
     did_work |= _storage_context.submit_work();
+    did_work |= await_events(0, nullptr);
+    did_work |= _storage_context.reap_completions();
     return did_work;
 }
 
@@ -918,9 +920,9 @@ public:
 bool reactor_backend_epoll::reap_kernel_completions() {
     // epoll does not have a separate submission stage, and just
     // calls epoll_ctl everytime it needs, so this method and
-    // kernel_submit_work are essentially the same. Ordering also
+    // submit_and_get_completions are essentially the same. Ordering also
     // doesn't matter much. wait_and_process is actually completing,
-    // but we prefer to call it in kernel_submit_work because the
+    // but we prefer to call it in submit_and_get_completions because the
     // reactor register two pollers for completions and one for submission,
     // since completion is cheaper for other backends like aio. This avoids
     // calling epoll_wait twice.
@@ -929,7 +931,7 @@ bool reactor_backend_epoll::reap_kernel_completions() {
     return _storage_context.reap_completions();
 }
 
-bool reactor_backend_epoll::kernel_submit_work() {
+bool reactor_backend_epoll::submit_and_get_completions() {
     bool result = false;
     _storage_context.submit_work();
     if (_need_epoll_events) {
@@ -937,7 +939,7 @@ bool reactor_backend_epoll::kernel_submit_work() {
     }
 
     result |= complete_hrtimer();
-
+    result |= _storage_context.reap_completions();
     return result;
 }
 
@@ -1104,7 +1106,7 @@ reactor_backend_osv::reap_kernel_completions() {
     return true;
 }
 
-reactor_backend_osv::kernel_submit_work() {
+reactor_backend_osv::submit_and_get_completions() {
 }
 
 void
@@ -1545,7 +1547,7 @@ public:
     virtual bool reap_kernel_completions() override {
         return do_process_kernel_completions();
     }
-    virtual bool kernel_submit_work() override {
+    virtual bool submit_and_get_completions() override {
         bool did_work = false;
         did_work |= _preempt_io_context.service_preempting_io();
         did_work |= queue_pending_file_io();
@@ -1554,6 +1556,7 @@ public:
             abort();
         }
         did_work |= ret;
+        did_work |= do_process_kernel_completions();
         return did_work;
     }
     virtual bool kernel_events_can_sleep() const override {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -180,13 +180,15 @@ public:
     // The methods below are used to communicate with the kernel.
     // reap_kernel_completions() will complete any previous async
     // work that is ready to consume.
-    // kernel_submit_work() submit new events that were produced.
+    // submit_and_get_completions() will both submit new events that were
+    // produced, and also complete any previous async work that is ready to
+    // consume.
     // Both of those methods are asynchronous and will never block.
     //
     // wait_and_process_events on the other hand may block, and is called when
     // we are about to go to sleep.
     virtual bool reap_kernel_completions() = 0;
-    virtual bool kernel_submit_work() = 0;
+    virtual bool submit_and_get_completions() = 0;
     virtual bool kernel_events_can_sleep() const = 0;
     virtual void wait_and_process_events(const sigset_t* active_sigmask = nullptr) = 0;
 
@@ -257,7 +259,7 @@ public:
     virtual ~reactor_backend_epoll() override;
 
     virtual bool reap_kernel_completions() override;
-    virtual bool kernel_submit_work() override;
+    virtual bool submit_and_get_completions() override;
     virtual bool kernel_events_can_sleep() const override;
     virtual void wait_and_process_events(const sigset_t* active_sigmask) override;
     virtual future<> readable(pollable_fd_state& fd) override;
@@ -307,7 +309,7 @@ public:
     explicit reactor_backend_aio(reactor& r);
 
     virtual bool reap_kernel_completions() override;
-    virtual bool kernel_submit_work() override;
+    virtual bool submit_and_get_completions() override;
     virtual bool kernel_events_can_sleep() const override;
     virtual void wait_and_process_events(const sigset_t* active_sigmask) override;
     virtual future<> readable(pollable_fd_state& fd) override;


### PR DESCRIPTION
this change consolidates the 3 pollfn classes into a single one.
this allows the backend to customize the way how the requests
are submitted, and how responses events are collected. for instance,
io_uring backend can submit and wait for events with a single syscall,
so a single place to do polling would make this possible.

in a follow-up change, we will move the part in the poller closer to
backend into backend.