### PR TITLE
Fix the L4 protocol routing issue in the native_stack.

### DIFF
--- a/include/seastar/net/ip.hh
+++ b/include/seastar/net/ip.hh
@@ -302,7 +302,6 @@ private:
         // fragment with MF == 0 inidates it is the last fragment
         bool last_frag_received = false;
 
-        packet get_assembled_packet(ethernet_address from, ethernet_address to);
         int32_t merge(ip_hdr &h, uint16_t offset, packet p);
         bool is_complete();
     };
@@ -318,6 +317,9 @@ private:
     metrics::metric_groups _metrics;
 private:
     future<> handle_received_packet(packet p, ethernet_address from);
+    void deliver_packet_to_l4(ethernet_address from, ip_protocol* l4,
+                              ip_hdr& ip_header, packet& ip_packet);
+    static packet assemble_ethernet_packet(ethernet_address from, ethernet_address to, packet& ip_packet);
     bool forward(forward_hash& out_hash_data, packet& p, size_t off);
     std::optional<l3_protocol::l3packet> get_packet();
     bool in_my_netmask(ipv4_address a) const;

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -136,7 +136,6 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
 
     auto h = ntoh(*iph);
     unsigned ip_len = h.len;
-    unsigned ip_hdr_len = h.ihl * 4;
     unsigned pkt_len = p.len();
     auto offset = h.offset();
     if (pkt_len > ip_len) {
@@ -178,45 +177,31 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
         if (mf == false) {
             frag.last_frag_received = true;
         }
+
         // This is a newly created frag_id
         if (frag.mem_size == 0) {
             _frags_age.push_back(frag_id);
             frag.rx_time = clock_type::now();
         }
+
         auto added_size = frag.merge(h, offset, std::move(p));
         _frag_mem += added_size;
+
         if (frag.is_complete()) {
             // All the fragments are received
-            auto dropped_size = frag.mem_size;
-            auto& ip_data = frag.data.map.begin()->second;
             // Choose a cpu to forward this packet
-            auto cpu_id = this_shard_id();
             auto l4 = _l4[h.ip_proto];
             if (l4) {
-                if (smp::count == 1) {
-                    l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
-                } else {
-                    size_t l4_offset = 0;
-                    forward_hash hash_data;
-                    hash_data.push_back(hton(h.src_ip.ip));
-                    hash_data.push_back(hton(h.dst_ip.ip));
-                    auto forwarded = l4->forward(hash_data, ip_data, l4_offset);
-                    if (forwarded) {
-                        cpu_id = _netif->hash2cpu(toeplitz_hash(_netif->rss_key(), hash_data));
-                        // No need to forward if the dst cpu is the current cpu
-                        if (cpu_id == this_shard_id()) {
-                            l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
-                        } else {
-                            auto to = _netif->hw_address();
-                            auto pkt = frag.get_assembled_packet(from, to);
-                            _netif->forward(cpu_id, std::move(pkt));
-                        }
-                    }
-                }
+                packet& ip_packet = frag.header;
+
+                packet& ip_data = frag.data.map.begin()->second;
+                frag.header.append(std::move(ip_data));
+
+                deliver_packet_to_l4(from, l4, *ip_packet.get_header<ip_hdr>(), ip_packet);
             }
 
             // Delete this frag from _frags and _frags_age
-            frag_drop(frag_id, dropped_size);
+            frag_drop(frag_id, frag.mem_size);
             _frags_age.remove(frag_id);
         } else {
             // Some of the fragments are missing
@@ -229,11 +214,58 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
 
     auto l4 = _l4[h.ip_proto];
     if (l4) {
-        // Trim IP header and pass to upper layer
-        p.trim_front(ip_hdr_len);
-        l4->received(std::move(p), h.src_ip, h.dst_ip);
+        deliver_packet_to_l4(from, l4, h, p);
     }
+
     return make_ready_future<>();
+}
+
+void ipv4::deliver_packet_to_l4(ethernet_address from, ip_protocol* l4,
+                                ip_hdr& ip_header, packet& ip_packet) {
+    if (smp::count == 1) {
+        l4->received(std::move(ip_packet), ip_header.src_ip, ip_header.dst_ip);
+    } else {
+        size_t l4_offset = 0;
+        forward_hash hash_data;
+        hash_data.push_back(hton(ip_header.src_ip.ip));
+        hash_data.push_back(hton(ip_header.dst_ip.ip));
+        auto forwarded = l4->forward(hash_data, ip_packet, l4_offset);
+        if (forwarded) {
+            auto cpu_id = _netif->hash2cpu(toeplitz_hash(_netif->rss_key(), hash_data));
+            // No need to forward if the dst cpu is the current cpu
+            if (cpu_id == this_shard_id()) {
+                // Trim IP header and pass to upper layer
+                unsigned ip_hdr_len = ip_header.ihl * 4;
+                ip_packet.trim_front(ip_hdr_len);
+                l4->received(std::move(ip_packet), ip_header.src_ip, ip_header.dst_ip);
+            } else {
+                auto to = _netif->hw_address();
+                auto pkt = assemble_ethernet_packet(from, to, ip_packet);
+                _netif->forward(cpu_id, std::move(pkt));
+            }
+        }
+    }
+}
+
+packet ipv4::assemble_ethernet_packet(ethernet_address from, ethernet_address to, packet& ip_packet) {
+    auto eh = ip_packet.prepend_header<eth_hdr>();
+    eh->src_mac = from;
+    eh->dst_mac = to;
+    eh->eth_proto = uint16_t(eth_protocol_num::ipv4);
+    *eh = hton(*eh);
+    // Prepare a packet contains both ethernet header, ip header and ip data
+    auto ethernet_pkt = std::move(ip_packet);
+    auto iph = ethernet_pkt.get_header<ip_hdr>(sizeof(eth_hdr));
+    // len is the sum of each fragment
+    iph->len = hton(uint16_t(ethernet_pkt.len() - sizeof(eth_hdr)));
+    // No fragmentation for the assembled datagram
+    iph->frag = 0;
+    // Since each fragment's csum is checked, no need to csum
+    // again for the assembled datagram
+    offload_info oi;
+    oi.reassembled = true;
+    ethernet_pkt.set_offload_info(oi);
+    return ethernet_pkt;
 }
 
 future<ethernet_address> ipv4::get_l2_dst_address(ipv4_address to) {
@@ -442,31 +474,6 @@ bool ipv4::frag::is_complete() {
     auto offset = data.map.begin()->first;
     auto nr_packet = data.map.size();
     return last_frag_received && nr_packet == 1 && offset == 0;
-}
-
-packet ipv4::frag::get_assembled_packet(ethernet_address from, ethernet_address to) {
-    auto& ip_header = header;
-    auto& ip_data = data.map.begin()->second;
-    // Append a ethernet header, needed for forwarding
-    auto eh = ip_header.prepend_header<eth_hdr>();
-    eh->src_mac = from;
-    eh->dst_mac = to;
-    eh->eth_proto = uint16_t(eth_protocol_num::ipv4);
-    *eh = hton(*eh);
-    // Prepare a packet contains both ethernet header, ip header and ip data
-    ip_header.append(std::move(ip_data));
-    auto pkt = std::move(ip_header);
-    auto iph = pkt.get_header<ip_hdr>(sizeof(eth_hdr));
-    // len is the sum of each fragment
-    iph->len = hton(uint16_t(pkt.len() - sizeof(eth_hdr)));
-    // No fragmentation for the assembled datagram
-    iph->frag = 0;
-    // Since each fragment's csum is checked, no need to csum
-    // again for the assembled datagram
-    offload_info oi;
-    oi.reassembled = true;
-    pkt.set_offload_info(oi);
-    return pkt;
 }
 
 void icmp::received(packet p, ipaddr from, ipaddr to) {


### PR DESCRIPTION
In my discussion on issue#2004, I mentioned that the TCP client implemented based on the native_network_stack exhibits significant issues in a multi-core sharded architecture. Specifically, when core-0 sends out a SYN, core-1 receives the corresponding ACK, leading to abnormal behavior. The root cause of this error seems to be that in cases where IP fragmentation is unnecessary, the initial determination of the core based on src_ip and dst_ip may not be accurate. This is because the initial core determination also depends on src_port and dst_port, but no secondary redirection occurs during the receive phase.
To address this issue, I extended the redirection strategy from cases involving IP fragmentation to scenarios where fragmentation is not required. Additionally, I extracted the assemble_packet method from the struct frag, which may have a certain impact.