### PR TITLE
memory: do not set_reclaim_hook if cpu_mem_ptr is not set

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1530,7 +1530,13 @@ void shrink(void* obj, size_t new_size) {
 }
 
 void set_reclaim_hook(std::function<void (std::function<void ()>)> hook) {
-    get_cpu_mem().set_reclaim_hook(hook);
+    // in general, we are using Seastar allocator here. but the Seastar application
+    // can still configure smp_opts.memory_allocator with memory_allocator::standard.
+    // in that case, the memory::configure() is not called, hence cpu_mem_ptr is not
+    // set.
+    if (cpu_mem_ptr) {
+        cpu_mem_ptr->set_reclaim_hook(hook);
+    }
 }
 
 reclaimer::reclaimer(std::function<reclaiming_result ()> reclaim, reclaimer_scope scope)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -409,6 +409,13 @@ seastar_add_test (simple_stream
 seastar_add_app_test (smp
   SOURCES smp_test.cc)
 
+if(NOT Seastar_DPDK)
+  # disabled if built with DPDK, see seastar#2003
+  seastar_add_test (app-template
+    KIND BOOST
+    SOURCES app-template_test.cc)
+endif()
+
 seastar_add_test (socket
   SOURCES socket_test.cc)
 

--- a/tests/unit/app-template_test.cc
+++ b/tests/unit/app-template_test.cc
@@ -1,0 +1,57 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+#define BOOST_TEST_MODULE app_template
+
+#include <string>
+#include <boost/test/unit_test.hpp>
+#include <seastar/core/app-template.hh>
+
+using namespace seastar;
+
+// NOTE: only a single test case is hosted in this test, because the underlying
+// Seastar runtime does not do cleanup every bits when it tears down. and this
+// is a design decision at this moment, so even launching two seastar
+// applications in the same process sequentially is not supported.
+//
+BOOST_AUTO_TEST_CASE(app_standard_memory_allocator) {
+    // by default, use conservative settings instead of maxing out the performance
+    // for testing app_template and underlying reactor's handling of different
+    // settings
+    app_template::seastar_options opts;
+    opts.smp_opts.thread_affinity.set_value(false);
+    opts.smp_opts.mbind.set_value(false);
+    opts.smp_opts.smp.set_value(1);
+    opts.smp_opts.lock_memory.set_value(false);
+    opts.smp_opts.memory_allocator = memory_allocator::standard;
+    opts.log_opts.default_log_level.set_value(log_level::error);
+    app_template app{std::move(opts)};
+    // app.run() takes `char**` not `char* const *`, so appease it
+    std::string prog_name{"prog"};
+    char* args[] = {prog_name.data()};
+    int expected_status = 42;
+    int actual_status = app.run(
+        std::size(args), std::data(args),
+        [expected_status] {
+            return make_ready_future<int>(expected_status);
+        });
+    BOOST_CHECK_EQUAL(actual_status, expected_status);
+}


### PR DESCRIPTION
in the release build, we use Seastar allocator, but the Seastar application
can still configure `smp_opts.memory_allocator` with `memory_allocator::standard`.
in that case, the `memory::configure()` is not called, hence `cpu_mem_ptr` is not
set.

but in the constructor of `reactor`, it is supposed to setup per-reactor
facilities, notably the ones backed by TLS variables, including the
memory subsystem. but we are not able to access the `smp_opts` anymore
in `reactor::reactor()`. because the memory subsystem is configured in
`smp::configure()`, where is `smp_opts` passed in.

so, in this change

* instead of conditionally calling
  `memory::set_reclaim_hook()` in `reactor::reactor()` based on the
  value of `smp_opts.memory_allocator`, we check for null in
  `memory::set_reclaim_hook()`. fortunately, this is not a hot path,
  we only call `memory::set_reclaim_hook()` when starting the reactor,
  so the extra check does not hurt the performance.
* add a test for exercising template_app, as the smp options is
  a public interface for customizing the behavior of app_template.
  because boot.test considers it an error if a test suite does not
  contains any test, and fails the test with:
  ```
  Test setup error: test tree is empty
  ```
  we cannot disable the test in app-template_test.cc using
  `boost::unit_test::enable_if<>`. neither can we add more
  test cases in this test, because seastar cannot be initialized
  multiple times in a single process. so we have to disable
  this test in the CMake.
