### PR TITLE
core/future: add as_ready_future utility

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -166,6 +166,15 @@ struct future_state_base;
 template <typename T = void, typename... A>
 future<T> make_ready_future(A&&... value) noexcept;
 
+
+/// \brief Returns a ready \ref future that is already resolved.
+template<typename T>
+inline
+future<std::remove_cv_t<std::remove_reference_t<T>>> as_ready_future(T&& v) noexcept {
+    return make_ready_future<std::remove_cv_t<std::remove_reference_t<T>>>(
+        std::forward<T>(v));
+}
+
 /// \brief Creates a \ref future in an available, failed state.
 ///
 /// Creates a \ref future object that is already resolved in a failed


### PR DESCRIPTION
seastar::make_ready_future requires a template parameter when
constructing being used due to the default of `void` and supporting
in place construction. Common usage (at least in Redpanda) is
to create a fully formed future from an already constructed struct.

Example with `seastar::make_ready_future`:

```
seastar::future<ss::sstring> foo() {
  ss::sstring str = compute_foo();
  return seastar::make_ready_future<ss::sstring>(std::move(str));
}
```

Using `seastar::as_ready_future`:

```
seastar::future<ss::sstring> foo() {
  ss::sstring str = compute_foo();
  return seastar::as_ready_future(std::move(str));
}
```

