### PR TITLE
build: do not provide zlib as an ingredient

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -119,14 +119,6 @@ cooking_ingredient (numactl
     BUILD_COMMAND <DISABLE>
     INSTALL_COMMAND ${make_command} install)
 
-cooking_ingredient (zlib
-  EXTERNAL_PROJECT_ARGS
-    URL https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
-    URL_MD5 9b8aa094c4e5765dabf4da391f00d15c
-    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
-    BUILD_COMMAND <DISABLE>
-    INSTALL_COMMAND ${make_command} install)
-
 ##
 ## Private and private/public dependencies.
 ##


### PR DESCRIPTION
zlib is used as the software implementation of SPDK's compressdev, and its hardware accelerated counterpart is QAT.

we can drop it as we are not using it, neither do we plan to use this DPDK API in our, so let's stop providing it as an ingredient.

Fixes #1901
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>