### PR TITLE
core: enable seastar to run multiple times in a single process

### DIFF
--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -90,6 +90,10 @@ static dl_iterate_fn dl_iterate_phdr_org() {
 static std::vector<dl_phdr_info> *phdrs_cache = nullptr;
 
 void init_phdr_cache() {
+    // this process started reactor before, no need to fill the cache
+    if (phdrs_cache) {
+        return;
+    }
     // Fill out elf header cache for access without locking.
     // This assumes no dynamic object loading/unloading after this point
     phdrs_cache = new std::vector<dl_phdr_info>();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3987,6 +3987,8 @@ void smp::allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_co
 void smp::cleanup() noexcept {
     smp::_threads = std::vector<posix_thread>();
     _thread_loops.clear();
+    reactor_holder.reset();
+    local_engine = nullptr;
 }
 
 void smp::cleanup_cpu() {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -409,12 +409,9 @@ seastar_add_test (simple_stream
 seastar_add_app_test (smp
   SOURCES smp_test.cc)
 
-if(NOT Seastar_DPDK)
-  # disabled if built with DPDK, see seastar#2003
-  seastar_add_test (app-template
-    KIND BOOST
-    SOURCES app-template_test.cc)
-endif()
+seastar_add_test (app-template
+  KIND BOOST
+  SOURCES app-template_test.cc)
 
 seastar_add_test (socket
   SOURCES socket_test.cc)


### PR DESCRIPTION
this series enables us to run multiple `seastar::app_template` instances sequentially in a single process. this is a false requirement in production, as we don't launch seastar app multiple times in a single process. but this is handy if we want to test, for instance, app_template in a single test process, where we need to start multiple app_template instances one after another.
