### PR TITLE
io_tester: implement request_type::unlink

### DIFF
--- a/apps/io_tester/conf.yaml
+++ b/apps/io_tester/conf.yaml
@@ -21,6 +21,15 @@
   shards: [0]
   type: cpu
   shard_info:
-    parallelim: 1
+    parallelism: 1
     execution_time: 90us
+    think_time: 10us
+
+- name: unlinking
+  shards: all
+  type: unlink
+  data_size: 2GB
+  files_count: 5000
+  shard_info:
+    parallelism: 10
     think_time: 10us

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -35,7 +35,10 @@
 #include <seastar/core/io_intent.hh>
 #include <seastar/util/later.hh>
 #include <chrono>
+#include <optional>
+#include <utility>
 #include <unordered_set>
+#include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -65,7 +68,7 @@ static auto random_seed = std::chrono::duration_cast<std::chrono::microseconds>(
 static thread_local std::default_random_engine random_generator(random_seed);
 
 class context;
-enum class request_type { seqread, seqwrite, randread, randwrite, append, cpu };
+enum class request_type { seqread, seqwrite, randread, randwrite, append, cpu, unlink };
 
 namespace std {
 
@@ -86,6 +89,39 @@ auto allocate_and_fill_buffer(size_t buffer_size) {
     memset(buffer.get(), fill(random_generator), buffer_size);
 
     return buffer;
+}
+
+future<std::pair<file, uint64_t>> create_and_fill_file(sstring name, uint64_t fsize, open_flags flags, file_open_options options) {
+    return open_file_dma(name, flags, options).then([fsize] (auto f) mutable {
+        return do_with(std::move(f), [fsize] (auto& f) {
+            return f.size().then([f, fsize] (uint64_t pre_truncate_size) mutable {
+                return f.truncate(fsize).then([f, fsize, pre_truncate_size] () mutable {
+                    if (pre_truncate_size >= fsize) {
+                        return make_ready_future<std::pair<file, uint64_t>>(std::pair{f, 0u});
+                    }
+
+                    const uint64_t buffer_size{256ul << 10};
+                    const uint64_t buffers_count{static_cast<uint64_t>(fsize / buffer_size) + 1u};
+                    const uint64_t last_buffer_id = (buffers_count - 1u);
+                    const uint64_t last_write_position = buffer_size * last_buffer_id;
+
+                    return do_with(boost::irange(UINT64_C(0), buffers_count), [f, buffer_size] (auto& buffers_range) mutable {
+                        return max_concurrent_for_each(buffers_range.begin(), buffers_range.end(), 64, [f, buffer_size] (auto buffer_id) mutable {
+                            auto source_buffer = allocate_and_fill_buffer(buffer_size);
+                            auto write_position = buffer_id * buffer_size;
+                            return do_with(std::move(source_buffer), [f, write_position, buffer_size] (const auto& buffer) mutable {
+                                return f.dma_write(write_position, buffer.get(), buffer_size).discard_result();
+                            });
+                        });
+                    }).then([f]() mutable {
+                        return f.flush();
+                    }).then([f, last_write_position]() {
+                        return make_ready_future<std::pair<file, uint64_t>>(std::pair{f, last_write_position});
+                    });
+                });
+            });
+        });
+    });
 }
 
 future<> busyloop_sleep(std::chrono::steady_clock::time_point until, std::chrono::steady_clock::time_point now) {
@@ -207,8 +243,12 @@ struct job_config {
     ::options options;
     // size of each individual file. Every class and every shard have its file, so in a normal
     // system with many shards we'll naturally have many files and that will push the data out
-    // of the disk's cache
+    // of the disk's cache. An exception to that rule is unlink_class_data, that creates files_count
+    // files with file_size/files_count.
     uint64_t file_size;
+    // the number of files to create and unlink by unlink_class_data per shard
+    // remaining operations utilize only one file per shard
+    std::optional<uint64_t> files_count;
     uint64_t offset_in_bdev;
     std::unique_ptr<class_data> gen_class_data();
 };
@@ -218,6 +258,10 @@ static bool keep_files = false;
 
 future<> maybe_remove_file(sstring fname) {
     return keep_files ? make_ready_future<>() : remove_file(fname);
+}
+
+future<> maybe_close_file(file& f) {
+    return f ? f.close() : make_ready_future<>();
 }
 
 class class_data {
@@ -359,15 +403,16 @@ public:
             return make_ready_future<>();
         }
     }
-    // Generate the test file for reads and writes alike. It is much simpler to just generate one file per job instead of expecting
-    // job dependencies between creators and consumers. So every job (a class in a shard) will have its own file and will operate
-    // this file differently depending on the type:
+    // Generate the test file(s) for reads and writes alike. It is much simpler to just generate one file per job instead of expecting
+    // job dependencies between creators and consumers. Removal of files is an exception - it creates multiple files during startup to
+    // unlink them. So every job (a class in a shard) will have its own file(s) and will operate differently depending on the type:
     //
     // sequential reads  : will read the file from pos = 0 onwards, back to 0 on EOF
     // sequential writes : will write the file from pos = 0 onwards, back to 0 on EOF
     // random reads      : will read the file at random positions, between 0 and EOF
     // random writes     : will overwrite the file at a random position, between 0 and EOF
     // append            : will write to the file from pos = EOF onwards, always appending to the end.
+    // unlink            : will unlink files created at the beginning of the execution
     // cpu               : CPU-only load, file is not created.
     future<> start(sstring dir, directory_entry_type type) {
         return do_start(dir, type).then([this] {
@@ -380,10 +425,9 @@ public:
     }
 
     future<> stop() {
-        if (_file) {
-            return _file.close();
-        }
-        return make_ready_future<>();
+        return stop_hook().finally([this] {
+            return maybe_close_file(_file);
+        });
     }
 
     const sstring name() const {
@@ -399,6 +443,7 @@ protected:
             { request_type::randwrite, "RAND WRITE" },
             { request_type::append , "APPEND" },
             { request_type::cpu , "CPU" },
+            { request_type::unlink, "UNLINK" },
         }[_config.type];;
     }
 
@@ -491,6 +536,9 @@ protected:
 
 public:
     virtual void emit_results(YAML::Emitter& out) = 0;
+    virtual future<> stop_hook() {
+        return make_ready_future<>();
+    }
 };
 
 class io_class_data : public class_data {
@@ -536,33 +584,16 @@ private:
         file_open_options options;
         options.extent_allocation_size_hint = _config.file_size;
         options.append_is_unlikely = true;
-        return open_file_dma(fname, flags, options).then([this, fname] (auto f) {
-            _file = f;
-            return maybe_remove_file(fname).then([this] {
-                return _file.size().then([this] (uint64_t size) {
-                    return _file.truncate(_config.file_size).then([this, size] {
-                        if (size >= _config.file_size) {
-                            return make_ready_future<>();
-                        }
 
-                        auto bufsize = 256ul << 10;
-                        return do_with(boost::irange(UINT64_C(0), (_config.file_size / bufsize) + 1), [this, bufsize] (auto& pos) mutable {
-                            return max_concurrent_for_each(pos.begin(), pos.end(), 64, [this, bufsize] (auto pos) mutable {
-                                auto bufptr = allocate_and_fill_buffer(bufsize);
-                                auto buf = bufptr.get();
-                                pos = pos * bufsize;
-                                return _file.dma_write(pos, buf, bufsize).finally([this, bufptr = std::move(bufptr), pos] {
-                                    if ((this->req_type() == request_type::append) && (pos > _last_pos)) {
-                                        _last_pos = pos;
-                                    }
-                                }).discard_result();
-                            });
-                        }).then([this] {
-                            return _file.flush();
-                        });
-                    });
-                });
-            });
+        return create_and_fill_file(fname, _config.file_size, flags, options).then([this](std::pair<file, uint64_t> p) {
+            _file = std::move(p.first);
+            _last_pos = (req_type() == request_type::append) ? p.second : 0u;
+
+            return make_ready_future<>();
+        }).then([fname] {
+            // If keep_files == false, then the file shall not exist after the execution.
+            // After the following function call the usage of the file is valid until `this->_file` object is closed.
+            return maybe_remove_file(fname);
         });
     }
 
@@ -657,6 +688,102 @@ public:
     }
 };
 
+class unlink_class_data : public class_data {
+private:
+    sstring _dir_path{};
+    uint64_t _file_id_to_remove{0u};
+
+public:
+    unlink_class_data(job_config cfg) : class_data(std::move(cfg)) {
+        if (!_config.files_count.has_value()) {
+            throw std::runtime_error("request_type::unlink requires specifying 'files_count'");
+        }
+    }
+
+    future<> do_start(sstring path, directory_entry_type type) override {
+        if (type == directory_entry_type::directory) {
+            return do_start_on_directory(path);
+        }
+        throw std::runtime_error(format("Unsupported storage. {} should be directory", path));
+    }
+
+    future<size_t> issue_request(char *buf, io_intent* intent) override {
+        if (all_files_removed()) {
+            fmt::print("[WARNING]: Cannot issue request in unlink_class_data! All files have been removed for shard_id={}\n"
+                       "[WARNING]: Please create more files or adjust the frequency of unlinks.", this_shard_id());
+            return make_ready_future<size_t>(0u);
+        }
+
+        const auto fname = get_filename(_file_id_to_remove);
+        ++_file_id_to_remove;
+
+        return remove_file(fname).then([]{
+            return make_ready_future<size_t>(0u);
+        });
+    }
+
+    void emit_results(YAML::Emitter& out) override {
+        const auto iops = requests() / total_duration().count();
+        out << YAML::Key << "IOPS" << YAML::Value << iops;
+        out << YAML::Key << "latencies" << YAML::Comment("usec");
+        out << YAML::BeginMap;
+        out << YAML::Key << "average" << YAML::Value << average_latency();
+        out << YAML::Key << "max" << YAML::Value << max_latency();
+        out << YAML::EndMap;
+        out << YAML::Key << "stats" << YAML::BeginMap;
+        out << YAML::Key << "total_requests" << YAML::Value << requests();
+        out << YAML::EndMap;
+    }
+
+private:
+    future<> stop_hook() override {
+        if (all_files_removed() || keep_files) {
+            return make_ready_future<>();
+        }
+
+        return max_concurrent_for_each(boost::irange(_file_id_to_remove, files_count()), max_concurrency(), [this] (uint64_t file_id) {
+            const auto fname = get_filename(file_id);
+            return remove_file(fname);
+        });
+    }
+
+    uint64_t files_count() const {
+        return *_config.files_count;
+    }
+
+    uint64_t max_concurrency() const {
+        // When we have many files it is easy to exceed the limit of open file descriptors.
+        // To avoid that the limit is divided between shards (leaving some room for other jobs).
+        return static_cast<uint64_t>((1024u / smp::count) * 0.8);
+    }
+
+    bool all_files_removed() const {
+        return files_count() <= _file_id_to_remove;
+    }
+
+    sstring get_filename(uint64_t file_id) const {
+        return format("{}/test-{}-shard-{:d}-file-{}", _dir_path, name(), this_shard_id(), file_id);
+    }
+
+    future<> do_start_on_directory(sstring path) {
+        _dir_path = std::move(path);
+
+        return max_concurrent_for_each(boost::irange(UINT64_C(0), files_count()), max_concurrency(), [this] (uint64_t file_id) {
+            const auto fname = get_filename(file_id);
+            const auto fsize = _config.file_size / files_count();
+            const auto flags = open_flags::rw | open_flags::create;
+
+            file_open_options options;
+            options.extent_allocation_size_hint = fsize;
+            options.append_is_unlikely = true;
+
+            return create_and_fill_file(fname, fsize, flags, options).then([](std::pair<file, uint64_t> p) {
+                return p.first.close();
+            });
+        });
+    }
+};
+
 class cpu_class_data : public class_data {
 public:
     cpu_class_data(job_config cfg) : class_data(std::move(cfg)) {}
@@ -684,6 +811,8 @@ public:
 std::unique_ptr<class_data> job_config::gen_class_data() {
     if (type == request_type::cpu) {
         return std::make_unique<cpu_class_data>(*this);
+    } else if (type == request_type::unlink) {
+        return std::make_unique<unlink_class_data>(*this);
     } else if ((type == request_type::seqread) || (type == request_type::randread)) {
         return std::make_unique<read_io_class_data>(*this);
     } else {
@@ -765,6 +894,7 @@ struct convert<request_type> {
             { "randwrite", request_type::randwrite },
             { "append", request_type::append},
             { "cpu", request_type::cpu},
+            { "unlink", request_type::unlink },
         };
         auto reqstr = node.as<std::string>();
         if (!mappings.count(reqstr)) {
@@ -858,12 +988,21 @@ struct convert<job_config> {
         } else {
             cl.file_size = 1ull << 30; // 1G by default
         }
+
+        // By default a job may create 0 or 1 file.
+        // That is not the case for unlink_class_data - it creates multiple
+        // files that are unlinked during the execution.
+        if (node["files_count"]) {
+            cl.files_count = node["files_count"].as<uint64_t>();
+        }
+
         if (node["shard_info"]) {
             cl.shard_info = node["shard_info"].as<shard_info>();
         }
         if (node["options"]) {
             cl.options = node["options"].as<options>();
         }
+
         return true;
     }
 };

--- a/doc/io-tester.md
+++ b/doc/io-tester.md
@@ -14,8 +14,9 @@ if that affects higher percentile latencies.
 Aside from the usual seastar options, I/O tester accepts the following options:
 
 * `duration`: for how long to run the evaluation,
-* `directory`: a directory where to run the evaluation (it must be on XFS),
-* `conf`: the path to a YAML file describing the evaluation.
+* `storage`: a directory or a block device where to execute the test (it must be on XFS),
+* `conf`: the path to a YAML file describing the evaluation,
+* `keep-files`: a flag that indicates keeping test files - next run may re-use them.
 
 # Describing the evaluation
 
@@ -43,6 +44,7 @@ For example:
 * `name`: mandatory property, a string that identifies jobs of this class
 * `type`: mandatory property, one of seqread, seqwrite, randread, randwrite, append, cpu
 * `shards`: mandatory property, either the string "all" or a list of shards where this class should place jobs.
+* `data_size`: optional property, used to divide the available disk space between workloads. Each shard inside the workload uses its portion of the assigned space. If not specified 1GB is used.
 
 The properties under `shard_info` represent properties of the job that will
 be replicated to each shard. All properties under `shard_info` are optional, and in case not specified, defaults are used.

--- a/doc/io-tester.md
+++ b/doc/io-tester.md
@@ -42,9 +42,10 @@ For example:
 ```
 
 * `name`: mandatory property, a string that identifies jobs of this class
-* `type`: mandatory property, one of seqread, seqwrite, randread, randwrite, append, cpu
+* `type`: mandatory property, one of seqread, seqwrite, randread, randwrite, append, cpu, unlink
 * `shards`: mandatory property, either the string "all" or a list of shards where this class should place jobs.
 * `data_size`: optional property, used to divide the available disk space between workloads. Each shard inside the workload uses its portion of the assigned space. If not specified 1GB is used.
+* `files_count`: optional property, relevant only for unlink job class - in such case it is required. Describes the number of files that need to be created during startup to be unlinked during evaluation.
 
 The properties under `shard_info` represent properties of the job that will
 be replicated to each shard. All properties under `shard_info` are optional, and in case not specified, defaults are used.
@@ -81,6 +82,6 @@ Some ideas for extending I/O tester:
 * allow properties like think time, request size, etc, to be specified as distributions instead of a fixed number
 * allow classes to have class-wide properties. For instance, we could define a class with parallelism of 100, and distribute those 100 requests over all shards in which this class is placed
 * allow some jobs to be executed sequentially in relationship to others, so we can have preparation jobs.
-* support other types, like delete, fsync, etc.
+* support other types, like sync, etc.
 * provide functionality similar to diskplorer.
 


### PR DESCRIPTION
This change introduces request_type::unlink as well
as unlink_class_data to io_tester. It also extends
the creation of operations to be executed to recognize
the new request type.

The purpose of this change is to enable io_tester to
analyze the impact of unlink operations on read and
write operations.

unlink_class_data creates a given number of files
during startup. When requests are issued it calls
unlink on the created files.


Refs: scylladb#1299