### PR TITLE
build: enable build C++20 modules with GCC 14

### DIFF
--- a/cmake/CxxModulesRules.cmake
+++ b/cmake/CxxModulesRules.cmake
@@ -1,9 +1,13 @@
-if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+    message (FATAL "C++20 module needs Clang++-16 or up")
+  endif ()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+    message (FATAL "C++20 module needs g++-14 or up")
+  endif ()
+else ()
   message (FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
-endif ()
-
-if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
-  message (FATAL "C++20 module needs Clang++-16 or up")
 endif ()
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)


### PR DESCRIPTION
since p1689r5 support was included in GCC master. this feature will be available in GCC-14. see
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=024f135a1e9b8f8e102960357cae6e99e1dbe6eb

so let's prepare for it.