### PR TITLE
build: do not install FindProtobuf.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1359,7 +1359,6 @@ if (Seastar_INSTALL)
     FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindGnuTLS.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLinuxMembarrier.cmake
-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindProtobuf.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSanitizers.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSourceLocation.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindStdAtomic.cmake


### PR DESCRIPTION
263cd37d introduced a regression which tried to install a non-existant file -- cmake/FindProtobuf.cmake.

since this FindProtobuf.cmake is shipped by CMake since 3.13, and our minimal required version of CMake 3.13, there is no need to vendor this file.

so, in this change, we don't install this file.

Fixes #2041
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>