### PR TITLE
fair_queue::unregister_priority_class:fix assertion

### DIFF
--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -290,7 +290,7 @@ void fair_queue::register_priority_class(class_id id, uint32_t shares) {
 
 void fair_queue::unregister_priority_class(class_id id) {
     auto& pclass = _priority_classes[id];
-    assert(pclass && pclass->_queue.empty());
+    assert(pclass);
     pclass.reset();
     _nr_classes--;
 }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -661,6 +661,7 @@ io_queue::~io_queue() {
     //
     // And that will happen only when there are no more fibers to run. If we ever change
     // that, then this has to change.
+    assert(_queued_requests == 0);
     for (auto&& pc_data : _priority_classes) {
         if (pc_data) {
             for (auto&& s : _streams) {


### PR DESCRIPTION
It is possible that the priority class is unregistered before all cancelled requests in that class have ended.

Following program that reads a file with read ahead causes current assertion to fail:

```

using namespace std;
using namespace seastar;

int main(int argc, char** argv) {
    app_template app;
    app.run(argc, argv, [&app] {
        return with_file_close_on_failure(
            open_file_dma("random_input_file", open_flags::ro),
            [] (file f) {
                auto stream = make_file_input_stream(std::move(f), {size_t{1}<<10, 2});
                auto istream = make_lw_shared(std::move(stream));
                return repeat([istream] () {
                    return istream->read().then([] (auto&& buf) {
                        return stop_iteration{buf.empty()};
                    });
                }).finally([istream = std::move(istream)] {
                    return istream->close().then([istream] {});
                });
            }
        );
    });
}
```

This patch excludes cancelled requests from the assertion check.

Fixes #1907