### PR TITLE
build: add GLOB parameter to seastar_check_self_contained()

### DIFF
--- a/cmake/CheckHeaders.cmake
+++ b/cmake/CheckHeaders.cmake
@@ -33,10 +33,18 @@ function (seastar_check_self_contained target library)
     parsed_args
     ""
     ""
-    "EXCLUDE;INCLUDE"
+    "GLOB;EXCLUDE;INCLUDE"
     ${ARGN})
 
   get_target_property (sources ${library} SOURCES)
+  if (DEFINED parsed_args_GLOB)
+    file (GLOB globbed_sources
+      LIST_DIRECTORIES false
+      RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+      "${parsed_args_GLOB}")
+    list (APPEND sources ${globbed_sources})
+    list (REMOVE_DUPLICATES sources)
+  endif ()
   list (FILTER sources INCLUDE REGEX "${parsed_args_INCLUDE}")
   list (FILTER sources EXCLUDE REGEX "${parsed_args_EXCLUDE}")
   foreach (fn ${sources})


### PR DESCRIPTION
sometimes, parent project would like to check header's self-containness without listing them in the CMake script, the project might want to specify a glob pattern instead.

this enables the parent projects to add header files by specifying a glob pattern, so they can add the header files in a more convenient way.