### PR TITLE
thread_pool: Reference reactor, not point to

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1036,7 +1036,7 @@ reactor::reactor(std::shared_ptr<smp> smp, alien::instance& alien, unsigned id, 
     , _cpu_started(0)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
     , _reuseport(posix_reuseport_detect())
-    , _thread_pool(std::make_unique<thread_pool>(this, seastar::format("syscall-{}", id))) {
+    , _thread_pool(std::make_unique<thread_pool>(*this, seastar::format("syscall-{}", id))) {
     /*
      * The _backend assignment is here, not on the initialization list as
      * the chosen backend constructor may want to handle signals and thus

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -38,7 +38,7 @@ namespace seastar {
 
 /* not yet implemented for OSv. TODO: do the notification like we do class smp. */
 #ifndef HAVE_OSV
-thread_pool::thread_pool(reactor* r, sstring name) : _reactor(r), _worker_thread([this, name] { work(name); }) {
+thread_pool::thread_pool(reactor& r, sstring name) : _reactor(r), _worker_thread([this, name] { work(name); }) {
 }
 
 void thread_pool::work(sstring name) {
@@ -68,7 +68,7 @@ void thread_pool::work(sstring name) {
             std::atomic_thread_fence(std::memory_order_seq_cst);
             if (_main_thread_idle.load(std::memory_order_relaxed)) {
                 uint64_t one = 1;
-                ::write(_reactor->_notify_eventfd.get(), &one, 8);
+                ::write(_reactor._notify_eventfd.get(), &one, 8);
             }
         }
     }

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -28,7 +28,7 @@ namespace seastar {
 class reactor;
 
 class thread_pool {
-    reactor* _reactor;
+    reactor& _reactor;
     uint64_t _aio_threaded_fallbacks = 0;
 #ifndef HAVE_OSV
     syscall_work_queue inter_thread_wq;
@@ -36,7 +36,7 @@ class thread_pool {
     std::atomic<bool> _stopped = { false };
     std::atomic<bool> _main_thread_idle = { false };
 public:
-    explicit thread_pool(reactor* r, sstring thread_name);
+    explicit thread_pool(reactor& r, sstring thread_name);
     ~thread_pool();
     template <typename T, typename Func>
     future<T> submit(Func func) noexcept {


### PR DESCRIPTION
The reactor* is non-null all the time, better make it a reactor&