### PR TITLE
docker: install clang-tools-17

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,7 +6,7 @@ RUN apt -y update \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13 \
-    && apt -y install clang-16 clang-17 \
+    && apt -y install clang-16 clang-17 clang-tools-17 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 16 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 16 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 17 \


### PR DESCRIPTION
to build with C++20 modules support, CMake needs to use clang-scan-deps, which is packaged by clang-tools-17, see
https://packages.debian.org/sid/amd64/clang-tools-17/filelist and
https://packages.ubuntu.com/mantic/amd64/clang-tools-17/filelist, so we have to install it in our CI image.