### PR TITLE
treewide: use *_v and *_t for better readability

### DIFF
--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -52,14 +52,14 @@ struct serializer {};
 template <typename T, typename Output>
 inline
 void write_arithmetic_type(Output& out, T v) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
 }
 
 template <typename T, typename Input>
 inline
 T read_arithmetic_type(Input& in) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     T v;
     in.read(reinterpret_cast<char*>(&v), sizeof(T));
     return v;

--- a/demos/rpc_demo.cc
+++ b/demos/rpc_demo.cc
@@ -35,14 +35,14 @@ struct serializer {
 template <typename T, typename Output>
 inline
 void write_arithmetic_type(Output& out, T v) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
 }
 
 template <typename T, typename Input>
 inline
 T read_arithmetic_type(Input& in) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     T v;
     in.read(reinterpret_cast<char*>(&v), sizeof(T));
     return v;

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -87,12 +87,12 @@ public:
     public:
         subscription() = default;
 
-        subscription(subscription&& other) noexcept(std::is_nothrow_move_constructible<subscription_callback_type>::value)
+        subscription(subscription&& other) noexcept(std::is_nothrow_move_constructible_v<subscription_callback_type>)
                 : _target(std::move(other._target)) {
             subscription_list_type::node_algorithms::swap_nodes(other.this_ptr(), this_ptr());
         }
 
-        subscription& operator=(subscription&& other) noexcept(std::is_nothrow_move_assignable<subscription_callback_type>::value) {
+        subscription& operator=(subscription&& other) noexcept(std::is_nothrow_move_assignable_v<subscription_callback_type>) {
             if (this != &other) {
                 _target = std::move(other._target);
                 unlink();

--- a/include/seastar/core/checked_ptr.hh
+++ b/include/seastar/core/checked_ptr.hh
@@ -101,7 +101,7 @@ inline T* checked_ptr_do_get(T* ptr) noexcept {
 SEASTAR_MODULE_EXPORT
 template<typename Ptr, typename NullDerefAction = default_null_deref_action>
 /// \cond SEASTAR_CONCEPT_DOC
-SEASTAR_CONCEPT( requires std::is_default_constructible<NullDerefAction>::value && requires (NullDerefAction action) {
+SEASTAR_CONCEPT( requires std::is_default_constructible_v<NullDerefAction> && requires (NullDerefAction action) {
     NullDerefAction();
 })
 /// \endcond
@@ -126,9 +126,9 @@ private:
 
 public:
     checked_ptr() noexcept(noexcept(Ptr(nullptr))) = default;
-    checked_ptr(std::nullptr_t) noexcept(std::is_nothrow_default_constructible<checked_ptr<Ptr, NullDerefAction>>::value) : checked_ptr() {}
-    checked_ptr(Ptr&& ptr) noexcept(std::is_nothrow_move_constructible<Ptr>::value) : _ptr(std::move(ptr)) {}
-    checked_ptr(const Ptr& p) noexcept(std::is_nothrow_copy_constructible<Ptr>::value) : _ptr(p) {}
+    checked_ptr(std::nullptr_t) noexcept(std::is_nothrow_default_constructible_v<checked_ptr<Ptr, NullDerefAction>>) : checked_ptr() {}
+    checked_ptr(Ptr&& ptr) noexcept(std::is_nothrow_move_constructible_v<Ptr>) : _ptr(std::move(ptr)) {}
+    checked_ptr(const Ptr& p) noexcept(std::is_nothrow_copy_constructible_v<Ptr>) : _ptr(p) {}
 
     /// \name Checked Methods
     /// These methods start with invoking a NullDerefAction functor if the underlying pointer is not engaged.

--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -490,7 +490,7 @@ template <typename T, typename Alloc>
 inline
 typename circular_buffer<T, Alloc>::iterator
 circular_buffer<T, Alloc>::erase(iterator first, iterator last) noexcept {
-    static_assert(std::is_nothrow_move_assignable<T>::value, "erase() assumes move assignment does not throw");
+    static_assert(std::is_nothrow_move_assignable_v<T>, "erase() assumes move assignment does not throw");
     if (first == last) {
         return last;
     }

--- a/include/seastar/core/circular_buffer_fixed_capacity.hh
+++ b/include/seastar/core/circular_buffer_fixed_capacity.hh
@@ -64,7 +64,7 @@ private:
     const T* obj(size_t idx) const { return &_storage[mask(idx)].data; }
 public:
     static_assert((Capacity & (Capacity - 1)) == 0, "capacity must be a power of two");
-    static_assert(std::is_nothrow_move_constructible<T>::value && std::is_nothrow_move_assignable<T>::value,
+    static_assert(std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T>,
             "circular_buffer_fixed_capacity only supports nothrow-move value types");
     using value_type = T;
     using size_type = size_t;
@@ -76,7 +76,7 @@ public:
 public:
     template <typename ValueType>
     class cbiterator {
-        using holder = std::conditional_t<std::is_const<ValueType>::value, const maybe_storage, maybe_storage>;
+        using holder = std::conditional_t<std::is_const_v<ValueType>, const maybe_storage, maybe_storage>;
         holder* _start;
         size_t _idx;
     private:
@@ -341,7 +341,7 @@ template <typename T, size_t Capacity>
 inline
 typename circular_buffer_fixed_capacity<T, Capacity>::iterator
 circular_buffer_fixed_capacity<T, Capacity>::erase(iterator first, iterator last) {
-    static_assert(std::is_nothrow_move_assignable<T>::value, "erase() assumes move assignment does not throw");
+    static_assert(std::is_nothrow_move_assignable_v<T>, "erase() assumes move assignment does not throw");
     if (first == last) {
         return last;
     }

--- a/include/seastar/core/enum.hh
+++ b/include/seastar/core/enum.hh
@@ -39,10 +39,10 @@ namespace seastar {
 SEASTAR_MODULE_EXPORT
 template <typename T>
 class enum_hash {
-    static_assert(std::is_enum<T>::value, "must be an enum");
+    static_assert(std::is_enum_v<T>, "must be an enum");
 public:
     std::size_t operator()(const T& e) const {
-        using utype = typename std::underlying_type<T>::type;
+        using utype = std::underlying_type_t<T>;
         return std::hash<utype>()(static_cast<utype>(e));
     }
 };

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -209,10 +209,10 @@ public:
 /// \tparam Args  argument pack containing arguments to the function object, needs
 ///                   to have move constructor that doesn't throw
 template<typename ReturnType, typename... Args>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible<std::tuple<Args...>>::value)
+SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>)
 class concrete_execution_stage final : public execution_stage {
     using args_tuple = std::tuple<Args...>;
-    static_assert(std::is_nothrow_move_constructible<args_tuple>::value,
+    static_assert(std::is_nothrow_move_constructible_v<args_tuple>,
                   "Function arguments need to be nothrow move constructible");
 
     static constexpr size_t flush_threshold = 128;
@@ -322,13 +322,13 @@ public:
 /// \tparam Args  argument pack containing arguments to the function object, needs
 ///                   to have move constructor that doesn't throw
 template<typename ReturnType, typename... Args>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible<std::tuple<Args...>>::value)
+SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>)
 class inheriting_concrete_execution_stage final : public inheriting_execution_stage {
     using return_type = futurize_t<ReturnType>;
     using args_tuple = std::tuple<Args...>;
     using per_group_stage_type = concrete_execution_stage<ReturnType, Args...>;
 
-    static_assert(std::is_nothrow_move_constructible<args_tuple>::value,
+    static_assert(std::is_nothrow_move_constructible_v<args_tuple>,
                   "Function arguments need to be nothrow move constructible");
 
     sstring _name;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -301,7 +301,7 @@ public:
     using class_id = unsigned int;
     class priority_class_data;
     using capacity_t = fair_group::capacity_t;
-    using signed_capacity_t = std::make_signed<capacity_t>::type;
+    using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:
     using clock_type = std::chrono::steady_clock;

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -344,8 +344,8 @@ template <typename T> struct uninitialized_wrapper_base<T, true> : private T {
 
 template <typename T>
 constexpr bool can_inherit =
-        (std::is_trivially_destructible<T>::value && std::is_trivially_constructible<T>::value &&
-                std::is_class<T>::value && !std::is_final<T>::value);
+        (std::is_trivially_destructible_v<T> && std::is_trivially_constructible_v<T> &&
+                std::is_class_v<T> && !std::is_final_v<T>);
 
 // The objective is to avoid extra space for empty types like std::tuple<>. We could use std::is_empty_v, but it is
 // better to check that both the constructor and destructor can be skipped.
@@ -355,7 +355,7 @@ struct uninitialized_wrapper
 
 template <typename T>
 struct is_trivially_move_constructible_and_destructible {
-    static constexpr bool value = std::is_trivially_move_constructible<T>::value && std::is_trivially_destructible<T>::value;
+    static constexpr bool value = std::is_trivially_move_constructible_v<T> && std::is_trivially_destructible_v<T>;
 };
 
 template <bool... v>
@@ -562,11 +562,11 @@ struct future_for_get_promise_marker {};
 /// \cond internal
 template <typename T>
 struct future_state :  public future_state_base, private internal::uninitialized_wrapper<T> {
-    static constexpr bool copy_noexcept = std::is_nothrow_copy_constructible<T>::value;
+    static constexpr bool copy_noexcept = std::is_nothrow_copy_constructible_v<T>;
     static constexpr bool has_trivial_move_and_destroy = internal::is_trivially_move_constructible_and_destructible<T>::value;
-    static_assert(std::is_nothrow_move_constructible<T>::value,
+    static_assert(std::is_nothrow_move_constructible_v<T>,
                   "Types must be no-throw move constructible");
-    static_assert(std::is_nothrow_destructible<T>::value,
+    static_assert(std::is_nothrow_destructible_v<T>,
                   "Types must be no-throw destructible");
     future_state() noexcept = default;
     void move_it(future_state&& x) noexcept {
@@ -639,7 +639,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
         return static_cast<T&&>(this->uninitialized_get());
     }
     template<typename U = T>
-    const std::enable_if_t<std::is_copy_constructible<U>::value, U>& get_value() const& noexcept(copy_noexcept) {
+    const std::enable_if_t<std::is_copy_constructible_v<U>, U>& get_value() const& noexcept(copy_noexcept) {
         assert(_u.st == state::result);
         return this->uninitialized_get();
     }
@@ -820,7 +820,7 @@ protected:
     }
 
     template<typename Exception>
-    std::enable_if_t<!std::is_same<std::remove_reference_t<Exception>, std::exception_ptr>::value, void> set_exception(Exception&& e) noexcept {
+    std::enable_if_t<!std::is_same_v<std::remove_reference_t<Exception>, std::exception_ptr>, void> set_exception(Exception&& e) noexcept {
         set_exception(std::make_exception_ptr(std::forward<Exception>(e)));
     }
 
@@ -987,7 +987,7 @@ public:
     /// Forwards the exception argument to the future and makes it
     /// available.  May be called either before or after \c get_future().
     template<typename Exception>
-    std::enable_if_t<!std::is_same<std::remove_reference_t<Exception>, std::exception_ptr>::value, void> set_exception(Exception&& e) noexcept {
+    std::enable_if_t<!std::is_same_v<std::remove_reference_t<Exception>, std::exception_ptr>, void> set_exception(Exception&& e) noexcept {
         internal::promise_base::set_exception(std::forward<Exception>(e));
     }
 

--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -111,7 +111,7 @@ output_stream<CharType>::zero_copy_split_and_put(net::packet p) noexcept {
 
 template<typename CharType>
 future<> output_stream<CharType>::write(net::packet p) noexcept {
-    static_assert(std::is_same<CharType, char>::value, "packet works on char");
+    static_assert(std::is_same_v<CharType, char>, "packet works on char");
   try {
     if (p.len() != 0) {
         assert(!_end && "Mixing buffered writes and zero-copy writes not supported yet");

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -120,7 +120,7 @@ SEASTAR_CONCEPT( requires std::is_invocable_r_v<stop_iteration, AsyncAction> || 
 inline
 future<> repeat(AsyncAction&& action) noexcept {
     using futurator = futurize<std::invoke_result_t<AsyncAction>>;
-    static_assert(std::is_same<future<stop_iteration>, typename futurator::type>::value, "bad AsyncAction signature");
+    static_assert(std::is_same_v<future<stop_iteration>, typename futurator::type>, "bad AsyncAction signature");
     for (;;) {
         // Do not type-erase here in case this is a short repeat()
         auto f = futurator::invoke(action);
@@ -505,7 +505,7 @@ inline
 size_t
 iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, IteratorCategory) {
     // May be linear time below random_access_iterator_tag, but still better than reallocation
-    if constexpr (std::is_base_of<std::forward_iterator_tag, IteratorCategory>::value) {
+    if constexpr (std::is_base_of_v<std::forward_iterator_tag, IteratorCategory>) {
         return std::distance(begin, end);
     }
 

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -277,13 +277,13 @@ struct real_counter_type_traits {
 
 template <typename T>
 struct real_counter_type_traits<true, T> {
-    using type = typename std::invoke_result<T>::type;
+    using type = std::invoke_result_t<T>;
 };
 
 template <typename T>
 struct counter_type_traits {
-    using real_traits = real_counter_type_traits<std::is_invocable<T>::value, T>;
-    static constexpr bool is_integral = std::is_integral<typename real_traits::type>::value;
+    using real_traits = real_counter_type_traits<std::is_invocable_v<T>, T>;
+    static constexpr bool is_integral = std::is_integral_v<typename real_traits::type>;
     static constexpr data_type type = is_integral ? data_type::COUNTER : data_type::REAL_COUNTER;
 };
 

--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -471,7 +471,7 @@ void throw_system_error_on(bool condition, const char* what_arg) {
 template <typename T>
 inline
 void throw_kernel_error(T r) {
-    static_assert(std::is_signed<T>::value, "kernel error variables must be signed");
+    static_assert(std::is_signed_v<T>, "kernel error variables must be signed");
     if (r < 0) {
         auto ec = -r;
         if ((ec == EBADF || ec == ENOTSOCK) && is_abort_on_ebadf_enabled()) {

--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -548,31 +548,31 @@ struct is_callable;
 
 template<typename T>
 struct is_callable<T,
-typename std::enable_if<
-!std::is_void<std::invoke_result_t<T>>::value,
-void>::type> : public std::true_type {
+std::enable_if_t<
+!std::is_void_v<std::invoke_result_t<T>>,
+void>> : public std::true_type {
 };
 
 template<typename T>
 struct is_callable<T,
-typename std::enable_if<std::is_fundamental<T>::value, void>::type> : public std::false_type {
+std::enable_if_t<std::is_fundamental_v<T>, void>> : public std::false_type {
 };
 
 template<typename T>
 struct data_type_for<T,
-typename std::enable_if<
-std::is_integral<T>::value && std::is_unsigned<T>::value,
-void>::type> : public std::integral_constant<data_type,
+std::enable_if_t<
+std::is_integral_v<T> && std::is_unsigned_v<T>,
+void>> : public std::integral_constant<data_type,
 data_type::COUNTER> {
 };
 template<typename T>
 struct data_type_for<T,
-typename std::enable_if<std::is_floating_point<T>::value, void>::type> : public std::integral_constant<
+std::enable_if_t<std::is_floating_point_v<T>, void>> : public std::integral_constant<
 data_type, data_type::GAUGE> {
 };
 template<typename T>
 struct data_type_for<T,
-typename std::enable_if<is_callable<T>::value, void>::type> : public data_type_for<
+std::enable_if_t<is_callable<T>::value, void>> : public data_type_for<
 std::invoke_result_t<T>> {
 };
 template<typename T>
@@ -593,10 +593,10 @@ public:
         const W & _v;
     };
 
-    typedef typename std::remove_reference<T>::type value_type;
-    typedef typename std::conditional<
-            is_callable<typename std::remove_reference<T>::type>::value,
-            value_type, wrap<value_type> >::type stored_type;
+    typedef std::remove_reference_t<T> value_type;
+    typedef std::conditional_t<
+            is_callable<std::remove_reference_t<T>>::value,
+            value_type, wrap<value_type> > stored_type;
 
     value(const value_type & t)
     : value<T>(data_type_for<value_type>::value, t) {
@@ -632,14 +632,14 @@ private:
         }
     }
     template<typename V>
-    typename std::enable_if<std::is_integral<V>::value, uint64_t>::type convert(
+    std::enable_if_t<std::is_integral_v<V>, uint64_t> convert(
             V v) const {
         uint64_t i = v;
         // network byte order
         return ntohq(i);
     }
     template<typename V>
-    typename std::enable_if<std::is_floating_point<V>::value, uint64_t>::type convert(
+    std::enable_if_t<std::is_floating_point_v<V>, uint64_t> convert(
             V t) const {
         union {
             uint64_t i;

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -192,13 +192,13 @@ private:
     friend struct shared_ptr_make_helper;
 
     template <typename T>
-    std::enable_if_t<std::is_base_of<peering_sharded_service<T>, T>::value>
+    std::enable_if_t<std::is_base_of_v<peering_sharded_service<T>, T>>
     set_container(T& service) noexcept {
         service.set_container(this);
     }
 
     template <typename T>
-    std::enable_if_t<!std::is_base_of<peering_sharded_service<T>, T>::value>
+    std::enable_if_t<!std::is_base_of_v<peering_sharded_service<T>, T>>
     set_container(T&) noexcept {
     }
 
@@ -846,7 +846,7 @@ SEASTAR_MODULE_EXPORT_BEGIN
 /// \c foreign_ptr<> is a move-only object; it cannot be copied.
 ///
 template <typename PtrType>
-SEASTAR_CONCEPT( requires (!std::is_pointer<PtrType>::value) )
+SEASTAR_CONCEPT( requires (!std::is_pointer_v<PtrType>) )
 class foreign_ptr {
 private:
     PtrType _value;
@@ -923,7 +923,7 @@ public:
     /// Checks whether the wrapped pointer is non-null.
     operator bool() const noexcept(noexcept(static_cast<bool>(_value))) { return static_cast<bool>(_value); }
     /// Move-assigns a \c foreign_ptr<>.
-    foreign_ptr& operator=(foreign_ptr&& other) noexcept(std::is_nothrow_move_constructible<PtrType>::value) {
+    foreign_ptr& operator=(foreign_ptr&& other) noexcept(std::is_nothrow_move_constructible_v<PtrType>) {
          destroy(std::move(_value), _cpu);
         _value = std::move(other._value);
         _cpu = other._cpu;

--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -239,7 +239,7 @@ struct lw_shared_ptr_accessors_no_esft {
 // implementation based on whether T inherits from enable_lw_shared_from_this<T>.
 template <typename T, typename U = void>
 struct lw_shared_ptr_accessors : std::conditional_t<
-         std::is_base_of<enable_lw_shared_from_this<T>, T>::value,
+         std::is_base_of_v<enable_lw_shared_from_this<T>, T>,
          lw_shared_ptr_accessors_esft<T>,
          lw_shared_ptr_accessors_no_esft<T>> {
 };
@@ -546,7 +546,7 @@ public:
         x._b = nullptr;
         x._p = nullptr;
     }
-    template <typename U, typename = std::enable_if_t<std::is_base_of<T, U>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
     shared_ptr(const shared_ptr<U>& x) noexcept
             : _b(x._b)
             , _p(x._p) {
@@ -554,7 +554,7 @@ public:
             ++_b->count;
         }
     }
-    template <typename U, typename = std::enable_if_t<std::is_base_of<T, U>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
     shared_ptr(shared_ptr<U>&& x) noexcept
             : _b(x._b)
             , _p(x._p) {
@@ -588,7 +588,7 @@ public:
     shared_ptr& operator=(std::nullptr_t) noexcept {
         return *this = shared_ptr();
     }
-    template <typename U, typename = std::enable_if_t<std::is_base_of<T, U>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
     shared_ptr& operator=(const shared_ptr<U>& x) noexcept {
         if (*this != x) {
             this->~shared_ptr();
@@ -596,7 +596,7 @@ public:
         }
         return *this;
     }
-    template <typename U, typename = std::enable_if_t<std::is_base_of<T, U>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
     shared_ptr& operator=(shared_ptr<U>&& x) noexcept {
         if (*this != x) {
             this->~shared_ptr();
@@ -681,7 +681,7 @@ template <typename T, typename... A>
 inline
 shared_ptr<T>
 make_shared(A&&... a) {
-    using helper = shared_ptr_make_helper<T, std::is_base_of<shared_ptr_count_base, T>::value>;
+    using helper = shared_ptr_make_helper<T, std::is_base_of_v<shared_ptr_count_base, T>>;
     return helper::make(std::forward<A>(a)...);
 }
 
@@ -689,7 +689,7 @@ template <typename T>
 inline
 shared_ptr<T>
 make_shared(T&& a) {
-    using helper = shared_ptr_make_helper<T, std::is_base_of<shared_ptr_count_base, T>::value>;
+    using helper = shared_ptr_make_helper<T, std::is_base_of_v<shared_ptr_count_base, T>>;
     return helper::make(std::forward<T>(a));
 }
 

--- a/include/seastar/core/simple-stream.hh
+++ b/include/seastar/core/simple-stream.hh
@@ -239,9 +239,9 @@ public:
         // fragmented and simple input stream are PODs and the branch below
         // is optimized away, so throwable copy constructors aren't something
         // we want.
-        static_assert(std::is_nothrow_copy_constructible<fragmented>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<fragmented>,
                       "seastar::memory_output_stream::fragmented should be copy constructible");
-        static_assert(std::is_nothrow_copy_constructible<simple>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<simple>,
                       "seastar::memory_output_stream::simple should be copy constructible");
         if (_is_simple) {
             new (&_simple) simple(other._simple);
@@ -262,7 +262,7 @@ public:
     [[gnu::always_inline]]
     memory_output_stream& operator=(const memory_output_stream& other) noexcept {
         // Copy constructor being noexcept makes copy assignment simpler.
-        static_assert(std::is_nothrow_copy_constructible<memory_output_stream>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<memory_output_stream>,
                       "memory_output_stream copy constructor shouldn't throw");
         if (this != &other) {
             this->~memory_output_stream();
@@ -505,9 +505,9 @@ public:
         // fragmented and simple input stream are PODs and the branch below
         // is optimized away, so throwable copy constructors aren't something
         // we want.
-        static_assert(std::is_nothrow_copy_constructible<fragmented>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<fragmented>,
                       "seastar::memory_input_stream::fragmented should be copy constructible");
-        static_assert(std::is_nothrow_copy_constructible<simple>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<simple>,
                       "seastar::memory_input_stream::simple should be copy constructible");
         if (_is_simple) {
             new (&_simple) simple(other._simple);
@@ -528,7 +528,7 @@ public:
     [[gnu::always_inline]]
     memory_input_stream& operator=(const memory_input_stream& other) noexcept {
         // Copy constructor being noexcept makes copy assignment simpler.
-        static_assert(std::is_nothrow_copy_constructible<memory_input_stream>::value,
+        static_assert(std::is_nothrow_copy_constructible_v<memory_input_stream>,
                       "memory_input_stream copy constructor shouldn't throw");
         if (this != &other) {
             this->~memory_input_stream();

--- a/include/seastar/core/slab.hh
+++ b/include/seastar/core/slab.hh
@@ -208,7 +208,7 @@ public:
                                std::function<void (slab_page_desc& desc)> insert_slab_page_desc,
                                Args&&... args) {
         // allocate slab page.
-        constexpr size_t alignment = std::alignment_of<Item>::value;
+        constexpr size_t alignment = std::alignment_of_v<Item>;
         void *slab_page = aligned_alloc(alignment, max_object_size);
         if (!slab_page) {
             throw std::bad_alloc{};
@@ -358,7 +358,7 @@ private:
     }
 
     void initialize_slab_allocator(double growth_factor, uint64_t limit) {
-        constexpr size_t alignment = std::alignment_of<Item>::value;
+        constexpr size_t alignment = std::alignment_of_v<Item>;
         constexpr size_t initial_size = 96;
         size_t size = initial_size; // initial object size
         uint8_t slab_class_id = 0U;

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -376,7 +376,7 @@ public:
                 if (!is_future<ret_type>::value) {
                     // Non-deferring function, so don't worry about func lifetime
                     return futurize<ret_type>::invoke(std::forward<Func>(func));
-                } else if (std::is_lvalue_reference<Func>::value) {
+                } else if (std::is_lvalue_reference_v<Func>) {
                     // func is an lvalue, so caller worries about its lifetime
                     return futurize<ret_type>::invoke(func);
                 } else {
@@ -427,7 +427,7 @@ public:
     template<typename Func>
     SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
     static future<> invoke_on_all(smp_submit_to_options options, Func&& func) noexcept {
-        static_assert(std::is_same<future<>, typename futurize<std::invoke_result_t<Func>>::type>::value, "bad Func signature");
+        static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
         return parallel_for_each(all_cpus(), [options, &func] (unsigned id) {
             return smp::submit_to(id, options, Func(func));
@@ -459,7 +459,7 @@ public:
     SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> &&
             std::is_nothrow_copy_constructible_v<Func> )
     static future<> invoke_on_others(unsigned cpu_id, smp_submit_to_options options, Func func) noexcept {
-        static_assert(std::is_same<future<>, typename futurize<std::invoke_result_t<Func>>::type>::value, "bad Func signature");
+        static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
         return parallel_for_each(all_cpus(), [cpu_id, options, func = std::move(func)] (unsigned id) {
             return id != cpu_id ? smp::submit_to(id, options, Func(func)) : make_ready_future<>();

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -74,9 +74,9 @@ SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 class basic_sstring {
     static_assert(
-            (std::is_same<char_type, char>::value
-             || std::is_same<char_type, signed char>::value
-             || std::is_same<char_type, unsigned char>::value),
+            (std::is_same_v<char_type, char>
+             || std::is_same_v<char_type, signed char>
+             || std::is_same_v<char_type, unsigned char>),
             "basic_sstring only supports single byte char types");
     union contents {
         struct external_type {

--- a/include/seastar/core/transfer.hh
+++ b/include/seastar/core/transfer.hh
@@ -47,7 +47,7 @@ template <typename T, typename Alloc>
 inline
 void
 transfer_pass1(Alloc& a, T* from, T* to,
-        typename std::enable_if<std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
+        std::enable_if_t<std::is_nothrow_move_constructible_v<T>>* = nullptr) {
     std::allocator_traits<Alloc>::construct(a, to, std::move(*from));
     std::allocator_traits<Alloc>::destroy(a, from);
 }
@@ -56,14 +56,14 @@ template <typename T, typename Alloc>
 inline
 void
 transfer_pass2(Alloc&, T*, T*,
-        typename std::enable_if<std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
+        std::enable_if_t<std::is_nothrow_move_constructible_v<T>>* = nullptr) {
 }
 
 template <typename T, typename Alloc>
 inline
 void
 transfer_pass1(Alloc& a, T* from, T* to,
-        typename std::enable_if<!std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
+        std::enable_if_t<!std::is_nothrow_move_constructible_v<T>>* = nullptr) {
     std::allocator_traits<Alloc>::construct(a, to, *from);
 }
 
@@ -71,7 +71,7 @@ template <typename T, typename Alloc>
 inline
 void
 transfer_pass2(Alloc& a, T* from, T*,
-        typename std::enable_if<!std::is_nothrow_move_constructible<T>::value>::type* = nullptr) {
+        std::enable_if_t<!std::is_nothrow_move_constructible_v<T>>* = nullptr) {
     std::allocator_traits<Alloc>::destroy(a, from);
 }
 SEASTAR_MODULE_EXPORT_END

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -340,7 +340,7 @@ namespace internal {
 template<typename Future>
 struct future_has_value {
     enum {
-        value = !std::is_same<std::decay_t<Future>, future<>>::value
+        value = !std::is_same_v<std::decay_t<Future>, future<>>
     };
 };
 

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -213,7 +213,7 @@ template <typename Serializer, typename Output>
 struct marshall_one {
     template <typename T> struct helper {
         static void doit(Serializer& serializer, Output& out, const T& arg) {
-            using serialize_helper_type = serialize_helper<is_smart_ptr<typename std::remove_reference<T>::type>::value>;
+            using serialize_helper_type = serialize_helper<is_smart_ptr<typename std::remove_reference_t<T>>::value>;
             serialize_helper_type::serialize(serializer, out, arg);
         }
     };
@@ -610,13 +610,13 @@ auto recv_helper(signature<Ret (InArgs...)> sig, Func&& func, WantClientInfo, Wa
 
 // helper to create copy constructible lambda from non copy constructible one. std::function<> works only with former kind.
 template<typename Func>
-auto make_copyable_function(Func&& func, std::enable_if_t<!std::is_copy_constructible<std::decay_t<Func>>::value, void*> = nullptr) {
+auto make_copyable_function(Func&& func, std::enable_if_t<!std::is_copy_constructible_v<std::decay_t<Func>>, void*> = nullptr) {
   auto p = make_lw_shared<typename std::decay_t<Func>>(std::forward<Func>(func));
   return [p] (auto&&... args) { return (*p)( std::forward<decltype(args)>(args)... ); };
 }
 
 template<typename Func>
-auto make_copyable_function(Func&& func, std::enable_if_t<std::is_copy_constructible<std::decay_t<Func>>::value, void*> = nullptr) {
+auto make_copyable_function(Func&& func, std::enable_if_t<std::is_copy_constructible_v<std::decay_t<Func>>, void*> = nullptr) {
     return std::forward<Func>(func);
 }
 

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -102,8 +102,8 @@ struct client_info {
         return boost::any_cast<T&>(it->second);
     }
     template <typename T>
-    typename std::add_const<T>::type& retrieve_auxiliary(const sstring& key) const {
-        return const_cast<client_info*>(this)->retrieve_auxiliary<typename std::add_const<T>::type>(key);
+    std::add_const_t<T>& retrieve_auxiliary(const sstring& key) const {
+        return const_cast<client_info*>(this)->retrieve_auxiliary<std::add_const_t<T>>(key);
     }
     template <typename T>
     T* retrieve_auxiliary_opt(const sstring& key) noexcept {

--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -265,7 +265,7 @@ protected:
         return if_constexpr_<is_future<decltype(_test->run())>::value>([&] (auto&&...) {
             measure_time.start_run(&_instructions_retired_counter);
             return do_until([this] { return this->stop_iteration(); }, [this] {
-                return if_constexpr_<std::is_same<decltype(_test->run()), future<>>::value>([&] (auto&&...) {
+                return if_constexpr_<std::is_same_v<decltype(_test->run()), future<>>>([&] (auto&&...) {
                     this->next_iteration(1);
                     return _test->run();
                 }, [&] (auto&&... dependency) {
@@ -283,7 +283,7 @@ protected:
         }, [&] (auto&&...) {
             measure_time.start_run(&_instructions_retired_counter);
             while (!stop_iteration()) {
-                if_constexpr_<std::is_void<decltype(_test->run())>::value>([&] (auto&&...) {
+                if_constexpr_<std::is_void_v<decltype(_test->run())>>([&] (auto&&...) {
                     (void)_test->run();
                     this->next_iteration(1);
                 }, [&] (auto&&... dependency) {

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -235,7 +235,7 @@ SEASTAR_MODULE_EXPORT
 template <class Exc, typename... Args>
 std::exception_ptr make_backtraced_exception_ptr(Args&&... args) {
     using exc_type = std::decay_t<Exc>;
-    static_assert(std::is_base_of<std::exception, exc_type>::value,
+    static_assert(std::is_base_of_v<std::exception, exc_type>,
             "throw_with_backtrace only works with exception types");
     return std::make_exception_ptr<internal::backtraced<exc_type>>(Exc(std::forward<Args>(args)...));
 }

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -51,7 +51,7 @@ class [[nodiscard("unassigned deferred_action")]] deferred_action {
     Func _func;
     bool _cancelled = false;
 public:
-    static_assert(std::is_nothrow_move_constructible<Func>::value, "Func(Func&&) must be noexcept");
+    static_assert(std::is_nothrow_move_constructible_v<Func>, "Func(Func&&) must be noexcept");
     deferred_action(Func&& func) noexcept : _func(std::move(func)) {}
     deferred_action(deferred_action&& o) noexcept : _func(std::move(o._func)), _cancelled(o._cancelled) {
         o._cancelled = true;

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -90,7 +90,7 @@ struct is_nothrow_if_object {
 
 template<typename Arg>
 struct is_nothrow_if_object<Arg> {
-    static constexpr bool value = !std::is_object<Arg>::value || std::is_nothrow_move_constructible<Arg>::value;
+    static constexpr bool value = !std::is_object_v<Arg> || std::is_nothrow_move_constructible_v<Arg>;
 };
 
 template<>
@@ -133,15 +133,15 @@ private:
             destroy(from);
         }
         static constexpr move_type select_move_thunk() {
-            bool can_trivially_move = std::is_trivially_move_constructible<Func>::value
-                    && std::is_trivially_destructible<Func>::value;
+            bool can_trivially_move = std::is_trivially_move_constructible_v<Func>
+                    && std::is_trivially_destructible_v<Func>;
             return can_trivially_move ? trivial_direct_move<internal::used_size<Func>::value> : move;
         }
         static void destroy(noncopyable_function_base* func) {
             access(func)->~Func();
         }
         static constexpr destroy_type select_destroy_thunk() {
-            return std::is_trivially_destructible<Func>::value ? trivial_direct_destroy : destroy;
+            return std::is_trivially_destructible_v<Func> ? trivial_direct_destroy : destroy;
         }
         static void initialize(Func&& from, noncopyable_function* to) {
             new (access(to)) Func(std::move(from));
@@ -173,7 +173,7 @@ private:
     template <typename Func>
     static constexpr bool is_direct() {
         return sizeof(Func) <= nr_direct && alignof(Func) <= alignof(storage)
-                && std::is_nothrow_move_constructible<Func>::value;
+                && std::is_nothrow_move_constructible_v<Func>;
     }
     template <typename Func>
     struct vtable_for : select_vtable_for<Func, is_direct<Func>()> {};

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -36,8 +36,8 @@ SEASTAR_CONCEPT(
 
 template<typename T>
 concept OptimizableOptional =
-    std::is_default_constructible<T>::value
-        && std::is_nothrow_move_assignable<T>::value
+    std::is_default_constructible_v<T>
+        && std::is_nothrow_move_assignable_v<T>
         && requires(const T& obj) {
             { bool(obj) } noexcept;
         };
@@ -70,7 +70,7 @@ public:
         return *this;
     }
     template<typename U>
-    std::enable_if_t<std::is_same<std::decay_t<U>, T>::value, optimized_optional&>
+    std::enable_if_t<std::is_same_v<std::decay_t<U>, T>, optimized_optional&>
     operator=(U&& obj) noexcept {
         _object = std::forward<U>(obj);
         return *this;

--- a/include/seastar/util/tmp_file.hh
+++ b/include/seastar/util/tmp_file.hh
@@ -37,9 +37,9 @@ class tmp_file {
     file _file;
     bool _is_open = false;
 
-    static_assert(std::is_nothrow_constructible<std::filesystem::path>::value,
+    static_assert(std::is_nothrow_constructible_v<std::filesystem::path>,
         "filesystem::path's constructor must not throw");
-    static_assert(std::is_nothrow_move_constructible<std::filesystem::path>::value,
+    static_assert(std::is_nothrow_move_constructible_v<std::filesystem::path>,
         "filesystem::path's move constructor must not throw");
 public:
     tmp_file() noexcept = default;
@@ -60,7 +60,7 @@ public:
     static future<> do_with(std::filesystem::path path_template, Func&& func,
             open_flags oflags = open_flags::rw,
             file_open_options options = {}) noexcept {
-        static_assert(std::is_nothrow_move_constructible<Func>::value,
+        static_assert(std::is_nothrow_move_constructible_v<Func>,
             "Func's move constructor must not throw");
         return seastar::do_with(tmp_file(), [func = std::move(func), path_template = std::move(path_template), oflags, options = std::move(options)] (tmp_file& t) mutable {
             return t.open(std::move(path_template), oflags, std::move(options)).then([&t, func = std::move(func)] () mutable {

--- a/include/seastar/util/used_size.hh
+++ b/include/seastar/util/used_size.hh
@@ -32,7 +32,7 @@ namespace internal {
 // used. This helper is used to avoid accessing that byte.
 template<typename T>
 struct used_size {
-    static constexpr size_t value = std::is_empty<T>::value ? 0 : sizeof(T);
+    static constexpr size_t value = std::is_empty_v<T> ? 0 : sizeof(T);
 };
 }
 }

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -39,7 +39,7 @@ namespace seastar {
 
 // We can't test future_state_base directly because its private
 // destructor is protected.
-static_assert(std::is_nothrow_move_constructible<future_state<std::tuple<int>>>::value,
+static_assert(std::is_nothrow_move_constructible_v<future_state<std::tuple<int>>>,
               "future_state's move constructor must not throw");
 
 static_assert(sizeof(future_state<std::tuple<>>) <= 8, "future_state<std::tuple<>> is too large");
@@ -50,14 +50,14 @@ static_assert(future_state<long>::has_trivial_move_and_destroy, "future_state<lo
 // We need to be able to move and copy std::exception_ptr in and out
 // of future/promise/continuations without that producing a new
 // exception.
-static_assert(std::is_nothrow_copy_constructible<std::exception_ptr>::value,
+static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>,
     "std::exception_ptr's copy constructor must not throw");
-static_assert(std::is_nothrow_move_constructible<std::exception_ptr>::value,
+static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>,
     "std::exception_ptr's move constructor must not throw");
 
 namespace internal {
 
-static_assert(std::is_empty<uninitialized_wrapper<std::tuple<>>>::value, "This should still be empty");
+static_assert(std::is_empty_v<uninitialized_wrapper<std::tuple<>>>, "This should still be empty");
 
 void promise_base::move_it(promise_base&& x) noexcept {
     // Don't use std::exchange to make sure x's values are nulled even

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -201,7 +201,7 @@ struct cpwriter {
         return *this;
     }
     template<typename T>
-    typename std::enable_if<std::is_integral<T>::value, cpwriter &>::type write(
+    std::enable_if_t<std::is_integral_v<T>, cpwriter &> write(
             const T & t) {
         T tmp = net::hton(t);
         auto * p = reinterpret_cast<const uint8_t *>(&tmp);
@@ -210,7 +210,7 @@ struct cpwriter {
         return *this;
     }
     template<typename T>
-    typename std::enable_if<std::is_integral<T>::value, cpwriter &>::type write_le(const T & t) {
+    std::enable_if_t<std::is_integral_v<T>, cpwriter &> write_le(const T & t) {
         T tmp = cpu_to_le(t);
         auto * p = reinterpret_cast<const uint8_t *>(&tmp);
         auto * e = p + sizeof(T);
@@ -253,7 +253,7 @@ struct cpwriter {
         return *this;
     }
     template<typename T>
-    typename std::enable_if<std::is_integral<T>::value, cpwriter &>::type put(
+    std::enable_if_t<std::is_integral_v<T>, cpwriter &> put(
             part_type type, T t) {
         write(uint16_t(type));
         write(uint16_t(4 + sizeof(t)));

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -80,7 +80,7 @@ public:
     template<typename Output, typename Function>
     SEASTAR_CONCEPT(requires requires (Function fn, char* ptr) {
         { fn(ptr) } -> std::convertible_to<size_t>;
-    } && (std::is_same<Output, snd_buf>::value || std::is_same<Output, rcv_buf>::value))
+    } && (std::is_same_v<Output, snd_buf> || std::is_same_v<Output, rcv_buf>))
     Output with_reserved(size_t max_size, Function&& fn) {
         if (max_size <= chunk_size) {
             auto dst = temporary_buffer<char>(max_size);

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -47,14 +47,14 @@ struct serializer {
 template <typename T, typename Output>
 inline
 void write_arithmetic_type(Output& out, T v) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
 }
 
 template <typename T, typename Input>
 inline
 T read_arithmetic_type(Input& in) {
-    static_assert(std::is_arithmetic<T>::value, "must be arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
     T v;
     in.read(reinterpret_cast<char*>(&v), sizeof(T));
     return v;

--- a/tests/unit/tuple_utils_test.cc
+++ b/tests/unit/tuple_utils_test.cc
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(map_types) {
     using before_tuple = std::tuple<double, bool, const char*>;
     using after_tuple = typename tuple_map_types<transform_type, before_tuple>::type;
 
-    BOOST_REQUIRE((std::is_same<after_tuple, std::tuple<char, int, const char*>>::value));
+    BOOST_REQUIRE((std::is_same_v<after_tuple, std::tuple<char, int, const char*>>));
 }
 
 namespace {
@@ -92,8 +92,8 @@ BOOST_AUTO_TEST_CASE(filter_by_type) {
     using before_tuple = std::tuple<bool, int, bool, double, bool, char>;
 
     const auto t = tuple_filter_by_type<keep_type>(before_tuple{true, 10, false, 5.5, true, 'a'});
-    using filtered_type = typename std::decay<decltype(t)>::type;
+    using filtered_type = std::decay_t<decltype(t)>;
 
-    BOOST_REQUIRE((std::is_same<filtered_type, std::tuple<int, double, char>>::value));
+    BOOST_REQUIRE((std::is_same_v<filtered_type, std::tuple<int, double, char>>));
     BOOST_REQUIRE(t == std::make_tuple(10, 5.5, 'a'));
 }


### PR DESCRIPTION
instead of using templates like `std::is_empty<foo>`, and check its member variable like `std::is_empty<foo>::value`, use its corresponding variable template of `std::is_empty_v<foo>` for better readablity.