### PR TITLE
rpc/rpc_types: do not use integer literal in preprocessor macro

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#if FMT_VERSION >= 9'00'00
+#if FMT_VERSION >= 90000
 #include <fmt/ostream.h>
 #endif
-#if FMT_VERSION >= 10'00'00
+#if FMT_VERSION >= 100000
 #include <fmt/std.h>
 #endif
 
@@ -421,11 +421,11 @@ struct tuple_element<I, seastar::rpc::tuple<T...>> : tuple_element<I, tuple<T...
 
 }
 
-#if FMT_VERSION >= 9'00'00
+#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_formatter {};
 #endif
 
-#if FMT_VERSION >= 10'00'00
+#if FMT_VERSION >= 100000
 template <typename T>
 struct fmt::formatter<seastar::rpc::optional<T>> : private fmt::formatter<std::optional<T>> {
     using fmt::formatter<std::optional<T>>::parse;


### PR DESCRIPTION
clang-17.0.6 complains like:
```
[83/819] Scanning /home/runner/work/seastar/seastar/src/rpc/lz4_fragmented_compressor.cc for CXX dependencies
FAILED: CMakeFiles/seastar.dir/src/rpc/lz4_fragmented_compressor.cc.o.ddi
"/usr/bin/clang-scan-deps-17" -format=p1689 -- /usr/bin/clang++-17 -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_LOCALE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_PTHREAD_ATTR_SETAFFINITY_NP -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -Dseastar_EXPORTS -I/home/runner/work/seastar/seastar/include -I/home/runner/work/seastar/seastar/build/debug/gen/include -I/home/runner/work/seastar/seastar/build/debug/gen/src -I/home/runner/work/seastar/seastar/src -g -std=gnu++20 -fPIC -U_FORTIFY_SOURCE -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -UNDEBUG -Wall -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -gz -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -x c++ /home/runner/work/seastar/seastar/src/rpc/lz4_fragmented_compressor.cc -c -o CMakeFiles/seastar.dir/src/rpc/lz4_fragmented_compressor.cc.o -MT CMakeFiles/seastar.dir/src/rpc/lz4_fragmented_compressor.cc.o.ddi -MD -MF CMakeFiles/seastar.dir/src/rpc/lz4_fragmented_compressor.cc.o.ddi.d > CMakeFiles/seastar.dir/src/rpc/lz4_fragmented_compressor.cc.o.ddi
Error while scanning dependencies for /home/runner/work/seastar/seastar/src/rpc/lz4_fragmented_compressor.cc:
In file included from /home/runner/work/seastar/seastar/src/rpc/lz4_fragmented_compressor.cc:22:
In file included from /home/runner/work/seastar/seastar/include/seastar/rpc/lz4_fragmented_compressor.hh:25:
Error: /home/runner/work/seastar/seastar/include/seastar/rpc/rpc_types.hh:24:21: error: token is not a valid binary operator in a preprocessor subexpression
```
when scanning this file for dependencies. this only happens when building the seastar C++20 module.