### PR TITLE
memory: do not use variable length array

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1149,7 +1149,7 @@ void cpu_pages::do_resize(size_t new_size, allocate_system_memory_fn alloc_sys_m
     mem.release();
     maybe_enable_transparent_hugepages(mmap_start, mmap_size);
     // one past last page structure is a sentinel
-    auto new_page_array_pages = align_up(sizeof(page[new_pages + 1]), page_size) / page_size;
+    auto new_page_array_pages = align_up(sizeof(page) * (new_pages + 1), page_size) / page_size;
     auto new_page_array
         = reinterpret_cast<page*>(allocate_large(new_page_array_pages));
     if (!new_page_array) {
@@ -1160,7 +1160,7 @@ void cpu_pages::do_resize(size_t new_size, allocate_system_memory_fn alloc_sys_m
     new_page_array[new_pages].free = false;
     auto old_pages = reinterpret_cast<char*>(pages);
     auto old_nr_pages = nr_pages;
-    auto old_pages_size = align_up(sizeof(page[nr_pages + 1]), page_size);
+    auto old_pages_size = align_up(sizeof(page) * (nr_pages + 1), page_size);
     old_pages_size = size_t(1) << log2ceil(old_pages_size);
     pages = new_page_array;
     nr_pages = new_pages;

--- a/tests/perf/fstream_perf.cc
+++ b/tests/perf/fstream_perf.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
 #include <fmt/printf.h>
+#include <string>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -60,9 +61,8 @@ int main(int ac, char** av) {
                         if (completed == total_ops) {
                             return make_ready_future<stop_iteration>(stop_iteration::yes);
                         }
-                        char buf[buffer_size];
-                        memset(buf, 0, buffer_size);
-                        return os.write(buf, buffer_size).then([&completed] {
+                        std::string buf(buffer_size, '\0');
+                        return os.write(buf).then([&completed] {
                             ++completed;
                             return stop_iteration::no;
                         });


### PR DESCRIPTION
vla (variable length array) is an extension in GCC and Clang. and it is not part of the C++ standard.

so let's avoid using it if possible, for better standard compliant and to silence the warning from Clang 18:

```
/home/kefu/.local/bin/clang++ -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_DEPRECATED_OSTREAM -DFMT_SHARED -DSCYLLA_BUILD_MODE=release -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_PTHREAD_ATTR_SETAFFINITY_NP -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DCMAKE_INTDIR=\"Release\" -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/seastar/gen/include -I/home/kefu/dev/scylladb/seastar/src -ffunction-sections -fdata-sections -O3 -g -gz -std=gnu++20 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-mismatched-tags -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-ignored-qualifiers -ffile-prefix-map=/home/kefu/dev/scylladb=. -march=westmere -mllvm -inline-threshold=2500 -fno-slp-vectorize -U_FORTIFY_SOURCE -Werror=unused-result "-Wno-error=#warnings" -UNDEBUG -Wdeprecated -Wno-error=deprecated -fvisibility=hidden -gz -MD -MT seastar/CMakeFiles/seastar.dir/Release/src/core/memory.cc.o -MF seastar/CMakeFiles/seastar.dir/Release/src/core/memory.cc.o.d -o seastar/CMakeFiles/seastar.dir/Release/src/core/memory.cc.o -c /home/kefu/dev/scylladb/seastar/src/core/memory.cc
/home/kefu/dev/scylladb/seastar/src/core/memory.cc:1152:54: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
 1152 |     auto new_page_array_pages = align_up(sizeof(page[new_pages + 1]), page_size) / page_size;
      |                                                      ^~~~~~~~~~~~~
```