### PR TITLE
net: add missing include

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -28,6 +28,8 @@
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/program-options.hh>
 
+#include <unordered_set>
+
 namespace seastar {
 
 namespace net {


### PR DESCRIPTION
A recent change to net/posix-stack.hh added a use of std::unordered_set but forgot to include the header file <unordered_set>. This was fine on some versions of the standard library, but ended up in a missing the include in other versions. So let's add the missing include.