### PR TITLE
file: use unbuffered generator in experimental_list_directory()

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -115,9 +115,6 @@ public:
     virtual shared_ptr<file_impl> to_file() && = 0;
 };
 
-template <typename T>
-using dir_entry_buffer = circular_buffer<T>;
-
 class file_impl {
     friend class file;
 protected:
@@ -175,7 +172,9 @@ public:
     virtual std::unique_ptr<file_handle_impl> dup();
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) = 0;
 #ifdef SEASTAR_COROUTINES_ENABLED
-    virtual coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory();
+    // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
+    // buffered generator yet.
+    virtual coroutine::experimental::generator<directory_entry> experimental_list_directory();
 #endif
 
     friend class reactor;
@@ -694,7 +693,9 @@ public:
 
 #ifdef SEASTAR_COROUTINES_ENABLED
     /// Returns a directory listing, given that this file object is a directory.
-    coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory();
+    // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
+    // buffered generator yet.
+    coroutine::experimental::generator<directory_entry> experimental_list_directory();
 #endif
 
 #if SEASTAR_API_LEVEL < 7

--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -29,7 +29,7 @@
 
 namespace seastar::coroutine::experimental {
 
-template<typename T, template <typename> class Container>
+template<typename T, template <typename> class Container = std::optional>
 class generator;
 
 /// `seastar::coroutine::experimental` is used as the type of the first

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -105,7 +105,7 @@ public:
     virtual std::unique_ptr<seastar::file_handle_impl> dup() override;
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) override;
 #ifdef SEASTAR_COROUTINES_ENABLED
-    virtual coroutine::experimental::generator<directory_entry, dir_entry_buffer> experimental_list_directory() override;
+    virtual coroutine::experimental::generator<directory_entry> experimental_list_directory() override;
 #endif
 
 #if SEASTAR_API_LEVEL >= 7


### PR DESCRIPTION
because the buggy buffered generator, as a workaround, let's use the unbuffered generator as an intermediate workaround of #1913 .

the downside of this change is that buffered generator allows the generator coroutine to yield the elements without being suspended, if it is able to generate the produced elements in batch, thus can have better performance. this design is a good fit of use cases like readdir. we will revert this change once #1913 is fixed.

Refs #1913
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>