### PR TITLE
Generalize `net::udp_channel` into `net::datagram_channel`

### DIFF
--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1293,7 +1293,7 @@ public:
         _chan = make_udp_channel({_port});
         // Run in the background.
         _task = keep_doing([this] {
-            return _chan.receive().then([this](udp_datagram dgram) {
+            return _chan.receive().then([this](datagram dgram) {
                 packet& p = dgram.get_data();
                 if (p.len() < sizeof(header)) {
                     // dropping invalid packet

--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1290,7 +1290,7 @@ public:
     }
 
     void start() {
-        _chan = make_udp_channel({_port});
+        _chan = make_bound_datagram_channel({_port});
         // Run in the background.
         _task = keep_doing([this] {
             return _chan.receive().then([this](datagram dgram) {

--- a/demos/udp_client_demo.cc
+++ b/demos/udp_client_demo.cc
@@ -40,7 +40,7 @@ public:
     void start(ipv4_addr server_addr) {
         std::cout << "Sending to " << server_addr << std::endl;
 
-        _chan = make_udp_channel();
+        _chan = make_unbound_datagram_channel(AF_INET);
 
         _stats_timer.set_callback([this] {
             std::cout << "Out: " << n_sent << " pps, \t";

--- a/demos/udp_server_demo.cc
+++ b/demos/udp_server_demo.cc
@@ -46,7 +46,7 @@ public:
 
         // Run server in background.
         (void)keep_doing([this] {
-            return _chan.receive().then([this] (udp_datagram dgram) {
+            return _chan.receive().then([this] (datagram dgram) {
                 return _chan.send(dgram.get_src(), std::move(dgram.get_data())).then([this] {
                     _n_sent++;
                 });

--- a/demos/udp_server_demo.cc
+++ b/demos/udp_server_demo.cc
@@ -36,7 +36,7 @@ private:
 public:
     void start(uint16_t port) {
         ipv4_addr listen_addr{port};
-        _chan = make_udp_channel(listen_addr);
+        _chan = make_bound_datagram_channel(listen_addr);
 
         _stats_timer.set_callback([this] {
             std::cout << "Out: " << _n_sent << " pps" << std::endl;

--- a/demos/udp_zero_copy_demo.cc
+++ b/demos/udp_zero_copy_demo.cc
@@ -105,7 +105,7 @@ public:
 
         // Run sender in background.
         (void)keep_doing([this] {
-            return _chan.receive().then([this] (udp_datagram dgram) {
+            return _chan.receive().then([this] (datagram dgram) {
                 auto chunk = next_chunk();
                 lw_shared_ptr<sstring> item;
                 if (_copy) {

--- a/demos/udp_zero_copy_demo.cc
+++ b/demos/udp_zero_copy_demo.cc
@@ -73,7 +73,7 @@ public:
     }
     void start(int chunk_size, bool copy, size_t mem_size) {
         ipv4_addr listen_addr{10000};
-        _chan = make_udp_channel(listen_addr);
+        _chan = make_bound_datagram_channel(listen_addr);
 
         std::cout << "Listening on " << listen_addr << std::endl;
 

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -176,6 +176,33 @@ net::udp_channel make_udp_channel();
 /// \return a \ref net::udp_channel object that can be used for UDP transfers.
 net::udp_channel make_udp_channel(const socket_address& local);
 
+/// Creates a datagram_channel object suitable for sending datagrams to
+/// destinations that belong to the provided address family.
+/// Supported address families: AF_INET, AF_INET6 and AF_UNIX.
+///
+/// Setting family to AF_INET or AF_INET6 creates a datagram_channel that uses
+/// UDP protocol. AF_UNIX creates a datagram_channel that uses UNIX domain
+/// sockets.
+///
+/// The channel is not bound to a local address, and thus can only be used
+/// for sending.
+///
+/// \param family address family in which the \ref datagram_channel will operate
+///
+/// \return a \ref net::datagram_channel object for sending datagrams in a
+/// specified address family.
+net::datagram_channel make_unbound_datagram_channel(sa_family_t family);
+
+/// Creates a datagram_channel object suitable for sending and receiving
+/// datagrams to/from destinations that belong to the provided address family.
+/// Supported address families: AF_INET, AF_INET6 and AF_UNIX.
+///
+/// \param local local address to bind to
+///
+/// \return a \ref net::datagram_channel object for sending/receiving datagrams
+/// in a specified address family.
+net::datagram_channel make_bound_datagram_channel(const socket_address& local);
+
 /// @}
 
 /// \defgroup fileio-module File Input/Output

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -166,6 +166,7 @@ socket make_socket();
 /// for sending.
 ///
 /// \return a \ref net::udp_channel object that can be used for UDP transfers.
+[[deprecated("Use `make_unbound_datagram_channel` instead")]]
 net::udp_channel make_udp_channel();
 
 
@@ -174,6 +175,7 @@ net::udp_channel make_udp_channel();
 /// \param local local address to bind to
 ///
 /// \return a \ref net::udp_channel object that can be used for UDP transfers.
+[[deprecated("Use `make_bound_datagram_channel` instead")]]
 net::udp_channel make_udp_channel(const socket_address& local);
 
 /// Creates a datagram_channel object suitable for sending datagrams to

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -84,7 +84,7 @@ struct stat_data;
 
 namespace net {
 
-class udp_channel;
+using udp_channel = class datagram_channel;
 
 }
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -431,7 +431,10 @@ public:
     // FIXME: local parameter assumes ipv4 for now, fix when adding other AF
     future<connected_socket> connect(socket_address sa, socket_address = {}, transport proto = transport::TCP);
     virtual ::seastar::socket socket() = 0;
+
+    [[deprecated("Use `make_[un]bound_datagram_channel` instead")]]
     virtual net::udp_channel make_udp_channel(const socket_address& = {}) = 0;
+
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) = 0;
     virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) = 0;
     virtual future<> initialize() {

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -99,16 +99,18 @@ public:
 
 using udp_datagram_impl = datagram_impl;
 
-class udp_datagram final {
+class datagram final {
 private:
     std::unique_ptr<datagram_impl> _impl;
 public:
-    udp_datagram(std::unique_ptr<datagram_impl>&& impl) noexcept : _impl(std::move(impl)) {};
+    datagram(std::unique_ptr<datagram_impl>&& impl) noexcept : _impl(std::move(impl)) {};
     socket_address get_src() { return _impl->get_src(); }
     socket_address get_dst() { return _impl->get_dst(); }
     uint16_t get_dst_port() { return _impl->get_dst_port(); }
     packet& get_data() { return _impl->get_data(); }
 };
+
+using udp_datagram = datagram;
 
 class udp_channel {
 private:
@@ -123,7 +125,7 @@ public:
 
     socket_address local_address() const;
 
-    future<udp_datagram> receive();
+    future<datagram> receive();
     future<> send(const socket_address& dst, const char* msg);
     future<> send(const socket_address& dst, packet p);
     bool is_closed() const;

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -112,16 +112,16 @@ public:
 
 using udp_datagram = datagram;
 
-class udp_channel {
+class datagram_channel {
 private:
     std::unique_ptr<datagram_channel_impl> _impl;
 public:
-    udp_channel() noexcept;
-    udp_channel(std::unique_ptr<datagram_channel_impl>) noexcept;
-    ~udp_channel();
+    datagram_channel() noexcept;
+    datagram_channel(std::unique_ptr<datagram_channel_impl>) noexcept;
+    ~datagram_channel();
 
-    udp_channel(udp_channel&&) noexcept;
-    udp_channel& operator=(udp_channel&&) noexcept;
+    datagram_channel(datagram_channel&&) noexcept;
+    datagram_channel& operator=(datagram_channel&&) noexcept;
 
     socket_address local_address() const;
 
@@ -140,6 +140,8 @@ public:
     /// shutdown_output().
     void close();
 };
+
+using udp_channel = datagram_channel;
 
 class network_interface_impl;
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -88,20 +88,22 @@ class udp_channel_impl;
 class get_impl;
 /// \endcond
 
-class udp_datagram_impl {
+class datagram_impl {
 public:
-    virtual ~udp_datagram_impl() {};
+    virtual ~datagram_impl() {};
     virtual socket_address get_src() = 0;
     virtual socket_address get_dst() = 0;
     virtual uint16_t get_dst_port() = 0;
     virtual packet& get_data() = 0;
 };
 
+using udp_datagram_impl = datagram_impl;
+
 class udp_datagram final {
 private:
-    std::unique_ptr<udp_datagram_impl> _impl;
+    std::unique_ptr<datagram_impl> _impl;
 public:
-    udp_datagram(std::unique_ptr<udp_datagram_impl>&& impl) noexcept : _impl(std::move(impl)) {};
+    udp_datagram(std::unique_ptr<datagram_impl>&& impl) noexcept : _impl(std::move(impl)) {};
     socket_address get_src() { return _impl->get_src(); }
     socket_address get_dst() { return _impl->get_dst(); }
     uint16_t get_dst_port() { return _impl->get_dst_port(); }

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -84,7 +84,7 @@ class connected_socket_impl;
 class socket_impl;
 
 class server_socket_impl;
-class udp_channel_impl;
+class datagram_channel_impl;
 class get_impl;
 /// \endcond
 
@@ -114,10 +114,10 @@ using udp_datagram = datagram;
 
 class udp_channel {
 private:
-    std::unique_ptr<udp_channel_impl> _impl;
+    std::unique_ptr<datagram_channel_impl> _impl;
 public:
     udp_channel() noexcept;
-    udp_channel(std::unique_ptr<udp_channel_impl>) noexcept;
+    udp_channel(std::unique_ptr<datagram_channel_impl>) noexcept;
     ~udp_channel();
 
     udp_channel(udp_channel&&) noexcept;

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -432,6 +432,8 @@ public:
     future<connected_socket> connect(socket_address sa, socket_address = {}, transport proto = transport::TCP);
     virtual ::seastar::socket socket() = 0;
     virtual net::udp_channel make_udp_channel(const socket_address& = {}) = 0;
+    virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) = 0;
+    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) = 0;
     virtual future<> initialize() {
         return make_ready_future();
     }

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -200,6 +200,8 @@ public:
     virtual server_socket listen(socket_address sa, listen_options opts) override;
     virtual ::seastar::socket socket() override;
     virtual net::udp_channel make_udp_channel(const socket_address&) override;
+    virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
+    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) {
         return make_ready_future<std::unique_ptr<network_stack>>(std::unique_ptr<network_stack>(new posix_network_stack(opts, allocator)));
     }

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -76,7 +76,7 @@ class udp_channel_impl {
 public:
     virtual ~udp_channel_impl() {}
     virtual socket_address local_address() const = 0;
-    virtual future<udp_datagram> receive() = 0;
+    virtual future<datagram> receive() = 0;
     virtual future<> send(const socket_address& dst, const char* msg) = 0;
     virtual future<> send(const socket_address& dst, packet p) = 0;
     virtual void shutdown_input() = 0;

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -72,9 +72,9 @@ public:
     virtual socket_address local_address() const = 0;
 };
 
-class udp_channel_impl {
+class datagram_channel_impl {
 public:
-    virtual ~udp_channel_impl() {}
+    virtual ~datagram_channel_impl() {}
     virtual socket_address local_address() const = 0;
     virtual future<datagram> receive() = 0;
     virtual future<> send(const socket_address& dst, const char* msg) = 0;
@@ -84,6 +84,8 @@ public:
     virtual bool is_closed() const = 0;
     virtual void close() = 0;
 };
+
+using udp_channel_impl = datagram_channel_impl;
 
 class network_interface_impl {
 protected:

--- a/include/seastar/net/udp.hh
+++ b/include/seastar/net/udp.hh
@@ -50,7 +50,7 @@ struct udp_hdr {
 } __attribute__((packed));
 
 struct udp_channel_state {
-    queue<udp_datagram> _queue;
+    queue<datagram> _queue;
     // Limit number of data queued into send queue
     semaphore _user_queue_space = {212992};
     udp_channel_state(size_t queue_size) : _queue(queue_size) {}

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4655,11 +4655,11 @@ socket make_socket() {
 }
 
 net::udp_channel make_udp_channel() {
-    return engine().net().make_udp_channel();
+    return make_unbound_datagram_channel(AF_INET);
 }
 
 net::udp_channel make_udp_channel(const socket_address& local) {
-    return engine().net().make_udp_channel(local);
+    return make_bound_datagram_channel(local);
 }
 
 net::datagram_channel make_unbound_datagram_channel(sa_family_t family) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4662,6 +4662,14 @@ net::udp_channel make_udp_channel(const socket_address& local) {
     return engine().net().make_udp_channel(local);
 }
 
+net::datagram_channel make_unbound_datagram_channel(sa_family_t family) {
+    return engine().net().make_unbound_datagram_channel(family);
+}
+
+net::datagram_channel make_bound_datagram_channel(const socket_address& local) {
+    return engine().net().make_bound_datagram_channel(local);
+}
+
 void reactor::add_high_priority_task(task* t) noexcept {
     add_urgent_task(t);
     // break .then() chains

--- a/src/core/scollectd-impl.hh
+++ b/src/core/scollectd-impl.hh
@@ -37,7 +37,7 @@ static const ipv4_addr default_addr("239.192.74.66:25826");
 static const std::chrono::milliseconds default_period(1s);
 
 class impl {
-    net::udp_channel _chan;
+    net::datagram_channel _chan;
     timer<> _timer;
 
     sstring _host = "localhost";

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -369,7 +369,7 @@ void impl::start(const sstring & host, const ipv4_addr & addr, const duration pe
     _period = period;
     _addr = addr;
     _host = host;
-    _chan = make_udp_channel();
+    _chan = make_unbound_datagram_channel(AF_INET);
     _timer.set_callback(std::bind(&impl::run, this));
 
     // dogfood ourselves

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -538,7 +538,7 @@ private:
             dns_log.trace("Created tcp socket {}", fd);
             break;
         case SOCK_DGRAM:
-            _sockets.emplace(fd, _stack.make_udp_channel());
+            _sockets.emplace(fd, _stack.make_unbound_datagram_channel(AF_INET));
             dns_log.trace("Created udp socket {}", fd);
             break;
         default: return -1;

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -936,10 +936,10 @@ private:
         temporary_buffer<char> indata;
     };
     struct udp_entry {
-        udp_entry(net::udp_channel c)
+        udp_entry(net::datagram_channel c)
                         : channel(std::move(c)) {
         }
-        net::udp_channel channel;
+        net::datagram_channel channel;
         std::optional<net::datagram> in;;
         socket_address dst;
         future<> f = make_ready_future<>();
@@ -974,7 +974,7 @@ private:
             : tcp(tcp_entry{std::move(s)})
             , typ(type::tcp)
         {}
-        sock_entry(net::udp_channel c)
+        sock_entry(net::datagram_channel c)
             : udp(udp_entry{std::move(c)})
             , typ(type::udp)
         {}

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -748,7 +748,7 @@ private:
                         use(fd);
                         dns_log.trace("Read {}: data unavailable", fd);
                         // FIXME: future is discarded
-                        (void)f.then_wrapped([me = shared_from_this(), &e, fd](future<net::udp_datagram> f) {
+                        (void)f.then_wrapped([me = shared_from_this(), &e, fd](future<net::datagram> f) {
                             try {
                                 auto d = f.get0();
                                 dns_log.trace("Read {} -> {} bytes", fd, d.get_data().len());
@@ -940,7 +940,7 @@ private:
                         : channel(std::move(c)) {
         }
         net::udp_channel channel;
-        std::optional<net::udp_datagram> in;;
+        std::optional<net::datagram> in;;
         socket_address dst;
         future<> f = make_ready_future<>();
     };

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -852,7 +852,7 @@ posix_network_stack::supports_ipv6() const {
     return has_ipv6;
 }
 
-class posix_datagram : public udp_datagram_impl {
+class posix_datagram : public datagram_impl {
 private:
     socket_address _src;
     socket_address _dst;

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -917,7 +917,12 @@ public:
     posix_datagram(const socket_address& src, const socket_address& dst, packet p) : _src(src), _dst(dst), _p(std::move(p)) {}
     virtual socket_address get_src() override { return _src; }
     virtual socket_address get_dst() override { return _dst; }
-    virtual uint16_t get_dst_port() override { return _dst.port(); }
+    virtual uint16_t get_dst_port() override {
+        if (_dst.family() != AF_INET && _dst.family() != AF_INET6) {
+            throw std::runtime_error(format("get_dst_port() called on non-IP address: {}", _dst));
+        }
+        return _dst.port();
+    }
     virtual packet& get_data() override { return _p; }
 };
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -838,6 +838,16 @@ posix_network_stack::make_udp_channel(const socket_address& addr) {
     return udp_channel(std::make_unique<posix_datagram_channel>(addr));
 }
 
+datagram_channel
+posix_network_stack::make_unbound_datagram_channel(sa_family_t family) {
+    throw "unimplemented"; // Changed later in the commit series.
+}
+
+datagram_channel
+posix_network_stack::make_bound_datagram_channel(const socket_address& local) {
+    throw "unimplemented"; // Changed later in the commit series.
+}
+
 bool
 posix_network_stack::supports_ipv6() const {
     static bool has_ipv6 = [] {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -798,7 +798,7 @@ public:
         _fd = std::move(fd);
     }
     virtual ~posix_udp_channel() { if (!_closed) close(); };
-    virtual future<udp_datagram> receive() override;
+    virtual future<datagram> receive() override;
     virtual future<> send(const socket_address& dst, const char *msg) override;
     virtual future<> send(const socket_address& dst, packet p) override;
     virtual void shutdown_input() override {
@@ -865,7 +865,7 @@ public:
     virtual packet& get_data() override { return _p; }
 };
 
-future<udp_datagram>
+future<datagram>
 posix_udp_channel::receive() {
     _recv.prepare();
     return _fd.recvmsg(&_recv._hdr).then([this] (size_t size) {
@@ -879,11 +879,11 @@ posix_udp_channel::receive() {
                 break;
             }
         }
-        return make_ready_future<udp_datagram>(udp_datagram(std::make_unique<posix_datagram>(
+        return make_ready_future<datagram>(datagram(std::make_unique<posix_datagram>(
             _recv._src_addr, dst, packet(fragment{_recv._buffer, size}, make_deleter([buf = _recv._buffer] { delete[] buf; })))));
     }).handle_exception([p = _recv._buffer](auto ep) {
         delete[] p;
-        return make_exception_future<udp_datagram>(std::move(ep));
+        return make_exception_future<datagram>(std::move(ep));
     });
 }
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -730,7 +730,7 @@ struct cmsg_with_pktinfo {
     };
 };
 
-class posix_udp_channel : public udp_channel_impl {
+class posix_udp_channel : public datagram_channel_impl {
 private:
     static constexpr int MAX_DATAGRAM_SIZE = 65507;
     struct recv_ctx {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -757,6 +757,9 @@ private:
             }
         }
 
+        recv_ctx(const recv_ctx&) = delete;
+        recv_ctx(recv_ctx&&) = delete;
+
         void prepare() {
             _buffer = new char[MAX_DATAGRAM_SIZE];
             _iov.iov_base = _buffer;
@@ -774,6 +777,9 @@ private:
             _hdr.msg_name = &_dst.u.sa;
             _hdr.msg_namelen = _dst.addr_length;
         }
+
+        send_ctx(const send_ctx&) = delete;
+        send_ctx(send_ctx&&) = delete;
 
         void prepare(const socket_address& dst, packet p) {
             _dst = dst;

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -66,7 +66,7 @@ socket_address net::udp_channel::local_address() const {
     }
 }
 
-future<net::udp_datagram> net::udp_channel::receive() {
+future<net::datagram> net::udp_channel::receive() {
     return _impl->receive();
 }
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -46,19 +46,19 @@ static_assert(std::is_nothrow_move_constructible_v<socket>);
 static_assert(std::is_nothrow_default_constructible_v<server_socket>);
 static_assert(std::is_nothrow_move_constructible_v<server_socket>);
 
-net::udp_channel::udp_channel() noexcept
+net::datagram_channel::datagram_channel() noexcept
 {}
 
-net::udp_channel::udp_channel(std::unique_ptr<datagram_channel_impl> impl) noexcept : _impl(std::move(impl))
+net::datagram_channel::datagram_channel(std::unique_ptr<datagram_channel_impl> impl) noexcept : _impl(std::move(impl))
 {}
 
-net::udp_channel::~udp_channel()
+net::datagram_channel::~datagram_channel()
 {}
 
-net::udp_channel::udp_channel(udp_channel&&) noexcept = default;
-net::udp_channel& net::udp_channel::operator=(udp_channel&&) noexcept = default;
+net::datagram_channel::datagram_channel(datagram_channel&&) noexcept = default;
+net::datagram_channel& net::datagram_channel::operator=(datagram_channel&&) noexcept = default;
 
-socket_address net::udp_channel::local_address() const {
+socket_address net::datagram_channel::local_address() const {
     if (_impl) {
         return _impl->local_address();
     } else {
@@ -66,32 +66,32 @@ socket_address net::udp_channel::local_address() const {
     }
 }
 
-future<net::datagram> net::udp_channel::receive() {
+future<net::datagram> net::datagram_channel::receive() {
     return _impl->receive();
 }
 
-future<> net::udp_channel::send(const socket_address& dst, const char* msg) {
+future<> net::datagram_channel::send(const socket_address& dst, const char* msg) {
     return _impl->send(dst, msg);
 }
 
-future<> net::udp_channel::send(const socket_address& dst, packet p) {
+future<> net::datagram_channel::send(const socket_address& dst, packet p) {
     return _impl->send(dst, std::move(p));
 }
 
-bool net::udp_channel::is_closed() const {
+bool net::datagram_channel::is_closed() const {
     return _impl->is_closed();
 }
 
-void net::udp_channel::shutdown_input() {
+void net::datagram_channel::shutdown_input() {
     _impl->shutdown_input();
 }
 
-void net::udp_channel::shutdown_output() {
+void net::datagram_channel::shutdown_output() {
     _impl->shutdown_output();
 }
 
 
-void net::udp_channel::close() {
+void net::datagram_channel::close() {
     return _impl->close();
 }
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -49,7 +49,7 @@ static_assert(std::is_nothrow_move_constructible_v<server_socket>);
 net::udp_channel::udp_channel() noexcept
 {}
 
-net::udp_channel::udp_channel(std::unique_ptr<udp_channel_impl> impl) noexcept : _impl(std::move(impl))
+net::udp_channel::udp_channel(std::unique_ptr<datagram_channel_impl> impl) noexcept : _impl(std::move(impl))
 {}
 
 net::udp_channel::~udp_channel()

--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -48,7 +48,7 @@ to_ipv4_addr(ipv4_address a, uint16_t port) {
     return {a.ip, port};
 }
 
-class native_datagram : public udp_datagram_impl {
+class native_datagram : public datagram_impl {
 private:
     ipv4_addr _src;
     ipv4_addr _dst;

--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -106,7 +106,7 @@ public:
         return socket_address(_proto.inet().host_address(), _reg.port());
     }
 
-    virtual future<udp_datagram> receive() override {
+    virtual future<datagram> receive() override {
         return _state->_queue.pop_eventually();
     }
 
@@ -172,7 +172,7 @@ bool ipv4_udp::forward(forward_hash& out_hash_data, packet& p, size_t off)
 
 void ipv4_udp::received(packet p, ipv4_address from, ipv4_address to)
 {
-    udp_datagram dgram(std::make_unique<native_datagram>(from, to, std::move(p)));
+    datagram dgram(std::make_unique<native_datagram>(from, to, std::move(p)));
 
     auto chan_it = _channels.find(dgram.get_dst_port());
     if (chan_it != _channels.end()) {

--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -80,7 +80,7 @@ public:
     }
 };
 
-class native_channel : public udp_channel_impl {
+class native_channel : public datagram_channel_impl {
 private:
     ipv4_udp& _proto;
     ipv4_udp::registration _reg;

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -43,11 +43,11 @@ SEASTAR_TEST_CASE(udp_packet_test) {
         return make_ready_future<>();
     }
 
-    auto sc = make_udp_channel(ipv6_addr{"::1"});
+    auto sc = make_bound_datagram_channel(ipv6_addr{"::1"});
 
     BOOST_REQUIRE(sc.local_address().addr().is_ipv6());
 
-    auto cc = make_udp_channel(ipv6_addr{"::1"});
+    auto cc = make_bound_datagram_channel(ipv6_addr{"::1"});
 
     auto f1 = cc.send(sc.local_address(), "apa");
 

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -20,9 +20,11 @@
  */ 
 
 #include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
@@ -230,3 +232,31 @@ SEASTAR_TEST_CASE(unixdomain_abort) {
     });
 }
 
+// From man 7 unix:
+//  If a bind(2) call specifies addrlen as sizeof(sa_family_t), or
+//  the SO_PASSCRED socket option was specified for a socket that was
+//  not explicitly bound to an address, then the socket is autobound
+//  to an abstract address.
+static socket_address autobind() {
+    socket_address addr;
+    addr.addr_length = offsetof(sockaddr_un, sun_path);
+    addr.u.sa.sa_family = AF_UNIX;
+    return addr;
+}
+
+static string to_string(net::packet p) {
+    p.linearize();
+    const auto& f = p.frag(0);
+    return std::string(f.base, f.size);
+}
+
+SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_autobind) {
+    auto chan1 = make_unbound_datagram_channel(AF_UNIX);
+    auto chan2 = make_bound_datagram_channel(autobind());
+
+    chan1.send(chan2.local_address(), "hello").get();
+    net::datagram dgram = chan2.receive().get0();
+
+    string received = to_string(std::move(dgram.get_data()));
+    BOOST_REQUIRE_EQUAL(received, "hello");
+}


### PR DESCRIPTION
This is a successor of: https://github.com/scylladb/seastar/pull/1804

@avikivity written in the previous PR:
> We could rename udp_channel to datagram_channel and deprecate the old name.

At first I wanted to do a basic rename, but forcing unbound&bound channel creation into the `make_udp_channel` signature turned out to be messy. 

This series:
- does a rename of udp related things
- introduces a new datagram channel creation API
- adapts `posix_udp_channel` to protocol stacks other than UDP over IP
- deprecates `udp_channel` creation methods

Fixes: #1894