### PR TITLE
perftune.py: skip discovering IRQs for iSCSI disks

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1359,6 +1359,12 @@ class DiskPerfTuner(PerfTunerBase):
                 udev_obj = pyudev.Devices.from_device_file(self.__pyudev_ctx, "/dev/{}".format(device))
                 dev_sys_path = udev_obj.sys_path
 
+                # If the device is iSCSI disk, we should skip discovering IRQs
+                # since it's virtual device
+                if re.search(r'^/sys/devices/platform/host[0-9]+/session[0-9]+', udev_obj.sys_path):
+                    disk2irqs[device] = []
+                    continue
+
                 # If the device is a virtual NVMe device it's sys file name goes as follows:
                 # /sys/devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1
                 #


### PR DESCRIPTION
Currently, when we use iSCSI disk for the data volume, we get following error while running "--tune disks":

 ERROR: [Errno 2] No such file or directory: '/sys/devices/platform/modalias'. Your system can't be tuned until the issue is fixed.

This is because iSCSI is virtual device, it does not pointed to /sys/devices/pciXXX, and does not have IRQs informations.

We should just skip discovering IRQs for such devices, instead of calling learn_all_irqs_one().

Fixes scylladb/scylladb#10367