### PR TITLE
build: do not error when run into GCC BZ-1017852

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,6 +767,14 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -Wimplicit-fallthrough
   -Wdeprecated
   -Wno-error=deprecated)
+
+include (CheckGcc107852)
+if (NOT Cxx_Compiler_BZ107852_Free)
+  list (APPEND Seastar_PRIVATE_CXX_FLAGS
+    -Wno-error=stringop-overflow
+    -Wno-error=array-bounds)
+endif ()
+
 if (NOT BUILD_SHARED_LIBS)
   list (APPEND Seastar_PRIVATE_CXX_FLAGS -fvisibility=hidden)
 endif ()

--- a/cmake/CheckGcc107852.cmake
+++ b/cmake/CheckGcc107852.cmake
@@ -1,0 +1,24 @@
+include (CheckCXXSourceCompiles)
+include (CMakePushCheckState)
+
+cmake_push_check_state (RESET)
+
+# these options are included by -Wall, which is in turn included by
+# Seastar_PRIVATE_CXX_FLAGS, which is not applied to CMAKE_CXX_FLAGS, so
+# let's apply them explicitly.
+set (CMAKE_REQUIRED_FLAGS "-Werror=stringop-overflow -Werror=array-bound")
+set (CMAKE_REQUIRED_LIBRARIES fmt::fmt)
+
+# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107852
+check_cxx_source_compiles ("
+#include <fmt/ranges.h>
+
+int main() {
+    float grades[] = {3.14};
+    fmt::print(\"{}\", grades);
+}"
+  Cxx_Compiler_BZ107852_Free
+  FAIL_REGEX "is out of the bounds")
+
+cmake_pop_check_state ()
+


### PR DESCRIPTION
if the compiler impacted by
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107852 is used to compile Seastar with fmtlib v10, the tree would fail to compile, because we consider `-Warray-bounds` warnings as error.

to build with compiler (typically GCC 13.1) which suffers from this bug. let's stop considering these false alarms as error. a minimal reproducer is introduced for testing this compiler bug.

Fixes #1716
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>