### PR TITLE
reactor: use zero-initialization to initialize io_uring_params

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1218,9 +1218,7 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
         }
     };
 
-    auto params = ::io_uring_params{
-        .flags = 0,
-    };
+    auto params = ::io_uring_params{};
     ::io_uring ring;
     auto err = ::io_uring_queue_init_params(queue_len, &ring, &params);
     if (err != 0) {


### PR DESCRIPTION
before this change, we use designated initializer to initialize an instance of io_uring_params. this has two problems:

* designated initializer was introduced by C++20, while we have to support C++17. despite that we haven't received any report that this breaks the build. but still, it is not standard compliant.
* designated initializer requires that the members to be initialized in the order they are declared. but `flags` is not the first member of `io_uring_params`. this is why we have following compilation warning from `-Wmissing-field-initializers`:

  ```
  /home/kefu/dev/scylladb/seastar/src/core/reactor_backend.cc:1228:5: error: missing field 'sq_entries' initializer [-Werror,-Wmissing-field-initializers]
   1228 |     };
        |     ^
  ```

  this warning option is included by `-Wextra`.

so, in this change, let's just initialize `params` with zero-initialization. it is not only simpler, but also more standard compliant.