### PR TITLE
src: include used headers for C++ modules build

### DIFF
--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -27,6 +27,7 @@ module;
 #include <string>
 #include <vector>
 #include <sstream>
+#include <fmt/core.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -25,6 +25,7 @@ module;
 #include <chrono>
 #include <string>
 #include <boost/asio/ip/address_v4.hpp>
+#include <fmt/core.h>
 module seastar;
 #else
 #include <seastar/net/ip.hh>


### PR DESCRIPTION
4654cab8 broke the C++ modules build, as it failed to include the used header of fmt/core.h. and the build fails like:

```
seastar/src/json/json_elements.cc:84:60: error: missing '#include <fmt/core.h>'; 'format' must be declared before it is used
   84 |             std::throw_with_nested(std::runtime_error(fmt::format("Json generation failed for field: {}",element->_name)));
      |                                                            ^
/usr/include/fmt/core.h:2815:31: note: declaration here is not visible
 2815 | FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
      |                               ^
1 error generated.
```

in this change, fmt/core.h is included when necessary.