### PR TITLE
rpc: add a way for compressors to send something to their peer

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -90,7 +90,13 @@ Actual negotiation looks like this:
     uint32_t len
     uint8_t compressed_data[len]
 
-    after compressed_data is uncompressed it becomes regular request, response or streaming frame 
+    After compressed_data is uncompressed, it becomes a regular request, response or streaming frame.
+
+    As a special case, it is allowed to send a compressed frame of size 0 (pre-compression).
+    Such a frame will be a no-op on the receiver.
+    (This can be used as a means of communication between the compressors themselves.
+    If a compressor wants to send some metadata to its peer, it can send a no-op frame,
+    and prepend the metadata as a compressor-specific header.)
 
 ## Request frame format
     uint64_t timeout_in_ms - only present if timeout propagation is negotiated

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -283,6 +283,7 @@ public:
     // decompress data
     virtual rcv_buf decompress(rcv_buf data) = 0;
     virtual sstring name() const = 0;
+    virtual future<> close() noexcept { return make_ready_future<>(); };
     
     // factory to create compressor for a connection
     class factory {
@@ -291,6 +292,12 @@ public:
         // return feature string that will be sent as part of protocol negotiation
         virtual const sstring& supported() const = 0;
         // negotiate compress algorithm
+        // send_empty_frame() requests an empty frame to be sent to the peer compressor on the other side of the connection. 
+        // By attaching a header to this empty frame, the compressor can communicate somthing to the peer,
+        // send_empty_frame() mustn't be called from inside compress() or decompress().
+        virtual std::unique_ptr<compressor> negotiate(sstring feature, bool is_server, std::function<future<>()> send_empty_frame) const {
+            return negotiate(feature, is_server);
+        }
         virtual std::unique_ptr<compressor> negotiate(sstring feature, bool is_server) const = 0;
     };
 };

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -134,7 +134,7 @@ namespace rpc {
 
   future<> connection::send_entry(outgoing_entry& d) noexcept {
     return futurize_invoke([this, &d] {
-      if (_propagate_timeout) {
+      if (d.buf.size && _propagate_timeout) {
           static_assert(snd_buf::chunk_size >= sizeof(uint64_t), "send buffer chunk size is too small");
           if (_timeout_negotiated) {
               auto expire = d.t.get_timeout();
@@ -671,7 +671,7 @@ namespace rpc {
           // supported features go here
           case protocol_features::COMPRESS:
               if (_options.compressor_factory) {
-                  _compressor = _options.compressor_factory->negotiate(e.second, false);
+                  _compressor = _options.compressor_factory->negotiate(e.second, false, [this] { return send({}); });
               }
               if (!_compressor) {
                   throw std::runtime_error(format("RPC server responded with compression {} - unsupported", e.second));
@@ -982,6 +982,8 @@ namespace rpc {
               } else {
                   abort_all_streams();
               }
+          }).finally([this] {
+              return _compressor ? _compressor->close() : make_ready_future();
           }).finally([this]{
               _stopped.set_value();
           });
@@ -1012,7 +1014,7 @@ namespace rpc {
           // supported features go here
           case protocol_features::COMPRESS: {
               if (get_server()._options.compressor_factory) {
-                  _compressor = get_server()._options.compressor_factory->negotiate(e.second, true);
+                  _compressor = get_server()._options.compressor_factory->negotiate(e.second, true, [this] { return send({}); });
                   if (_compressor) {
                        ret[protocol_features::COMPRESS] = _compressor->name();
                   }
@@ -1191,6 +1193,8 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
               } else {
                   return abort_all_streams();
               }
+          }).finally([this] {
+              return _compressor ? _compressor->close() : make_ready_future();
           }).finally([this] {
               _stopped.set_value();
           });

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -461,12 +461,18 @@ namespace rpc {
               }
               auto ptr = compress_header.get();
               auto size = read_le<uint32_t>(ptr);
-              return read_rcv_buf(in, size).then([this, size, &compressor, info] (rcv_buf compressed_data) {
+              return read_rcv_buf(in, size).then([this, size, &compressor, info, &in] (rcv_buf compressed_data) {
                   if (compressed_data.size != size) {
                       _logger(info, format("unexpected eof on a {} while reading compressed data: expected {:d} got {:d}", FrameType::role(), size, compressed_data.size));
                       return FrameType::empty_value();
                   }
                   auto eb = compressor->decompress(std::move(compressed_data));
+                  if (eb.size == 0) {
+                      // Empty frames might be sent as means of communication between the compressors, and should be skipped by the RPC layer.
+                      // We skip the empty frame here. We recursively restart the function, as if the empty frame didn't happen.
+                      // The yield() is here to limit the stack depth of the recursion to 1.
+                      return yield().then([this, info, &in, &compressor] { return read_frame_compressed<FrameType>(info, compressor, in); });
+                  }
                   net::packet p;
                   auto* one = std::get_if<temporary_buffer<char>>(&eb.bufs);
                   if (one) {


### PR DESCRIPTION
In some situations, we might want to re-negotiate some parameters of RPC compression. For example, a fancy streaming compressor might want to shrink the compression context of the connection to reclaim some memory for other, more important connection that just came up.

But for that, there needs to be some way for the two compressors to communicate with each other, in finite time. Currently, there is no such way. Compressors can send messages to each other by simply prepending them to the actual RPC frames, but there never is a guarantee that an actual RPC frame will be sent anytime soon.

This patch adds a mechanism which allows compressors to communicate. For each RPC connection, it spawns a worker fiber which listens on a condition_variable (passed to the compressor's constructor), and sends an empty RPC frame (eventually/soon) whenever the variable is signaled. A compressor can communicate something to the peer in finite time by requesting an empty frame to be sent, and prepending its message to the next sent frame.