### PR TITLE
circleci: build with C++20 modules enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ jobs:
         description: build with DPDK enabled
         type: enum
         enum: ["disable-dpdk", "enable-dpdk"]
+      with_modules:
+        default: "disable-modules"
+        description: build with C++20 modules enabled
+        type: enum
+        enum: ["disable-modules", "enable-modules"]
     machine:
       image:  ubuntu-2204:2023.04.2
     resource_class: large
@@ -31,7 +36,14 @@ jobs:
             - run: ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >> --cook dpdk --enable-dpdk
       - when:
           condition:
-            equal: [ "disable-dpdk", << parameters.with_dpdk >> ]
+            equal: [ "enable-modules", << parameters.with_modules >> ]
+          steps:
+            - run: ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >> --enable-cxx-modules
+      - when:
+          condition:
+            and:
+              - equal: [ "disable-dpdk", << parameters.with_dpdk >> ]
+              - equal: [ "disable-modules", << parameters.with_modules >> ]
           steps:
             - run: ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >>
       - when:
@@ -39,8 +51,17 @@ jobs:
             equal: [ dev, << parameters.mode >> ]
           steps:
             - run: ./run ninja -C build/<< parameters.mode >> checkheaders
-      - run: ./run ninja -C build/<< parameters.mode >>
-      - run: ./run ./test.py --mode=<< parameters.mode >>
+      - when:
+          condition:
+            equal: [ "enable-modules", << parameters.with_modules >> ]
+          steps:
+            - run: ./run ninja -C build/<< parameters.mode >> hello_cxx_module
+      - when:
+          condition:
+            equal: [ "disable-modules", << parameters.with_modules >> ]
+          steps:
+            - run: ./run ninja -C build/<< parameters.mode >>
+            - run: ./run ./test.py --mode=<< parameters.mode >>
 
 workflows:
   version: 2
@@ -62,3 +83,13 @@ workflows:
               standard: ["20"]
               mode: ["release"]
               with_dpdk: [ "enable-dpdk" ]
+      # only build this combination with C++20 moduels enabled, so we don't double
+      # the size of the test matrix, and can at least test the build with
+      # C++20 modules enabled.
+      - build_and_test:
+          matrix:
+            parameters:
+              compiler: ["clang++-17"]
+              standard: ["20"]
+              mode: ["debug"]
+              with_modules: [ "enable-modules" ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,6 @@ target_link_libraries (seastar-module
     Boost::program_options
     Boost::thread
     c-ares::cares
-    cryptopp::cryptopp
     fmt::fmt
     lz4::lz4
     SourceLocation::source_location

--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -24,6 +24,7 @@
 module;
 #endif
 
+#include <compare>
 #include <atomic>
 #include <iterator>
 #include <memory>

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -116,6 +116,7 @@ module;
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
+#include <gnutls/crypto.h>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <xmmintrin.h>
@@ -144,8 +145,6 @@ module;
 #include <spawn.h>
 #include <ucontext.h>
 #include <unistd.h>
-#define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
-#include <cryptopp/md5.h>
 
 export module seastar;
 

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -50,6 +50,7 @@ module;
 #include <bitset>
 #include <cassert>
 #include <chrono>
+#include <compare>
 #include <concepts>
 #include <coroutine>
 #include <cstddef>
@@ -66,6 +67,7 @@ module;
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <list>
 #include <memory>
 #include <memory_resource>
 #include <mutex>


### PR DESCRIPTION
add one more build with the combination of "clang++17", C++20, debug with C++20 modules enabled. so that we can at least test with C++20 modules build without doubling the size of the test matrix.