### PR TITLE
build: use new behavior defined by CMP0155 when building C++ modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -858,6 +858,9 @@ set( MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --leak-check=no --trace-chi
 include (CTest)
 
 if (Seastar_MODULE)
+  if (POLICY CMP0155)
+    cmake_policy (SET CMP0155 NEW)
+  endif ()
   include (CxxModulesRules)
   add_subdirectory (src)
 endif ()


### PR DESCRIPTION
use the new behavior defined by CMP0155, so that when creating the building system with CMake 3.28 and up, the rules are generated to scan the targets for imports when C++20 standard is used.

without this change, when compiling C++20 modules with CMake 3.28, the modmap and related targets are not generated, hence when building the compilation units for the implementation of the "seastar" module, they cannot find the "seastar" module.

after this change, the corresponding rules are generated.

please note, unlike other policies, the new behavior adds a step to can the imported modules when building a compilation unit. but quite a few Seastar application do not use C++ modules yet. so unlike other CMake policies, we only enable CMP0155 when C++20 modules is enabled to avoid the build-time overhead when building with CMake 3.28 and up and a capable compiler.

also, we can only call `cmake_policy (SET CMP0155 NEW)` at the toplevel of a CMake project. so we cannot set the policy in `CxxModulesRules.cmake`.

see also https://cmake.org/cmake/help/latest/policy/CMP0155.html