### PR TITLE
http: make_request accept optional expected status

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -229,16 +229,16 @@ public:
      * \brief Send the request and handle the response
      *
      * Sends the provided request to the server and calls the provided callback to handle
-     * the response when it arrives. If the reply's status code is not equals the expected
-     * value, the handler is not called and the method resolves with exceptional future.
-     * Otherwise returns the handler's future
+     * the response when it arrives. If the expected status is specified and the response's
+     * status is not the expected one, the handler is not called and the method resolves
+     * with exceptional future. Otherwise returns the handler's future
      *
      * \param req -- request to be sent
      * \param handle -- the response handler
-     * \param expected -- the expected reply status code
+     * \param expected -- the optional expected reply status code, default is std::nullopt
      *
      */
-    future<> make_request(request req, reply_handler handle, reply::status_type expected = reply::status_type::ok);
+    future<> make_request(request req, reply_handler handle, std::optional<reply::status_type> expected = std::nullopt);
 
     /**
      * \brief Updates the maximum number of connections a client may have

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -301,11 +301,11 @@ auto client::with_connection(Fn&& fn) {
     });
 }
 
-future<> client::make_request(request req, reply_handler handle, reply::status_type expected) {
+future<> client::make_request(request req, reply_handler handle, std::optional<reply::status_type> expected) {
     return with_connection([req = std::move(req), handle = std::move(handle), expected] (connection& con) mutable {
         return con.do_make_request(std::move(req)).then([&con, expected, handle = std::move(handle)] (connection::reply_ptr reply) mutable {
             auto& rep = *reply;
-            if (rep._status != expected) {
+            if (expected.has_value() && rep._status != expected.value()) {
                 if (!http_log.is_enabled(log_level::debug)) {
                     return make_exception_future<>(httpd::unexpected_status_error(rep._status));
                 }


### PR DESCRIPTION
The original API requires passing the expected status into the `﻿make_request` function. The ﻿reply_handle function will only be called if the expected status matches. Otherwise, an ﻿`httpd::unexpected_status_error` will be returned and there is no way to handle the response body, which contains additional information. With the `httpd::unexpected_status_error`, `reply->status` is not enough. This was discussed in detail on https://github.com/scylladb/seastar/pull/1963

This PR patches the API in a backward incompatible way. If the expected status is ﻿std::nullopt, the reply_handler will handle any reply without missing anything.