### PR TITLE
future: deprecate future::get0()

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1355,6 +1355,7 @@ public:
     ///
     /// Equivalent to: \c std::get<0>(f.get()).
     using get0_return_type = typename future_state::get0_return_type;
+    [[deprecated("Use get() instead")]]
     get0_return_type get0() {
         return (get0_return_type)get();
     }


### PR DESCRIPTION
In the days when futures carried tuples, it was useful to get the first/only element. But it's now a synonym for get(), so deprecate it.