### PR TITLE
build: do not expose -Wno-error=#warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1045,7 +1045,7 @@ endif ()
 check_cxx_compiler_flag ("-Wno-error=#warnings" ErrorWarnings_FOUND)
 if (ErrorWarnings_FOUND)
   target_compile_options (seastar
-      PUBLIC "-Wno-error=#warnings")
+      PRIVATE "-Wno-error=#warnings")
 endif ()
 
 foreach (definition

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -32,7 +32,7 @@ numactl_cflags=-I$<JOIN:@numactl_INCLUDE_DIRS@, -I>
 numactl_libs=$<JOIN:@numactl_LIBRARIES@, >
 dpdk_libs=$<JOIN:@dpdk_LIBRARIES@, >
 # Us.
-seastar_cflags=${seastar_include_flags} $<JOIN:$<FILTER:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>,EXCLUDE,-Wno-error=#warnings>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
+seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 
 Requires: liblz4 >= 1.7.3


### PR DESCRIPTION
the option of `-Wno-error=#warnings` is added to address the FTBFS when the compiler runs into `#warning` preprocessor, and fails because it takes warning as errors. but we only use `#warning` in the internal header/source files. we even filter out `-Wno-error=#warnings` in 83339edb. this is another proof that this compile option is not necessary to be a public of the public interface of Seastar.

but we still expose this option when the Seastar application is still consuming Seastar via CMake. this causes discrepancies between the public compiling options of Seastar applications.

so, in this change, we

* mark `-Wno-error=#warnings` one of the private compile option instead.
* revert 83339edb

with this change, we

* reduce the differences between the compiling options exposed by seastar.pc and CMake config module,
* and avoid exposing unnecessary compiling options to Seastar applications.