### PR TITLE
io: Apply rate-factor early

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -244,7 +244,6 @@ public:
          */
         double min_tokens = 0.0;
         double limit_min_tokens = 0.0;
-        float rate_factor = 1.0;
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -152,7 +152,6 @@ public:
         size_t disk_write_saturation_length = std::numeric_limits<size_t>::max();
         sstring mountpoint = "undefined";
         bool duplex = false;
-        float rate_factor = 1.0;
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
         size_t block_count_limit_min = 1;
         unsigned flow_ratio_ticks = 100;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -103,16 +103,12 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
 }
 
 fair_group::fair_group(config cfg, unsigned nr_queues)
-        : _token_bucket(cfg.rate_factor * fixed_point_factor,
-                        std::max<capacity_t>(cfg.rate_factor * fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
+        : _token_bucket(fixed_point_factor,
+                        std::max<capacity_t>(fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
                         tokens_capacity(cfg.min_tokens)
                        )
         , _per_tick_threshold(_token_bucket.limit() / nr_queues)
 {
-    if (cfg.rate_factor * fixed_point_factor > _token_bucket.max_rate) {
-        throw std::runtime_error("Fair-group rate_factor is too large");
-    }
-
     if (tokens_capacity(cfg.min_tokens) > _token_bucket.threshold()) {
         throw std::runtime_error("Fair-group replenisher limit is lower than threshold");
     }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -600,7 +600,6 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
     double limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     double limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
     cfg.limit_min_tokens = limit_min_weight / qcfg.req_count_rate + limit_min_size / qcfg.blocks_count_rate;
-    cfg.rate_factor = qcfg.rate_factor;
     cfg.rate_limit_duration = qcfg.rate_limit_duration;
     return cfg;
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4131,6 +4131,12 @@ public:
                         throw std::runtime_error(fmt::format("Configured number of queues {} is larger than the maximum {}",
                                                  _mountpoints.size(), _max_queues));
                     }
+
+                    d.read_bytes_rate *= d.rate_factor;
+                    d.write_bytes_rate *= d.rate_factor;
+                    d.read_req_rate *= d.rate_factor;
+                    d.write_req_rate *= d.rate_factor;
+
                     if (d.read_bytes_rate == 0 || d.write_bytes_rate == 0 ||
                             d.read_req_rate == 0 || d.write_req_rate == 0) {
                         throw std::runtime_error(fmt::format("R/W bytes and req rates must not be zero"));
@@ -4170,7 +4176,6 @@ public:
         }
         cfg.mountpoint = p.mountpoint;
         cfg.duplex = p.duplex;
-        cfg.rate_factor = p.rate_factor;
         cfg.rate_limit_duration = latency_goal();
         cfg.flow_ratio_backpressure_threshold = _flow_ratio_backpressure_threshold;
         // Block count limit should not be less than the minimal IO size on the device


### PR DESCRIPTION
Here's the sched throttling math:

  bw/bw_max + iops/iops_max <= C

The "rate_factor" is the C and it's usually set to be 1.0, but there was a reservation for convex/concave io profiles where the C would be set to lower or higher values to adjust the limit.

The same goal can be achieved by scaling ..._max values on the right side of the equation, like this

  bw/(bw_max*C) + iops/(iopx_max*C) <= 1.0

This makes the fair-queue code a bit simpler and, as a nice side effect, adds sanity check for the rate-factor not been too low.