### PR TITLE
shared_future: make available() immediate after set_value()

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1747,6 +1747,11 @@ public:
     using future_base::set_coroutine;
 #endif
 private:
+    void set_task(task& t) noexcept {
+        assert(_promise);
+        _promise->_task = &t;
+    }
+
     void set_callback(continuation_base<T>* callback) noexcept {
         if (_state.available()) {
             callback->set_state(get_available_state_ref());

--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -239,6 +239,11 @@ private:
         bool failed() const noexcept {
             return _original_future.failed();
         }
+
+        // Used only in tests (see shared_future_tester in futures_test.cc)
+        bool has_scheduled_task() const noexcept {
+            return _keepaliver != nullptr;
+        }
     };
     /// \endcond
     lw_shared_ptr<shared_state> _state;
@@ -296,6 +301,10 @@ public:
     bool valid() const noexcept {
         return bool(_state);
     }
+
+    /// \cond internal
+    friend class shared_future_tester;
+    /// \endcond
 };
 
 /// \brief Like \ref promise except that its counterpart is \ref shared_future instead of \ref future

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1547,6 +1547,20 @@ SEASTAR_THREAD_TEST_CASE(test_shared_future_with_abort) {
     BOOST_REQUIRE(f4.available());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_shared_promise_with_outstanding_future_is_immediately_available) {
+    shared_promise<> pr1;
+    auto f1 = pr1.get_shared_future();
+    pr1.set_value();
+    BOOST_REQUIRE(pr1.available());
+    BOOST_REQUIRE_NO_THROW(f1.get());
+
+    shared_promise<> pr2;
+    auto f2 = pr2.get_shared_future();
+    pr2.set_exception(std::runtime_error("oops"));
+    BOOST_REQUIRE(pr2.available());
+    BOOST_REQUIRE_THROW(f2.get(), std::runtime_error);
+}
+
 SEASTAR_TEST_CASE(test_when_all_succeed_tuples) {
     return seastar::when_all_succeed(
         make_ready_future<>(),


### PR DESCRIPTION
A shared future takes a regular future on construction and resolves after the original future resolves. This is implemented by attaching a `then_wrapped` continuation on the original future which, when run, forwards the result of the original future to the currently registered waiters.

The original future is kept in the `_original_future` field. The continuation is attached on the first `shared_future::get_future()` call - which causes the `_original_future` to become invalid - and it is reassigned again at the end of the continuation.

This implementation detail has an effect on `shared_future::available()`, which is implemented via `_original_future.available()`. When the promise associated with the original future is set, the continuation is scheduled for execution but does not run immediately. Because of that, `_original_future` is not updated immediately after `promise::set_value` and `shared_future::available()` keeps returning false until the continuation runs.

This is especially confusing for `shared_promise`, which are essentially a `promise` + `shared_future` pair and have both `set_value` and `available` methods: setting the shared promise does not cause it to become available.

Fix this by implementing the `task` interface for the shared state. Instead of creating a continuation via `.then_wrapped`, the shared state is attached directly as a task to the future. There is no longer need to move the `_original_future` back and forth so the `available()` method now works correctly.

This is a reworked version of the earlier fix in 9f561da which got reverted. It avoids the memory leak issue by scheduling the task only in the same circumstances as the current implementation. A regression test is included.

Fixes: https://github.com/scylladb/seastar/issues/1926