### PR TITLE
condition_variable: add support for wait with abort_source

### DIFF
--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -28,6 +28,7 @@
 #include <functional>
 #endif
 
+#include "seastar/core/abort_source.hh"
 #include <seastar/core/timer.hh>
 #ifdef SEASTAR_COROUTINES_ENABLED
 #   include <seastar/core/coroutine.hh>
@@ -58,6 +59,14 @@ public:
     virtual const char* what() const noexcept;
 };
 
+/// Exception thrown when wait() operation is aborted
+/// \ref condition_variable::wait(abort_source& as).
+class condition_variable_aborted : public std::exception {
+  public:
+    /// Reports the exception reason.
+    virtual const char *what() const noexcept;
+};
+
 /// \brief Conditional variable.
 ///
 /// This is a standard computer science condition variable sans locking,
@@ -82,6 +91,7 @@ private:
         waiter& operator=(const waiter&) = delete;
         virtual ~waiter() = default;
         void timeout() noexcept;
+        void abort() noexcept;
 
         virtual void signal() noexcept = 0;
         virtual void set_exception(std::exception_ptr) noexcept = 0;
@@ -296,6 +306,52 @@ public:
     SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
     future<> wait(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return wait(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
+    }
+
+    /// Waits until condition variable is signaled or operation is aborted.
+    ///
+    /// \param as abort source.
+    ///
+    /// \return a future that becomes ready when \ref signal() is called
+    ///         If the condition variable was \ref broken() will return \ref
+    ///         broken_condition_variable exception. On abort, the future
+    ///         contains a \ref condition_variable_aborted exception.
+    future<> wait(abort_source &as) noexcept {
+        if (check_and_consume_signal()) {
+            return make_ready_future();
+        }
+        if (as.abort_requested()) {
+            return make_exception_future(condition_variable_aborted());
+        }
+
+        struct abortable_promise_waiter : public promise_waiter {
+            abort_source::subscription sub;
+        };
+        auto w = new abortable_promise_waiter();
+        auto f = w->get_future();
+        w->sub = std::move(*as.subscribe([w](const std::optional<std::exception_ptr> &) noexcept {
+            w->abort();
+        }));
+        add_waiter(*w);
+        return f;
+    }
+
+    /// Waits until condition variable is signaled and pred() == true or
+    /// operation is aborted, otherwise wait again.
+    ///
+    /// \param as abort source.
+    /// \param pred predicate that checks that awaited condition is true
+    ///
+    /// \return a future that becomes ready when \ref signal() is called
+    ///         If the condition variable was \ref broken() will return \ref
+    ///         broken_condition_variable exception. On abort, the future
+    ///         contains a \ref condition_variable_aborted exception.
+    template <typename Pred>
+    SEASTAR_CONCEPT(requires std::is_invocable_r_v<bool, Pred>)
+    future<> wait(abort_source &as, Pred &&pred) noexcept {
+        return do_until(std::forward<Pred>(pred), [this, &as] {
+            return wait(as);
+        });
     }
 
 #ifdef SEASTAR_COROUTINES_ENABLED

--- a/src/core/condition-variable.cc
+++ b/src/core/condition-variable.cc
@@ -38,6 +38,10 @@ const char* condition_variable_timed_out::what() const noexcept {
     return "Condition variable timed out";
 }
 
+const char *condition_variable_aborted::what() const noexcept {
+    return "Condition variable was aborted";
+}
+
 condition_variable::~condition_variable() {
     broken();
 }
@@ -54,6 +58,11 @@ void condition_variable::add_waiter(waiter& w) noexcept {
 void condition_variable::waiter::timeout() noexcept {
     this->unlink();
     this->set_exception(std::make_exception_ptr(condition_variable_timed_out()));
+}
+
+void condition_variable::waiter::abort() noexcept {
+    this->unlink();
+    this->set_exception(std::make_exception_ptr(condition_variable_aborted()));
 }
 
 bool condition_variable::wakeup_first() noexcept {


### PR DESCRIPTION
Hi Seastar developers 👋 

I've come across a use-case where I need to abort waiting on a condition variable (e.g. when client aborts the connection).

I've come up with the following patch. I've used sleep_abortable and abortable_fifo as an inspiration. The tests are pretty match copy & paste of the "wait with timeout" ones.

Haven't added "native" coroutine (`when(...)`) support as I couldn't figure out where is most reasonable to check the status of the abort source and to create the subscription. I.e. `constructor` vs `operator co_await`.

Please let me know what you think about this change and whether "native" coroutine support is a requirement for merging (given that there are no other objections).

Also, I've done best-effort for code formatting. Couldn't figure out how to automatically format it and match the codebase style.