### PR TITLE
future: future_state_base: assert owner shard in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1029,6 +1029,15 @@ if (condition)
       $<${condition}:SEASTAR_DEBUG_SHARED_PTR>)
 endif ()
 
+tri_state_option (${Seastar_DEBUG_SHARED_PTR}
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
+  CONDITION condition)
+if (condition)
+  target_compile_definitions (seastar
+    PUBLIC
+      $<${condition}:SEASTAR_DEBUG_PROMISE>)
+endif ()
+
 include (CheckLibc)
 
 tri_state_option (${Seastar_STACK_GUARDS}

--- a/include/seastar/core/shard_id.hh
+++ b/include/seastar/core/shard_id.hh
@@ -1,0 +1,57 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2023-present ScyllaDB
+ */
+
+#pragma once
+
+/// \file
+
+namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
+
+using shard_id = unsigned;
+
+SEASTAR_MODULE_EXPORT_END
+
+namespace internal {
+
+#ifdef SEASTAR_BUILD_SHARED_LIBS
+shard_id* this_shard_id_ptr() noexcept;
+#else
+inline shard_id* this_shard_id_ptr() noexcept {
+    static thread_local shard_id g_this_shard_id;
+    return &g_this_shard_id;
+}
+#endif
+
+} // namespace internal
+
+SEASTAR_MODULE_EXPORT_BEGIN
+
+/// Returns shard_id of the of the current shard.
+inline shard_id this_shard_id() noexcept {
+    return *internal::this_shard_id_ptr();
+}
+
+SEASTAR_MODULE_EXPORT_END
+
+
+} // namespace seastar

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
+#include <seastar/core/shard_id.hh>
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE
@@ -46,7 +47,6 @@ namespace seastar {
 class reactor_backend_selector;
 
 SEASTAR_MODULE_EXPORT_BEGIN
-using shard_id = unsigned;
 
 class smp_service_group;
 
@@ -61,15 +61,6 @@ namespace internal {
 
 unsigned smp_service_group_id(smp_service_group ssg) noexcept;
 
-#ifdef SEASTAR_BUILD_SHARED_LIBS
-shard_id* this_shard_id_ptr() noexcept;
-#else
-inline shard_id* this_shard_id_ptr() noexcept {
-    static thread_local shard_id g_this_shard_id;
-    return &g_this_shard_id;
-}
-#endif
-
 class memory_prefaulter;
 
 }
@@ -81,11 +72,6 @@ struct numa_layout;
 }
 
 SEASTAR_MODULE_EXPORT_BEGIN
-
-/// Returns shard_id of the of the current shard.
-inline shard_id this_shard_id() noexcept {
-    return *internal::this_shard_id_ptr();
-}
 
 /// Configuration for smp_service_group objects.
 ///


### PR DESCRIPTION
Assert that the future state is accessed only
on the shard on which it was created as the future
and promise objects are not designed to be accessed
across shards.

For example, currenty, if promise.set_value() (or
set_exception) is called on a promise from a foreign
shard the promise.get_future() continuation would
run on the foreign shard.

Fixes scylladb/seastar#1563