### PR TITLE
memory: include used header

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -84,6 +84,7 @@ module;
 #include <fmt/ostream.h>
 
 #include <boost/container/static_vector.hpp>
+#include <seastar/util/concepts.hh>
 
 #include <dlfcn.h>
 


### PR DESCRIPTION
in 477827b841, we started using `SEASTAR_CONCEPT` in core/memory.cc. but we failed to include the header providing this macro. this breaks the build of seastar C++ module, which requires the .cc file to be self-contained. the failure looks like:
```
FAILED: src/CMakeFiles/seastar-module.dir/core/memory.cc.o
/usr/bin/clang++-17 -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_COROUTINES_ENABLED -DSEASTAR_MODULE -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -Dseastar_module_EXPORTS -I/home/circleci/project/include -I/home/circleci/project/build/debug/gen/include -I/home/circleci/project/src -g -std=c++20 -fPIC -U_FORTIFY_SOURCE -MD -MT src/CMakeFiles/seastar-module.dir/core/memory.cc.o -MF src/CMakeFiles/seastar-module.dir/core/memory.cc.o.d @src/CMakeFiles/seastar-module.dir/core/memory.cc.o.modmap -o src/CMakeFiles/seastar-module.dir/core/memory.cc.o -c /home/circleci/project/src/core/memory.cc
/home/circleci/project/src/core/memory.cc:1131:1: error: a type specifier is required for all declarations
 1131 | SEASTAR_CONCEPT(requires std::same_as<S, size_t> || std::same_as<S, no_size>)
      | ^
```

so, in this change the header is included.