### PR TITLE
util/spinlock: use #warning instead of #warn

### DIFF
--- a/include/seastar/util/spinlock.hh
+++ b/include/seastar/util/spinlock.hh
@@ -71,7 +71,7 @@ inline void cpu_relax() {
 
 [[gnu::always_inline]]
 inline void cpu_relax() {}
-#warn "Using an empty cpu_relax() for this architecture"
+#warning "Using an empty cpu_relax() for this architecture"
 
 #endif
 


### PR DESCRIPTION
`#warning` is a preprocessor macro in C/C++, while `#warn` is not. the reason we haven't run into the build failure caused by this is that we are not building on an architecture other than amd64, i386, PowerPC and aarch64 yet.