### PR TITLE
build: generate config-specific rules using generator expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,10 +919,12 @@ endif ()
 # as many compilation units as possible.  So while these flags don't
 # have to be public, we don't expect anyone to want to build seastar
 # with them and some client code without.
-if (Seastar_SPLIT_DWARF AND (NOT (CMAKE_BUILD_TYPE STREQUAL "Dev")))
+if (Seastar_SPLIT_DWARF)
   set (Seastar_SPLIT_DWARF_FLAG "-Wl,--gdb-index")
-  target_link_libraries (seastar PUBLIC ${Seastar_SPLIT_DWARF_FLAG})
-  target_compile_options (seastar PUBLIC "-gsplit-dwarf")
+  target_link_libraries (seastar PUBLIC
+    $<$<NOT:$<CONFIG:Dev>>:${Seastar_SPLIT_DWARF_FLAG}>)
+  target_compile_options (seastar PUBLIC
+    $<$<NOT:$<CONFIG:Dev>>:-gsplit-dwarf>)
 endif ()
 
 if (Seastar_HEAP_PROFILING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,6 @@ project (Seastar
   VERSION 1.0
   LANGUAGES CXX)
 
-# generic boolean values passed as string, potentially from configure.py
-set (True_STRING_VALUES "ON" "yes" "Yes" "YES" "true" "True" "TRUE")
-set (False_STRING_VALUES "OFF" "no" "No" "NO" "false" "False" "FALSE")
-set (Default_STRING_VALUES "DEFAULT" "default" "Default")
-
 set (Seastar_ALLOC_FAILURE_INJECTION
   "DEFAULT"
   CACHE
@@ -880,10 +875,12 @@ if (LinuxMembarrier_FOUND)
     PRIVATE LinuxMembarrier::membarrier)
 endif ()
 
-set (Seastar_ALLOC_FAILURE_INJECTION_MODES "Dev")
-if ((Seastar_ALLOC_FAILURE_INJECTION IN_LIST True_STRING_VALUES) OR
-    ((Seastar_ALLOC_FAILURE_INJECTION STREQUAL "DEFAULT") AND
-     (CMAKE_BUILD_TYPE IN_LIST Seastar_ALLOC_FAILURE_INJECTION_MODES)))
+include (TriStateOption)
+
+tri_state_option (${Seastar_ALLOC_FAILURE_INJECTION}
+  DEFAULT_BUILD_TYPES "Dev"
+  OUTPUT ALLOC_FAILURE_INJECTION)
+if (ALLOC_FAILURE_INJECTION)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION)
 endif ()
@@ -1016,10 +1013,10 @@ foreach (definition
       $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:${definition}>)
 endforeach ()
 
-set (Seastar_DEBUG_SHARED_PTR_MODES "Debug" "Sanitize")
-if (Seastar_DEBUG_SHARED_PTR IN_LIST True_STRING_VALUES OR
-    ((Seastar_DEBUG_SHARED_PTR IN_LIST Default_STRING_VALUES) AND
-     (CMAKE_BUILD_TYPE IN_LIST Seastar_DEBUG_SHARED_PTR_MODES)))
+tri_state_option (${Seastar_DEBUG_SHARED_PTR}
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
+  OUTPUT DEBUG_SHARED_PTR)
+if (DEBUG_SHARED_PTR)
   target_compile_definitions (seastar
     PUBLIC
       SEASTAR_DEBUG_SHARED_PTR)
@@ -1027,10 +1024,10 @@ endif ()
 
 include (CheckLibc)
 
-set (Seastar_STACK_GUARD_MODES "Debug" "Sanitize" "Dev")
-if ((Seastar_STACK_GUARDS STREQUAL "ON") OR
-    ((Seastar_STACK_GUARDS STREQUAL "DEFAULT") AND
-     (CMAKE_BUILD_TYPE IN_LIST Seastar_STACK_GUARD_MODES)))
+tri_state_option (${Seastar_STACK_GUARDS}
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize" "Dev"
+  OUTPUT STACK_GUARDS)
+if(STACK_GUARDS)
   # check for -fstack-clash-protection together with -Werror, because
   # otherwise clang can soft-fail (return 0 but emit a warning) instead.
   seastar_supports_flag ("-fstack-clash-protection -Werror" StackClashProtection_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1007,13 +1007,14 @@ if (ErrorWarnings_FOUND)
       PUBLIC "-Wno-error=#warnings")
 endif ()
 
-if ((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "Sanitize"))
+foreach (definition
+    SEASTAR_DEBUG
+    SEASTAR_DEFAULT_ALLOCATOR
+    SEASTAR_SHUFFLE_TASK_QUEUE)
   target_compile_definitions (seastar
     PUBLIC
-      SEASTAR_DEBUG
-      SEASTAR_DEFAULT_ALLOCATOR
-      SEASTAR_SHUFFLE_TASK_QUEUE)
-endif ()
+      $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:${definition}>)
+endforeach ()
 
 set (Seastar_DEBUG_SHARED_PTR_MODES "Debug" "Sanitize")
 if (Seastar_DEBUG_SHARED_PTR IN_LIST True_STRING_VALUES OR
@@ -1043,11 +1044,10 @@ if ((Seastar_STACK_GUARDS STREQUAL "ON") OR
       SEASTAR_THREAD_STACK_GUARDS)
 endif ()
 
-if ((CMAKE_BUILD_TYPE STREQUAL "Dev") OR (CMAKE_BUILD_TYPE STREQUAL "Debug"))
-  target_compile_definitions (seastar
-    PUBLIC
-      SEASTAR_TYPE_ERASE_MORE)
-endif ()
+target_compile_definitions (seastar
+  PUBLIC
+    $<$<IN_LIST:$<CONFIG>,Dev;Debug>:SEASTAR_TYPE_ERASE_MORE>
+    SEASTAR_TYPE_ERASE_MORE)
 
 target_compile_definitions (seastar
   PRIVATE ${Seastar_PRIVATE_COMPILE_DEFINITIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,10 +879,10 @@ include (TriStateOption)
 
 tri_state_option (${Seastar_ALLOC_FAILURE_INJECTION}
   DEFAULT_BUILD_TYPES "Dev"
-  OUTPUT ALLOC_FAILURE_INJECTION)
-if (ALLOC_FAILURE_INJECTION)
+  CONDITION condition)
+if (condition)
   target_compile_definitions (seastar
-    PUBLIC SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION)
+    PUBLIC $<${condition}:SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION>)
 endif ()
 
 if (Seastar_TASK_BACKTRACE)
@@ -1015,30 +1015,30 @@ endforeach ()
 
 tri_state_option (${Seastar_DEBUG_SHARED_PTR}
   DEFAULT_BUILD_TYPES "Debug" "Sanitize"
-  OUTPUT DEBUG_SHARED_PTR)
-if (DEBUG_SHARED_PTR)
+  CONDITION condition)
+if (condition)
   target_compile_definitions (seastar
     PUBLIC
-      SEASTAR_DEBUG_SHARED_PTR)
+      $<${condition}:SEASTAR_DEBUG_SHARED_PTR>)
 endif ()
 
 include (CheckLibc)
 
 tri_state_option (${Seastar_STACK_GUARDS}
   DEFAULT_BUILD_TYPES "Debug" "Sanitize" "Dev"
-  OUTPUT STACK_GUARDS)
-if(STACK_GUARDS)
+  CONDITION condition)
+if(condition)
   # check for -fstack-clash-protection together with -Werror, because
   # otherwise clang can soft-fail (return 0 but emit a warning) instead.
   seastar_supports_flag ("-fstack-clash-protection -Werror" StackClashProtection_FOUND)
   if (StackClashProtection_FOUND)
     target_compile_options (seastar
       PUBLIC
-      -fstack-clash-protection)
+        $<${condition}:-fstack-clash-protection>)
   endif ()
   target_compile_definitions (seastar
     PRIVATE
-      SEASTAR_THREAD_STACK_GUARDS)
+      $<${condition}:SEASTAR_THREAD_STACK_GUARDS>)
 endif ()
 
 target_compile_definitions (seastar

--- a/cmake/TriStateOption.cmake
+++ b/cmake/TriStateOption.cmake
@@ -1,0 +1,25 @@
+# the "option()" defined by CMake represents a boolean. but somtimes, we want
+# to enable/disable it depending on the CMAKE_BUILD_TYPE, if user leaves the
+# option unset.
+function (tri_state_option option)
+  cmake_parse_arguments (
+    parsed_args
+    ""
+    "OUTPUT"
+    "DEFAULT_BUILD_TYPES"
+    ${ARGN})
+  # generic boolean values passed as string, potentially from configure.py
+  set (True_STRING_VALUES "ON" "yes" "Yes" "YES" "true" "True" "TRUE")
+  set (Default_STRING_VALUES "DEFAULT" "default" "Default")
+  if ("${option}" IN_LIST True_STRING_VALUES)
+    set (${parsed_args_OUTPUT} ON PARENT_SCOPE)
+  elseif ("${option}" IN_LIST Default_STRING_VALUES)
+    if ("${CMAKE_BUILD_TYPE}" IN_LIST ${parsed_args_ENABLED_TYPES})
+      set (${parsed_args_OUTPUT} ON PARENT_SCOPE)
+    else ()
+      set (${parsed_args_OUTPUT} OFF PARENT_SCOPE)
+    endif ()
+  else ()
+    set (${parsed_args_OUTPUT} OFF PARENT_SCOPE)
+  endif ()
+endfunction ()

--- a/cmake/TriStateOption.cmake
+++ b/cmake/TriStateOption.cmake
@@ -5,21 +5,31 @@ function (tri_state_option option)
   cmake_parse_arguments (
     parsed_args
     ""
-    "OUTPUT"
     "DEFAULT_BUILD_TYPES"
+    "CONDITION"
     ${ARGN})
+
+  if (CMAKE_CONFIGURATION_TYPES)
+    set (all_build_types ${CMAKE_CONFIGURATION_TYPES})
+  else ()
+    set (all_build_types ${CMAKE_BUILD_TYPE})
+  endif ()
+
   # generic boolean values passed as string, potentially from configure.py
   set (True_STRING_VALUES "ON" "yes" "Yes" "YES" "true" "True" "TRUE")
   set (Default_STRING_VALUES "DEFAULT" "default" "Default")
+
   if ("${option}" IN_LIST True_STRING_VALUES)
-    set (${parsed_args_OUTPUT} ON PARENT_SCOPE)
+    set (enabled_types ${all_build_types})
   elseif ("${option}" IN_LIST Default_STRING_VALUES)
-    if ("${CMAKE_BUILD_TYPE}" IN_LIST ${parsed_args_ENABLED_TYPES})
-      set (${parsed_args_OUTPUT} ON PARENT_SCOPE)
-    else ()
-      set (${parsed_args_OUTPUT} OFF PARENT_SCOPE)
-    endif ()
+    set (enabled_types ${parsed_args_DEFAULT_BUILD_TYPES})
   else ()
-    set (${parsed_args_OUTPUT} OFF PARENT_SCOPE)
+    set (enabled_types "")
+  endif ()
+
+  if (enabled_types)
+    set (${parsed_args_CONDITION} "$<IN_LIST:$<CONFIG>,${enabled_types}>" PARENT_SCOPE)
+  else ()
+    set (${parsed_args_CONDITION} OFF PARENT_SCOPE)
   endif ()
 endfunction ()


### PR DESCRIPTION
in this series, we start to use  generator expressions to set config-specific rules instead of checking `CMAKE_BUILD_TYPE`. if we check `CMAKE_BUILD_TYPE` for setting the compiling options, we won't be able to support multi-config generator.

another missing puzzle to support Multi-Config is to generate different options or different `seastar.pc`, it is addressed by #1929.