### PR TITLE
Sanitize test-only reactor facilities

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -201,8 +201,6 @@ void report_failed_future(const std::exception_ptr& ex) noexcept;
 
 void report_failed_future(const future_state_base& state) noexcept;
 
-void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);
-
 /// \endcond
 
 /// \brief Exception type for broken promises

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -709,15 +709,16 @@ public:
     void set_bypass_fsync(bool value);
     void update_blocked_reactor_notify_ms(std::chrono::milliseconds ms);
     std::chrono::milliseconds get_blocked_reactor_notify_ms() const;
-    /// For testing, sets the stall reporting function which is called when
-    /// a stall is detected (and not suppressed). Setting the function also
-    /// resets the supression state.
-    void set_stall_detector_report_function(std::function<void ()> report);
-    std::function<void ()> get_stall_detector_report_function() const;
 
     class test {
     public:
         static void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);
+
+        /// Sets the stall reporting function which is called when a stall
+        /// is detected (and not suppressed). Setting the function also
+        /// resets the supression state.
+        static void set_stall_detector_report_function(std::function<void ()> report);
+        static std::function<void ()> get_stall_detector_report_function();
     };
 };
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -682,7 +682,6 @@ private:
     friend void internal::add_to_flush_poller(output_stream<char>& os) noexcept;
     friend void seastar::internal::increase_thrown_exceptions_counter() noexcept;
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
-    friend void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);
     metrics::metric_groups _metric_groups;
     friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
@@ -715,6 +714,11 @@ public:
     /// resets the supression state.
     void set_stall_detector_report_function(std::function<void ()> report);
     std::function<void ()> get_stall_detector_report_function() const;
+
+    class test {
+    public:
+        static void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func);
+    };
 };
 
 template <typename Func>

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -224,7 +224,7 @@ void report_failed_future(future_state_base::any&& state) noexcept {
     report_failed_future(std::move(state).take_exception());
 }
 
-void with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func) {
+void reactor::test::with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func) {
     auto before = engine()._abandoned_failed_futures;
     auto old_level = seastar_logger.level();
     seastar_logger.set_level(log_level::error);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1489,16 +1489,17 @@ reactor::get_blocked_reactor_notify_ms() const {
 }
 
 void
-reactor::set_stall_detector_report_function(std::function<void ()> report) {
-    auto cfg = _cpu_stall_detector->get_config();
+reactor::test::set_stall_detector_report_function(std::function<void ()> report) {
+    auto& r = engine();
+    auto cfg = r._cpu_stall_detector->get_config();
     cfg.report = std::move(report);
-    _cpu_stall_detector->update_config(std::move(cfg));
-    _cpu_stall_detector->reset_suppression_state(reactor::now());
+    r._cpu_stall_detector->update_config(std::move(cfg));
+    r._cpu_stall_detector->reset_suppression_state(reactor::now());
 }
 
 std::function<void ()>
-reactor::get_stall_detector_report_function() const {
-    return _cpu_stall_detector->get_config().report;
+reactor::test::get_stall_detector_report_function() {
+    return engine()._cpu_stall_detector->get_config().report;
 }
 
 void

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1731,7 +1731,7 @@ SEASTAR_TEST_CASE(test_warn_on_broken_promise_with_no_future) {
     // Intentionally destroy the future
     (void)p.get_future();
 
-    with_allow_abandoned_failed_futures(1, [&] {
+    reactor::test::with_allow_abandoned_failed_futures(1, [&] {
         p.set_exception(std::runtime_error("foo"));
     });
 
@@ -1772,7 +1772,7 @@ SEASTAR_THREAD_TEST_CASE(test_exception_future_with_backtrace) {
     // Example code where we expect a "Exceptional future ignored"
     // warning.
     (void)outer(true).then_wrapped([](future<int> fut) {
-        with_allow_abandoned_failed_futures(1, [fut = std::move(fut)]() mutable {
+        reactor::test::with_allow_abandoned_failed_futures(1, [fut = std::move(fut)]() mutable {
             auto foo = std::move(fut);
         });
     });

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -48,14 +48,14 @@ public:
      */
     temporary_stall_detector_settings(std::chrono::duration<double> threshold, std::function<void ()> report = {})
             : _old_threshold(engine().get_blocked_reactor_notify_ms())
-            , _old_report(engine().get_stall_detector_report_function()) {
+            , _old_report(reactor::test::get_stall_detector_report_function()) {
         engine().update_blocked_reactor_notify_ms(std::chrono::duration_cast<std::chrono::milliseconds>(threshold));
-        engine().set_stall_detector_report_function(std::move(report));
+        reactor::test::set_stall_detector_report_function(std::move(report));
     }
 
     ~temporary_stall_detector_settings() {
         engine().update_blocked_reactor_notify_ms(_old_threshold);
-        engine().set_stall_detector_report_function(std::move(_old_report));
+        reactor::test::set_stall_detector_report_function(std::move(_old_report));
     }
 };
 


### PR DESCRIPTION
There are several calls that are declared as a part of reactor API, while they are only for testing purposes. This PR wraps them into test sub-class (which makes them reactor friends automatically) to emphasize the intent and shrink the overloaded reactor API a bit