### PR TITLE
io_tester: disable -Wuninitialized when including boost.accumulators

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -38,6 +38,10 @@
 #include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string.hpp>
+
+#pragma GCC diagnostic push
+// see https://github.com/boostorg/accumulators/pull/54
+#pragma GCC diagnostic ignored "-Wuninitialized"
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/max.hpp>
@@ -45,6 +49,7 @@
 #include <boost/accumulators/statistics/p_square_quantile.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
 #include <boost/accumulators/statistics/extended_p_square_quantile.hpp>
+#pragma GCC diagnostic pop
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/array.hpp>


### PR DESCRIPTION
io_tester: disable -Wuninitialized when including boost.accumulators

before this change, when compiling boost.accumulators headers, if
the library does not include the fix for
https://github.com/boostorg/accumulators/pull/54. and we are building
the release build with GCC-13, we'd have following -Wuninitialized build
failure:

```
In copy constructor ‘constexpr boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>::extended_p_square_quantile_impl(const boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>&)’,
    inlined from ‘boost::accumulators::detail::accumulator_wrapper<Accumulator, Feature>::accumulator_wrapper(const boost::accumulators::detail::accumulator_wrapper<Accumulator, Feature>&) [with Accumulator = boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>; Feature = boost::accumulators::tag::extended_p_square_quantile_quadratic]’ at /usr/include/boost/accumulators/framework/depends_on.hpp:320:69,
    inlined from ‘constexpr boost::fusion::cons<Car, Cdr>::cons(typename boost::fusion::detail::call_param<Car>::type, typename boost::fusion::detail::call_param<Cdr>::type) [with Car = boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>; Cdr = boost::fusion::cons<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::sum_impl<double, boost::accumulators::tag::sample>, boost::accumulators::tag::sum>, boost::fusion::cons<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::mean_impl<double, boost::accumulators::tag::sum>, boost::accumulators::tag::mean>, boost::fusion::cons<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::max_impl<double>, boost::accumulators::tag::max>, boost::fusion::nil_> > >]’ at /usr/include/boost/fusion/container/list/cons.hpp:66:15,
    inlined from ‘static boost::accumulators::detail::build_acc_list<First, Last, false>::type boost::accumulators::detail::build_acc_list<First, Last, false>::call(const Args&, const First&, const Last&) [with Args = boost::parameter::aux::flat_like_arg_list<boost::parameter::aux::flat_like_arg_tuple<boost::accumulators::tag::accumulator, boost::parameter::aux::tagged_argument<boost::accumulators::tag::accumulator, boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::extended_p_square_quantile(boost::accumulators::quadratic), boost::accumulators::tag::mean, boost::accumulators::tag::max, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, void> >, std::integral_constant<bool, true> >, boost::parameter::aux::flat_like_arg_tuple<boost::accumulators::tag::extended_p_square_probabilities_<0>, boost::parameter::aux::tagged_argument<boost::accumulators::tag::extended_p_square_probabilities_<0>, std::array<double, 4> >, std::integral_constant<bool, true> > >; First = boost::fusion::mpl_iterator<boost::mpl::v_iter<boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::max_impl<double>, boost::accumulators::tag::max>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::mean_impl<double, boost::accumulators::tag::sum>, boost::accumulators::tag::mean>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::sum_impl<double, boost::accumulators::tag::sample>, boost::accumulators::tag::sum>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_impl<double>, boost::accumulators::tag::extended_p_square>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::count_impl, boost::accumulators::tag::count>, boost::mpl::vector0<mpl_::na>, 0>, 0>, 0>, 0>, 0>, 0>, 2> >; Last = boost::fusion::mpl_iterator<boost::mpl::v_iter<boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::max_impl<double>, boost::accumulators::tag::max>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::mean_impl<double, boost::accumulators::tag::sum>, boost::accumulators::tag::mean>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::sum_impl<double, boost::accumulators::tag::sample>, boost::accumulators::tag::sum>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_impl<double>, boost::accumulators::tag::extended_p_square>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::count_impl, boost::accumulators::tag::count>, boost::mpl::vector0<mpl_::na>, 0>, 0>, 0>, 0>, 0>, 0>, 6> >]’ at /usr/include/boost/accumulators/framework/depends_on.hpp:252:86,
    inlined from ‘static boost::accumulators::detail::build_acc_list<First, Last, false>::type boost::accumulators::detail::build_acc_list<First, Last, false>::call(const Args&, const First&, const Last&) [with Args = boost::parameter::aux::flat_like_arg_list<boost::parameter::aux::flat_like_arg_tuple<boost::accumulators::tag::accumulator, boost::parameter::aux::tagged_argument<boost::accumulators::tag::accumulator, boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::extended_p_square_quantile(boost::accumulators::quadratic), boost::accumulators::tag::mean, boost::accumulators::tag::max, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, void> >, std::integral_constant<bool, true> >, boost::parameter::aux::flat_like_arg_tuple<boost::accumulators::tag::extended_p_square_probabilities_<0>, boost::parameter::aux::tagged_argument<boost::accumulators::tag::extended_p_square_probabilities_<0>, std::array<double, 4> >, std::integral_constant<bool, true> > >; First = boost::fusion::mpl_iterator<boost::mpl::v_iter<boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::max_impl<double>, boost::accumulators::tag::max>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::mean_impl<double, boost::accumulators::tag::sum>, boost::accumulators::tag::mean>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::sum_impl<double, boost::accumulators::tag::sample>, boost::accumulators::tag::sum>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_impl<double>, boost::accumulators::tag::extended_p_square>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::count_impl, boost::accumulators::tag::count>, boost::mpl::vector0<mpl_::na>, 0>, 0>, 0>, 0>, 0>, 0>, 1> >; Last = boost::fusion::mpl_iterator<boost::mpl::v_iter<boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::max_impl<double>, boost::accumulators::tag::max>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::mean_impl<double, boost::accumulators::tag::sum>, boost::accumulators::tag::mean>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::sum_impl<double, boost::accumulators::tag::sample>, boost::accumulators::tag::sum>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_impl<double>, boost::accumulators::tag::extended_p_square>, boost::mpl::v_item<boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::count_impl, boost::accumulators::tag::count>, boost::mpl::vector0<mpl_::na>, 0>, 0>, 0>, 0>, 0>, 0>, 6> >]’ at /usr/include/boost/accumulators/framework/depends_on.hpp:252:86:
/usr/include/boost/accumulators/statistics/extended_p_square_quantile.hpp:57:12: error: ‘<unnamed>.boost::accumulators::detail::accumulator_wrapper<boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>, boost::accumulators::tag::extended_p_square_quantile_quadratic>::<unnamed>.boost::accumulators::impl::extended_p_square_quantile_impl<double, boost::accumulators::unweighted, boost::accumulators::quadratic>::probability’ is used uninitialized [-Werror=uninitialized]
   57 |     struct extended_p_square_quantile_impl
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

so, in this change, we temporarily disable this warning when
including these boost.accumulators headers, to workaround this
build failure, as we consider this warning as error.

Refs #1634
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>