### PR TITLE
build: cleanups configure.py to be more PEP8 compatible

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -26,14 +26,14 @@ tempfile.tempdir = "./build/tmp"
 
 
 def add_tristate(arg_parser, name, dest, help, default=None):
-    arg_parser.add_argument('--enable-' + name, dest = dest, action = 'store_true', default = default,
-                            help = 'Enable ' + help + ' [default]' if default else '')
-    arg_parser.add_argument('--disable-' + name, dest = dest, action = 'store_false', default = None,
-                            help = 'Disable ' + help)
+    arg_parser.add_argument('--enable-' + name, dest=dest, action='store_true', default=default,
+                            help='Enable ' + help + ' [default]' if default else '')
+    arg_parser.add_argument('--disable-' + name, dest=dest, action='store_false', default=None,
+                            help='Disable ' + help)
 
 
-def try_compile(compiler, source = '', flags = []):
-    return try_compile_and_link(compiler, source, flags = flags + ['-c'])
+def try_compile(compiler, source='', flags=[]):
+    return try_compile_and_link(compiler, source, flags=flags + ['-c'])
 
 
 def ensure_tmp_dir_exists():
@@ -41,7 +41,7 @@ def ensure_tmp_dir_exists():
         os.makedirs(tempfile.tempdir)
 
 
-def try_compile_and_link(compiler, source = '', flags = []):
+def try_compile_and_link(compiler, source='', flags=[]):
     ensure_tmp_dir_exists()
     with tempfile.NamedTemporaryFile() as sfile:
         ofd, ofile = tempfile.mkstemp()
@@ -52,8 +52,8 @@ def try_compile_and_link(compiler, source = '', flags = []):
             # We can't write to /dev/null, since in some cases (-ftest-coverage) gcc will create an auxiliary
             # output file based on the name of the output file, and "/dev/null.gcsa" is not a good name
             return subprocess.call([compiler, '-x', 'c++', '-o', ofile, sfile.name] + flags,
-                                   stdout = subprocess.DEVNULL,
-                                   stderr = subprocess.DEVNULL) == 0
+                                   stdout=subprocess.DEVNULL,
+                                   stderr=subprocess.DEVNULL) == 0
         finally:
             if os.path.exists(ofile):
                 os.unlink(ofile)
@@ -68,20 +68,20 @@ arg_parser.add_argument('--mode', action='store', choices=seastar_cmake.SUPPORTE
 arg_parser.add_argument('--build-root', action='store', default=seastar_cmake.DEFAULT_BUILD_ROOT, type=str,
                         help='The name of the build root build directoy: using a different name allows multiple '
                         'configurations to co-exist in the same repository')
-arg_parser.add_argument('--cflags', action = 'store', dest = 'user_cflags', default = '',
-                        help = 'Extra flags for the C++ compiler')
-arg_parser.add_argument('--ldflags', action = 'store', dest = 'user_ldflags', default = '',
-                        help = 'Extra flags for the linker')
-arg_parser.add_argument('--optflags', action = 'store', dest = 'user_optflags', default = '',
-                        help = 'Extra optimization flags for the release mode')
+arg_parser.add_argument('--cflags', action = 'store', dest='user_cflags', default='',
+                        help='Extra flags for the C++ compiler')
+arg_parser.add_argument('--ldflags', action='store', dest='user_ldflags', default='',
+                        help='Extra flags for the linker')
+arg_parser.add_argument('--optflags', action='store', dest='user_optflags', default='',
+                        help='Extra optimization flags for the release mode')
 arg_parser.add_argument('--api-level', action='store', dest='api_level', default='7',
                         help='Compatibility API level (7=latest)')
-arg_parser.add_argument('--compiler', action = 'store', dest = 'cxx', default = 'g++',
-                        help = 'C++ compiler path')
+arg_parser.add_argument('--compiler', action='store', dest='cxx', default='g++',
+                        help='C++ compiler path')
 arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc',
-                        help = 'C compiler path (for bundled libraries such as dpdk)')
+                        help='C compiler path (for bundled libraries such as dpdk)')
 arg_parser.add_argument('--ccache', nargs='?', const='ccache', default='', metavar='CCACHE_BINARY_PATH',
-                        help = 'Use ccache to cache compilation (and optionally provide a path to ccache binary)')
+                        help='Use ccache to cache compilation (and optionally provide a path to ccache binary)')
 arg_parser.add_argument('--c++-standard', action='store', dest='cpp_standard', default='',
                         help='C++ standard to build with [default: %(default)s]')
 arg_parser.add_argument('--cook', action='append', dest='cook', default=[],
@@ -92,39 +92,39 @@ arg_parser.add_argument('--scheduling-groups-count', action='store', dest='sched
 
 add_tristate(
     arg_parser,
-    name = 'dpdk',
-    dest = 'dpdk',
-    help = 'DPDK support')
+    name='dpdk',
+    dest='dpdk',
+    help='DPDK support')
 add_tristate(
     arg_parser,
-    name = 'cxx-modules',
-    dest = 'cxx_modules',
-    help = 'build as C++20 module')
+    name='cxx-modules',
+    dest='cxx_modules',
+    help='build as C++20 module')
 add_tristate(
     arg_parser,
-    name = 'hwloc',
-    dest = 'hwloc',
-    help = 'hwloc support')
+    name='hwloc',
+    dest='hwloc',
+    help='hwloc support')
 add_tristate(
     arg_parser,
-    name = 'alloc-failure-injector',
-    dest = 'alloc_failure_injection',
-    help = 'allocation failure injection')
+    name='alloc-failure-injector',
+    dest='alloc_failure_injection',
+    help='allocation failure injection')
 add_tristate(
     arg_parser,
-    name = 'task-backtrace',
-    dest = 'task_backtrace',
-    help = 'Collect backtrace at deferring points')
+    name='task-backtrace',
+    dest='task_backtrace',
+    help='Collect backtrace at deferring points')
 add_tristate(
     arg_parser,
-    name = 'unused-result-error',
-    dest = "unused_result_error",
-    help = 'Make [[nodiscard]] violations an error')
+    name='unused-result-error',
+    dest="unused_result_error",
+    help='Make [[nodiscard]] violations an error')
 add_tristate(
     arg_parser,
-    name = 'debug-shared-ptr',
-    dest = "debug_shared_ptr",
-    help = 'Debug shared_ptr')
+    name='debug-shared-ptr',
+    dest="debug_shared_ptr",
+    help='Debug shared_ptr')
 add_tristate(
     arg_parser,
     name='io_uring',

--- a/configure.py
+++ b/configure.py
@@ -194,7 +194,7 @@ MODES = seastar_cmake.SUPPORTED_MODES if args.mode == 'all' else [args.mode]
 # For convenience.
 tr = seastar_cmake.translate_arg
 
-MODE_TO_CMAKE_BUILD_TYPE = {'release' : 'RelWithDebInfo', 'debug' : 'Debug', 'dev' : 'Dev', 'sanitize' : 'Sanitize' }
+MODE_TO_CMAKE_BUILD_TYPE = {'release': 'RelWithDebInfo', 'debug': 'Debug', 'dev': 'Dev', 'sanitize': 'Sanitize' }
 
 
 def configure_mode(mode):

--- a/configure.py
+++ b/configure.py
@@ -24,18 +24,22 @@ import tempfile
 
 tempfile.tempdir = "./build/tmp"
 
+
 def add_tristate(arg_parser, name, dest, help, default=None):
     arg_parser.add_argument('--enable-' + name, dest = dest, action = 'store_true', default = default,
                             help = 'Enable ' + help + ' [default]' if default else '')
     arg_parser.add_argument('--disable-' + name, dest = dest, action = 'store_false', default = None,
                             help = 'Disable ' + help)
 
+
 def try_compile(compiler, source = '', flags = []):
     return try_compile_and_link(compiler, source, flags = flags + ['-c'])
+
 
 def ensure_tmp_dir_exists():
     if not os.path.exists(tempfile.tempdir):
         os.makedirs(tempfile.tempdir)
+
 
 def try_compile_and_link(compiler, source = '', flags = []):
     ensure_tmp_dir_exists()
@@ -53,8 +57,11 @@ def try_compile_and_link(compiler, source = '', flags = []):
         finally:
             if os.path.exists(ofile):
                 os.unlink(ofile)
+
+
 def standard_supported(standard, compiler='g++'):
     return try_compile(compiler=compiler, source='', flags=['-std=' + standard])
+
 
 arg_parser = argparse.ArgumentParser('Configure seastar')
 arg_parser.add_argument('--mode', action='store', choices=seastar_cmake.SUPPORTED_MODES + ['all'], default='all')
@@ -136,6 +143,7 @@ add_tristate(arg_parser, name='deferred-action-require-noexcept', dest='deferred
 arg_parser.add_argument('--prefix', dest='install_prefix', default='/usr/local', help='Root installation path of Seastar files')
 args = arg_parser.parse_args()
 
+
 def identify_best_standard(cpp_standards, compiler):
     """Returns the first C++ standard accepted by the compiler in the sequence,
     assuming the "best" standards appear first.
@@ -149,9 +157,11 @@ def identify_best_standard(cpp_standards, compiler):
             return std
     raise Exception(f"{compiler} does not seem to support any of Seastar's preferred C++ standards - {cpp_standards}. Please upgrade your compiler.")
 
+
 if args.cpp_standard == '':
     cpp_standards = ['23', '20', '17']
     args.cpp_standard = identify_best_standard(cpp_standards, compiler=args.cxx)
+
 
 def infer_dpdk_machine(user_cflags):
     """Infer the DPDK machine identifier (e.g., 'ivb') from the space-separated
@@ -178,12 +188,14 @@ def infer_dpdk_machine(user_cflags):
 
     return MAPPING.get(arch, 'native')
 
+
 MODES = seastar_cmake.SUPPORTED_MODES if args.mode == 'all' else [args.mode]
 
 # For convenience.
 tr = seastar_cmake.translate_arg
 
 MODE_TO_CMAKE_BUILD_TYPE = {'release' : 'RelWithDebInfo', 'debug' : 'Debug', 'dev' : 'Dev', 'sanitize' : 'Sanitize' }
+
 
 def configure_mode(mode):
     BUILD_PATH = seastar_cmake.build_path(mode, build_root=args.build_root)
@@ -262,6 +274,7 @@ def configure_mode(mode):
         print(" \\\n  ".join(ARGS))
     os.makedirs(BUILD_PATH, exist_ok=True)
     subprocess.check_call(ARGS, shell=False, cwd=dir)
+
 
 for mode in MODES:
     configure_mode(mode)


### PR DESCRIPTION
to make `configure.py` more readable, clean it up a little bit.