### PR TITLE
io_tester: Allow running on non-XFS fs

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -968,7 +968,7 @@ int main(int ac, char** av) {
             if (*st_type == directory_entry_type::directory) {
                 auto fs = file_system_at(storage).get0();
                 if (fs != fs_type::xfs) {
-                    throw std::runtime_error(format("This is a performance test. {} is not on XFS", storage));
+                    std::cout << "WARNING!!! This is a performance test. " << storage << " is not on XFS" << std::endl;
                 }
             }
 


### PR DESCRIPTION
Currently io-tester just exits in this case, but it's a testing app, it doesn't need to be smarter than whoever uses it, so a WARNING should be enough.