### PR TITLE
build: define SEASTAR_COROUTINES_ENABLED for Seastar module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ target_compile_definitions (seastar-module
     $<$<BOOL:${Seastar_SSTRING}>:SEASTAR_SSTRING>
     SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
     SEASTAR_SCHEDULING_GROUPS_COUNT=${Seastar_SCHEDULING_GROUPS_COUNT}
+    SEASTAR_COROUTINES_ENABLED
   PRIVATE
     SEASTAR_MODULE)
 target_compile_options (seastar-module

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -147,7 +147,6 @@ module;
 
 export module seastar;
 
-#define SEASTAR_COROUTINES_ENABLED
 // include all declaration and definitions to be exported in the the module
 // purview
 #include <seastar/util/std-compat.hh>


### PR DESCRIPTION
before this change, SEASTAR_COROUTINES_ENABLED is defined in seastar.cc so all the headers includes in it are aware that coroutine should be enabled. but we now have a .cc file which conditionalize on this macro as well: src/core/file.cc check SEASTAR_COROUTINES_ENABLED for enabling the
make_list_directory_generator() function.

in non-modules build, this macro is defined by util/std-compat.h, we could include this header file in file.cc in its global purview, but unfortunately, std-compat.h also exposes symbols like `seastar::compat::source_location` as a part of the seastar module, which cannot be included by global purview. so, to enable the build with C++20 module enabled, and to avoid redefinition of this macro, let's define it in the building system, as we assume that C++20 module support implies the availability of C++20 coroutine, as both of them are introduced by C++20, and pratically, the latter has better support from the C++ compilers than C++20 modules, so if one has the luxury of using C++20 modules, he/she should be able to use C++20 coroutines.