### PR TITLE
reactor: set local_engine after it is fully initialized

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3971,9 +3971,8 @@ void smp::allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_co
     void *buf;
     int r = posix_memalign(&buf, cache_line_size, sizeof(reactor));
     assert(r == 0);
-    local_engine = reinterpret_cast<reactor*>(buf);
     *internal::this_shard_id_ptr() = id;
-    new (buf) reactor(this->shared_from_this(), _alien, id, std::move(rbs), cfg);
+    local_engine = new (buf) reactor(this->shared_from_this(), _alien, id, std::move(rbs), cfg);
     reactor_holder.reset(local_engine);
 }
 


### PR DESCRIPTION
in reactor's constructor, `_cpu_stall_detector` is initialized before `_task_queues` as they are declared in this order. normally, this arrangement works just fine. but there is cases where `make_cpu_stall_detector()` fails, then we would have following sequence:

1. in `make_cpu_stall_detector()`, it tries to to set up the performance monitoring using `perf_event_open()`,
2. if `perf_event_open()` fails, `make_cpu_stall_detector()` writes a logging message, which ends up calling `logger::do_log()`
3. in `logger::do_log()`, it formats the logging message with the output of `scheduling_group::short_name()` if `local_engine` is set
4. `scheduling_group::short_name()` checks if `_task_queues` of local reactor engine is empty, and indexes it with the scheduling group's id

but at that moment, despite that `local_engine` is set, it is not fully initialized yet, `scheduling_group::short_name` is accessing a yet-initialized member variable of `local_engine`, and with a yet-initialized scheduling group id. this ends up with dereferencing an uninitialized pointer.

so, in this change, we set `local_engine` only after it is created, to avoid the logging subsystem to print the logging messages with scheduling group information which is not yet available at that moment.