### PR TITLE
scripts: Add ability to add extra configure arguments

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,6 +27,7 @@ MODE=$1
 COMPILER=$2
 VERSION=$3
 STANDARD=$4
+CONF_EXTRA=$5
 
 CONFIGURE="--mode=$MODE"
 if [ ! -z "$COMPILER" ]; then
@@ -50,5 +51,5 @@ if [ ! -z "$COMPILER" ]; then
     fi
 fi
 
-./configure.py $CONFIGURE
+./configure.py $CONFIGURE $CONF_EXTRA
 ninja -C build/$MODE


### PR DESCRIPTION
The build.sh script performs full bulding cycle inside seastar-dev container but generates configure.py arguments out of script's args, no extras (like --enable-dpdk) are allowed. This patch fixes that