### PR TITLE
Revert "shared_future: make available() immediate after set_value()"

### DIFF
--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1547,20 +1547,6 @@ SEASTAR_THREAD_TEST_CASE(test_shared_future_with_abort) {
     BOOST_REQUIRE(f4.available());
 }
 
-SEASTAR_THREAD_TEST_CASE(test_shared_promise_with_outstanding_future_is_immediately_available) {
-    shared_promise<> pr1;
-    auto f1 = pr1.get_shared_future();
-    pr1.set_value();
-    BOOST_REQUIRE(pr1.available());
-    BOOST_REQUIRE_NO_THROW(f1.get());
-
-    shared_promise<> pr2;
-    auto f2 = pr2.get_shared_future();
-    pr2.set_exception(std::runtime_error("oops"));
-    BOOST_REQUIRE(pr2.available());
-    BOOST_REQUIRE_THROW(f2.get(), std::runtime_error);
-}
-
 SEASTAR_TEST_CASE(test_when_all_succeed_tuples) {
     return seastar::when_all_succeed(
         make_ready_future<>(),


### PR DESCRIPTION
This reverts commit 9f561daa42c5cd1e8ac6640a24a060692eb77cb3. which causes leak of shared_state. because, if shared_state has a member which holds a strong reference of itself, and the reference is released only when the shared_state is scheduled as a task by reactor. otherwise, the shared_state instance would be leaked.

Fixes #1937
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>