### PR TITLE
seastar.cc: include "core/prefault.hh"

### DIFF
--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -306,6 +306,7 @@ module : private;
 
 #include "core/cgroup.hh"
 #include "core/file-impl.hh"
+#include "core/prefault.hh"
 #include "core/program_options.hh"
 #include "core/reactor_backend.hh"
 #include "core/syscall_result.hh"


### PR DESCRIPTION
core/prefault.hh should be added to the global module fragment. otherwise we would have:
```
  /home/kefu/dev/seastar/src/core/smp.cc:169:11: error: incomplete type 'seastar::internal::memory_prefaulter' named in nested name specifier
  169 | internal::memory_prefaulter::memory_prefaulter(const resource::resources& res, memory::internal::numa_layout layout) {
      | ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```