### PR TITLE
http/exception: Make unexpected status message more informative

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -155,7 +155,7 @@ private:
 class unexpected_status_error : public base_exception {
 public:
     unexpected_status_error(http::reply::status_type st)
-        : base_exception("Unexpected reply status", st)
+        : base_exception(fmt::to_string(st), st)
     {}
 };
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1407,3 +1407,12 @@ SEASTAR_TEST_CASE(test_url_param_encode_decode) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_unexpected_exception_format) {
+    try {
+        throw httpd::unexpected_status_error(http::reply::status_type::see_other);
+    } catch (const std::exception& ex) {
+        BOOST_REQUIRE_EQUAL(sstring(ex.what()), format("{}", http::reply::status_type::see_other));
+    }
+    return make_ready_future<>();
+}


### PR DESCRIPTION
The exception in question initializes its base's message with useless "Unexpected reply status" string. This message is what returned from the virtual exception::what() method and when printed in logs given no glue to what the problem was.

Fix it by putting the status' string explanation into base string. When printed, the "unexpected status" would be clear from the exception real data type, and the what() would then reveral the actual problem.

fixes: #1931