### PR TITLE
defer, closeable: do not use [[nodiscard(str)]]

### DIFF
--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -48,7 +48,7 @@ concept closeable = requires (Object o) {
 /// needs to wait on the \c obj close() future.
 template <typename Object>
 SEASTAR_CONCEPT( requires closeable<Object> )
-class [[nodiscard("unassigned deferred_close")]] deferred_close {
+class [[nodiscard]] deferred_close {
     std::reference_wrapper<Object> _obj;
     bool _closed = false;
 
@@ -122,7 +122,7 @@ concept stoppable = requires (Object o) {
 /// needs to wait on the \c obj stop() future.
 template <typename Object>
 SEASTAR_CONCEPT( requires stoppable<Object> )
-class [[nodiscard("unassigned deferred_stop")]] deferred_stop {
+class [[nodiscard]] deferred_stop {
     std::reference_wrapper<Object> _obj;
     bool _stopped = false;
 

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -47,7 +47,7 @@ namespace seastar {
 
 template <typename Func>
 SEASTAR_CONCEPT( requires deferrable_action<Func> )
-class [[nodiscard("unassigned deferred_action")]] deferred_action {
+class [[nodiscard]] deferred_action {
     Func _func;
     bool _cancelled = false;
 public:


### PR DESCRIPTION
`[[nodiscard]]` does not accept an argument until C++20, but we still support C++17, so let's avoid using the C++20 feature before dropping the support of C++17.

Fixes #1932
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>