### PR TITLE
treewide: s/format/fmt::format/ when appropriate

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3818,7 +3818,7 @@ static program_options::selection_value<network_stack_factory> create_network_st
     }
 
     return program_options::selection_value<network_stack_factory>(zis, "network-stack", std::move(candidates), default_stack,
-            format("select network stack (valid values: {})", format_separated(net_stack_names.begin(), net_stack_names.end(), ", ")));
+            fmt::format("select network stack (valid values: {})", format_separated(net_stack_names.begin(), net_stack_names.end(), ", ")));
 }
 
 static program_options::selection_value<reactor_backend_selector>::candidates backend_selector_candidates() {
@@ -3867,7 +3867,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                  " The diagnostics will be written to the seastar_memory logger, with error level."
                  " Note that if the seastar_memory logger is set to debug or trace level, the diagnostics will be logged irrespective of this setting.")
     , reactor_backend(*this, "reactor-backend", backend_selector_candidates(), reactor_backend_selector::default_backend().name(),
-                format("Internal reactor implementation ({})", reactor_backend_selector::available()))
+                fmt::format("Internal reactor implementation ({})", reactor_backend_selector::available()))
     , aio_fsync(*this, "aio-fsync", kernel_supports_aio_fsync(),
                 "Use Linux aio for fsync() calls. This reduces latency; requires Linux 4.18 or later.")
     , max_networking_io_control_blocks(*this, "max-networking-io-control-blocks", 10000,
@@ -4497,7 +4497,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
-            auto thread_name = seastar::format("reactor-{}", i);
+            auto thread_name = fmt::format("reactor-{}", i);
             pthread_setname_np(pthread_self(), thread_name.c_str());
             if (thread_affinity) {
                 smp::pin(allocation.cpu_id);

--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -81,7 +81,7 @@ public:
         try {
             add(element->_name, element->to_string());
         } catch (...) {
-            std::throw_with_nested(std::runtime_error(format("Json generation failed for field: {}",element->_name)));
+            std::throw_with_nested(std::runtime_error(fmt::format("Json generation failed for field: {}",element->_name)));
         }
     }
 

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -232,7 +232,7 @@ seastar::net::ipv6_address::ipv6_address() noexcept
 
 seastar::net::ipv6_address::ipv6_address(const std::string& addr) {
     if (!::inet_pton(AF_INET6, addr.c_str(), ip.data())) {
-        throw std::runtime_error(format("Wrong format for IPv6 address {}. Please ensure it's in colon-hex format",
+        throw std::runtime_error(fmt::format("Wrong format for IPv6 address {}. Please ensure it's in colon-hex format",
                                         addr));
     }
 }

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -43,7 +43,7 @@ ipv4_address::ipv4_address(const std::string& addr) {
     auto ipv4 = boost::asio::ip::address_v4::from_string(addr, ec);
     if (ec) {
         throw std::runtime_error(
-            format("Wrong format for IPv4 address {}. Please ensure it's in dotted-decimal format", addr));
+            fmt::format("Wrong format for IPv4 address {}. Please ensure it's in dotted-decimal format", addr));
     }
     ip = static_cast<uint32_t>(std::move(ipv4).to_ulong());
 }

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -54,7 +54,7 @@ void exception_generator(uint32_t test_instance, int nesting_level) {
             exception_generator(test_instance>>1, nesting_level-1);
         }
     } catch(...) {
-        auto msg = format("Exception Level {}", nesting_level);
+        auto msg = fmt::format("Exception Level {}", nesting_level);
         if(test_instance&1) {
             // Throw a non std::exception derived type
             std::throw_with_nested(unknown_obj(msg));
@@ -64,9 +64,9 @@ void exception_generator(uint32_t test_instance, int nesting_level) {
     }
     if (nesting_level == 0) {
         if (test_instance & 1) {
-            throw unknown_obj(format("Exception Level {}", nesting_level));
+            throw unknown_obj(fmt::format("Exception Level {}", nesting_level));
         } else {
-            throw std::runtime_error(format("Exception Level {}", nesting_level));
+            throw std::runtime_error(fmt::format("Exception Level {}", nesting_level));
         }
     }
 }
@@ -76,17 +76,16 @@ void exception_generator(uint32_t test_instance, int nesting_level) {
 std::string exception_generator_str(uint32_t test_instance,int nesting_level) {
     std::ostringstream ret;
     const std::string runtime_err_str = "std::runtime_error";
-    const std::string exception_level_fmt_str = "Exception Level {}";
     const std::string unknown_obj_str = "unknown_obj";
     const std::string nested_exception_with_unknown_obj_str = "std::_Nested_exception<unknown_obj>";
     const std::string nested_exception_with_runtime_err_str = "std::_Nested_exception<std::runtime_error>";
 
     for(; nesting_level > 0; nesting_level--) {
         if (test_instance & 1) {
-            ret << nested_exception_with_unknown_obj_str;
+            fmt::print(ret, "{}", nested_exception_with_unknown_obj_str);
         } else {
-            ret << nested_exception_with_runtime_err_str << " (" <<
-                    format(exception_level_fmt_str.c_str(), nesting_level) << ")";
+            fmt::print(ret, "{} (Exception Level {})", nested_exception_with_runtime_err_str,
+                       nesting_level);
         }
         ret << ": ";
         test_instance >>= 1;
@@ -94,9 +93,9 @@ std::string exception_generator_str(uint32_t test_instance,int nesting_level) {
 
 
     if (test_instance & 1) {
-        ret << unknown_obj_str;
+        fmt::print(ret, "{}", unknown_obj_str);
     } else {
-        ret << runtime_err_str << " (" << format(exception_level_fmt_str.c_str(), nesting_level) << ")";
+        fmt::print(ret, "{} (Exception Level {})", runtime_err_str, nesting_level);
     }
     return ret.str();
 }


### PR DESCRIPTION
this change replace some `format()` calls with `fmt::format()`.

before this change, we use `format()` when formatting to an sstring and when formatting to an std::string.

the upside of this design is that we don't need to differentiate the calls where an sstring is expected from those where an std::string is expected.

but the downside is that we create an `std::string` by deep copy the content of sstring after formatting the parameters and then drop the `sstring` on the floor in the second use case, where only an std::string is expected.

another potential problem is that there are actually three `format()` functions. they are from three different namespaces: `seastar`, `std` and `fmt` in C++20. currently, the `seastar::format()` one wins in the function loopup. because the other two are templated format string, while `seastar::format()` accepts a plain `const char*`, and we always open the `seastar` namespace in this project.

and in future, once we switch over to the compile-time format check, the function signature of `seastar::format()` will be changed from `format(const char* fmt, A&&... a)` to
`format(fmt::format_string<A...> fmt, A&&... a)`, the compiler would have trouble when performing the function lookup because of the ambiguity.

so, to address the second problem we have to change all call sites of this function to one of these three format functions.

but before that, just to prepare for the change, let's change some of them to `fmt::format()` to address both the first problem and the second one.