### PR TITLE
sstring_test: include fmt/std.h only if fmtlib >= 10.0.0

### DIFF
--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -25,7 +25,7 @@
 #include <seastar/core/sstring.hh>
 #include <list>
 #include <fmt/ranges.h>
-#if FMT_VERSION >= 10000  // formatting of std::optional was introduced in fmt 10
+#if FMT_VERSION >= 100000  // formatting of std::optional was introduced in fmt 10
 #include <fmt/std.h>
 #endif
 


### PR DESCRIPTION
Fixup https://github.com/scylladb/seastar/pull/1897 where we miss one zero.

See https://github.com/fmtlib/fmt/blob/c13753a70cc55f3b1c99fb8f8395e78e5f9cae43/include/fmt/core.h#L20-L21