### PR TITLE
build: silence the waring of -Winclude-angled-in-module-purview

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,13 @@ target_compile_definitions (seastar-module
 target_compile_options (seastar-module
   PUBLIC
     -U_FORTIFY_SOURCE)
+include (CheckCXXCompilerFlag)
+check_cxx_compiler_flag ("-Winclude-angled-in-module-purview"
+    Warning_IncludeAngledInModulePurview_FOUND)
+if (Warning_IncludeAngledInModulePurview_FOUND)
+  target_compile_options (seastar-module
+    PRIVATE "-Wno-include-angled-in-module-purview")
+endif ()
 
 target_link_libraries (seastar-module
   PUBLIC


### PR DESCRIPTION
-Winclude-angled-in-module-purview was introduced in clang 18 to complain if the compiler spot something like `"#include <filename>"` in the module purview. as it is a signal that the purview is exposing something which does not belong to it.

but in Seastar, we include the public Seastar headers using angled bracket also, so this warning does not apply to us. as an exception, we _could_ include headers using quotes instead of angled brackets in seastar.cc, as we don't redistribute this source file as a header, so `#include "seastar/foobar.hh"` does not give user an impression that we are including an in-project file. but this does not address the whole problem, because we have other headers including headers using angled bracket in their module purview.

so, let's silence this warning at this moment before we have a better solution.