### PR TITLE
lazy: add fmt::formatter for lazy_eval types

### DIFF
--- a/include/seastar/util/lazy.hh
+++ b/include/seastar/util/lazy.hh
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <ostream>
+#include <fmt/core.h>
 
 /// \addtogroup logging
 /// @{
@@ -150,4 +151,25 @@ ostream& operator<<(ostream& os, seastar::lazy_deref_wrapper<T> ld) {
     return os << "null";
 }
 }
+
+template <typename Func>
+struct fmt::formatter<seastar::lazy_eval<Func>> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const seastar::lazy_eval<Func>& lf, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", lf());
+    }
+};
+
+template <typename T>
+struct fmt::formatter<seastar::lazy_deref_wrapper<T>> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const seastar::lazy_deref_wrapper<T>& ld, FormatContext& ctx) const {
+        if (ld.p) {
+            return fmt::format_to(ctx.out(), "{}", *ld.p);
+        } else {
+            return fmt::format_to(ctx.out(), "null");
+        }
+    }
+};
+
 /// @}


### PR DESCRIPTION
fmtlib v10.0.0 stopped defining the formatter for the types with operator<<() even with `FMT_DEPRECATED_OSTREAM` defined. so let's define the formatters for shared_ptr types.