### PR TITLE
shared_future: make available() immediate after set_value()

### DIFF
--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -53,6 +53,7 @@ struct future_option_traits<with_clock<Clock>, T> {
 
     using future_type = future<T>;
     using promise_type = promise<T>;
+    using continuation_base_type = continuation_base<T>;
 };
 
 template <typename Clock>
@@ -61,6 +62,7 @@ struct future_option_traits<with_clock<Clock>> {
 
     using future_type = future<>;
     using promise_type = promise<>;
+    using continuation_base_type = continuation_base<>;
 };
 
 template <typename T>
@@ -109,6 +111,7 @@ template<typename... T>
 class shared_future {
     template <typename... U> friend class shared_promise;
     using options = future_option_traits<T...>;
+    using continuation_base_type = typename options::continuation_base_type;
 public:
     using clock = typename options::clock_type;
     using time_point = typename clock::time_point;
@@ -117,8 +120,9 @@ public:
     using value_tuple_type = typename future_type::tuple_type;
 private:
     /// \cond internal
-    class shared_state : public enable_lw_shared_from_this<shared_state> {
-        future_type _original_future;
+    class shared_state final : public enable_lw_shared_from_this<shared_state>, public continuation_base_type {
+        // Ensures that shared_state is alive until run_and_dispose() runs.
+        lw_shared_ptr<shared_state> _keepaliver;
         struct entry {
             promise_type pr;
             std::optional<abort_on_expiry<clock>> timer;
@@ -141,41 +145,47 @@ private:
             // Don't warn if the shared future is exceptional. Any
             // warnings will be reported by the futures returned by
             // get_future.
-            if (_original_future.failed()) {
-                _original_future.ignore_ready_future();
+            if (this->_state.failed()) {
+                this->_state.ignore();
             }
         }
-        explicit shared_state(future_type f) noexcept : _original_future(std::move(f)) { }
-        void resolve(future_type&& f) noexcept {
-            _original_future = std::move(f);
-            auto& state = _original_future._state;
-            if (_original_future.failed()) {
+        explicit shared_state(future_type f) noexcept
+                : _keepaliver(f.available() ? nullptr : this->shared_from_this()) {
+            if (f.available()) {
+                this->set_state(f.get_available_state_ref());
+            } else {
+                internal::set_callback(std::move(f), this);
+            }
+        }
+        virtual void run_and_dispose() noexcept override {
+            if (this->_state.failed()) {
                 while (_peers) {
-                    _peers.front().pr.set_exception(state.get_exception());
+                    _peers.front().pr.set_exception(this->_state.get_exception());
                     _peers.pop_front();
                 }
             } else {
                 while (_peers) {
                     auto& p = _peers.front().pr;
                     try {
-                        p.set_value(state.get_value());
+                        p.set_value(this->_state.get_value());
                     } catch (...) {
                         p.set_exception(std::current_exception());
                     }
                     _peers.pop_front();
                 }
             }
+            _keepaliver.release();
         }
 
         future_type get_future(time_point timeout = time_point::max()) noexcept {
             // Note that some functions called below may throw,
-            // like pushing to _peers or copying _original_future's ready value.
+            // like pushing to _peers or copying _state's ready value.
             // We'd rather terminate than propagate these errors similar to
             // .then()'s failure to allocate a continuation as the caller cannot
             // distinguish between an error returned by the original future to
             // failing to perform `get_future` itself.
             memory::scoped_critical_alloc_section _;
-            if (!_original_future.available()) {
+            if (!this->_state.available()) {
                 entry& e = _peers.emplace_back();
 
                 auto f = e.pr.get_future();
@@ -184,53 +194,41 @@ private:
                     abort_source& as = e.timer->abort_source();
                    _peers.make_back_abortable(as);
                 }
-                if (_original_future._state.valid()) {
-                    // _original_future's result is forwarded to each peer.
-                    (void)_original_future.then_wrapped([s = this->shared_from_this()] (future_type&& f) mutable {
-                        s->resolve(std::move(f));
-                    });
-                }
                 return f;
-            } else if (_original_future.failed()) {
-                return future_type(exception_future_marker(), std::exception_ptr(_original_future._state.get_exception()));
+            } else if (this->_state.failed()) {
+                return future_type(exception_future_marker(), std::exception_ptr(this->_state.get_exception()));
             } else {
-                return future_type(ready_future_marker(), _original_future._state.get_value());
+                return future_type(ready_future_marker(), this->_state.get_value());
             }
         }
 
         future_type get_future(abort_source& as) noexcept {
             // Note that some functions called below may throw,
-            // like pushing to _peers or copying _original_future's ready value.
+            // like pushing to _peers or copying _state's ready value.
             // We'd rather terminate than propagate these errors similar to
             // .then()'s failure to allocate a continuation as the caller cannot
             // distinguish between an error returned by the original future to
             // failing to perform `get_future` itself.
             memory::scoped_critical_alloc_section _;
-            if (!_original_future.available()) {
+            if (!this->_state.available()) {
                 entry& e = _peers.emplace_back();
 
                 auto f = e.pr.get_future();
                 _peers.make_back_abortable(as);
-                if (_original_future._state.valid()) {
-                    // _original_future's result is forwarded to each peer.
-                    (void)_original_future.then_wrapped([s = this->shared_from_this()] (future_type&& f) mutable {
-                        s->resolve(std::move(f));
-                    });
-                }
                 return f;
-            } else if (_original_future.failed()) {
-                return future_type(exception_future_marker(), std::exception_ptr(_original_future._state.get_exception()));
+            } else if (this->_state.failed()) {
+                return future_type(exception_future_marker(), std::exception_ptr(this->_state.get_exception()));
             } else {
-                return future_type(ready_future_marker(), _original_future._state.get_value());
+                return future_type(ready_future_marker(), this->_state.get_value());
             }
         }
 
         bool available() const noexcept {
-            return _original_future.available();
+            return this->_state.available();
         }
 
         bool failed() const noexcept {
-            return _original_future.failed();
+            return this->_state.failed();
         }
     };
     /// \endcond

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1547,6 +1547,20 @@ SEASTAR_THREAD_TEST_CASE(test_shared_future_with_abort) {
     BOOST_REQUIRE(f4.available());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_shared_promise_with_outstanding_future_is_immediately_available) {
+    shared_promise<> pr1;
+    auto f1 = pr1.get_shared_future();
+    pr1.set_value();
+    BOOST_REQUIRE(pr1.available());
+    BOOST_REQUIRE_NO_THROW(f1.get());
+
+    shared_promise<> pr2;
+    auto f2 = pr2.get_shared_future();
+    pr2.set_exception(std::runtime_error("oops"));
+    BOOST_REQUIRE(pr2.available());
+    BOOST_REQUIRE_THROW(f2.get(), std::runtime_error);
+}
+
 SEASTAR_TEST_CASE(test_when_all_succeed_tuples) {
     return seastar::when_all_succeed(
         make_ready_future<>(),


### PR DESCRIPTION
A shared future takes a regular future on construction and resolves after the original future resolves. This is implemented by attaching a `then_wrapped` continuation on the original future which, when run, forwards the result of the original future to the currently registered waiters.

The original future is kept in the `_original_future` field. The continuation is attached on the first `shared_future::get_future()` call - which causes the `_original_future` to become invalid - and it is reassigned again at the end of the continuation.

This implementation detail has an effect on `shared_future::available()`, which is implemented via `_original_future.available()`. When the promise associated with the original future is set, the continuation is scheduled for execution but does not run immediately. Because of that, `_original_future` is not updated immediately after `promise::set_value` and `shared_future::available()` keeps returning false until the continuation runs.

This is especially confusing for `shared_promise`, which are essentially a `promise` + `shared_future` pair and have both `set_value` and `available` methods: setting the shared promise does not cause it to become available.

Fix this by getting rid of the `_original_future` field and by changing the internal `shared_state` to derive from `continuation_base`. By being a continuation, the shared state now always has access to the current `future_state` (no reassigning is necessary), so the `available()` method now works properly.

Fixes: scylladb/seastar#1926