### PR TITLE
rpc: fix a deadlock in connection::send()

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -298,7 +298,7 @@ namespace rpc {
               }
 
               p->uncancellable();
-              return send_entry(*p).then_wrapped([this, p = std::move(p)] (auto f) mutable {
+              return futurize_invoke([this, &pp = *p] { return send_entry(pp); }).then_wrapped([this, p = std::move(p)] (auto f) mutable {
                   if (f.failed()) {
                       f.ignore_ready_future();
                       abort();


### PR DESCRIPTION
If send_entry() throws (e.g. because compression is unable to allocate an output buffer), then the intended error handling never gets to run. In particular, the connection isn't aborted, and the promise of outgoing_entry is never completed -- the connection is stuck.

The fix is to extend the exception catching back to the send_entry() call.