### PR TITLE
metrics: Add update_aggregate_labels()

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -679,6 +679,13 @@ impl::metric_definition_impl make_total_operations(metric_name_type name,
     return make_counter(name, std::forward<T>(val), d, labels).set_type("total_operations");
 }
 
+/*!
+ * \brief Update the aggregation labels of a metric family
+ */
+void update_aggregate_labels(const group_name_type& group_name,
+                             const metric_name_type& metric_name,
+                             const std::vector<label>& aggregate_labels);
+
 /*! @} */
 }
 }

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -369,6 +369,7 @@ public:
     }
 
     void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip, const std::vector<std::string>& aggregate_labels);
+    void update_aggregate_labels(const metric_id& id, const std::vector<label>& aggregate_labels);
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();

--- a/include/seastar/core/metrics_registration.hh
+++ b/include/seastar/core/metrics_registration.hh
@@ -62,6 +62,7 @@ class metric_groups_impl;
 SEASTAR_MODULE_EXPORT_BEGIN
 
 using group_name_type = sstring; /*!< A group of logically related metrics */
+using metric_name_type = sstring; /*!< A single metric name */
 class metric_groups;
 
 class metric_definition {

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -460,6 +460,19 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
     dirty();
 }
 
+void impl::update_aggregate_labels(const metric_id& id,
+                                   const std::vector<label>& aggregate_labels) {
+    auto iter = _value_map.find(id.full_name());
+    if (iter != _value_map.end()) {
+        iter->second.info().aggregate_labels.clear();
+        std::transform(aggregate_labels.begin(), aggregate_labels.end(),
+            std::back_inserter(iter->second.info().aggregate_labels),
+            [] (const label& l) { return l.name(); });
+
+        dirty();
+    }
+}
+
 future<metric_relabeling_result> impl::set_relabel_configs(const std::vector<relabel_config>& relabel_configs) {
     _relabel_configs = relabel_configs;
     metric_relabeling_result conflicts{0};
@@ -556,5 +569,11 @@ histogram histogram::operator+(histogram&& c) const {
     return std::move(c);
 }
 
+void update_aggregate_labels(const group_name_type& group_name,
+                             const metric_name_type& metric_name,
+                             const std::vector<label>& aggregate_labels) {
+    impl::metric_id id(group_name, metric_name, {});
+    impl::get_local_impl()->update_aggregate_labels(id, aggregate_labels);
+}
 }
 }


### PR DESCRIPTION
Extends the metrics api to allow changing the aggregation labels of a
metrics family.

Otherwise one had to un-register every single metric instance in a
metric family and then re-register with the changed aggregation labels.

For metric families with thousands of instances (e.g.: histograms with
lots of different labels) this is quite expensive.

With this change we avoid the full reconstruction of the metrics family
and all its metrics. Only the work associated with marking the metrics
`dirty()` is needed then.
