### PR TITLE
shared_future: shared_state::run_and_dispose(): release reserve of _peers

### DIFF
--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -168,6 +168,9 @@ private:
                     _peers.pop_front();
                 }
             }
+            // _peer is now empty, but let's also make sure it releases any
+            // memory it might hold in reserve.
+            _peers = {};
             _keepaliver.release();
         }
 


### PR DESCRIPTION
run_and_dispose() clears _peers but if it was non empty at some point, it might still hold on to some reserve memory after it was cleared. After run_and_dispose() was run, it won't ever contain members again, so this is just a waste, kept around until the shard_state is finally destroyed. Since _peers is a chunked_fifo under the hood, this memory amount might be significant too.
Prevent this waste by resetting _peers to default state at the end of said method.

Refs: scylladb/scylladb#16493