### PR TITLE
Prometheus protobuf add the enhanced functionality from the text based and Native histogram support

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,4 +1,3 @@
-#
 # This file is open source software, licensed to you under the terms
 # of the Apache License, Version 2.0 (the "License").  See the NOTICE file
 # distributed with this work for additional information regarding copyright
@@ -52,6 +51,7 @@ endmacro ()
 add_subdirectory (httpd)
 add_subdirectory (io_tester)
 add_subdirectory (rpc_tester)
+add_subdirectory(metrics_tester)
 add_subdirectory (iotune)
 add_subdirectory (memcached)
 add_subdirectory (seawreck)

--- a/apps/metrics_tester/CMakeLists.txt
+++ b/apps/metrics_tester/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2024 Scylladb, Ltd.
+#
+
+seastar_add_app (metrics_tester
+  SOURCES metrics_tester.cc)
+
+target_link_libraries (app_metrics_tester)

--- a/apps/metrics_tester/metrics_tester.cc
+++ b/apps/metrics_tester/metrics_tester.cc
@@ -1,0 +1,91 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2024 ScyllaDB
+ */
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/prometheus.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/relabel_config.hh>
+#include <seastar/core/internal/estimated_histogram.hh>
+#include "../lib/stop_signal.hh"
+using namespace seastar;
+using namespace std::chrono_literals;
+
+struct serializer {};
+
+int main(int ac, char** av) {
+    namespace bpo = boost::program_options;
+
+    app_template app;
+    auto opt_add = app.add_options();
+    opt_add
+        ("listen", bpo::value<sstring>()->default_value("0.0.0.0"), "address to start Prometheus server on")
+        ("port", bpo::value<uint16_t>()->default_value(9180), "Prometheus port")
+    ;
+    httpd::http_server_control prometheus_server;
+
+    return app.run(ac, av, [&] {
+        return seastar::async([&] {
+            namespace sm = seastar::metrics;
+            sm::internal::time_estimated_histogram histogram;
+            sm::metric_groups _metrics;
+            histogram.add_micro(1000);
+            histogram.add_micro(2000);
+            histogram.add_micro(30000);
+            seastar_apps_lib::stop_signal stop_signal;
+            auto& opts = app.configuration();
+            auto& listen = opts["listen"].as<sstring>();
+            auto private_label = sm::label_instance("private", "1");
+            auto& port = opts["port"].as<uint16_t>();
+            _metrics.add_group("test_group", {
+                    sm::make_gauge("gauge1", [] { return 1; },
+                            sm::description("A test gauge"),{private_label} ),
+                    sm::make_histogram("histogram1", [histogram]{return histogram.to_metrics_histogram();}
+                           ,sm::description("A test histogram"),{private_label})
+            });
+            smp::invoke_on_all([] {
+                    std::vector<metrics::relabel_config> rl(2);
+                    rl[0].source_labels = {"__name__"};
+                    rl[0].expr = ".*";
+                    rl[0].action = metrics::relabel_config::relabel_action::drop;
+
+                    rl[1].source_labels = {"private"};
+                    rl[1].expr = "1";
+                    rl[1].action = metrics::relabel_config::relabel_action::keep;
+                    return metrics::set_relabel_configs(rl).then([](metrics::metric_relabeling_result) {
+                        return;
+                    });
+            }).get();
+
+            if (port) {
+                prometheus_server.start("prometheus").get();
+
+                prometheus::config pctx;
+                pctx.allow_protobuf = true;
+                prometheus::start(prometheus_server, pctx).get();
+                prometheus_server.listen(socket_address{listen, port}).handle_exception([] (auto ep) {
+                    return make_exception_future<>(ep);
+                }).get();
+                stop_signal.wait().get();
+            }
+        });
+    });
+}

--- a/include/seastar/core/metrics_types.hh
+++ b/include/seastar/core/metrics_types.hh
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <vector>
 #include <seastar/util/modules.hh>
+#include <optional>
 #endif
 
 namespace seastar {
@@ -42,7 +43,21 @@ struct histogram_bucket {
     uint64_t count = 0; // number of events.
     double upper_bound = 0;      // Inclusive.
 };
-
+/*!
+ * \brief native histogram specific information
+ *
+ * Native histograms (also known as sparse histograms) are an experimental Prometheus feature.
+ */
+struct native_histogram_info {
+    // schema defines the bucket schema. Currently, valid numbers are -4 <= n <= 8.
+    // They are all for base-2 bucket schemas, where 1 is a bucket boundary in each case, and
+    // then each power of two is divided into 2^n logarithmic buckets.
+    // Or in other words, each bucket boundary is the previous boundary times 2^(2^-n).
+    // In the future, more bucket schemas may be added using numbers < -4 or > 8.
+    int32_t schema;
+    // min_id is the first bucket id of a given schema.
+    int32_t min_id;
+};
 
 /*!
  * \brief Histogram data type
@@ -82,6 +97,8 @@ struct histogram {
      */
     histogram operator+(histogram&& h) const;
 
+    // Native histograms are an experimental Prometheus feature.
+    std::optional<native_histogram_info> native_histogram;
 };
 
 SEASTAR_MODULE_EXPORT_END

--- a/src/proto/metrics2.proto
+++ b/src/proto/metrics2.proto
@@ -11,72 +11,137 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+// This is copied and lightly edited from
+// github.com/prometheus/client_model/io/prometheus/client/metrics.proto
+// and finally converted to proto3 syntax to make it usable for the
+// gogo-protobuf approach taken within prometheus/prometheus.
+
+syntax = "proto3";
 
 package io.prometheus.client;
-option java_package = "io.prometheus.client";
+option go_package = "io_prometheus_client";
+
+//import "google/protobuf/gogo.proto";
+import "google/protobuf/timestamp.proto";
 
 message LabelPair {
-  optional string name  = 1;
-  optional string value = 2;
+  string name  = 1;
+  string value = 2;
 }
 
 enum MetricType {
-  COUNTER    = 0;
-  GAUGE      = 1;
-  SUMMARY    = 2;
-  UNTYPED    = 3;
-  HISTOGRAM  = 4;
+  // COUNTER must use the Metric field "counter".
+  COUNTER = 0;
+  // GAUGE must use the Metric field "gauge".
+  GAUGE = 1;
+  // SUMMARY must use the Metric field "summary".
+  SUMMARY = 2;
+  // UNTYPED must use the Metric field "untyped".
+  UNTYPED = 3;
+  // HISTOGRAM must use the Metric field "histogram".
+  HISTOGRAM = 4;
+  // GAUGE_HISTOGRAM must use the Metric field "histogram".
+  GAUGE_HISTOGRAM = 5;
 }
 
 message Gauge {
-  optional double value = 1;
+  double value = 1;
 }
 
 message Counter {
-  optional double value = 1;
+  double   value    = 1;
+  Exemplar exemplar = 2;
 }
 
 message Quantile {
-  optional double quantile = 1;
-  optional double value    = 2;
+  double quantile = 1;
+  double value    = 2;
 }
 
 message Summary {
-  optional uint64   sample_count = 1;
-  optional double   sample_sum   = 2;
-  repeated Quantile quantile     = 3;
+  uint64            sample_count = 1;
+  double            sample_sum   = 2;
+  repeated Quantile quantile     = 3 ;// [(gogoproto.nullable) = false];
 }
 
 message Untyped {
-  optional double value = 1;
+  double value = 1;
 }
 
 message Histogram {
-  optional uint64 sample_count = 1;
-  optional double sample_sum   = 2;
-  repeated Bucket bucket       = 3; // Ordered in increasing order of upper_bound, +Inf bucket is optional.
+  uint64 sample_count       = 1;
+  double sample_count_float = 4; // Overrides sample_count if > 0.
+  double sample_sum         = 2;
+  // Buckets for the conventional histogram.
+  repeated Bucket bucket = 3 ;// [(gogoproto.nullable) = false]; // Ordered in increasing order of upper_bound, +Inf bucket is optional.
+
+  // Everything below here is for native histograms (also known as sparse histograms).
+  // Native histograms are an experimental feature without stability guarantees.
+
+  // schema defines the bucket schema. Currently, valid numbers are -4 <= n <= 8.
+  // They are all for base-2 bucket schemas, where 1 is a bucket boundary in each case, and
+  // then each power of two is divided into 2^n logarithmic buckets.
+  // Or in other words, each bucket boundary is the previous boundary times 2^(2^-n).
+  // In the future, more bucket schemas may be added using numbers < -4 or > 8.
+  sint32 schema           = 5;
+  double zero_threshold   = 6; // Breadth of the zero bucket.
+  uint64 zero_count       = 7; // Count in zero bucket.
+  double zero_count_float = 8; // Overrides sb_zero_count if > 0.
+
+  // Negative buckets for the native histogram.
+  repeated BucketSpan negative_span = 9 ;// [(gogoproto.nullable) = false];
+  // Use either "negative_delta" or "negative_count", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 negative_delta = 10; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double negative_count = 11; // Absolute count of each bucket.
+
+  // Positive buckets for the native histogram.
+  repeated BucketSpan positive_span = 12 ;// [(gogoproto.nullable) = false];
+  // Use either "positive_delta" or "positive_count", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 positive_delta = 13; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double positive_count = 14; // Absolute count of each bucket.
 }
 
 message Bucket {
-  optional uint64 cumulative_count = 1; // Cumulative in increasing order.
-  optional double upper_bound = 2;      // Inclusive.
+  uint64   cumulative_count       = 1; // Cumulative in increasing order.
+  double   cumulative_count_float = 4; // Overrides cumulative_count if > 0.
+  double   upper_bound            = 2; // Inclusive.
+  Exemplar exemplar               = 3;
+}
+
+// A BucketSpan defines a number of consecutive buckets in a native
+// histogram with their offset. Logically, it would be more
+// straightforward to include the bucket counts in the Span. However,
+// the protobuf representation is more compact in the way the data is
+// structured here (with all the buckets in a single array separate
+// from the Spans).
+message BucketSpan {
+  sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
+  uint32 length = 2; // Length of consecutive buckets.
+}
+
+message Exemplar {
+  repeated LabelPair        label     = 1 ;// [(gogoproto.nullable) = false];
+  double                    value     = 2;
+  google.protobuf.Timestamp timestamp = 3; // OpenMetrics-style.
 }
 
 message Metric {
-  repeated LabelPair label        = 1;
-  optional Gauge     gauge        = 2;
-  optional Counter   counter      = 3;
-  optional Summary   summary      = 4;
-  optional Untyped   untyped      = 5;
-  optional Histogram histogram    = 7;
-  optional int64     timestamp_ms = 6;
+  repeated LabelPair label        = 1 ;// [(gogoproto.nullable) = false];
+  Gauge              gauge        = 2;
+  Counter            counter      = 3;
+  Summary            summary      = 4;
+  Untyped            untyped      = 5;
+  Histogram          histogram    = 7;
+  int64              timestamp_ms = 6;
 }
 
 message MetricFamily {
-  optional string     name   = 1;
-  optional string     help   = 2;
-  optional MetricType type   = 3;
-  repeated Metric     metric = 4;
+  string          name   = 1;
+  string          help   = 2;
+  MetricType      type   = 3;
+  repeated Metric metric = 4 ;// [(gogoproto.nullable) = false];
 }
-


### PR DESCRIPTION
While the Prometheus protobuf support was removed, the metrics layer, and specifically the Prometheus text representation, kept evolving.
This series addresses multiple issues:
1. Prometheus protobuf definition (metrics2.proto) uses the later protobuf version with additional definitions towards native histogram support.
2. Prometheus text representation has new features: Label-based filtering, aggregate by label, and skip_when_empty, which were added while the protobuf was not supported.
3. Prometheus native histogram is an alternative representation that supports high resolution with lower resource cost.
4. Seastar approximate_exponential_histogram uses similar logic to the native histogram, which allows Prometheus to choose to send it as a native histogram
5. Prometheus chooses which representation format to use when answering a request based on configuration and the accept header. The default is text representation. The code needs to reflect that logic clearly. 

The series is around the Prometheus code, but each set of changes has its own commit.