### PR TITLE
include fmt/ostream.h to make headers self-sufficient

### DIFF
--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -35,7 +35,6 @@
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/include/seastar/net/ethernet.hh
+++ b/include/seastar/net/ethernet.hh
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
 #include <array>
 #include <assert.h>
 #include <algorithm>

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <functional>
 #include <iosfwd>
+#include <fmt/ostream.h>
 #endif
 #include <seastar/net/byteorder.hh>
 #include <seastar/net/unix_address.hh>

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
 #include <seastar/net/api.hh>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
When SEASTAR_MODULE isn't used and FMT_VERSION >= 90000 some headers define specialized fmt::formatter templates, so #include <fmt/ostream.h> to statisfy their requirements.