### PR TITLE
httpd: support temporary redirect from inside async reply

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -65,9 +65,8 @@ private:
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url)
-            : base_exception("", http::reply::status_type::moved_permanently), url(
-                    url) {
+    redirect_exception(const std::string& url, http::reply::status_type status = http::reply::status_type::moved_permanently)
+            : base_exception("", status), url(url) {
     }
     std::string url;
 };


### PR DESCRIPTION
- The redirect_exception is hard coded for permanent move status. In Redpanda we also have cases where we need to use temporary redirect, which has the same Location header but different http status. This PR allows the status code to be customized for the redirect_exception.

- Additionally, this PR handles redirect for thrown from future returned from handler. Previous the redirect was only handled when returned from the synchronous code inside handler.

- Adds test for redirect_exception