### PR TITLE
make reactor::_task_queue init before the reactor::_cpu_stall_detector

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -297,7 +297,6 @@ private:
     uint64_t _global_tasks_processed = 0;
     uint64_t _polls = 0;
     metrics::internal::time_estimated_histogram _stalls_histogram;
-    std::unique_ptr<internal::cpu_stall_detector> _cpu_stall_detector;
 
     unsigned _max_task_backlog = 1000;
     timer_set<timer<>, &timer<>::_link> _timers;
@@ -340,6 +339,7 @@ private:
     };
 
     boost::container::static_vector<std::unique_ptr<task_queue>, max_scheduling_groups()> _task_queues;
+    std::unique_ptr<internal::cpu_stall_detector> _cpu_stall_detector;
     internal::scheduling_group_specific_thread_local_data _scheduling_group_specific_data;
     int64_t _last_vruntime = 0;
     task_queue_list _active_task_queues;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1034,6 +1034,7 @@ reactor::reactor(std::shared_ptr<smp> smp, alien::instance& alien, unsigned id, 
     , _engine_thread(sched::thread::current())
 #endif
     , _cpu_started(0)
+    , _task_queues()
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
     , _reuseport(posix_reuseport_detect())
     , _thread_pool(std::make_unique<thread_pool>(*this, seastar::format("syscall-{}", id))) {


### PR DESCRIPTION
because if kernel.perf_event_paranoid = 2, the seastar_logger will be used, and it need check reactor::_task_queues if is empty. In release, the reactor::_task_queue was not initialized, and it was not empty, but just can get a null unique_ptr, the programm will be crash.

BTW. my environment is clang17.0.4 and fedora 39