### PR TITLE
file: construct directory_entry with aggregated ctor

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -414,7 +414,8 @@ static coroutine::experimental::generator<directory_entry, dir_entry_buffer> mak
                 continue;
             }
             std::optional<directory_entry_type> type = dirent_type(*de);
-            directory_entry ret(std::move(name), type);
+            // See: https://github.com/scylladb/seastar/issues/1677
+            directory_entry ret{std::move(name), type};
             co_yield ret;
         }
     }


### PR DESCRIPTION
despite that `directory_entry` can be default constructed, it does not have a contructor which accepts two parameters. so, in order to construct an instance of it, we either need to use the aggregated contructor, or the list-initialization.

in this change, in order to appease the compiler which does not accept the form of construct, let's use the aggregated constructor.

this should address the FTBFS with Clang-15 + C++20
```
/home/circleci/project/src/core/file.cc:417:29: error: no matching constructor for initialization of 'seastar::directory_entry'
            directory_entry ret(std::move(name), type);
                            ^   ~~~~~~~~~~~~~~~~~~~~~
/home/circleci/project/include/seastar/core/file.hh:58:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct directory_entry {
       ^
/home/circleci/project/include/seastar/core/file.hh:58:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
/home/circleci/project/include/seastar/core/file.hh:58:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided
1 error generated.
```