### PR TITLE
shared_future: remove unused #include

### DIFF
--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -30,7 +30,6 @@
 #include <seastar/util/modules.hh>
 #include <exception>
 #include <optional>
-#include <tuple>
 #endif
 
 namespace seastar {


### PR DESCRIPTION
tuple<> or the related helper functions defined by `<tuple>` header is not used in this header file. so let's remove `#include <tuple` from this header file.