### PR TITLE
build: expose flag like -std=c++20 via seastar.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1262,6 +1262,12 @@ if (Seastar_INSTALL)
     set (Seastar_PC ".pc")
   endif ()
 
+  if(CMAKE_CXX_EXTENSIONS)
+    set(Seastar_CXX_COMPILE_OPTION ${CMAKE_CXX${CMAKE_CXX_STANDARD}_EXTENSION_COMPILE_OPTION})
+  else()
+    set(Seastar_CXX_COMPILE_OPTION ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION})
+  endif()
+
   configure_file (
     ${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/seastar.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/seastar-install${Seastar_PC}.in

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -38,6 +38,6 @@ seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<
 Requires: liblz4 >= 1.7.3
 Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
-Cflags: ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${numactl_cflags} ${seastar_cflags}
+Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${numactl_cflags} ${seastar_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${boost_thread_libs} ${c_ares_libs} ${fmt_libs}
 Libs.private: ${dl_libs} ${rt_libs} ${boost_thread_libs} ${lksctp_tools_libs} ${liburing_libs} ${numactl_libs} ${stdatomic_libs} ${dpdk_libs}


### PR DESCRIPTION
before this change, we don't expose compiling option like `-std=c++20` if Seastar is configured with `-DCMAKE_CXX_STANDARD=20`, and the Seastar application which consumes Seastar via seastar.pc should specify its compiling option by itself. while the CMake config file of Seastar exposes the C++ standard using

```
target_compile_features(seastar
  PUBLIC
    cxx_std_${CMAKE_CXX_STANDARD})
```

this allows the Seastar application consuming Seastar via its CMake config file to use the compile flags exposed by this setting.

after this change, users of seastar.pc will be able to have the `-std=c++20` included the cflags exposed by
`pkgconfig --cflags seastar`.