### PR TITLE
sstring_test: include fmt/std.h only if fmtlib >= 10.0.0

### DIFF
--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -25,7 +25,9 @@
 #include <seastar/core/sstring.hh>
 #include <list>
 #include <fmt/ranges.h>
+#if FMT_VERSION >= 10000  // formatting of std::optional was introduced in fmt 10
 #include <fmt/std.h>
+#endif
 
 using namespace std::literals;
 using namespace seastar;


### PR DESCRIPTION
fmt/std.h was introduced to fmtlib v9.0.0, but the formatter for std::optional<> was added to this library in v10.0.0. the purpose of including `fmt/std.h` is for accessing the formatter of std::optional<> and verify if sstring's formatter can work with it, so there is no need to include this header if fmt::formatter<std::optional<T>> is not available. and without this header, the build fails on systems building hosts where fmtlib < 9 and fmtlib >= 5.0.

in this change, we `#include <fmt/std.h>` only if fmtlib's version is greater or equal to 10.0.0, this macro is defined by fmt/core.h which is practically included by all fmt headers.

Fixes #1896
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>