### PR TITLE
rpc: extend the use_gate until request processing is finished

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1157,12 +1157,9 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
 
                       // If the new method of per-connection scheduling group was used, honor it.
                       // Otherwise, use the old per-handler scheduling group.
-                      auto sg = _isolation_config ? _isolation_config->sched_group : h->sg;
-                      return with_scheduling_group(sg, [this, timeout, msg_id, h, data = std::move(data.value())] () mutable {
-                          return h->func(shared_from_this(), timeout, msg_id, std::move(data)).finally([this, h] {
-                              // If anything between get_handler() and here throws, we leak put_handler
-                              get_server()._proto.put_handler(h);
-                          });
+                      auto sg = _isolation_config ? _isolation_config->sched_group : h->handler.sg;
+                      return with_scheduling_group(sg, [this, timeout, msg_id, &h = h->handler, data = std::move(data.value()), guard = std::move(h->holder)] () mutable {
+                          return h.func(shared_from_this(), timeout, msg_id, std::move(data), std::move(guard));
                       });
                   }
               });


### PR DESCRIPTION
Before the patch we released the `use_gate` in `server::connection::process` when the future, returned by handler `func` is complete. This doesn't mean though that the request processing is finished, it continues in the background and can cause segfaults during node shutdown when `unregister_handler` is called.

To resolve this we extend the `use_gate` until all request related background activity is finished.

The ticket in Scylla: scylladb/scylladb#16382