### PR TITLE
net/posix: Track ap-server ports conflict

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -140,15 +140,18 @@ class posix_ap_server_socket_impl : public server_socket_impl {
         conntrack::handle connection_tracking_handle;
         connection(pollable_fd xfd, socket_address xaddr, conntrack::handle cth) : fd(std::move(xfd)), addr(xaddr), connection_tracking_handle(std::move(cth)) {}
     };
+    using port_map_t = std::unordered_set<protocol_and_socket_address>;
     using sockets_map_t = std::unordered_map<protocol_and_socket_address, promise<accept_result>>;
     using conn_map_t = std::unordered_multimap<protocol_and_socket_address, connection>;
+    static thread_local port_map_t ports;
     static thread_local sockets_map_t sockets;
     static thread_local conn_map_t conn_q;
     int _protocol;
     socket_address _sa;
     std::pmr::polymorphic_allocator<char>* _allocator;
 public:
-    explicit posix_ap_server_socket_impl(int protocol, socket_address sa, std::pmr::polymorphic_allocator<char>* allocator = memory::malloc_allocator) : _protocol(protocol), _sa(sa), _allocator(allocator) {}
+    explicit posix_ap_server_socket_impl(int protocol, socket_address sa, std::pmr::polymorphic_allocator<char>* allocator = memory::malloc_allocator);
+    ~posix_ap_server_socket_impl();
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     socket_address local_address() const override {


### PR DESCRIPTION
If creating two listening posix sockets with conflicting ports on non-main thread, the listen() call succeeds, but subsequent server_socket::accept() steps on assertion.

The thing is that posix_ap_server_socket_impl() accept() may try to emplace a promise into thread-local sockets map which is used to wait for the main thread to accept() the connection for real and then send it to this map. The map uses server socket as a key in the map, and when emplaced, the code asserts that insertion did took place, not the existing object was found. This is because listening can only be done once, if there's no listened, main thread sends ready sockets via another thread-local container.

When two ap server sockets bound to the same port call accept() only one of them them manages to _insert_ the promise -- the other one will find that the promise is already there and assertion fires.

The fix is in tracking ports for ap stack and throwing EADDRINUSE in case of conflict early.

fixes: #2036