### PR TITLE
coroutine: fix use-after-free in parallel_for_each

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -579,6 +579,11 @@ public:
     }
 
     task* current_task() const { return _current_task; }
+    // If a task wants to resume a different task instead of returning control to the reactor,
+    // it should set _current_task to the resumed task.
+    // In particular, this is mandatory if the task is going to die before control is returned
+    // to the reactor -- otherwise _current_task will be left dangling.
+    void set_current_task(task* t) { _current_task = t; }
 
     void add_task(task* t) noexcept;
     void add_urgent_task(task* t) noexcept;

--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -27,6 +27,7 @@
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/reactor.hh>
 
 namespace seastar::coroutine {
 
@@ -101,6 +102,7 @@ class [[nodiscard("must co_await an parallel_for_each() object")]] parallel_for_
 
     void resume_or_set_callback() noexcept {
         if (consume_next()) {
+            local_engine->set_current_task(_waiting_task);
             _when_ready.resume();
         } else {
             set_callback();


### PR DESCRIPTION
After coroutine::parallel_for_each resumes its caller coroutine and dies, reactor::_current_task might be left dangling.

To fix this without allocations, we have to set _current_task to the coroutine before resuming it.

Fixes #1902