### PR TITLE
reactor: poll less frequently in debug mode

### DIFF
--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -250,7 +250,7 @@ private:
             futurize<ReturnType>::apply(_function, unwrap(std::move(wi_in))).forward_to(std::move(wi_ready));
             _stats.function_calls_executed++;
 
-            if (need_preempt()) {
+            if (internal::scheduler_need_preempt()) {
                 _stats.tasks_preempted++;
                 break;
             }

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -32,6 +32,8 @@
 #include <chrono>
 #include <sys/mman.h>
 
+#ifndef SEASTAR_DEBUG
+
 using namespace seastar;
 using namespace std::chrono_literals;
 
@@ -172,3 +174,11 @@ SEASTAR_THREAD_TEST_CASE(spin_in_kernel) {
     // doing 128K mmaps
     test_spin_with_body("kernel", [] { mmap_populate(128 * 1024); });
 }
+
+
+#else
+
+SEASTAR_THREAD_TEST_CASE(stall_detector_test_not_valid_in_debug_mode) {
+}
+
+#endif


### PR DESCRIPTION
Usually, seastar loops will try to run in one task, until the task quota expires. This avoids the overhead of breaking out into the reactor and running run_some_tasks(). To avoid going over the task quota and generating high latency, these loops check the need_preempt() function to see whether the task quota expired.

Since many loops often do not preempt, the code paths where they do are a source of bugs. To root them out, need_preempt() is defined in debug mode as always true. As a result, every loop will immediately break into the scheduler, which also checks need_preempt() to see if new I/O has arrived and needs servicing (perhaps by a high priority scheduling_group). The end result is that every loop body execution is accompanies by a reactor poll, which is an expensive operation designed to happen every 0.5ms, not on every vector element (or whatever is being processed in the loop).

To fix this, we split need_preempt() into two functions: the original need_preempt(), which tells loops whether they need to preempt, and a new internal::scheduler_need_preempt(), which tells the scheduler whether it needs to poll for I/O. Outside debug mode, they are the same, since in both cases the goal is to limit latency to the task quota. In debug mode, need_preempt() always returns true (to check the preemption code paths in loops), while scheduler_need_preempt() returns true every 64 calls (to allow for some I/O polling without destroying loop efficiency).

This improves debug mode performance by more than 2X in some tests [1].

[1] https://github.com/scylladb/scylladb/issues/16470