### PR TITLE
treewide: include used headers

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -25,6 +25,9 @@ module;
 
 #include <algorithm>
 #include <atomic>
+#ifdef SEASTAR_COROUTINES_ENABLED
+#include <coroutine>
+#endif
 #include <deque>
 #include <filesystem>
 #include <functional>

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -23,6 +23,7 @@
 module;
 #endif
 
+#include <sys/socket.h>
 #include <cassert>
 #include <chrono>
 #include <cmath>

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -23,6 +23,7 @@ module;
 #endif
 
 #include <boost/range/algorithm/find_if.hpp>
+#include <memory>
 #include <vector>
 
 #ifdef SEASTAR_MODULE

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -23,6 +23,7 @@
 module;
 #endif
 
+#include <algorithm>
 #include <ostream>
 #include <arpa/inet.h>
 #include <boost/functional/hash.hpp>

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -26,6 +26,7 @@ module;
 
 #include <boost/asio/ip/address_v4.hpp>
 #include <boost/algorithm/string.hpp>
+#include <map>
 #include <utility>
 
 #ifdef SEASTAR_MODULE


### PR DESCRIPTION
* core/smp.cc: in 63d39d0698d0e0baeb1413f50710e86c37c9a677, we use `std::make_unique` in this source file, so need to include the corresponding "<memory>"
* net/net.cc: std::map is used, so include "<map>".
* core/scollectd.cc: include sys/socket.h for accessing AF_INET
* net/inet_address.cc: include <algorithm> for using std::all_of()
* core/file.cc: include <coroutine>, as `co_await` requires the `std::coroutine_traits` type. and when compiling C++20 modules, the .cc files are supposed to be self-contained. our own headers does not expose the symbols in standard library, so the .cc file does not get automatically the access to them by putting "export module seastar;" or "module seastar;" like '#include <seastar/foobar.hh>', where foobar.hh includes the C++ standard library headers. in other words, the .cc files have to include the used standard library headers explicitly.

otherwise, we have FTBFS with Seastar_MODULE enabled.