### PR TITLE
Keep pollers in internal/poll.hh

### DIFF
--- a/include/seastar/core/internal/poll.hh
+++ b/include/seastar/core/internal/poll.hh
@@ -72,6 +72,28 @@ std::unique_ptr<seastar::pollfn> make_pollfn(Func&& func) {
     return std::make_unique<the_pollfn>(std::forward<Func>(func));
 }
 
+class poller {
+    std::unique_ptr<pollfn> _pollfn;
+    class registration_task;
+    class deregistration_task;
+    registration_task* _registration_task = nullptr;
+public:
+    template <typename Func>
+    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
+    static poller simple(Func&& poll) {
+        return poller(make_pollfn(std::forward<Func>(poll)));
+    }
+    poller(std::unique_ptr<pollfn> fn)
+            : _pollfn(std::move(fn)) {
+        do_register();
+    }
+    ~poller();
+    poller(poller&& x) noexcept;
+    poller& operator=(poller&& x) noexcept;
+    void do_register() noexcept;
+    friend class reactor;
+};
+
 } // internal namespace
 
 }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -144,10 +144,6 @@ class cpu_stall_detector;
 class buffer_allocator;
 class priority_class;
 
-template <typename Func>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
-std::unique_ptr<pollfn> make_pollfn(Func&& func);
-
 class poller {
     std::unique_ptr<pollfn> _pollfn;
     class registration_task;
@@ -720,21 +716,6 @@ public:
         static std::function<void ()> get_stall_detector_report_function();
     };
 };
-
-template <typename Func>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
-inline
-std::unique_ptr<seastar::pollfn>
-internal::make_pollfn(Func&& func) {
-    struct the_pollfn : simple_pollfn<false> {
-        the_pollfn(Func&& func) : func(std::forward<Func>(func)) {}
-        Func func;
-        virtual bool poll() override final {
-            return func();
-        }
-    };
-    return std::make_unique<the_pollfn>(std::forward<Func>(func));
-}
 
 extern __thread reactor* local_engine;
 extern __thread size_t task_quota;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -60,7 +60,6 @@
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #include "internal/pollable_fd.hh"
-#include "internal/poll.hh"
 
 #ifndef SEASTAR_MODULE
 #include <boost/container/static_vector.hpp>
@@ -136,6 +135,7 @@ class smp;
 class reactor_backend_selector;
 
 class reactor_backend;
+struct pollfn;
 
 namespace internal {
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -143,28 +143,7 @@ class reactor_stall_sampler;
 class cpu_stall_detector;
 class buffer_allocator;
 class priority_class;
-
-class poller {
-    std::unique_ptr<pollfn> _pollfn;
-    class registration_task;
-    class deregistration_task;
-    registration_task* _registration_task = nullptr;
-public:
-    template <typename Func>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
-    static poller simple(Func&& poll) {
-        return poller(make_pollfn(std::forward<Func>(poll)));
-    }
-    poller(std::unique_ptr<pollfn> fn)
-            : _pollfn(std::move(fn)) {
-        do_register();
-    }
-    ~poller();
-    poller(poller&& x) noexcept;
-    poller& operator=(poller&& x) noexcept;
-    void do_register() noexcept;
-    friend class reactor;
-};
+class poller;
 
 size_t scheduling_group_count();
 

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -33,6 +33,7 @@ module seastar;
 #else
 #include <seastar/net/net.hh>
 #include <seastar/net/toeplitz.hh>
+#include <seastar/core/internal/poll.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/print.hh>

--- a/src/net/virtio.cc
+++ b/src/net/virtio.cc
@@ -46,6 +46,7 @@ module seastar;
 #include <seastar/net/virtio.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/internal/pollable_fd.hh>
+#include <seastar/core/internal/poll.hh>
 #include "core/vla.hh"
 #include <seastar/core/reactor.hh>
 #include <seastar/core/stream.hh>


### PR DESCRIPTION
The pollers concept is indeed internal, but is kept in reactor.hh which is (still) a public header. Fortunately, the class poller and make_pollfn<>() helper can be both moved to internal/poll.hh and the latter header can be removed from reactor.hh without pain at all.