### PR TITLE
Address issue where Seastar faults in toeplitz hash when reassembling fragment

### DIFF
--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -196,22 +196,22 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
                 if (smp::count == 1) {
                     l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
                 } else {
-                size_t l4_offset = 0;
-                forward_hash hash_data;
-                hash_data.push_back(hton(h.src_ip.ip));
-                hash_data.push_back(hton(h.dst_ip.ip));
-                auto forwarded = l4->forward(hash_data, ip_data, l4_offset);
-                if (forwarded) {
-                    cpu_id = _netif->hash2cpu(toeplitz_hash(_netif->rss_key(), hash_data));
-                    // No need to forward if the dst cpu is the current cpu
-                    if (cpu_id == this_shard_id()) {
-                        l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
-                    } else {
-                        auto to = _netif->hw_address();
-                        auto pkt = frag.get_assembled_packet(from, to);
-                        _netif->forward(cpu_id, std::move(pkt));
+                    size_t l4_offset = 0;
+                    forward_hash hash_data;
+                    hash_data.push_back(hton(h.src_ip.ip));
+                    hash_data.push_back(hton(h.dst_ip.ip));
+                    auto forwarded = l4->forward(hash_data, ip_data, l4_offset);
+                    if (forwarded) {
+                        cpu_id = _netif->hash2cpu(toeplitz_hash(_netif->rss_key(), hash_data));
+                        // No need to forward if the dst cpu is the current cpu
+                        if (cpu_id == this_shard_id()) {
+                            l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
+                        } else {
+                            auto to = _netif->hw_address();
+                            auto pkt = frag.get_assembled_packet(from, to);
+                            _netif->forward(cpu_id, std::move(pkt));
+                        }
                     }
-                }
                 }
             }
 

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -193,6 +193,9 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
             auto cpu_id = this_shard_id();
             auto l4 = _l4[h.ip_proto];
             if (l4) {
+                if (smp::count == 1) {
+                    l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
+                } else {
                 size_t l4_offset = 0;
                 forward_hash hash_data;
                 hash_data.push_back(hton(h.src_ip.ip));
@@ -208,6 +211,7 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
                         auto pkt = frag.get_assembled_packet(from, to);
                         _netif->forward(cpu_id, std::move(pkt));
                     }
+                }
                 }
             }
 


### PR DESCRIPTION
In dpdk.cc:1515 when running program utilizing Seastar with smp::count == 1, rss hashing is NOT enabled, but when a fragmented packet is reassembled in ip.cc:195, no check is done if smp::count == 1, so the following line is called to identify cpu to forward packet to:

cpu_id = _netif->hash2cpu(toeplitz_hash(_netif->rss_key(), hash_data));

Since running with only a single cpu and hashing not enabled, the call to toeplitz_hash faults. 

Issue resolved by checking to see if smp::count == 1 after defragmentation and if so, bypassing hash calls and just calling l4->received() directly