### PR TITLE
Add sampling memory profiler mode

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,7 @@ under the BSD license.
 
 This work contains software from the DPDK project (http://dpdk.org), licensed
 under the BSD license.  The software is under the dpdk/ directory.
+
+This work contains software from the Android Open Source Project,
+licensed under the Apache2 license.
+The software is in the include/seastar/util/sampler.hh file.

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -414,8 +414,13 @@ public:
 struct allocation_site {
     mutable size_t count = 0; /// number of live objects allocated at backtrace.
     mutable size_t size = 0; /// amount of bytes in live objects allocated at backtrace.
-    mutable const allocation_site* next = nullptr; // TODO: remove
     simple_backtrace backtrace; /// call site for this allocation
+
+    // All allocation sites are linked to each other. This can be used for easy
+    // iteration across them in gdb scripts where it's difficult to work with
+    // the C++ data structures.
+    mutable const allocation_site* next = nullptr; // next allocation site in the chain
+    mutable const allocation_site* prev = nullptr; // previous allocation site in the chain
 
     bool operator==(const allocation_site& o) const {
         return backtrace == o.backtrace;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -159,8 +159,12 @@ struct reactor_options : public program_options::option_group {
     program_options::value<unsigned> max_networking_io_control_blocks;
     /// \brief Enable seastar heap profiling.
     ///
+    /// Allocations will be sampled every N bytes on average. Zero means off.
+    ///
+    /// Default: 0
+    ///
     /// \note Unused when seastar was compiled without heap profiling support.
-    program_options::value<> heapprof;
+    program_options::value<unsigned> heapprof;
     /// Ignore SIGINT (for gdb).
     program_options::value<> no_handle_interrupt;
 

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -88,8 +88,8 @@ private:
 private:
     size_t calculate_hash() const noexcept;
 public:
-    simple_backtrace(char delimeter = ' ') noexcept : _delimeter(delimeter) {}
-    simple_backtrace(vector_type f, char delimeter = ' ') noexcept : _frames(std::move(f)), _delimeter(delimeter) {}
+    simple_backtrace(vector_type f, char delimeter = ' ') noexcept : _frames(std::move(f)), _hash(calculate_hash()), _delimeter(delimeter) {}
+    simple_backtrace(char delimeter = ' ') noexcept : simple_backtrace({}, delimeter) {}
 
     size_t hash() const noexcept { return _hash; }
     char delimeter() const noexcept { return _delimeter; }

--- a/include/seastar/util/sampler.hh
+++ b/include/seastar/util/sampler.hh
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_PROFILING_MEMORY_SAMPLER_H_
+#define SRC_PROFILING_MEMORY_SAMPLER_H_
+
+#include <stdint.h>
+
+#include <atomic>
+#include <random>
+
+#include "perfetto/ext/base/utils.h"
+
+namespace perfetto {
+namespace profiling {
+
+constexpr uint64_t kSamplerSeed = 1;
+
+std::default_random_engine& GetGlobalRandomEngineLocked();
+
+// Poisson sampler for memory allocations. We apply sampling individually to
+// each byte. The whole allocation gets accounted as often as the number of
+// sampled bytes it contains.
+//
+// The algorithm is inspired by the Chromium sampling algorithm at
+// https://cs.chromium.org/search/?q=f:cc+symbol:AllocatorShimLogAlloc+package:%5Echromium$&type=cs
+// Googlers: see go/chrome-shp for more details.
+//
+// NB: not thread-safe, requires external synchronization.
+class Sampler {
+ public:
+  void SetSamplingInterval(uint64_t sampling_interval) {
+    sampling_interval_ = sampling_interval;
+    sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
+    interval_to_next_sample_ = NextSampleInterval();
+  }
+
+  // Returns number of bytes that should be be attributed to the sample.
+  // If returned size is 0, the allocation should not be sampled.
+  //
+  // Due to how the poission sampling works, some samples should be accounted
+  // multiple times.
+  size_t SampleSize(size_t alloc_sz) {
+    if (PERFETTO_UNLIKELY(alloc_sz >= sampling_interval_))
+      return alloc_sz;
+    return static_cast<size_t>(sampling_interval_ * NumberOfSamples(alloc_sz));
+  }
+
+  uint64_t sampling_interval() const { return sampling_interval_; }
+
+ private:
+  int64_t NextSampleInterval() {
+    std::exponential_distribution<double> dist(sampling_rate_);
+    int64_t next = static_cast<int64_t>(dist(GetGlobalRandomEngineLocked()));
+    // We approximate the geometric distribution using an exponential
+    // distribution.
+    // We need to add 1 because that gives us the number of failures before
+    // the next success, while our interval includes the next success.
+    return next + 1;
+  }
+
+  // Returns number of times a sample should be accounted. Due to how the
+  // poission sampling works, some samples should be accounted multiple times.
+  size_t NumberOfSamples(size_t alloc_sz) {
+    interval_to_next_sample_ -= alloc_sz;
+    size_t num_samples = 0;
+    while (PERFETTO_UNLIKELY(interval_to_next_sample_ <= 0)) {
+      interval_to_next_sample_ += NextSampleInterval();
+      ++num_samples;
+    }
+    return num_samples;
+  }
+
+  uint64_t sampling_interval_;
+  double sampling_rate_;
+  int64_t interval_to_next_sample_;
+};
+
+}  // namespace profiling
+}  // namespace perfetto
+
+#endif  // SRC_PROFILING_MEMORY_SAMPLER_H_

--- a/include/seastar/util/sampler.hh
+++ b/include/seastar/util/sampler.hh
@@ -14,82 +14,148 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PROFILING_MEMORY_SAMPLER_H_
-#define SRC_PROFILING_MEMORY_SAMPLER_H_
+// This file has been originally been imported from:
+// https://cs.android.com/android/platform/superproject/+/013901367630d3ec71c9f2bb3f3077bd11585301:external/perfetto/src/profiling/memory/sampler.h
 
-#include <stdint.h>
+//
+// The code has been modified as follows:
+//
+//  - Integrated into seastar and adapted to coding style
+//  - Right now we don't account for samples multiple times (in case we have
+//  multiple loops of drawing from the exp distribution). The reason is that
+//  in our memory sampler we would have to store the weight in addition to the
+//  alloation site ptr as on free we need to know how much a sample accounted
+//  for. Hence, for now we simply always use the sampling interval.
+//  - Sampler can be turned "off" with a 0 sampling rate
+//  - The fast path is more optimized (as a consequence of the first point)
+//  - Provide a way to temporarily pause sampling
+//
+// Changes Copyright (C) 2023 ScyllaDB
 
-#include <atomic>
+#pragma once
+
 #include <random>
 
-#include "perfetto/ext/base/utils.h"
+// See also: https://perfetto.dev/docs/design-docs/heapprofd-sampling for more
+// background of how the sampler works
 
-namespace perfetto {
-namespace profiling {
-
-constexpr uint64_t kSamplerSeed = 1;
-
-std::default_random_engine& GetGlobalRandomEngineLocked();
-
-// Poisson sampler for memory allocations. We apply sampling individually to
-// each byte. The whole allocation gets accounted as often as the number of
-// sampled bytes it contains.
-//
-// The algorithm is inspired by the Chromium sampling algorithm at
-// https://cs.chromium.org/search/?q=f:cc+symbol:AllocatorShimLogAlloc+package:%5Echromium$&type=cs
-// Googlers: see go/chrome-shp for more details.
-//
-// NB: not thread-safe, requires external synchronization.
-class Sampler {
- public:
-  void SetSamplingInterval(uint64_t sampling_interval) {
-    sampling_interval_ = sampling_interval;
-    sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
-    interval_to_next_sample_ = NextSampleInterval();
-  }
-
-  // Returns number of bytes that should be be attributed to the sample.
-  // If returned size is 0, the allocation should not be sampled.
-  //
-  // Due to how the poission sampling works, some samples should be accounted
-  // multiple times.
-  size_t SampleSize(size_t alloc_sz) {
-    if (PERFETTO_UNLIKELY(alloc_sz >= sampling_interval_))
-      return alloc_sz;
-    return static_cast<size_t>(sampling_interval_ * NumberOfSamples(alloc_sz));
-  }
-
-  uint64_t sampling_interval() const { return sampling_interval_; }
-
- private:
-  int64_t NextSampleInterval() {
-    std::exponential_distribution<double> dist(sampling_rate_);
-    int64_t next = static_cast<int64_t>(dist(GetGlobalRandomEngineLocked()));
-    // We approximate the geometric distribution using an exponential
-    // distribution.
-    // We need to add 1 because that gives us the number of failures before
-    // the next success, while our interval includes the next success.
-    return next + 1;
-  }
-
-  // Returns number of times a sample should be accounted. Due to how the
-  // poission sampling works, some samples should be accounted multiple times.
-  size_t NumberOfSamples(size_t alloc_sz) {
-    interval_to_next_sample_ -= alloc_sz;
-    size_t num_samples = 0;
-    while (PERFETTO_UNLIKELY(interval_to_next_sample_ <= 0)) {
-      interval_to_next_sample_ += NextSampleInterval();
-      ++num_samples;
+class sampler {
+public:
+    sampler() : random_gen(rd_device()) {
+        set_sampling_interval(0);
     }
-    return num_samples;
-  }
+    /// Sets the sampling interval in bytes. Setting it to 0 means to never sample
+    void set_sampling_interval(uint64_t sampling_interval) {
+        sampling_interval_ = sampling_interval;
+        if (sampling_interval_ == 0) {
+            // Set the interval very large. This means in practice we will
+            // likely never get this below zero and hence it's unlikely we will
+            // ever have to run the reset path with sampling off
+            interval_to_next_sample_ = std::numeric_limits<int64_t>::max();
+            return;
+        }
+        sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
+        interval_to_next_sample_ = next_sampling_interval();
+    }
+    /// Returns true if this allocation of size `alloc_size` should be sampled
+    bool should_sample(size_t alloc_size) {
+        // We need to check the sampling_interval as 0 means off. Also we need
+        // to check whether this allocation has brought the interval
+        // below/to 0. We chose to check the interval_to_next_sample first. If
+        // heap profiling is compiled in it's likely we are using it as well.
+        // Hence, lets do the interval decrement and check first and only check
+        // whether sampling is off after.
+        interval_to_next_sample_ -= alloc_size;
+        if (interval_to_next_sample_ > 0) {
+            return false;
+        }
+        reset_interval_to_next_sample(alloc_size);
+        return sampling_interval_ != 0;
+    }
 
-  uint64_t sampling_interval_;
-  double sampling_rate_;
-  int64_t interval_to_next_sample_;
+    uint64_t sampling_interval() const { return sampling_interval_; }
+
+    /// How much should an allocation of size `allocation_size` count for
+    size_t sample_size(size_t allocation_size) const {
+        return std::max(allocation_size, sampling_interval_);
+    }
+
+    /// RAII class to temporarily pause sampling
+    struct disable_sampling_temporarily {
+        disable_sampling_temporarily() = default;
+        disable_sampling_temporarily(sampler& sampler)
+        : sampler_(&sampler)
+        , previous_sampling_interval_(sampler_->sampling_interval_)
+        , previous_sampling_rate_(sampler_->sampling_rate_)
+        , previous_interval_to_next_sample_(sampler_->interval_to_next_sample_) {
+            sampler_->set_sampling_interval(0);
+        }
+
+        ~disable_sampling_temporarily() {
+            if (sampler_) {
+                sampler_->sampling_interval_ = previous_sampling_interval_;
+                sampler_->sampling_rate_ = previous_sampling_rate_;
+                sampler_->interval_to_next_sample_ = previous_interval_to_next_sample_;
+            }
+        }
+
+    private:
+        sampler* sampler_ = nullptr;
+        uint64_t previous_sampling_interval_ = 0; // sampling interval before pausing
+        double previous_sampling_rate_ = 0; // sampling rate before pausing
+        int64_t previous_interval_to_next_sample_ = 0; // interval to next sample before pausing
+    };
+
+    /// Pauses sampling temporarily until the returned object is destroyed. This
+    /// is more efficient and statisically more correct than doing a back and
+    /// fourth of set_sampling_interval(0) and set_sampling_interval(RATE). The
+    /// reason is that that would reset the interval to the next sample and
+    /// force a reevaluation of the exponential distribution. This method avoids
+    /// that.
+    disable_sampling_temporarily pause_sampling() {
+        return disable_sampling_temporarily(*this);
+    }
+
+private:
+    /// Resets interval_to_next_sample_ by repeatedly drawing from the
+    /// exponential distribution given an allocation of size `alloc_size`
+    /// breached the current interval
+    void reset_interval_to_next_sample(size_t alloc_size)
+    {
+        if (sampling_interval_ == 0) { // sampling is off
+            interval_to_next_sample_ = std::numeric_limits<int64_t>::max();
+        }
+        else {
+            // Large allocations we will just consider in whole. This avoids
+            // having to sample the distribution too many times if a large alloc
+            // took us very negative we just add the alloc size back on
+            if (alloc_size > sampling_interval_) {
+                interval_to_next_sample_ += alloc_size;
+            }
+            else {
+                while (interval_to_next_sample_ < 0) {
+                    interval_to_next_sample_ += next_sampling_interval();
+                }
+            }
+        }
+    }
+
+    int64_t next_sampling_interval() {
+        std::exponential_distribution<double> dist(sampling_rate_);
+        int64_t next = static_cast<int64_t>(dist(random_gen));
+        // We approximate the geometric distribution using an exponential
+        // distribution.
+        // We need to add 1 because that gives us the number of failures before
+        // the next success, while our interval includes the next success.
+        return next + 1;
+    }
+
+    uint64_t sampling_interval_; // Sample every N bytes ; 0 means off
+    double sampling_rate_; // 1 / sampling_interval_ ; used by the exp distribution
+    // How many bytes remain to be allocated before we take a sample.
+    // Specifically, if this member has value N, a sample will be taken of the allocation
+    // that allocates the Nth+1 byte.
+    int64_t interval_to_next_sample_;
+    std::random_device rd_device;
+    std::mt19937_64 random_gen;
 };
-
-}  // namespace profiling
-}  // namespace perfetto
-
-#endif  // SRC_PROFILING_MEMORY_SAMPLER_H_

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -51,6 +51,23 @@
 // by size.  When spans are broken up or coalesced, they may move into new lists.
 // Spans have a size that is a power-of-two and are naturally aligned (aka buddy
 // allocator)
+//
+// If compiled with SEASTAR_HEAPPROF seastar features a sampling memory
+// profiler. Allocations are sampled at random (see `sampler` for the sampling
+// logic) and tracked. The sampled live set can be retrieved with
+// `sampled_memory_profile()`. Sampled allocations carry an extra
+// allocation_site pointer with them which is used on free to remove them from
+// the sampled live set.
+//
+// Large allocations are tracked via a pointer to the allocation_site which is
+// stored on the page structure. To check whether an allocation was sampled or
+// not this pointer is being looked at on free.
+//
+// Small allocations store an extra 8 bytes at the end of their allocation.
+// Sampled allocations are allocated in a separate set of small pools. Hence, to
+// check whether an allocation was sampled or not one only has to look at the
+// tag in pool.
+//
 
 #ifdef SEASTAR_MODULE
 module;

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -342,6 +342,10 @@ static char* mem_base() {
         known = align_up(cr, mem_base_alloc);
         ::munmap(cr, known - cr);
         ::munmap(known + mem_base_alloc, cr + 2 * mem_base_alloc - (known + mem_base_alloc));
+        // extremely unlikely for mmap to return a mapping at 0, but our detection of free(null)
+        // depends on it not doing that so check it
+        assert(known != nullptr);
+        assert(reinterpret_cast<uintptr_t>(known) != 0);
     });
     return known;
 }
@@ -429,7 +433,7 @@ class small_pool {
     free_object* _free = nullptr;
     unsigned _object_size;
     span_sizes _span_sizes;
-    size_t _free_count = 0;
+    unsigned _free_count = 0;
     unsigned _min_free;
     unsigned _max_free;
     unsigned _pages_in_use = 0;
@@ -592,13 +596,17 @@ struct cpu_pages {
     void free_span_unaligned(pageidx start, uint32_t nr_pages);
     void free(void* ptr);
     void free(void* ptr, size_t size);
-    static bool try_foreign_free(void* ptr);
+    static bool try_free_fastpath(void* ptr);
+    static bool is_local_pointer(void* ptr);
+    static void do_foreign_free(void* ptr);
     void shrink(void* ptr, size_t new_size);
     static void free_cross_cpu(unsigned cpu_id, void* ptr);
     bool drain_cross_cpu_freelist();
     size_t object_size(void* ptr);
+
     page* to_page(void* p) {
-        return &pages[(reinterpret_cast<char*>(p) - mem()) / page_size];
+        size_t page_idx = ((uintptr_t)p) << (64 - cpu_id_shift) >> (64 - cpu_id_shift + page_bits);
+        return &pages[page_idx];
     }
 
     bool is_initialized() const;
@@ -1043,7 +1051,8 @@ bool cpu_pages::drain_cross_cpu_freelist() {
     return true;
 }
 
-void cpu_pages::free(void* ptr) {
+[[gnu::always_inline]]
+inline void cpu_pages::free(void* ptr) {
     page* span = to_page(ptr);
     if (span->pool) {
         small_pool& pool = *span->pool;
@@ -1081,12 +1090,71 @@ void cpu_pages::free(void* ptr, size_t size) {
 #endif
 }
 
-bool
-cpu_pages::try_foreign_free(void* ptr) {
-    // fast path for local free
-    if (__builtin_expect((reinterpret_cast<uintptr_t>(ptr) & cpu_id_and_mem_base_mask) == local_expected_cpu_id, true)) {
-        return false;
+// Is the passed pointer a local pointer, i.e., allocated on the current shard from the 
+// per-shard allocator.
+[[gnu::always_inline]]
+inline bool
+cpu_pages::is_local_pointer(void* ptr) {
+    return (reinterpret_cast<uintptr_t>(ptr) & cpu_id_and_mem_base_mask) == local_expected_cpu_id;
+}
+
+// Try to execute free on the fast path, which succeeds if:
+//
+// 1) The pointer is local to this shard
+// 2) The pointer is from a small pool
+// 3) The small pool is not sampled
+//
+// In this case, complete the de-allocation and return true.
+// Otherwise, modify nothing and return false.
+[[gnu::always_inline]]
+inline bool
+cpu_pages::try_free_fastpath(void* ptr) {
+    if (__builtin_expect(is_local_pointer(ptr), true)) {
+        auto pool = get_cpu_mem().to_page(ptr)->pool;
+        if (__builtin_expect(pool && !pool->is_sampled_pool(), true)) {
+            alloc_stats::increment_local(alloc_stats::types::frees);
+            pool->deallocate(ptr);
+            return true;
+        }
     }
+    return false;
+}
+
+/// Helper to allow a single implementation for sized and non-sized functions.
+/// Indicator to allow a single implementation for sized and non-sized functions.
+/// The size parameter will be either no_size tag type or size_t, and most
+/// of the implementation can be shared, using constexpr if or other dispatch
+/// in the places where there should be a difference of behavior.
+struct no_size {};
+
+template <typename S>
+SEASTAR_CONCEPT(requires std::same_as<S, size_t> || std::same_as<S, no_size>)
+[[gnu::noinline]]
+static void free_slowpath(void* obj, S size) {
+    if (cpu_pages::is_local_pointer(obj)) {
+        alloc_stats::increment_local(alloc_stats::types::frees);
+        if constexpr (std::is_same_v<decltype(size), no_size>) {
+            get_cpu_mem().free(obj);
+        } else {
+            get_cpu_mem().free(obj, size);
+        }
+    } else {
+        cpu_pages::do_foreign_free(obj);
+    }
+}
+
+[[gnu::noinline]]
+void
+cpu_pages::do_foreign_free(void* ptr) {
+    // handles:
+    // 1) non-seastar pointers
+    // 2) cross-shard frees
+    // 3) null pointer
+
+    if (!ptr) {
+        return;
+    }
+
     if (!is_seastar_memory(ptr)) {
         if (is_reactor_thread) {
             alloc_stats::increment_local(alloc_stats::types::foreign_cross_frees);
@@ -1094,10 +1162,9 @@ cpu_pages::try_foreign_free(void* ptr) {
             alloc_stats::increment(alloc_stats::types::foreign_frees);
         }
         original_free_func(ptr);
-        return true;
+        return;
     }
     free_cross_cpu(object_cpu_id(ptr), ptr);
-    return true;
 }
 
 void cpu_pages::shrink(void* ptr, size_t new_size) {
@@ -1144,7 +1211,7 @@ bool cpu_pages::initialize() {
     }
     cpu_id = cpu_id_gen.fetch_add(1, std::memory_order_relaxed);
     local_expected_cpu_id = (static_cast<uint64_t>(cpu_id) << cpu_id_shift)
-	| reinterpret_cast<uintptr_t>(mem_base());
+	        | reinterpret_cast<uintptr_t>(mem_base());
     assert(cpu_id < max_cpus);
     all_cpus[cpu_id] = this;
     auto base = mem_base() + (size_t(cpu_id) << cpu_id_shift);
@@ -1650,20 +1717,12 @@ void* allocate_aligned(size_t align, size_t size) {
     return ptr;
 }
 
-void free(void* obj) {
-    if (cpu_pages::try_foreign_free(obj)) {
-        return;
+template <typename S = no_size>
+[[gnu::always_inline]]
+inline void free(void* obj, S size = {}) {
+    if (!__builtin_expect(cpu_pages::try_free_fastpath(obj), true)) {
+        free_slowpath(obj, size);
     }
-    alloc_stats::increment_local(alloc_stats::types::frees);
-    get_cpu_mem().free(obj);
-}
-
-void free(void* obj, size_t size) {
-    if (cpu_pages::try_foreign_free(obj)) {
-        return;
-    }
-    alloc_stats::increment_local(alloc_stats::types::frees);
-    get_cpu_mem().free(obj, size);
 }
 
 void free_aligned(void* obj, size_t align, size_t size) {
@@ -2118,9 +2177,7 @@ extern "C"
 [[gnu::visibility("default")]]
 [[gnu::used]]
 void free(void* ptr) {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C"

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1720,6 +1720,14 @@ void* allocate_aligned(size_t align, size_t size) {
     return ptr;
 }
 
+
+/// Similarly to memory::allocate() we expect to inline the whole fast path
+/// of free into all the variations of the top level dallocation functions like
+/// free, delete, sized delete, etc. The slow path is not inline and is shared
+/// by all implementations.
+///
+/// The S template object allows us to handle both sized and unsized allocations
+/// in the same code path.
 template <typename S = no_size>
 [[gnu::always_inline]]
 inline void free(void* obj, S size = {}) {
@@ -2389,33 +2397,25 @@ void* operator new[](size_t size) {
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr, size_t size) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr, size);
-    }
+    seastar::memory::free(ptr, size);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr, size_t size) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr, size);
-    }
+    seastar::memory::free(ptr, size);
 }
 
 extern "C++"
@@ -2436,33 +2436,25 @@ void* operator new[](size_t size, std::nothrow_t) noexcept {
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr, std::nothrow_t) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr, std::nothrow_t) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr, size_t size, std::nothrow_t) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr, size);
-    }
+    seastar::memory::free(ptr, size);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr, size_t size, std::nothrow_t) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr, size);
-    }
+    seastar::memory::free(ptr, size);
 }
 
 #ifdef __cpp_aligned_new
@@ -2504,17 +2496,13 @@ void* operator new[](size_t size, std::align_val_t a, const std::nothrow_t&) noe
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr, std::align_val_t a) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr, std::align_val_t a) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
@@ -2536,17 +2524,13 @@ void operator delete[](void* ptr, size_t size, std::align_val_t a) noexcept {
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete(void* ptr, std::align_val_t a, const std::nothrow_t&) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 extern "C++"
 [[gnu::visibility("default")]]
 void operator delete[](void* ptr, std::align_val_t a, const std::nothrow_t&) noexcept {
-    if (ptr) {
-        seastar::memory::free(ptr);
-    }
+    seastar::memory::free(ptr);
 }
 
 #endif

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -126,6 +126,12 @@ module seastar;
 #endif
 #endif
 
+#ifdef SEASTAR_DEBUG
+#define dassert(expr) assert(expr)
+#else
+#define dassert(expr) do {} while(false)
+#endif
+
 namespace seastar {
 
 extern seastar::logger seastar_logger;
@@ -216,6 +222,7 @@ namespace memory {
 [[gnu::unused]]
 static allocation_site_ptr get_allocation_site();
 
+[[gnu::noinline]]
 static void on_allocation_failure(size_t size);
 
 static constexpr unsigned cpu_id_shift = 36; // FIXME: make dynamic
@@ -419,9 +426,9 @@ class small_pool {
         uint8_t preferred;
         uint8_t fallback;
     };
+    free_object* _free = nullptr;
     unsigned _object_size;
     span_sizes _span_sizes;
-    free_object* _free = nullptr;
     size_t _free_count = 0;
     unsigned _min_free;
     unsigned _max_free;
@@ -438,7 +445,7 @@ class small_pool {
 public:
     explicit small_pool(unsigned object_size, bool is_sampled) noexcept;
     ~small_pool();
-    void* allocate();
+    inline void* allocate();
     void deallocate(void* object);
     unsigned object_size() const { return _object_size; }
     /// See _sampled_pool
@@ -454,7 +461,8 @@ public:
     static constexpr unsigned idx_to_size(unsigned idx);
     allocation_site_ptr& alloc_site_holder(void* ptr);
 private:
-    void add_more_objects();
+    inline void* pop_free();
+    [[gnu::noinline]] void* add_more_objects();
     void trim_free_list();
     friend seastar::internal::log_buf::inserter_iterator do_dump_memory_diagnostics(seastar::internal::log_buf::inserter_iterator);
 };
@@ -536,6 +544,7 @@ struct cross_cpu_free_item {
 };
 
 struct cpu_pages {
+    small_pool_array<false> small_pools;
     uint32_t min_free_pages = 20000000 / page_size;
     char* memory;
     page* pages;
@@ -548,8 +557,6 @@ struct cpu_pages {
     std::vector<reclaimer*> reclaimers;
     static constexpr unsigned nr_span_lists = 32;
     page_list free_spans[nr_span_lists];  // contains aligned spans with span_size == 2^idx
-    small_pool_array<false> small_pools;
-    small_pool_array<true> sampled_small_pools;
     alignas(seastar::cache_line_size) std::atomic<cross_cpu_free_item*> xcpu_freelist;
     static std::atomic<unsigned> cpu_id_gen;
     static cpu_pages* all_cpus[max_cpus];
@@ -562,6 +569,7 @@ struct cpu_pages {
     } asu;
     allocation_site_ptr alloc_site_list_head = nullptr; // For easy traversal of asu.alloc_sites from scylla-gdb.py
     sampler heap_prof_sampler;
+    small_pool_array<true> sampled_small_pools;
 
     char* mem() { return memory; }
 
@@ -606,7 +614,8 @@ struct cpu_pages {
     void warn_large_allocation(size_t size);
     allocation_site_ptr add_alloc_site(size_t allocated_size);
     void remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size);
-    bool should_sample(size_t size);
+    bool maybe_sample(size_t size);
+    bool definitely_sample(size_t size);
     memory::memory_layout memory_layout();
     ~cpu_pages();
 };
@@ -865,11 +874,27 @@ cpu_pages::remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_
     }
 }
 
-bool
-cpu_pages::should_sample(size_t size) {
-    return heap_prof_sampler.should_sample(size);
+[[gnu::always_inline]]
+inline bool
+cpu_pages::maybe_sample(size_t size) {
+#ifdef SEASTAR_HEAPPROF
+    return heap_prof_sampler.maybe_sample(size);
+#else
+    return false;
+#endif
 }
 
+[[gnu::always_inline]]
+inline bool
+cpu_pages::definitely_sample(size_t size) {
+#ifdef SEASTAR_HEAPPROF
+    return heap_prof_sampler.definitely_sample(size);
+#else
+    return false;
+#endif
+}
+
+[[gnu::always_inline]]
 void
 inline
 cpu_pages::check_large_allocation(size_t size) {
@@ -878,7 +903,8 @@ cpu_pages::check_large_allocation(size_t size) {
     }
 }
 
-void*
+[[gnu::always_inline]]
+inline void*
 cpu_pages::allocate_large(unsigned n_pages, bool should_sample) {
     check_large_allocation(n_pages * page_size);
     return allocate_large_and_trim(n_pages, should_sample);
@@ -1329,21 +1355,24 @@ small_pool::~small_pool() {
     trim_free_list();
 }
 
+/**
+ * Remove the next object from the freelist and return it.
+ * It must exist (caller must check) or UB.
+ */
+void *
+small_pool::pop_free() {
+    auto* obj = _free;
+    _free = _free->next;
+    --_free_count;
+    return obj;
+}
+
 // Should not throw in case of running out of memory to avoid infinite recursion,
 // becaue throwing std::bad_alloc requires allocation. __cxa_allocate_exception
 // falls back to the emergency pool in case malloc() returns nullptr.
 void*
 small_pool::allocate() {
-    if (!_free) {
-        add_more_objects();
-    }
-    if (!_free) {
-        return nullptr;
-    }
-    auto* obj = _free;
-    _free = _free->next;
-    --_free_count;
-    return obj;
+    return __builtin_expect((bool)_free, true) ? pop_free() : add_more_objects();
 }
 
 void
@@ -1357,7 +1386,7 @@ small_pool::deallocate(void* object) {
     }
 }
 
-void
+void*
 small_pool::add_more_objects() {
     auto goal = (_min_free + _max_free) / 2;
     while (!_span_list.empty() && _free_count < goal) {
@@ -1379,7 +1408,7 @@ small_pool::add_more_objects() {
             span_size = _span_sizes.fallback;
             data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size, false));
             if (!data) {
-                return;
+                break;
             }
         }
         auto span = get_cpu_mem().to_page(data);
@@ -1391,7 +1420,7 @@ small_pool::add_more_objects() {
         }
         span->nr_small_alloc = 0;
         span->freelist = nullptr;
-        for (unsigned offset = 0; offset <= span_size * page_size - _object_size; offset += _object_size) {
+        for (size_t offset = 0; offset <= span_size * page_size - _object_size; offset += _object_size) {
             auto h = reinterpret_cast<free_object*>(data + offset);
             h->next = _free;
             _free = h;
@@ -1399,6 +1428,8 @@ small_pool::add_more_objects() {
             ++span->nr_small_alloc;
         }
     }
+
+    return _free ? pop_free() : nullptr;
 }
 
 void
@@ -1432,7 +1463,8 @@ abort_on_underflow(size_t size) {
     }
 }
 
-void* allocate_large(size_t size, bool should_sample) {
+[[gnu::always_inline]]
+inline void* allocate_large(size_t size, bool should_sample) {
     abort_on_underflow(size);
     unsigned size_in_pages = (size + page_size - 1) >> page_bits;
     if ((size_t(size_in_pages) << page_bits) < size) {
@@ -1492,7 +1524,7 @@ void* allocate_from_sampled_small_pool(size_t size) {
     }
     auto idx = small_pool::size_to_idx(size);
     auto& pool = get_cpu_mem().sampled_small_pools[idx];
-    assert(size <= pool.object_size());
+    dassert(size <= pool.object_size());
     void* ptr = pool.allocate();
     auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
     new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
@@ -1509,11 +1541,28 @@ void* allocate_from_small_pool(size_t size)
     }
     auto idx = small_pool::size_to_idx(size);
     auto& pool = get_cpu_mem().small_pools[idx];
-    assert(size <= pool.object_size());
+    dassert(size <= pool.object_size());
     return pool.allocate();
 }
 
-void* allocate(size_t size) {
+/**
+ * Common handling code when a pointer (possibly null) has
+ * been returned by any allocation path.
+ */
+[[gnu::always_inline]]
+static inline void* finish_allocation(void* ptr, size_t size) {
+    if (!ptr) {
+        on_allocation_failure(size);
+    } else {
+#ifdef SEASTAR_DEBUG_ALLOCATIONS
+    std::memset(ptr, debug_allocation_pattern, size);
+#endif
+    }
+    alloc_stats::increment_local(alloc_stats::types::allocs);
+    return ptr;
+}
+
+void *allocate_slowpath(size_t size) {
     if (!is_reactor_thread) {
         if (original_malloc_func) {
             alloc_stats::increment(alloc_stats::types::foreign_mallocs);
@@ -1526,12 +1575,9 @@ void* allocate(size_t size) {
     if (size <= sizeof(free_object)) {
         size = sizeof(free_object);
     }
-
-#ifdef SEASTAR_HEAPPROF
-    bool should_sample = get_cpu_mem().should_sample(size);
-#else
-    bool should_sample = get_cpu_mem().should_sample(size);
-#endif
+    // On the fast path we've already called maybe_sample, except in the case
+    // of !is_reactor_thread (we don't sample such alloctions).
+    bool should_sample = get_cpu_mem().definitely_sample(size);
     void* ptr;
     if (size <= max_small_allocation) {
 #ifdef SEASTAR_HEAPPROF
@@ -1545,15 +1591,18 @@ void* allocate(size_t size) {
     } else {
         ptr = allocate_large(size, should_sample);
     }
-    if (!ptr) {
-        on_allocation_failure(size);
-    } else {
-#ifdef SEASTAR_DEBUG_ALLOCATIONS
-        std::memset(ptr, debug_allocation_pattern, size);
-#endif
+    return finish_allocation(ptr, size);
+}
+
+[[gnu::always_inline]]
+inline void* allocate(size_t size) {
+    if (__builtin_expect(is_reactor_thread && !get_cpu_mem().maybe_sample(size) && size <= max_small_allocation, true)) {
+        size = std::max(size, sizeof(free_object));
+        auto ptr = allocate_from_small_pool<alignment_t::unaligned>(size);
+        return finish_allocation(ptr, size);
     }
-    alloc_stats::increment_local(alloc_stats::types::allocs);
-    return ptr;
+
+    return allocate_slowpath(size);
 }
 
 void* allocate_aligned(size_t align, size_t size) {
@@ -1570,7 +1619,8 @@ void* allocate_aligned(size_t align, size_t size) {
         size = std::max(sizeof(free_object), align);
     }
 #ifdef SEASTAR_HEAPPROF
-    bool should_sample = get_cpu_mem().should_sample(size);
+    auto& mem = get_cpu_mem();
+    bool should_sample = mem.maybe_sample(size) && mem.definitely_sample(size);
 #else
     bool should_sample = false;
 #endif

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1593,8 +1593,11 @@ void* allocate_from_sampled_small_pool(size_t size) {
     auto& pool = get_cpu_mem().sampled_small_pools[idx];
     dassert(size <= pool.object_size());
     void* ptr = pool.allocate();
-    auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
-    new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
+    if (__builtin_expect(ptr != nullptr, true)) {
+        // we failed to allocate, so we won't sample either
+        auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
+        new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
+    }
     return ptr;
 }
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1618,14 +1618,14 @@ void* allocate_from_small_pool(size_t size)
  */
 [[gnu::always_inline]]
 static inline void* finish_allocation(void* ptr, size_t size) {
-    if (!ptr) {
+    alloc_stats::increment_local(alloc_stats::types::allocs);
+    if (__builtin_expect(!ptr, false)) {
         on_allocation_failure(size);
     } else {
 #ifdef SEASTAR_DEBUG_ALLOCATIONS
     std::memset(ptr, debug_allocation_pattern, size);
 #endif
     }
-    alloc_stats::increment_local(alloc_stats::types::allocs);
     return ptr;
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3859,7 +3859,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                 "Maximum number of I/O control blocks (IOCBs) to allocate per shard. This translates to the number of sockets supported per shard."
                 " Requires tuning /proc/sys/fs/aio-max-nr. Only valid for the linux-aio reactor backend (see --reactor-backend).")
 #ifdef SEASTAR_HEAPPROF
-    , heapprof(*this, "heapprof", "enable seastar heap profiling")
+    , heapprof(*this, "heapprof", 0, "Enable seastar heap profiling. Sample every ARG bytes. 0 means off")
 #else
     , heapprof(*this, "heapprof", program_options::unused{})
 #endif
@@ -4394,12 +4394,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     std::mutex mtx;
 
 #ifdef SEASTAR_HEAPPROF
-    bool heapprof_enabled = reactor_opts.heapprof;
-    if (heapprof_enabled) {
-        memory::set_heap_profiling_enabled(heapprof_enabled);
+    size_t heapprof_sampling_rate = reactor_opts.heapprof.get_value();
+    if (heapprof_sampling_rate) {
+        memory::set_heap_profiling_sampling_rate(heapprof_sampling_rate);
     }
 #else
-    bool heapprof_enabled = false;
+    size_t heapprof_sampling_rate = 0;
 #endif
 
 #ifdef SEASTAR_HAVE_DPDK
@@ -4477,7 +4477,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     auto smp_tmain = smp::_tmain;
     for (i = 1; i < smp::count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4491,8 +4491,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 auto guard = std::lock_guard(mtx);
                 *layout = memory::internal::merge(std::move(*layout), std::move(another_layout));
             }
-            if (heapprof_enabled) {
-                memory::set_heap_profiling_enabled(heapprof_enabled);
+            if (heapprof_sampling_rate) {
+                memory::set_heap_profiling_sampling_rate(heapprof_sampling_rate);
             }
             sigset_t mask;
             sigfillset(&mask);

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -82,3 +82,6 @@ seastar_add_test (smp_submit_to
 
 seastar_add_test (coroutine
   SOURCES coroutine_perf.cc)
+
+seastar_add_test (allocator
+  SOURCES allocator_perf.cc)

--- a/tests/perf/allocator_perf.cc
+++ b/tests/perf/allocator_perf.cc
@@ -152,3 +152,33 @@ PERF_TEST_F(alloc_bench, single_alloc_and_free_small_many_cross_page_alloc_more)
         free(_pointers[i]);
     }
 }
+
+template <typename DistType>
+static size_t dist_bench() {
+    std::random_device rd_device;
+    std::mt19937_64 random_gen(rd_device());
+
+    constexpr size_t ITERS = 10000;
+    size_t rate = 3'000'000;
+    perf_tests::do_not_optimize(rate);
+
+    DistType dist(rate);
+
+    typename DistType::result_type sum = 0;
+
+    for (size_t i = 0; i < ITERS; i++) {
+        sum += dist(random_gen);
+    }
+
+    perf_tests::do_not_optimize(sum);
+
+    return ITERS;
+}
+
+PERF_TEST(random_sampling, exp_dist) {
+    return dist_bench<std::exponential_distribution<double>>();
+}
+
+PERF_TEST(random_sampling, geo_dist) {
+    return dist_bench<std::geometric_distribution<size_t>>();
+}

--- a/tests/perf/allocator_perf.cc
+++ b/tests/perf/allocator_perf.cc
@@ -1,0 +1,126 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <seastar/core/memory.hh>
+#include <sys/mman.h>
+
+struct allocator_test {
+    static constexpr size_t COUNT = 1000;
+    std::array<void *, COUNT> _pointers{};
+};
+
+struct allocator_test_split : public allocator_test {
+    enum alloc_test_flags {
+        MEASURE_ALLOC = 1,
+        MEASURE_FREE = 2,
+    };
+
+    template <size_t alloc_size, alloc_test_flags F = alloc_test_flags(MEASURE_ALLOC |
+                                                    MEASURE_FREE)>
+    size_t alloc_test() {
+        // in some cases we want to measure allocation, on deallocation or
+        // both, and this helper facilitates that with a minimum of fuss
+        // it always executes fn on every pointer in the array, but only
+        // measures when should_measure is true
+        auto run_maybe_measure = [this](bool should_measure, auto fn) {
+            if (should_measure) {
+                perf_tests::start_measuring_time();
+            }
+            for (auto &p : _pointers) {
+                fn(p);
+            }
+            if (should_measure) {
+                perf_tests::stop_measuring_time();
+            }
+        };
+
+        run_maybe_measure(F & MEASURE_ALLOC, [](auto& p) { p = std::malloc(alloc_size); });
+        run_maybe_measure(F & MEASURE_FREE, [](auto& p) { std::free(p); });
+        return _pointers.size();
+    }
+};
+
+PERF_TEST_F(allocator_test_split, alloc_only) { return alloc_test<8, MEASURE_ALLOC>(); }
+
+PERF_TEST_F(allocator_test_split, free_only) { return alloc_test<8, MEASURE_FREE>(); }
+
+PERF_TEST_F(allocator_test_split, alloc_free) { return alloc_test<8>(); }
+
+// this test doesn't serve much value. It should take about 10 times as the
+// single alloc test above. If not, something is wrong.
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many)
+{
+    const std::size_t allocs = 10;
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        auto ptr = malloc(10);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        free(_pointers[i]);
+    }
+}
+
+// Allocate from more than one page. Should also not suffer a perf penalty 
+// As we should have at least min free of 50 objects (hard coded internally)
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many_cross_page)
+{
+    const std::size_t alloc_size = 1024;
+    const std::size_t allocs = (seastar::memory::page_size / alloc_size) + 1;
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        auto ptr = malloc(alloc_size);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        free(_pointers[i]);
+    }
+}
+
+// Include an allocation in the benchmark that will require going to the large pool
+// for more data for the small pool
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many_cross_page_alloc_more)
+{
+    const std::size_t alloc_size = 1024;
+    const std::size_t allocs = 101; // at 1024 alloc size we will have a _max_free of 100 objects
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        auto ptr = malloc(alloc_size);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i) {
+        free(_pointers[i]);
+    }
+}
+
+PERF_TEST_F(allocator_test_split, alloc_only_large) { return alloc_test<32000, MEASURE_ALLOC>(); }
+
+PERF_TEST_F(allocator_test_split, free_only_large) { return alloc_test<32000, MEASURE_FREE>(); }
+
+PERF_TEST_F(allocator_test_split, alloc_free_large) { return alloc_test<32000>(); }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -132,6 +132,12 @@ function (seastar_add_test name)
           SEASTAR_THREAD_STACK_GUARDS)
     endif ()
 
+    if (Seastar_HEAP_PROFILING)
+      target_compile_definitions (${executable_target}
+        PRIVATE
+          SEASTAR_HEAPPROF)
+    endif ()
+
     target_include_directories (${executable_target}
       PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -331,35 +331,225 @@ SEASTAR_TEST_CASE(test_diagnostics_allocation) {
 
 #ifdef SEASTAR_HEAPPROF
 
-SEASTAR_TEST_CASE(test_sampled_profile_collection)
+// small wrapper to disincentivize gcc from unrolling the loop
+[[gnu::noinline]]
+char* malloc_wrapper(size_t size) {
+    auto ret = static_cast<char*>(malloc(size));
+    *ret = 'c'; // to prevent compiler from considering this a dead allocation and optimizing it out
+    return ret;
+}
+
+namespace seastar::memory {
+std::ostream& operator<<(std::ostream& os, const allocation_site& site) {
+    os << "allocation_site[count: " << site.count << ", size: " << site.size << "]";
+    return os;
+}
+}
+
+SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 {
-    BOOST_REQUIRE(!seastar::memory::get_heap_profiling_enabled());
-    seastar::memory::set_heap_profiling_enabled(true);
-    BOOST_REQUIRE(seastar::memory::get_heap_profiling_enabled());
-
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
-    volatile char* ptr = static_cast<char*>(malloc(10));
-    *ptr = 'c'; // to prevent compiler from considering this a dead allocation and optimizing it out
+    std::size_t count = 100;
+    std::vector<volatile char*> ptrs(count);
+
+    seastar::memory::set_heap_profiling_sampling_rate(100);
+
+#ifdef __clang__
+    #pragma nounroll
+#endif
+    for (std::size_t i = 0; i < count / 2; ++i) {
+        ptrs[i] = malloc_wrapper(10);
+    }
+
+#ifdef __clang__
+    #pragma nounroll
+#endif
+    for (std::size_t i = count / 2; i < count; ++i) {
+        ptrs[i] = malloc_wrapper(10);
+    }
+
+    auto get_samples = []() {
+        auto stats0 = seastar::memory::sampled_memory_profile();
+        auto stats1 = seastar::memory::sampled_memory_profile();
+
+        // two back-to-back copies of the sample should have the same value
+        BOOST_CHECK_EQUAL(stats0, stats1);
+
+        // check that we get the same value from the raw array iterface
+        std::vector<seastar::memory::allocation_site> stats2(stats0.size());
+        auto sz2 = seastar::memory::sampled_memory_profile(stats2.data(), stats2.size());
+        BOOST_CHECK_EQUAL(stats0.size(), sz2);
+        BOOST_CHECK_EQUAL(stats0, stats2);
+
+        // check with +1 size, we expect to still only get size elements
+        std::vector<seastar::memory::allocation_site> stats3(stats0.size() + 1);
+        auto sz3 = seastar::memory::sampled_memory_profile(stats3.data(), stats3.size());
+        BOOST_CHECK_EQUAL(stats0.size(), sz3);
+        stats3.resize(sz3);
+        BOOST_CHECK_EQUAL(stats0, stats3);
+
+        return stats0;
+    };
+
+    // NB: the test framework allocates
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = get_samples();
+        BOOST_REQUIRE_EQUAL(stats.size(), 2);
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 100);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(100);
+
+    for (auto ptr : ptrs) {
+        free((void*)ptr);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = get_samples();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    return seastar::make_ready_future();
+}
+
+SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
+{
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    std::size_t count = 100;
+    std::vector<volatile char*> ptrs(count);
+
+    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+
+#ifdef __clang__
+    #pragma nounroll
+#endif
+    for (std::size_t i = 0; i < count / 2; ++i) {
+        ptrs[i] = malloc_wrapper(100000);
+    }
+
+#ifdef __clang__
+    #pragma nounroll
+#endif
+    for (std::size_t i = count / 2; i < count; ++i) {
+        ptrs[i] = malloc_wrapper(100000);
+    }
+
+    // NB: the test framework allocate
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 2);
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+
+    for (auto ptr : ptrs) {
+        free((void*)ptr);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        // NOTE this is because right now the tracking structure doesn't delete call sites ever
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    return seastar::make_ready_future();
+}
+
+SEASTAR_TEST_CASE(test_change_sample_rate)
+{
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    std::size_t sample_rate = 100;
+    std::size_t count = 10000;
+    std::vector<volatile char*> ptrs(count);
+
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
+
+#ifdef __clang__
+    #pragma nounroll
+#endif
+    for (std::size_t i = 0; i < count; ++i) {
+        ptrs[i] = malloc_wrapper(10);
+    }
+
+    // NB: the test framework allocates
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    size_t last_alloc_size = 0;
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 1);
-        BOOST_REQUIRE_EQUAL(stats[0].size, 32); // 10 + 8 falls into 32 byte pool
+        last_alloc_size = stats[0].size;
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
     }
 
-    free((void*)ptr);
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
+
+    size_t free_iter = 0;
+    // free some of the allocations to check size changes
+    for (size_t i = 0; i < count / 4; ++i, ++free_iter) {
+        free((void*)ptrs[free_iter]);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
+        BOOST_REQUIRE_NE(stats[0].size, last_alloc_size);
+        BOOST_REQUIRE_GT(stats[0].size, 0);
+        last_alloc_size = stats[0].size;
     }
 
-    // Needed for now because we can't differentiate between sampled allocations and non-sampled ones
-    seastar::memory::set_heap_profiling_enabled(false);
+    // now increase the sampling rate with outstanding allocations from the old rate
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate * 100);
+
+    for (size_t i = 0; i < count / 4; ++i, ++free_iter) {
+        free((void*)ptrs[free_iter]);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        BOOST_REQUIRE_LT(stats[0].size, last_alloc_size); // should not have underflowed
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
+
+    // free the rest
+    for (size_t i = 0; i < count / 2; ++i, ++free_iter) {
+        free((void*)ptrs[free_iter]);
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
 
     return seastar::make_ready_future();
 }

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -472,6 +472,34 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     return seastar::make_ready_future();
 }
 
+SEASTAR_TEST_CASE(test_sampled_profile_collection_max_sites)
+{
+    std::size_t count = 1010;
+    std::vector<volatile char*> ptrs(count);
+
+    seastar::memory::set_heap_profiling_sampling_rate(100);
+
+    #pragma GCC unroll 1010
+    for (std::size_t i = 0; i < count; ++i) {
+        volatile char* ptr = static_cast<char*>(malloc(1000));
+        *ptr = 'c'; // to prevent compiler from considering this a dead allocation and optimizing it out
+        ptrs[i] = ptr;
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 1000);
+    }
+
+    for (auto ptr : ptrs) {
+        free((void*)ptr);
+    }
+
+    return seastar::make_ready_future();
+}
+
 SEASTAR_TEST_CASE(test_change_sample_rate)
 {
     {
@@ -553,6 +581,7 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
 
     return seastar::make_ready_future();
 }
+
 
 #endif // SEASTAR_HEAPPROF
 


### PR DESCRIPTION
This series changes the existing heap profiling to support a sampling mode, added
by @StephanDollberg and includes also some optimizations of the allocation fast paths.

The following description of the sampling profiler comes from Stephan:

Instead of tracking every allocation, it will track a sampled subset of allocations. This
is useful for profiling in production systems where the overhead of tracking every
allocation is too high.

A sample is taken at a set sample rate which feeds into an exponential
distribution. Hence we avoid falling into patterns that would potentially make
the profile biased otherwise. This approach is inspired by the android heapprofd
memory profiler.

By adjusting the sample rate it's possible to tune the overhead of the memory
profiler. The idea is to make this an always-on production profiler that can
give insight into allocations in OOM scenarios with negliable overhead.

Starting with the latest release of Redpanda we are using this in a default
always-on mode with a sampling period of 3MB. This is a rather conservative
setting and results in no measurable overhead while still giving good resolution
for the top allocation contributors.

We also add an API to retrieve the current heap profile programmatically. In
Redpanda we use this to print the top sites on OOM using the additional
diagnostics API. Further it allows easier retrieval of the data in a
dev/profiling fashion.

As today heap profiler can be compiled in or not (using `--heap-prof` at 
./configure.py time) and can also be enabled or disabled at runtime if it
has been compiled in.

The individual commits contain a more detailed description of the respective
changes. Note the heap profiler and all added codepaths still require explicit
opt in via the extra define.

This series also includes some optimizations that especially improve
small allocations and hence we end up faster than the current state even with
the profiler on, under the assumption that small allocations (which here means
<= 16 KiB) are considerably more frequent than larger allocations, which is 
overwhelmingly the case for most applications.

For example, a new/delete pair for a small allocation prior to this series take on
average ~104 instructions, versus ~73 after _with heap profiling on_ or ~67 with
it compiled out. Performance measured in time rather than instructions generally
follows the same improvement factors as time, though with more variance.

To aid with analysis of the above we also added a set of microbenchmarks. Below
you will find the selected key numbers from this benchmark comparing current
master and this patch set with the profiler compiled in and
out. 

Note profiler-on numbers are taken from a run with very high sample period
to avoid actually taking any samples. Sample creation is fully dominated by
backtrace creation so this avoids noise.

With the profiler enabled at compile time the runtime performance is identical 
between "compiler turned off at runtime" and "very large sample period such
that zero samples are actually taken". That is, there is no additional check for
sampler enablement on the fast path, only the single check to see if the sampling
period has been reached.

There are a lot of profiling results, so I'll share first this summary of a single 
test, which uses `new` to allocate many small pointers and then deletes them.

The configurations show are:

*Baseline:* Current `master` without any of the changes in this series.
*New-OFF:* This series but with heap profiling disabled at compile time.
*New-ON:* This series and with heap profiling enabled at compile time.

First the instruction counts:

| Config | Compiler | test | instructions |
| - | - | - | -: | 
| Baseline | gcc-11   | alloc_bench.op_new_delete                | 97.6 |
| New-OFF  | gcc-11   | alloc_bench.op_new_delete                | 74.6 |
| New-ON   | gcc-11   | alloc_bench.op_new_delete                | 82.6 |
| Baseline | clang-16 | alloc_bench.op_new_delete                | 104.6 |
| New-OFF  | clang-16 | alloc_bench.op_new_delete                | 67.5|
| New-ON   | clang-16 |alloc_bench.op_new_delete                |  73.5 |

Next, runtimes on Skylake and Zen 4, these are from separate runs than the instruction counts above as I found that enabling instruction count measurement disturbed (i.e., increased) the timings by a significant amount, probably because some part of the perf syscall cost ends up timed.

| Config | Arch | Compiler | test                                     |  iterations |      median |         mad |         min |         max |
|-|-|-| -                                        |           - |           -: |           -: |           -: |           -: |
| Baseline | Skylake | clang-16  | alloc_bench.op_new_delete                |   134081000 |     7.376ns |     0.005ns |     7.370ns |     7.534ns |
| New-OFF  | Skylake | clang-16  | alloc_bench.op_new_delete                |   146836000 |     6.586ns |     0.008ns |     6.577ns |     6.765ns |
| New-ON   | Skylake | clang-16  | alloc_bench.op_new_delete                |   193241000 |     5.113ns |     0.004ns |     5.110ns |     5.246ns |
||
| Baseline | Zen4 | gcc-11   | alloc_bench.op_new_delete                |   207025000 |     4.796ns |     0.000ns |     4.795ns |     4.797ns |
| New-OFF  | Zen4 | gcc-11   | alloc_bench.op_new_delete                |   305103000 |     3.241ns |     0.000ns |     3.240ns |     3.241ns |
| New-ON   | Zen4 | gcc-11   | alloc_bench.op_new_delete                |   302127000 |     3.271ns |     0.000ns |     3.271ns |     3.273ns |
||
| Baseline | Zen4 | clang-16 | alloc_bench.op_new_delete                |   212207000 |     4.663ns |     0.000ns |     4.661ns |     4.663ns |
| New-OFF  | Zen4 | clang-16 | alloc_bench.op_new_delete                |   358628000 |     2.742ns |     0.001ns |     2.740ns |     2.745ns |
| New-ON   | Zen4 | clang-16 | alloc_bench.op_new_delete                |   347325000 |     2.833ns |     0.003ns |     2.830ns |     2.836ns |

The primary anomalous result is New-OFF on clang-16 on Skylake (also shows up on Alder Lake, not shown). The runtime is considerably slower than the instruction count would suggest (i.e., it is lower IPC than other configurations) and I don't see any problem in a manual inspection of the assembly. The same function is fast on Zen 2 and Zen 4. I believe it is probably an Intel-specific alignment effect. I did move the bottom of the test loop around to avoid the jcc erratum (results not shown) which improved the results but the result was still slower than expected. In any case, even this configuration is faster than the baseline and I expect the issue to go away at some point.

Large allocations are a bit slower, very slightly when heap profiling is off at compile time and more when they are enabled, e.g., here with 32,000 byte allocations:

*Baseline*
```
test                                      iterations      median         mad         min         max      allocs       tasks        inst
alloc_bench.alloc_free_large                72444000    13.125ns     0.010ns    13.073ns    13.140ns       1.000       0.000       336.1
```

*New-OFF*
```
test                                      iterations      median         mad         min         max      allocs       tasks        inst
alloc_bench.alloc_free_large                71368000    13.334ns     0.004ns    13.287ns    13.338ns       1.000       0.000       343.0
```

*New-ON*
```
test                                      iterations      median         mad         min         max      allocs       tasks        inst
alloc_bench.alloc_free_large                65224000    14.623ns     0.002ns    14.604ns    14.628ns       1.000       0.000       399.5
```

Such allocations are rare compared to small allocations, however, and in any case the relative cost of allocation goes down compared to the work done on the allocated memory itself (e.g., writing into it) and that ratio becomes ~negligible except for an application which allocates large regions but then does not use them.

We have many micro-benchmarks but this description is already quite long: let me know what you think would be useful.


