### PR TITLE
build: install Finducontext.cmake and FindSystem-SDT.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,11 +396,9 @@ seastar_find_dependencies ()
 
 # Private build dependencies not visible to consumers
 find_package (ragel 6.10 REQUIRED)
-find_package (ucontext REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
-find_package (SystemTap-SDT)
 
 #
 # Code generation helpers.
@@ -1328,9 +1326,11 @@ if (Seastar_INSTALL)
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findnumactl.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findragel.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findrt.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Finducontext.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findyaml-cpp.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SeastarDependencies.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibUring.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSystemTap-SDT.cmake
     DESTINATION ${install_cmakedir})
 
   install (

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -99,10 +99,12 @@ macro (seastar_find_dependencies)
     Sanitizers
     SourceLocation
     StdAtomic
+    SystemTap-SDT
     hwloc
     lksctp-tools # No version information published.
     numactl # No version information published.
     rt
+    ucontext
     yaml-cpp)
 
   # Arguments to `find_package` for each 3rd-party dependency.
@@ -141,6 +143,7 @@ macro (seastar_find_dependencies)
   seastar_set_dep_args (rt REQUIRED)
   seastar_set_dep_args (numactl
     OPTION ${Seastar_NUMA})
+  seastar_set_dep_args (ucontext REQUIRED)
   seastar_set_dep_args (yaml-cpp REQUIRED
     VERSION 0.5.1)
 


### PR DESCRIPTION
in 6d2b0a72, Finducontext.cmake was introduced to find libucontext if necessary. and ucontext::ucontext was added as yet another linkage of Seastar::seastar if Seastar is built in Release mode as one of its INTERFACE_LINK_LIBRARIES. but we failed to install Finducontext.cmake along with the Seastar's module config file. so, if user configure the building system for an application with a Seastar installed into the system, cmake would fail like:

```
CMake Warning (dev) at /home/ubuntu/.local/lib/cmake/Seastar/SeastarTargets.cmake:61 (set_target_properties):
  Policy CMP0028 is not set: Double colon in target name means ALIAS or
  IMPORTED target.  Run "cmake --help-policy CMP0028" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The link interface of target "Seastar::seastar" contains:

    ucontext::ucontext

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /home/ubuntu/.local/lib/cmake/Seastar/SeastarConfig.cmake:36 (include)
  CMakeLists.txt:1 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

the same applies to SystemTap-SDT.
in this change,

* ucontext is checked using SeastarDependencies.cmake, so we can check for it when building Seastar and when building Seastar applications.
* Finducontext.cmake is installed.
* apply the same change to SystemTap-SDT

Refs 6d2b0a72
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>