### PR TITLE
gate: correct the typo in doxygen comment

### DIFF
--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -161,7 +161,7 @@ public:
 
     /// Facility to hold a gate opened using RAII.
     ///
-    /// A \ref gate::holder is usually obtained using \ref gate::get_holder.
+    /// A \ref gate::holder is usually obtained using \ref gate::hold.
     ///
     /// The \c gate is entered when the \ref gate::holder is constructed,
     /// And the \c gate is left when the \ref gate::holder is destroyed.


### PR DESCRIPTION
gate::get_holder never exists, it should be gate::hold.