### PR TITLE
future: use "(T(...))" instead of "{T(...)}" in uninitialized_set()

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -298,7 +298,7 @@ public:
     template<typename... U>
     std::enable_if_t<!std::is_same_v<std::tuple<std::remove_cv_t<U>...>, std::tuple<tuple_type>>, void>
     uninitialized_set(U&&... vs) {
-        new (&_v.value) maybe_wrap_ref<T>{T(std::forward<U>(vs)...)};
+        new (&_v.value) maybe_wrap_ref<T>(T(std::forward<U>(vs)...));
     }
     void uninitialized_set(tuple_type&& v) {
         uninitialized_set(std::move(std::get<0>(v)));


### PR DESCRIPTION
in `uninitialized_wrapper_base::uninitialized_set()`, we initialize
the value of a future using

```c++
new (&_v.value) maybe_wrap_ref<T>{T(std::forward<U>(vs)...)};
```

this has been working fine even if `T` provides a constructor
accepting a C++20 range -- the move constructor is picked as
expected.

but the lastest clang (920bb5430a96c346f7afcbe288e3546513b58012)
starts trying to match the constructor of `maybe_wrap_ref<T>`
which accepts a C++20 range, and fails like:

```
/home/kefu/dev/scylladb/utils/chunked_vector.hh:110:38: note: in instantiation of function template specialization 'utils::chunked_vector<int>::chunked_vector<__gnu_cxx::__normal_iterator<const utils::chunked_vector<int> *, std::vector<utils::chunked_vector<int>>>>' requested here
  110 |     chunked_vector(const Range& r) : chunked_vector(r.begin(), r.end()) {}
      |                                      ^
/home/kefu/dev/scylladb/seastar/include/seastar/core/future.hh:301:43: note: in instantiation of function template specialization 'utils::chunked_vector<int>::chunked_vector<std::vector<utils::chunked_vector<int>>>' requested here
  301 |         new (&_v.value) maybe_wrap_ref<T>{T(std::forward<U>(vs)...)};
      |                                           ^
/home/kefu/dev/scylladb/seastar/include/seastar/core/future.hh:615:15: note: in instantiation of function template specialization 'seastar::internal::uninitialized_wrapper_base<std::vector<utils::chunked_vector<int>>, false>::uninitialized_set<std::vector<utils::chunked_vector<int>>>' requested here
  615 |         this->uninitialized_set(std::forward<A>(a)...);
      |               ^
/home/kefu/dev/scylladb/seastar/include/seastar/core/future.hh:1253:56: note: in instantiation of function template specialization 'seastar::future_state<std::vector<utils::chunked_vector<int>>>::future_state<std::vector<utils::chunked_vector<int>>>' requested here
 1253 |     future(ready_future_marker m, A&&... a) noexcept : _state(m, std::forward<A>(a)...) { }
      |                                                        ^
/home/kefu/dev/scylladb/seastar/include/seastar/core/future.hh:1934:12: note: in instantiation of function template specialization 'seastar::future<std::vector<utils::chunked_vector<int>>>::future<std::vector<utils::chunked_vector<int>>>' requested here
 1934 |     return future<T>(ready_future_marker(), std::forward<A>(value)...);
      |            ^
```

where, `T` is std::vector<chunked_vector<int>>`, and the code
which fails to compile is:
```c++
std::vector<utils::chunked_vector<int>> vec;
return make_ready_future<std::vector<utils::chunked_vector<int>>>(std::move(vec));`
````

where compiler is imagining something like:
```c++
std::vector<utils::chunked_vector<int>> vc{a_chunked_vector};
```
but what we are trying to tell it is:
```c++
std::vector<utils::chunked_vector<int>> vc{a_vector_of_chunked_vector};
```

unfortunately, the compiler hit a brick wall. the reason is that
Clang merged a fix of
https://github.com/llvm/llvm-project/commit/924701311aa79180e86ad8ce43d253f27d25ec7d
to implement a proposal of
https://cplusplus.github.io/CWG/issues/2137.html, regarding initializing
object with initializer list. see also
https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#2638
for an example, which hasn't been included by
https://eel.is/c++draft/dcl.init.list#3.7 at the time of writing though.

both Clang and GCC trunk have implemented the proposed change in C++
standard.

so this issue above is a generalized use form `std::initializer_list`,
and it actually impacts the initialization of all future types accepting
accept `std::initializer_list`.

in this change, let's use '()' instead of '{}', to avoid the resolution
to the constructor from `std::initializer_list`, and to ensure the
compiler picks the right constructor.
