### PR TITLE
net/posix: include used header

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -20,7 +20,9 @@
  */
 
 #pragma once
-
+#ifndef SEASTAR_MODULE
+#include <unordered_set>
+#endif
 #include <seastar/core/sharded.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/net/stack.hh>


### PR DESCRIPTION
in 8b9ae36b, we started to use `std::unordered_set` in `include/seastar/net/posix-stack.hh`, but we failed to include the used header. this breaks the `checkheaders` check.

so, in this change, let's include the userd header.