### PR TITLE
build: do not define SEASTAR_TYPE_ERASE_MORE on all builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1043,8 +1043,7 @@ endif ()
 
 target_compile_definitions (seastar
   PUBLIC
-    $<$<IN_LIST:$<CONFIG>,Dev;Debug>:SEASTAR_TYPE_ERASE_MORE>
-    SEASTAR_TYPE_ERASE_MORE)
+    $<$<IN_LIST:$<CONFIG>,Dev;Debug>:SEASTAR_TYPE_ERASE_MORE>)
 
 target_compile_definitions (seastar
   PRIVATE ${Seastar_PRIVATE_COMPILE_DEFINITIONS})


### PR DESCRIPTION
this change addresses the regression introduced by 3536f55d.

in 3536f55d, we should have defined SEASTAR_TYPE_ERASE_MORE only for the enabled build modes. but in that commit, this macro was defined for all builds modes. this introduces a regression which erases the coroutine type for release build. this pratically prevents us from checking a coroutine task by looking at its symbol name.