### PR TITLE
test_runner: do not throw when seastar.app fails to start

### DIFF
--- a/include/seastar/testing/test_runner.hh
+++ b/include/seastar/testing/test_runner.hh
@@ -48,7 +48,7 @@ private:
         start_thread_args(int ac_, char** av_) noexcept : ac(ac_), av(av_) {}
     };
     std::unique_ptr<start_thread_args> _st_args;
-    void start_thread(int ac, char** av);
+    int start_thread(int ac, char** av);
 public:
     // Returns whether initialization was successful.
     // Will return as soon as the seastar::app was started.


### PR DESCRIPTION
we feed seastar::app with the command line options passed in the command line as they are, and seastar::app chokes at seeing unknown options.

in `test_runner::start_thread()`, we throw in this case, but `test_runner::run_sync()` expects that the worker thread to start the reactor and then to serve the tasks, without throwing any exception. while, if an exception is thrown in the worker thread, the worker thread exits. the parent thread is still waiting and expecting the worker thread to signal it for serving, that's why the test executable hangs at seeing unknown arguments.

in this change, instead of throwing at unknown arguments or when unable to start the reactor, we just report it back to the caller, so that it can recored the failure as `_exit_code`, and skip this test and all following tests. so `alloc_test  -- c2` does not hang anymore.

Fixes #673
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>