### PR TITLE
print: deprecate format_separated() 

### DIFF
--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -86,6 +86,7 @@ sprint(const sstring& fmt, A&&... a) {
 }
 
 template <typename Iterator>
+[[deprecated("use fmt::join()")]]
 std::string
 format_separated(Iterator b, Iterator e, const char* sep = ", ") {
     std::string ret;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3811,7 +3811,7 @@ static program_options::selection_value<network_stack_factory> create_network_st
     }
 
     return program_options::selection_value<network_stack_factory>(zis, "network-stack", std::move(candidates), default_stack,
-            format("select network stack (valid values: {})", format_separated(net_stack_names.begin(), net_stack_names.end(), ", ")));
+            format("select network stack (valid values: {})", fmt::join(net_stack_names, ", ")));
 }
 
 static program_options::selection_value<reactor_backend_selector>::candidates backend_selector_candidates() {


### PR DESCRIPTION
`fmt::join()` is a better alternative than `format_separated()`. because Seastar should focus on what it is good at instead of trying to help resolving all the problems.

in this changeset, we replace the only caller site of this function with `fmt::join()`, and mark `format_separated()` deprecated.