### PR TITLE
http/client: include used header files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources (seastar-module
     net/socket_address.cc
     net/tls.cc
     net/virtio.cc
+    http/client.cc
     http/common.cc
     http/file_handler.cc
     http/httpd.cc

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -21,6 +21,15 @@
 
 #ifdef SEASTAR_MODULE
 module;
+#endif
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <seastar/util/concepts.hh>
+
+#ifdef SEASTAR_MODULE
 module seastar;
 #else
 #include <seastar/core/loop.hh>


### PR DESCRIPTION
we failed to include http/client.cc in the seastar module, so let's build it and also include the user headers in that source file.