### PR TITLE
tls: add format_as(subject_alt_name_type) overload

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -469,6 +469,7 @@ namespace tls {
      * othername: "OTHERNAME"
      * dn: "DIRNAME"
     */
+    std::string_view format_as(subject_alt_name_type);
     std::ostream& operator<<(std::ostream&, subject_alt_name_type);
 
     /**

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1965,17 +1965,27 @@ future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connect
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
 }
 
-std::ostream& tls::operator<<(std::ostream& os, subject_alt_name_type type) {
+std::string_view tls::format_as(subject_alt_name_type type) {
     switch (type) {
-        case subject_alt_name_type::dnsname: os << "DNS"; break;
-        case subject_alt_name_type::rfc822name: os << "EMAIL"; break;
-        case subject_alt_name_type::uri: os << "URI"; break;
-        case subject_alt_name_type::ipaddress: os << "IP"; break;
-        case subject_alt_name_type::othername: os << "OTHERNAME"; break;
-        case subject_alt_name_type::dn: os << "DIRNAME"; break;
-        default: break;
+        case subject_alt_name_type::dnsname:
+            return "DNS";
+        case subject_alt_name_type::rfc822name:
+            return "EMAIL";
+        case subject_alt_name_type::uri:
+            return "URI";
+        case subject_alt_name_type::ipaddress:
+            return "IP";
+        case subject_alt_name_type::othername:
+            return "OTHERNAME";
+        case subject_alt_name_type::dn:
+            return "DIRNAME";
+        default:
+            return "UNKNOWN";
     }
-    return os;
+}
+
+std::ostream& tls::operator<<(std::ostream& os, subject_alt_name_type type) {
+    return os << format_as(type);
 }
 
 std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name::value_type& v) {


### PR DESCRIPTION
this change addresses the formatting with fmtlib v10, which stopped creating the default-generated formatter even if FMT_DEPRECATED_OSTREAM preprocess macro is defined. but it allows us to format by providing a format_as() overload. please note this does not work with fmtlib v9, in which, we still need either define FMT_DEPRECATED_OSTREAM or define a proper fmt::formatter<> for this type.

Refs https://github.com/scylladb/scylladb/issues/13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>