### PR TITLE
file: s/ino64_t/ino_t/, s/off64_t/off_t/

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -87,8 +87,8 @@ static_assert(sizeof(off_t) == 8, "large file support not enabled");
 
 // From getdents(2):
 struct linux_dirent64 {
-    ino64_t        d_ino;    /* 64-bit inode number */
-    off64_t        d_off;    /* 64-bit offset to next structure */
+    ino_t          d_ino;    /* 64-bit inode number */
+    off_t          d_off;    /* 64-bit offset to next structure */
     unsigned short d_reclen; /* Size of this dirent */
     unsigned char  d_type;   /* File type */
     char           d_name[]; /* Filename (null-terminated) */


### PR DESCRIPTION
turns out 9e37a6fc overwrote the changes made by 2638c51cc3, so lets resurrect them.