### PR TITLE
build: s/exec_program/execute_process/

### DIFF
--- a/cmake/Findragel.cmake
+++ b/cmake/Findragel.cmake
@@ -34,8 +34,7 @@ set (_ragel_version_pattern "[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?")
 if (ragel_RAGEL_EXECUTABLE)
   set (ragel_FOUND ON)
 
-  exec_program (${ragel_RAGEL_EXECUTABLE}
-    ARGS -v
+  execute_process (COMMAND ${ragel_RAGEL_EXECUTABLE} -v
     OUTPUT_VARIABLE _ragel_version_output)
 
   if (${_ragel_version_output} MATCHES "version (${_ragel_version_pattern})")


### PR DESCRIPTION
exec_program() was deprecated since CMake v3.0. and the minimal required CMake version is 3.13. so let's use the recommended execute_process().

see also
https://cmake.org/cmake/help/latest/policy/CMP0153.html and https://cmake.org/cmake/help/latest/command/exec_program.html#command:exec_program

this change silence the warning like:

```
CMake Warning (dev) at seastar/cmake/Findragel.cmake:37 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  seastar/CMakeLists.txt:398 (find_package)
```