### PR TITLE
build: prevent gcc -Wstringop-overflow workaround from affecting clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,11 +797,13 @@ set (Seastar_PRIVATE_CXX_FLAGS
   -Wdeprecated
   -Wno-error=deprecated)
 
-include (CheckGcc107852)
-if (NOT Cxx_Compiler_BZ107852_Free)
-  list (APPEND Seastar_PRIVATE_CXX_FLAGS
-    -Wno-error=stringop-overflow
-    -Wno-error=array-bounds)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  include (CheckGcc107852)
+  if (NOT Cxx_Compiler_BZ107852_Free)
+    list (APPEND Seastar_PRIVATE_CXX_FLAGS
+      -Wno-error=stringop-overflow
+      -Wno-error=array-bounds)
+  endif()
 endif ()
 
 if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
We check for a gcc-specific bug, but because we inject warning flags, the test fails on newer versions of clang (since it doesn't like the warning flags). Due to the failure, we then inject the workaround for clang builds, which again fails.

Fix that by only applying the workaround for gcc.