### PR TITLE
treewide: replace calls to future::get0() by calls to future::get()

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -307,7 +307,7 @@ private:
                         return issue_request(buf, &intent).then_wrapped([this, start, pause, stop, &in_flight] (auto size_f) {
                             size_t size;
                             try {
-                                size = size_f.get0();
+                                size = size_f.get();
                             } catch (...) {
                                 // cancelled
                                 in_flight--;
@@ -959,14 +959,14 @@ int main(int ac, char** av) {
             auto& opts = app.configuration();
             auto& storage = opts["storage"].as<sstring>();
 
-            auto st_type = engine().file_type(storage).get0();
+            auto st_type = engine().file_type(storage).get();
 
             if (!st_type) {
                 throw std::runtime_error(format("Unknown storage {}", storage));
             }
 
             if (*st_type == directory_entry_type::directory) {
-                auto fs = file_system_at(storage).get0();
+                auto fs = file_system_at(storage).get();
                 if (fs != fs_type::xfs) {
                     throw std::runtime_error(format("This is a performance test. {} is not on XFS", storage));
                 }
@@ -1010,7 +1010,7 @@ int main(int ac, char** av) {
                 }
             }
 
-            ctx.start(storage, *st_type, reqs, duration).get0();
+            ctx.start(storage, *st_type, reqs, duration).get();
             engine().at_exit([&ctx] {
                 return ctx.stop();
             });
@@ -1023,7 +1023,7 @@ int main(int ac, char** av) {
                 return c.issue_requests();
             }).get();
             show_results(ctx);
-            ctx.stop().get0();
+            ctx.stop().get();
         }).or_terminate();
     });
 }

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -173,8 +173,8 @@ public:
 
     future<> discover_directory() {
         return seastar::async([this] {
-            auto f = open_directory(_name).get0();
-            auto st = f.stat().get0();
+            auto f = open_directory(_name).get();
+            auto st = f.stat().get();
             f.close().get();
 
             scan_device(major(st.st_dev), minor(st.st_dev));
@@ -666,8 +666,8 @@ fs::path mountpoint_of(sstring filename) {
     std::optional<dev_t> candidate_id = {};
     auto current = mnt_candidate;
     do {
-        auto f = open_directory(current.string()).get0();
-        auto st = f.stat().get0();
+        auto f = open_directory(current.string()).get();
+        auto st = f.stat().get();
         if ((candidate_id) && (*candidate_id != st.st_dev)) {
             return mnt_candidate;
         }
@@ -745,7 +745,7 @@ int main(int ac, char** av) {
                 }
 
                 auto rec = 10000000000ULL;
-                auto avail = fs_avail(eval_dir).get0();
+                auto avail = fs_avail(eval_dir).get();
                 if (avail < rec) {
                     uint64_t val;
                     const char* units;
@@ -799,10 +799,10 @@ int main(int ac, char** av) {
                 io_rates write_bw;
                 size_t sequential_buffer_size = 1 << 20;
                 for (unsigned shard = 0; shard < smp::count; ++shard) {
-                    write_bw += iotune_tests.write_sequential_data(shard, sequential_buffer_size, duration * 0.70 / smp::count).get0();
+                    write_bw += iotune_tests.write_sequential_data(shard, sequential_buffer_size, duration * 0.70 / smp::count).get();
                 }
                 write_bw.bytes_per_sec /= smp::count;
-                rates = iotune_tests.get_serial_rates().get0();
+                rates = iotune_tests.get_serial_rates().get();
                 fmt::print("{} MB/s{}\n", uint64_t(write_bw.bytes_per_sec / (1024 * 1024)), accuracy_msg());
 
                 std::optional<uint64_t> write_sat;
@@ -810,14 +810,14 @@ int main(int ac, char** av) {
                 if (write_saturation) {
                     fmt::print("Measuring write saturation length: ");
                     std::cout.flush();
-                    write_sat = iotune_tests.saturate_write(write_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.70).get0();
+                    write_sat = iotune_tests.saturate_write(write_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.70).get();
                     fmt::print("{}\n", *write_sat);
                 }
 
                 fmt::print("Measuring sequential read bandwidth: ");
                 std::cout.flush();
-                auto read_bw = iotune_tests.read_sequential_data(0, sequential_buffer_size, duration * 0.1).get0();
-                rates = iotune_tests.get_serial_rates().get0();
+                auto read_bw = iotune_tests.read_sequential_data(0, sequential_buffer_size, duration * 0.1).get();
+                rates = iotune_tests.get_serial_rates().get();
                 fmt::print("{} MB/s{}\n", uint64_t(read_bw.bytes_per_sec / (1024 * 1024)), accuracy_msg());
 
                 std::optional<uint64_t> read_sat;
@@ -825,20 +825,20 @@ int main(int ac, char** av) {
                 if (read_saturation) {
                     fmt::print("Measuring read saturation length: ");
                     std::cout.flush();
-                    read_sat = iotune_tests.saturate_read(read_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.1).get0();
+                    read_sat = iotune_tests.saturate_read(read_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.1).get();
                     fmt::print("{}\n", *read_sat);
                 }
 
                 fmt::print("Measuring random write IOPS: ");
                 std::cout.flush();
-                auto write_iops = iotune_tests.write_random_data(test_directory.minimum_io_size(), duration * 0.1).get0();
-                rates = iotune_tests.get_sharded_worst_rates().get0();
+                auto write_iops = iotune_tests.write_random_data(test_directory.minimum_io_size(), duration * 0.1).get();
+                rates = iotune_tests.get_sharded_worst_rates().get();
                 fmt::print("{} IOPS{}\n", uint64_t(write_iops.iops), accuracy_msg());
 
                 fmt::print("Measuring random read IOPS: ");
                 std::cout.flush();
-                auto read_iops = iotune_tests.read_random_data(test_directory.minimum_io_size(), duration * 0.1).get0();
-                rates = iotune_tests.get_sharded_worst_rates().get0();
+                auto read_iops = iotune_tests.read_random_data(test_directory.minimum_io_size(), duration * 0.1).get();
+                rates = iotune_tests.get_sharded_worst_rates().get();
                 fmt::print("{} IOPS{}\n", uint64_t(read_iops.iops), accuracy_msg());
 
                 struct disk_descriptor desc;

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -714,7 +714,7 @@ int main(int ac, char** av) {
                 jc.duration = duration;
                 if (groups.count(jc.sg_name) == 0) {
                     fmt::print("Make sched group {}, {} shares\n", jc.sg_name, jc.shares);
-                    groups[jc.sg_name] = create_scheduling_group(jc.sg_name, jc.shares).get0();
+                    groups[jc.sg_name] = create_scheduling_group(jc.sg_name, jc.shares).get();
                 }
                 jc.sg = groups[jc.sg_name];
             }

--- a/demos/file_demo.cc
+++ b/demos/file_demo.cc
@@ -76,7 +76,7 @@ future<> demo_with_file() {
         auto write_to_file = [] (const sstring filename, temporary_buffer<char>& wbuf) {
             auto count = with_file(open_file_dma(filename, open_flags::rw | open_flags::create), [&wbuf] (file& f) {
                 return f.dma_write(0, wbuf.get(), aligned_size);
-            }).get0();
+            }).get();
             assert(count == aligned_size);
         };
 
@@ -144,7 +144,7 @@ future<> demo_with_file_close_on_failure() {
         // `make_file_output_stream` returns an error. Otherwise, in the error-free path,
         // the opened file is moved to `file_output_stream` that in-turn closes it
         // when the stream is closed.
-        output_stream<char> o = make_output_stream(meta_filename).get0();
+        output_stream<char> o = make_output_stream(meta_filename).get();
 
         write_to_stream(o, wbuf).get();
 
@@ -152,7 +152,7 @@ future<> demo_with_file_close_on_failure() {
         fmt::print("  writing random data into {}\n", data_filename);
         std::generate(wbuf.get_write(), wbuf.get_write() + aligned_size, [&dist, &rnd] { return dist(rnd); });
 
-        o = make_output_stream(data_filename).get0();
+        o = make_output_stream(data_filename).get();
 
         write_to_stream(o, wbuf).get();
 
@@ -172,7 +172,7 @@ future<> demo_with_io_intent() {
     fmt::print("\nDemonstrating demo_with_io_intent():\n");
     return tmp_dir::do_with_thread([] (tmp_dir& t) {
         sstring filename = (t.get_path() / "testfile.tmp").native();
-        auto f = open_file_dma(filename, open_flags::rw | open_flags::create).get0();
+        auto f = open_file_dma(filename, open_flags::rw | open_flags::create).get();
 
         auto rnd = std::mt19937(std::random_device()());
         auto dist = std::uniform_int_distribution<int>(0, std::numeric_limits<char>::max());

--- a/demos/http_client_demo.cc
+++ b/demos/http_client_demo.cc
@@ -65,7 +65,7 @@ int main(int ac, char** av) {
         auto https = config["https"].as<bool>();
 
         return seastar::async([=] {
-            net::hostent e = net::dns::get_host_by_name(host, net::inet_address::family::INET).get0();
+            net::hostent e = net::dns::get_host_by_name(host, net::inet_address::family::INET).get();
             std::unique_ptr<http::experimental::client> cln;
             if (https) {
                 auto certs = ::make_shared<tls::certificate_credentials>();
@@ -81,7 +81,7 @@ int main(int ac, char** av) {
                 future<file> f = open_file_dma(body, open_flags::ro);
                 req.write_body("txt", [ f = std::move(f) ] (output_stream<char>&& out) mutable {
                     return seastar::async([f = std::move(f), out = std::move(out)] () mutable {
-                        auto in = make_file_input_stream(f.get0());
+                        auto in = make_file_input_stream(f.get());
                         copy(in, out).get();
                         out.flush().get();
                         out.close().get();

--- a/demos/scheduling_group_demo.cc
+++ b/demos/scheduling_group_demo.cc
@@ -140,11 +140,11 @@ int main(int ac, char** av) {
     app_template app;
     return app.run(ac, av, [] {
         return seastar::async([] {
-            auto sg100 = seastar::create_scheduling_group("sg100", 100).get0();
+            auto sg100 = seastar::create_scheduling_group("sg100", 100).get();
             auto ksg100 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg100).get(); });
-            auto sg20 = seastar::create_scheduling_group("sg20", 20).get0();
+            auto sg20 = seastar::create_scheduling_group("sg20", 20).get();
             auto ksg20 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg20).get(); });
-            auto sg50 = seastar::create_scheduling_group("sg50", 50).get0();
+            auto sg50 = seastar::create_scheduling_group("sg50", 50).get();
             auto ksg50 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg50).get(); });
 
             bool done = false;

--- a/doc/rpc-streaming.md
+++ b/doc/rpc-streaming.md
@@ -32,7 +32,7 @@ To receive:
 
 ```cpp
       while (true) {
-          std:optional<std::tuple<int, long>> data = source().get0();
+          std:optional<std::tuple<int, long>> data = source().get();
           if (!data) {
              // unengaged optional means EOS
              break;
@@ -51,7 +51,7 @@ before streaming is. Given RPC client `rc`, and a `serializer` class that models
 (again assuming `seastar::async` context):
 
 ```cpp
-    rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get0();
+    rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get();
 ```
 
 Now the client has the sink that can be used for streaming data to
@@ -95,8 +95,8 @@ Client code will be:
 
 ```cpp
    auto rpc_call = rpc_proto.make_client<rpc::source<sstring> (int, rpc::sink<int>)>(1);
-   rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get0();
-   rpc::source<sstring> source = rpc_call(rc, aux_data, sink).get0();
+   rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get();
+   rpc::source<sstring> source = rpc_call(rc, aux_data, sink).get();
    // use sink and source here
 ```
 
@@ -111,7 +111,7 @@ The feature will contain ID of an RPC client that was used to create the stream.
 So in the example from previous chapter:
 
 ```cpp
-    rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get0();
+    rpc::sink<int, long> sink = rc.make_stream_sink<serializer, int, long>().get();
 ```
 
 the call will initiate a new TCP connection to the same server `rc` is connected to. During RPC

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1207,8 +1207,8 @@ future<> f() {
                     make_ready_future<double>(3.5)
            ).then([] (auto tup) {
             std::cout << std::get<0>(tup).available() << "\n";
-            std::cout << std::get<1>(tup).get0() << "\n";
-            std::cout << std::get<2>(tup).get0() << "\n";
+            std::cout << std::get<1>(tup).get() << "\n";
+            std::cout << std::get<2>(tup).get() << "\n";
     });
 }
 ```
@@ -2281,8 +2281,8 @@ seastar::future<> f() {
 ```cpp
 seastar::future<seastar::sstring> read_file(sstring file_name) {
     return seastar::async([file_name] () {  // lambda executed in a thread
-        file f = seastar::open_file_dma(file_name).get0();  // get0() call "blocks"
-        auto buf = f.dma_read(0, 512).get0();  // "block" again
+        file f = seastar::open_file_dma(file_name).get();  // get() call "blocks"
+        auto buf = f.dma_read(0, 512).get();  // "block" again
         return seastar::sstring(buf.get(), buf.size());
     });
 };

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -155,7 +155,7 @@ public:
         }
     }
 
-    T await_resume() { return _future.get0(); }
+    T await_resume() { return _future.get(); }
 };
 
 template<bool CheckPreempt>

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -67,7 +67,7 @@ public:
             delete this;
             return;
         } else {
-            if (_state.get0() == stop_iteration::yes) {
+            if (_state.get() == stop_iteration::yes) {
                 _promise.set_value();
                 delete this;
                 return;
@@ -81,7 +81,7 @@ public:
                     internal::set_callback(std::move(f), this);
                     return;
                 }
-                if (f.get0() == stop_iteration::yes) {
+                if (f.get() == stop_iteration::yes) {
                     _promise.set_value();
                     delete this;
                     return;
@@ -135,7 +135,7 @@ future<> repeat(AsyncAction&& action) noexcept {
             }();
         }
 
-        if (f.get0() == stop_iteration::yes) {
+        if (f.get() == stop_iteration::yes) {
             return make_ready_future<>();
         }
     }
@@ -183,7 +183,7 @@ public:
             delete this;
             return;
         } else {
-            auto v = std::move(this->_state).get0();
+            auto v = std::move(this->_state).get();
             if (v) {
                 _promise.set_value(std::move(*v));
                 delete this;
@@ -198,7 +198,7 @@ public:
                     internal::set_callback(std::move(f), this);
                     return;
                 }
-                auto ret = f.get0();
+                auto ret = f.get();
                 if (ret) {
                     _promise.set_value(std::move(*ret));
                     delete this;
@@ -230,8 +230,8 @@ public:
 ///         a call to to \c action failed.  The \c optional's value is returned.
 template<typename AsyncAction>
 SEASTAR_CONCEPT( requires requires (AsyncAction aa) {
-    bool(futurize_invoke(aa).get0());
-    futurize_invoke(aa).get0().value();
+    bool(futurize_invoke(aa).get());
+    futurize_invoke(aa).get().value();
 } )
 repeat_until_value_return_type<AsyncAction>
 repeat_until_value(AsyncAction action) noexcept {
@@ -257,7 +257,7 @@ repeat_until_value(AsyncAction action) noexcept {
             return make_exception_future<value_type>(f.get_exception());
         }
 
-        optional_type&& optional = std::move(f).get0();
+        optional_type&& optional = std::move(f).get();
         if (optional) {
             return make_ready_future<value_type>(std::move(optional.value()));
         }

--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -100,7 +100,7 @@ SEASTAR_CONCEPT( requires requires (Iterator i, Mapper mapper, Reducer reduce) {
      *i++;
      { i != i } -> std::convertible_to<bool>;
      mapper(*i);
-     reduce(futurize_invoke(mapper, *i).get0());
+     reduce(futurize_invoke(mapper, *i).get());
 } )
 inline
 auto
@@ -120,7 +120,7 @@ map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&& r)
                     f.ignore_ready_future();
                     return rf;
                 } else {
-                    return futurize_invoke(s->reducer, std::move(f.get0()));
+                    return futurize_invoke(s->reducer, std::move(f.get()));
                 }
             });
         });
@@ -176,7 +176,7 @@ SEASTAR_CONCEPT( requires requires (Iterator i, Mapper mapper, Initial initial, 
      { i != i} -> std::convertible_to<bool>;
      mapper(*i);
      requires is_future<decltype(mapper(*i))>::value;
-     { reduce(std::move(initial), mapper(*i).get0()) } -> std::convertible_to<Initial>;
+     { reduce(std::move(initial), mapper(*i).get()) } -> std::convertible_to<Initial>;
 } )
 inline
 future<Initial>
@@ -191,7 +191,7 @@ map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Initial initial, Reduc
     while (begin != end) {
         ret = futurize_invoke(s->mapper, *begin++).then_wrapped([s = s.get(), ret = std::move(ret)] (auto f) mutable {
             try {
-                s->result = s->reduce(std::move(s->result), f.get0());
+                s->result = s->reduce(std::move(s->result), f.get());
                 return std::move(ret);
             } catch (...) {
                 return std::move(ret).then_wrapped([ex = std::current_exception()] (auto f) {
@@ -254,7 +254,7 @@ SEASTAR_CONCEPT( requires requires (Range range, Mapper mapper, Initial initial,
      std::end(range);
      mapper(*std::begin(range));
      requires is_future<std::remove_reference_t<decltype(mapper(*std::begin(range)))>>::value;
-     { reduce(std::move(initial), mapper(*std::begin(range)).get0()) } -> std::convertible_to<Initial>;
+     { reduce(std::move(initial), mapper(*std::begin(range)).get()) } -> std::convertible_to<Initial>;
 } )
 inline
 future<Initial>

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -371,7 +371,7 @@ class extract_values_from_futures_tuple {
         auto prepare_result = [] (auto futures) noexcept {
             auto fs = tuple_filter_by_type<internal::future_has_value>(std::move(futures));
             return tuple_map(std::move(fs), [] (auto&& e) {
-                return e.get0();
+                return e.get();
             });
         };
 
@@ -432,7 +432,7 @@ struct extract_values_from_futures_vector {
                 if (f.failed()) {
                     excp = f.get_exception();
                 } else {
-                    values.emplace_back(f.get0());
+                    values.emplace_back(f.get());
                 }
             } else {
                 f.ignore_ready_future();

--- a/include/seastar/coroutine/all.hh
+++ b/include/seastar/coroutine/all.hh
@@ -131,7 +131,7 @@ class [[nodiscard("must co_await an all() object")]] all {
                 if constexpr (std::same_as<std::tuple_element_t<idx, tuple>, future<>>) {
                     std::get<idx>(container.state._futures) = make_ready_future<>();
                 } else {
-                    std::get<idx>(container.state._futures) = make_ready_future<value_type>(std::move(this->_state).get0());
+                    std::get<idx>(container.state._futures) = make_ready_future<value_type>(std::move(this->_state).get());
                 }
             }
             this->~intermediate_task();
@@ -177,7 +177,7 @@ private:
             // This immediately-invoked lambda is used to materialize the indexes
             // of non-void futures in the tuple.
             return [&] <size_t... Idx> (std::integer_sequence<size_t, Idx...>) {
-                return value_tuple(std::get<Idx>(state._futures).get0()...);
+                return value_tuple(std::get<Idx>(state._futures).get()...);
             } (internal::index_sequence_for_non_void_futures<Futures...>());
         }
         template <unsigned idx>

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -510,7 +510,7 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, int64_t msg_id, shared_
                 ret.get();
                 data = std::invoke(marshall<Serializer>, std::ref(client->template serializer<Serializer>()), response_frame_headroom);
             } else {
-                data = std::invoke(marshall<Serializer, const RetTypes&>, std::ref(client->template serializer<Serializer>()), response_frame_headroom, std::move(ret.get0()));
+                data = std::invoke(marshall<Serializer, const RetTypes&>, std::ref(client->template serializer<Serializer>()), response_frame_headroom, std::move(ret.get()));
             }
         } catch (std::exception& ex) {
             uint32_t len = std::strlen(ex.what());

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -611,7 +611,7 @@ posix_file_impl::read_maybe_eof(uint64_t pos, size_t len, internal::maybe_priori
     return read_dma_one(pos, dst, buf_size, pc, intent).then_wrapped(
             [buf = std::move(buf)](future<size_t> f) mutable {
         try {
-            size_t size = f.get0();
+            size_t size = f.get();
 
             buf.trim(size);
 

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -329,7 +329,7 @@ private:
                     return make_exception_future<temporary_buffer<char>>(ret.get_exception());
                 } else {
                     // first or last buffer, need trimming
-                    auto tmp = ret.get0();
+                    auto tmp = ret.get();
                     auto real_end = start + tmp.size();
                     if (real_end <= pos) {
                         return make_ready_future<temporary_buffer<char>>();

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -996,7 +996,7 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
         for (auto&& res : results) {
             if (!res.failed()) {
                 if (prev_ok) {
-                    size_t sz = res.get0();
+                    size_t sz = res.get();
                     total += sz;
                     prev_ok &= (sz == max_length);
                 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3609,7 +3609,7 @@ void smp_message_queue::submit_item(shard_id t, smp_timeout_clock::time_point ti
     _tx.a.pending_fifo.push_back(item.get());
     // no exceptions from this point
     item.release();
-    units_fut.get0().release();
+    units_fut.get().release();
     if (_tx.a.pending_fifo.size() >= batch_size) {
         move_pending();
     }
@@ -4650,7 +4650,7 @@ future<> check_direct_io_support(std::string_view path) noexcept {
             auto w = w::parse(path, type);
             return open_file_dma(w.path, w.flags).then_wrapped([path = w.path, cleanup = std::move(w.cleanup)] (future<file> f) {
                 try {
-                    auto fd = f.get0();
+                    auto fd = f.get();
                     return cleanup().finally([fd = std::move(fd)] () mutable {
                         return fd.close();
                     });

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -269,7 +269,7 @@ void aio_storage_context::schedule_retry() {
                 seastar_logger.warn("aio_storage_context::schedule_retry failed: {}", std::move(ex));
                 return;
             }
-            auto result = f.get0();
+            auto result = f.get();
             auto iocbs = _aio_retries.data();
             size_t nr_consumed = 0;
             if (result.result == -1) {

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -620,7 +620,7 @@ private:
                     // FIXME: future is discarded
                     (void)f.then_wrapped([me = shared_from_this(), &e, fd](future<connected_socket> f) {
                         try {
-                            e.tcp.socket = f.get0();
+                            e.tcp.socket = f.get();
                             dns_log.trace("Connection complete: {}", fd);
                         } catch (...) {
                             dns_log.debug("Connect {} failed: {}", fd, std::current_exception());
@@ -632,7 +632,7 @@ private:
                     errno = EWOULDBLOCK;
                     return -1;
                 }
-                e.tcp.socket = f.get0();
+                e.tcp.socket = f.get();
                 break;
             }
             case type::udp:
@@ -687,7 +687,7 @@ private:
                         // FIXME: future is discarded
                         (void)f.then_wrapped([me = shared_from_this(), &e, fd](future<temporary_buffer<char>> f) {
                             try {
-                                auto buf = f.get0();
+                                auto buf = f.get();
                                 dns_log.trace("Read {} -> {} bytes", fd, buf.size());
                                 e.tcp.indata = std::move(buf);
                             } catch (...) {
@@ -702,7 +702,7 @@ private:
                     }
 
                     try {
-                        tcp.indata = f.get0();
+                        tcp.indata = f.get();
                         continue; // loop will take care of data
                     } catch (std::system_error& e) {
                         errno = e.code().value();
@@ -750,7 +750,7 @@ private:
                         // FIXME: future is discarded
                         (void)f.then_wrapped([me = shared_from_this(), &e, fd](future<net::datagram> f) {
                             try {
-                                auto d = f.get0();
+                                auto d = f.get();
                                 dns_log.trace("Read {} -> {} bytes", fd, d.get_data().len());
                                 e.udp.in = std::move(d);
                                 e.avail |= POLLIN;
@@ -765,7 +765,7 @@ private:
                     }
 
                     try {
-                        udp.in = f.get0();
+                        udp.in = f.get();
                         continue; // loop will take care of data
                     } catch (std::system_error& e) {
                         errno = e.code().value();

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -763,7 +763,7 @@ public:
         void run() {
             while (_creds) {
                 try {
-                    auto events = _fsn.wait().get0();
+                    auto events = _fsn.wait().get();
                     if (events.empty() && _creds == nullptr) {
                         return;
                     }
@@ -833,7 +833,7 @@ public:
                     // just ignore for now, and hope the dir watch will tell us when it is back...
                     return;
                 }
-                temporary_buffer<char> buf = read_fully(filename, "reloading").get0();
+                temporary_buffer<char> buf = read_fully(filename, "reloading").get();
                 dst = to_buffer(buf);
                 ++num_changed;
             };
@@ -896,7 +896,7 @@ public:
             auto dir = std::filesystem::path(filename).parent_path();
             for (;;) {
                 try {
-                    return add_watch(dir.native(), fsnotifier::flags::create_child | fsnotifier::flags::move).get0();
+                    return add_watch(dir.native(), fsnotifier::flags::create_child | fsnotifier::flags::move).get();
                 } catch (...) {
                     auto parent = dir.parent_path();
                     if (parent.empty() || dir == parent) {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -191,7 +191,7 @@ namespace rpc {
           // _negotiated abortion set it such
           std::get<0>(res).ignore_ready_future();
           // _sink_closed_future is never exceptional
-          bool sink_closed = std::get<1>(res).get0();
+          bool sink_closed = std::get<1>(res).get();
           return _connected && !sink_closed ? _write_buf.close() : make_ready_future();
       });
   }

--- a/tests/unit/chunk_parsers_test.cc
+++ b/tests/unit/chunk_parsers_test.cc
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_size_and_extensions_parsing) {
     http_chunk_size_and_ext_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get0().has_value());
+        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             BOOST_REQUIRE_EQUAL(parser.get_size(), std::move(tset.size));
@@ -109,7 +109,7 @@ SEASTAR_TEST_CASE(test_trailer_headers_parsing) {
     http_chunk_trailer_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get0().has_value());
+        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto heads = parser.get_parsed_headers();

--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -50,9 +50,9 @@ SEASTAR_TEST_CASE(test_incomplete_content) {
         auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;"))));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
-        auto content1 = content_strm.read().get0();
+        auto content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("asdfghjkl;", 10) == content1);
-        auto content2 = content_strm.read().get0();
+        auto content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
         BOOST_REQUIRE(inp.eof());
@@ -61,9 +61,9 @@ SEASTAR_TEST_CASE(test_incomplete_content) {
         std::unordered_map<sstring, sstring> tmp, tmp2;
         content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 
-        content1 = content_strm.read().get0();
+        content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("132", 3) == content1);
-        content2 = content_strm.read().get0();
+        content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
     });
@@ -74,9 +74,9 @@ SEASTAR_TEST_CASE(test_complete_content) {
         auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;1234567890"))));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
-        auto content1 = content_strm.read().get0();
+        auto content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("asdfghjkl;1234567890", 20) == content1);
-        auto content2 = content_strm.read().get0();
+        auto content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
 
@@ -84,9 +84,9 @@ SEASTAR_TEST_CASE(test_complete_content) {
         std::unordered_map<sstring, sstring> tmp, tmp2;
         content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 
-        content1 = content_strm.read().get0();
+        content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("1324", 4) == content1);
-        content2 = content_strm.read().get0();
+        content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
     });
@@ -97,24 +97,24 @@ SEASTAR_TEST_CASE(test_more_than_requests_content) {
         auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;1234567890xyz"))));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
-        auto content1 = content_strm.read().get0();
+        auto content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("asdfghjkl;1234567890", 20) == content1);
-        auto content2 = content_strm.read().get0();
+        auto content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
-        auto content3 = inp.read().get0();
+        auto content3 = inp.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("xyz", 3) == content3);
 
         inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("4\r\n1324\r\n0\r\n\r\nxyz"))));
         std::unordered_map<sstring, sstring> tmp, tmp2;
         content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 
-        content1 = content_strm.read().get0();
+        content1 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("1324", 4) == content1);
-        content2 = content_strm.read().get0();
+        content2 = content_strm.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == content2);
         BOOST_REQUIRE(content_strm.eof());
-        content3 = inp.read().get0();
+        content3 = inp.read().get();
         BOOST_REQUIRE(temporary_buffer<char>("xyz", 3) == content3);
     });
 }
@@ -146,7 +146,7 @@ SEASTAR_TEST_CASE(test_single_bytes_source) {
         for (auto& ch : input_str) {
             temporary_buffer<char> one_letter_buf(1);
             *one_letter_buf.get_write() = ch;
-            auto get_buf = ds.get().get0();
+            auto get_buf = ds.get().get();
             BOOST_REQUIRE(one_letter_buf == get_buf);
         }
     });
@@ -163,10 +163,10 @@ SEASTAR_TEST_CASE(test_fragmented_chunks) {
         for (auto& ch : sstring("1234567890")) {
             temporary_buffer<char> one_letter_buf(1);
             *one_letter_buf.get_write() = ch;
-            auto read_buf = content_stream.read().get0();
+            auto read_buf = content_stream.read().get();
             BOOST_REQUIRE(one_letter_buf == read_buf);
         }
-        auto read_buf = content_stream.read().get0();
+        auto read_buf = content_stream.read().get();
         BOOST_REQUIRE(temporary_buffer<char>() == read_buf);
         BOOST_REQUIRE(chunk_extensions[sstring("chunk")] == sstring("ext"));
         BOOST_REQUIRE(trailing_headers[sstring("trailer")] == sstring("part"));

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -91,7 +91,7 @@ future<int> failing_coroutine2() noexcept {
 SEASTAR_TEST_CASE(test_simple_coroutines) {
     BOOST_REQUIRE_EQUAL(co_await old_fashioned_continuations(), 42);
     BOOST_REQUIRE_EQUAL(co_await simple_coroutine(), 53);
-    BOOST_REQUIRE_EQUAL(ready_coroutine().get0(), 64);
+    BOOST_REQUIRE_EQUAL(ready_coroutine().get(), 64);
     BOOST_REQUIRE(co_await tuple_coroutine() == std::tuple(1, 2.));
     BOOST_REQUIRE_EXCEPTION((void)co_await failing_coroutine(), int, [] (auto v) { return v == 42; });
     BOOST_CHECK_EQUAL(co_await failing_coroutine().then_wrapped([] (future<int> f) -> future<int> {
@@ -679,7 +679,7 @@ SEASTAR_TEST_CASE(test_void_as_future_without_preemption_check) {
 
 SEASTAR_TEST_CASE(test_non_void_as_future) {
     auto f = co_await coroutine::as_future(make_ready_future<int>(42));
-    BOOST_REQUIRE_EQUAL(f.get0(), 42);
+    BOOST_REQUIRE_EQUAL(f.get(), 42);
 
     f = co_await coroutine::as_future(make_exception_future<int>(std::runtime_error("exception")));
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
@@ -687,7 +687,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future) {
     auto p = promise<int>();
     (void)sleep(1ms).then([&] { p.set_value(314); });
     f = co_await coroutine::as_future(p.get_future());
-    BOOST_REQUIRE_EQUAL(f.get0(), 314);
+    BOOST_REQUIRE_EQUAL(f.get(), 314);
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);
@@ -699,7 +699,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future) {
 
 SEASTAR_TEST_CASE(test_non_void_as_future_without_preemption_check) {
     auto f = co_await coroutine::as_future_without_preemption_check(make_ready_future<int>(42));
-    BOOST_REQUIRE_EQUAL(f.get0(), 42);
+    BOOST_REQUIRE_EQUAL(f.get(), 42);
 
     f = co_await coroutine::as_future_without_preemption_check(make_exception_future<int>(std::runtime_error("exception")));
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
@@ -707,7 +707,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future_without_preemption_check) {
     auto p = promise<int>();
     (void)sleep(1ms).then([&] { p.set_value(314); });
     f = co_await coroutine::as_future_without_preemption_check(p.get_future());
-    BOOST_REQUIRE_EQUAL(f.get0(), 314);
+    BOOST_REQUIRE_EQUAL(f.get(), 314);
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -338,10 +338,10 @@ SEASTAR_TEST_CASE(test_smp_service_groups) {
     return async([] {
         smp_service_group_config ssgc1;
         ssgc1.max_nonlocal_requests = 1;
-        auto ssg1 = create_smp_service_group(ssgc1).get0();
+        auto ssg1 = create_smp_service_group(ssgc1).get();
         smp_service_group_config ssgc2;
         ssgc2.max_nonlocal_requests = 1000;
-        auto ssg2 = create_smp_service_group(ssgc2).get0();
+        auto ssg2 = create_smp_service_group(ssgc2).get();
         shard_id other_shard = smp::count - 1;
         remote_worker rm1(1);
         remote_worker rm2(1000);
@@ -363,10 +363,10 @@ SEASTAR_TEST_CASE(test_smp_service_groups_re_construction) {
     // holding the groups did not expand correctly. This test triggers the
     // bug.
     return async([] {
-        auto ssg1 = create_smp_service_group({}).get0();
-        auto ssg2 = create_smp_service_group({}).get0();
+        auto ssg1 = create_smp_service_group({}).get();
+        auto ssg2 = create_smp_service_group({}).get();
         destroy_smp_service_group(ssg1).get();
-        auto ssg3 = create_smp_service_group({}).get0();
+        auto ssg3 = create_smp_service_group({}).get();
         destroy_smp_service_group(ssg2).get();
         destroy_smp_service_group(ssg3).get();
     });
@@ -376,7 +376,7 @@ SEASTAR_TEST_CASE(test_smp_timeout) {
     return async([] {
         smp_service_group_config ssgc1;
         ssgc1.max_nonlocal_requests = 1;
-        auto ssg1 = create_smp_service_group(ssgc1).get0();
+        auto ssg1 = create_smp_service_group(ssgc1).get();
 
         auto _ = defer([ssg1] () noexcept {
             destroy_smp_service_group(ssg1).get();
@@ -448,6 +448,6 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_parameter) {
             ).get();
     auto undo2 = deferred_stop(s_service);
 
-    auto all_ok = s_service.map_reduce0(std::mem_fn(&some_service::ok), true, std::multiplies<>()).get0();
+    auto all_ok = s_service.map_reduce0(std::mem_fn(&some_service::ok), true, std::multiplies<>()).get();
     BOOST_REQUIRE(all_ok);
 }

--- a/tests/unit/execution_stage_test.cc
+++ b/tests/unit/execution_stage_test.cc
@@ -39,7 +39,7 @@ SEASTAR_TEST_CASE(test_create_stage_from_lvalue_function_object) {
     return seastar::async([] {
         auto dont_move = [obj = make_shared<int>(53)] { return *obj; };
         auto stage = seastar::make_execution_stage("test", dont_move);
-        BOOST_REQUIRE_EQUAL(stage().get0(), 53);
+        BOOST_REQUIRE_EQUAL(stage().get(), 53);
         BOOST_REQUIRE_EQUAL(dont_move(), 53);
     });
 }
@@ -48,7 +48,7 @@ SEASTAR_TEST_CASE(test_create_stage_from_rvalue_function_object) {
     return seastar::async([] {
         auto dont_copy = [obj = std::make_unique<int>(42)] { return *obj; };
         auto stage = seastar::make_execution_stage("test", std::move(dont_copy));
-        BOOST_REQUIRE_EQUAL(stage().get0(), 42);
+        BOOST_REQUIRE_EQUAL(stage().get(), 42);
     });
 }
 
@@ -59,7 +59,7 @@ int func() {
 SEASTAR_TEST_CASE(test_create_stage_from_function) {
     return seastar::async([] {
         auto stage = seastar::make_execution_stage("test", func);
-        BOOST_REQUIRE_EQUAL(stage().get0(), 64);
+        BOOST_REQUIRE_EQUAL(stage().get(), 64);
     });
 }
 
@@ -92,9 +92,9 @@ SEASTAR_TEST_CASE(test_simple_stage_returning_int) {
             }
         }, [] (int original, future<int> result) {
             if (original % 2) {
-                BOOST_REQUIRE_EQUAL(original * 2, result.get0());
+                BOOST_REQUIRE_EQUAL(original * 2, result.get());
             } else {
-                BOOST_REQUIRE_EXCEPTION(result.get0(), int, [&] (int v) { return original == v; });
+                BOOST_REQUIRE_EXCEPTION(result.get(), int, [&] (int v) { return original == v; });
             }
         });
     });
@@ -110,9 +110,9 @@ SEASTAR_TEST_CASE(test_simple_stage_returning_future_int) {
             }
         }, [] (int original, future<int> result) {
             if (original % 2) {
-                BOOST_REQUIRE_EQUAL(original * 2, result.get0());
+                BOOST_REQUIRE_EQUAL(original * 2, result.get());
             } else {
-                BOOST_REQUIRE_EXCEPTION(result.get0(), int, [&] (int v) { return original == v; });
+                BOOST_REQUIRE_EXCEPTION(result.get(), int, [&] (int v) { return original == v; });
             }
         });
     });
@@ -125,7 +125,7 @@ void test_execution_stage_avoids_copy() {
     });
 
     auto f = stage(T());
-    T obj = f.get0();
+    T obj = f.get();
     (void)obj;
 }
 
@@ -170,7 +170,7 @@ SEASTAR_TEST_CASE(test_rref_decays_to_value) {
         }
 
         for (size_t i = 0; i < 100; i++) {
-            BOOST_REQUIRE_EQUAL(fs[i].get0(), i);
+            BOOST_REQUIRE_EQUAL(fs[i].get(), i);
         }
     });
 }
@@ -233,7 +233,7 @@ SEASTAR_TEST_CASE(test_function_is_class_member) {
         }
 
         for (auto i = 0; i < 100; i++) {
-            BOOST_REQUIRE_EQUAL(fs[i].get0(), i - 1);
+            BOOST_REQUIRE_EQUAL(fs[i].get(), i - 1);
         }
         BOOST_REQUIRE_EQUAL(object.value, 99);
     });
@@ -250,7 +250,7 @@ SEASTAR_TEST_CASE(test_function_is_const_class_member) {
         auto stage = seastar::make_execution_stage("test", &foo::member);
 
         const foo object;
-        BOOST_REQUIRE_EQUAL(stage(&object).get0(), 999);
+        BOOST_REQUIRE_EQUAL(stage(&object).get(), 999);
     });
 }
 
@@ -292,9 +292,9 @@ SEASTAR_TEST_CASE(test_unique_stage_names_are_enforced) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_inheriting_concrete_execution_stage) {
-    auto sg1 = seastar::create_scheduling_group("sg1", 300).get0();
+    auto sg1 = seastar::create_scheduling_group("sg1", 300).get();
     auto ksg1 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg1).get(); });
-    auto sg2 = seastar::create_scheduling_group("sg2", 100).get0();
+    auto sg2 = seastar::create_scheduling_group("sg2", 100).get();
     auto ksg2 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg2).get(); });
     auto check_sg = [] (seastar::scheduling_group sg) {
         BOOST_REQUIRE(seastar::current_scheduling_group() == sg);

--- a/tests/unit/file_utils_test.cc
+++ b/tests/unit/file_utils_test.cc
@@ -45,10 +45,10 @@ SEASTAR_TEST_CASE(test_make_tmp_file) {
     return make_tmp_file().then([] (tmp_file tf) {
         return async([tf = std::move(tf)] () mutable {
             const sstring tmp_path = tf.get_path().native();
-            BOOST_REQUIRE(file_exists(tmp_path).get0());
+            BOOST_REQUIRE(file_exists(tmp_path).get());
             tf.close().get();
             tf.remove().get();
-            BOOST_REQUIRE(!file_exists(tmp_path).get0());
+            BOOST_REQUIRE(!file_exists(tmp_path).get());
         });
     });
 }
@@ -153,16 +153,16 @@ SEASTAR_THREAD_TEST_CASE(test_recursive_remove_directory) {
     base.random_fill(0, levels, dist, eng);
     base.populate().get();
     recursive_remove_directory(base.path()).get();
-    BOOST_REQUIRE(!file_exists(base.path().native()).get0());
+    BOOST_REQUIRE(!file_exists(base.path().native()).get());
 }
 
 SEASTAR_TEST_CASE(test_make_tmp_dir) {
     return make_tmp_dir().then([] (tmp_dir td) {
         return async([td = std::move(td)] () mutable {
             const sstring tmp_path = td.get_path().native();
-            BOOST_REQUIRE(file_exists(tmp_path).get0());
+            BOOST_REQUIRE(file_exists(tmp_path).get());
             td.remove().get();
-            BOOST_REQUIRE(!file_exists(tmp_path).get0());
+            BOOST_REQUIRE(!file_exists(tmp_path).get());
         });
     });
 }
@@ -212,11 +212,11 @@ SEASTAR_THREAD_TEST_CASE(test_tmp_dir_with_non_existing_path) {
 
 SEASTAR_TEST_CASE(tmp_dir_with_thread_test) {
     return tmp_dir::do_with_thread([] (tmp_dir& td) {
-        tmp_file tf = make_tmp_file(td.get_path()).get0();
+        tmp_file tf = make_tmp_file(td.get_path()).get();
         auto& f = tf.get_file();
         auto buf = get_init_buffer(f);
         auto expected = buf.size();
-        auto actual = f.dma_write(0, buf.get(), buf.size()).get0();
+        auto actual = f.dma_write(0, buf.get(), buf.size()).get();
         BOOST_REQUIRE_EQUAL(expected, actual);
         tf.close().get();
         tf.remove().get();
@@ -227,7 +227,7 @@ SEASTAR_TEST_CASE(tmp_dir_with_leftovers_test) {
     return tmp_dir::do_with_thread([] (tmp_dir& td) {
         fs::path path = td.get_path() / "testfile.tmp";
         touch_file(path.native()).get();
-        BOOST_REQUIRE(file_exists(path.native()).get0());
+        BOOST_REQUIRE(file_exists(path.native()).get());
     });
 }
 
@@ -251,8 +251,8 @@ SEASTAR_TEST_CASE(tmp_dir_do_with_fail_remove_test) {
             inner_path_renamed = inner_path + ".renamed";
             return rename_file(inner_path, inner_path_renamed);
         }).get(), std::system_error);
-        BOOST_REQUIRE(!file_exists(inner_path).get0());
-        BOOST_REQUIRE(file_exists(inner_path_renamed).get0());
+        BOOST_REQUIRE(!file_exists(inner_path).get());
+        BOOST_REQUIRE(file_exists(inner_path_renamed).get());
         set_default_tmpdir(saved_default_tmpdir.c_str());
     });
 }
@@ -277,8 +277,8 @@ SEASTAR_TEST_CASE(tmp_dir_do_with_thread_fail_remove_test) {
             inner_path_renamed = inner_path + ".renamed";
             return rename_file(inner_path, inner_path_renamed);
         }).get(), std::system_error);
-        BOOST_REQUIRE(!file_exists(inner_path).get0());
-        BOOST_REQUIRE(file_exists(inner_path_renamed).get0());
+        BOOST_REQUIRE(!file_exists(inner_path).get());
+        BOOST_REQUIRE(file_exists(inner_path_renamed).get());
         set_default_tmpdir(saved_default_tmpdir.c_str());
     });
 }
@@ -296,10 +296,10 @@ SEASTAR_TEST_CASE(test_read_entire_file_contiguous) {
                 wbuf.get_write()[i] = chars[dist(eng) % sizeof(chars)];
             }
 
-            BOOST_REQUIRE_EQUAL(f.dma_write(0, wbuf.begin(), wbuf.size()).get0(), wbuf.size());
+            BOOST_REQUIRE_EQUAL(f.dma_write(0, wbuf.begin(), wbuf.size()).get(), wbuf.size());
             f.flush().get();
 
-            sstring res = util::read_entire_file_contiguous(tf.get_path()).get0();
+            sstring res = util::read_entire_file_contiguous(tf.get_path()).get();
             BOOST_REQUIRE_EQUAL(res, std::string_view(wbuf.begin(), wbuf.size()));
         });
     });

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -53,7 +53,7 @@ SEASTAR_TEST_CASE(foreign_ptr_copy_test) {
     return seastar::async([] {
         auto ptr = make_foreign(make_shared<sstring>("foo"));
         BOOST_REQUIRE(ptr->size() == 3);
-        auto ptr2 = ptr.copy().get0();
+        auto ptr2 = ptr.copy().get();
         BOOST_REQUIRE(ptr2->size() == 3);
     });
 }
@@ -108,7 +108,7 @@ SEASTAR_TEST_CASE(foreign_ptr_cpu_test) {
     return seastar::async([] {
         auto p = smp::submit_to(1, [] {
             return make_foreign(std::make_unique<dummy>());
-        }).get0();
+        }).get();
 
         p.reset(std::make_unique<dummy>());
     }).then([] {
@@ -128,7 +128,7 @@ SEASTAR_TEST_CASE(foreign_ptr_move_assignment_test) {
     return seastar::async([] {
         auto p = smp::submit_to(1, [] {
             return make_foreign(std::make_unique<dummy>());
-        }).get0();
+        }).get();
 
         p = foreign_ptr<std::unique_ptr<dummy>>();
     }).then([] {
@@ -166,7 +166,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
 
     auto val = smp::submit_to(1, [&] () mutable {
         return make_foreign(std::make_unique<deferred>(done));
-    }).get0();
+    }).get();
 
     val.destroy().get();
 

--- a/tests/unit/fsnotifier_test.cc
+++ b/tests/unit/fsnotifier_test.cc
@@ -50,32 +50,32 @@ SEASTAR_THREAD_TEST_CASE(test_notify_modify_close_delete) {
     fsnotifier fsn;
 
     auto p = tmp.path() / "kossa.dat";
-    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
+    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
     auto w = fsn.create_watch(p.native(), fsnotifier::flags::delete_self
         | fsnotifier::flags::modify
         | fsnotifier::flags::close
-    ).get0();
+    ).get();
 
-    auto os = make_file_output_stream(f).get0();
+    auto os = make_file_output_stream(f).get();
     os.write("kossa").get();
     os.flush().get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::modify));
     }
 
     os.close().get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::close_write));
     }
 
     remove_file(p.native()).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::delete_self));
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::ignored));
     }
@@ -88,8 +88,8 @@ SEASTAR_THREAD_TEST_CASE(test_notify_overwrite) {
     auto p = tmp.path() / "kossa.dat";
 
     auto write_file = [](fs::path& p, sstring content) {
-        auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
-        auto os = make_file_output_stream(f).get0();
+        auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
+        auto os = make_file_output_stream(f).get();
         os.write(content).get();
         os.flush().get();
         os.close().get();
@@ -100,31 +100,31 @@ SEASTAR_THREAD_TEST_CASE(test_notify_overwrite) {
     auto w = fsn.create_watch(p.native(), fsnotifier::flags::delete_self
         | fsnotifier::flags::modify
         | fsnotifier::flags::close
-    ).get0();
+    ).get();
 
     write_file(p, "kossabello");
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::modify));
     }
 
     write_file(p, "kossaruffalobill");
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::modify));
     }
 
     auto p2 = tmp.path() / "tmp.apa";
     write_file(p2, "le apa");
 
-    auto w2 = fsn.create_watch(tmp.path().native(), fsnotifier::flags::move_to).get0();
+    auto w2 = fsn.create_watch(tmp.path().native(), fsnotifier::flags::move_to).get();
 
     rename_file(p2.native(), p.native()).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::delete_self));
         BOOST_REQUIRE(find_event(events, w2, fsnotifier::flags::move_to, p.filename().native()));
     }
@@ -137,12 +137,12 @@ SEASTAR_THREAD_TEST_CASE(test_notify_create_delete_child) {
     auto p = tmp.path() / "kossa.dat";
     auto w = fsn.create_watch(tmp.path().native(), fsnotifier::flags::create_child
         | fsnotifier::flags::delete_child
-    ).get0();
+    ).get();
 
-    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
+    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::create_child));
     }
 
@@ -150,7 +150,7 @@ SEASTAR_THREAD_TEST_CASE(test_notify_create_delete_child) {
     remove_file(p.native()).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::delete_child));
         BOOST_REQUIRE(!find_event(events, w, fsnotifier::flags::ignored));
     }
@@ -161,15 +161,15 @@ SEASTAR_THREAD_TEST_CASE(test_notify_open) {
     fsnotifier fsn;
 
     auto p = tmp.path() / "kossa.dat";
-    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
+    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
     f.close().get();
 
-    auto w = fsn.create_watch(p.native(), fsnotifier::flags::open).get0();
+    auto w = fsn.create_watch(p.native(), fsnotifier::flags::open).get();
 
-    auto f2 = open_file_dma(p.native(), open_flags::ro).get0();
+    auto f2 = open_file_dma(p.native(), open_flags::ro).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::open));
     }
 
@@ -181,29 +181,29 @@ SEASTAR_THREAD_TEST_CASE(test_notify_move) {
     fsnotifier fsn;
 
     auto p = tmp.path() / "kossa.dat";
-    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
+    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
 
     f.close().get();
 
-    auto w = fsn.create_watch(tmp.path().native(), fsnotifier::flags::move).get0();
+    auto w = fsn.create_watch(tmp.path().native(), fsnotifier::flags::move).get();
     auto p2 = tmp.path() / "kossa.mu";
 
     rename_file(p.native(), p2.native()).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::move_from, p.filename().native()));
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::move_to, p2.filename().native()));
     }
 
     tmpdir tmp2;
     auto p3 = tmp2.path() / "ninja.mission";
-    auto w2 = fsn.create_watch(tmp2.path().native(), fsnotifier::flags::move).get0();
+    auto w2 = fsn.create_watch(tmp2.path().native(), fsnotifier::flags::move).get();
 
     rename_file(p2.native(), p3.native()).get();
 
     {
-        auto events = fsn.wait().get0();
+        auto events = fsn.wait().get();
         BOOST_REQUIRE(find_event(events, w, fsnotifier::flags::move_from, p2.filename().native()));
         BOOST_REQUIRE(find_event(events, w2, fsnotifier::flags::move_to, p3.filename().native()));
     }
@@ -214,15 +214,15 @@ SEASTAR_THREAD_TEST_CASE(test_shutdown_notifier) {
     fsnotifier fsn;
 
     auto p = tmp.path() / "kossa.dat";
-    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get0();
+    auto f = open_file_dma(p.native(), open_flags::create|open_flags::rw).get();
 
     f.close().get();
 
-    auto w = fsn.create_watch(tmp.path().native(), fsnotifier::flags::delete_child).get0();
+    auto w = fsn.create_watch(tmp.path().native(), fsnotifier::flags::delete_child).get();
     auto fut = fsn.wait();
 
     fsn.shutdown();
 
-    auto events = fut.get0();
+    auto events = fut.get();
     BOOST_REQUIRE(events.empty());
 }

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -237,8 +237,8 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
     fake_file file;
 
     io_queue_for_tests tio;
-    auto pc0 = internal::priority_class(create_scheduling_group("a", 100).get0());
-    auto pc1 = internal::priority_class(create_scheduling_group("b", 100).get0());
+    auto pc0 = internal::priority_class(create_scheduling_group("a", 100).get());
+    auto pc1 = internal::priority_class(create_scheduling_group("b", 100).get());
 
     size_t idx = 0;
     int val = 100;

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -80,8 +80,8 @@ SEASTAR_TEST_CASE(tcp_packet_test) {
 
         BOOST_REQUIRE(la.addr().is_ipv6());
 
-        auto cc = connect(la).get0();
-        auto lc = std::move(sc.accept().get0().connection);
+        auto cc = connect(la).get();
+        auto lc = std::move(sc.accept().get().connection);
 
         auto strm = cc.output();
         strm.write("los lobos").get();

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -127,7 +127,7 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_abort) {
             as.request_abort();
         });
 
-        BOOST_REQUIRE_THROW(f.get0(), semaphore_aborted);
+        BOOST_REQUIRE_THROW(f.get(), semaphore_aborted);
     }
 
     {
@@ -139,14 +139,14 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_abort) {
             as.request_abort();
         });
 
-        BOOST_REQUIRE_THROW(f.get0(), semaphore_aborted);
+        BOOST_REQUIRE_THROW(f.get(), semaphore_aborted);
     }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_rwlock_hold_abort) {
     rwlock l;
 
-    auto wh = l.hold_write_lock().get0();
+    auto wh = l.hold_write_lock().get();
 
     {
         abort_source as;
@@ -157,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_hold_abort) {
             as.request_abort();
         });
 
-        BOOST_REQUIRE_THROW(f.get0(), semaphore_aborted);
+        BOOST_REQUIRE_THROW(f.get(), semaphore_aborted);
     }
 
     {
@@ -169,7 +169,7 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_hold_abort) {
             as.request_abort();
         });
 
-        BOOST_REQUIRE_THROW(f.get0(), semaphore_aborted);
+        BOOST_REQUIRE_THROW(f.get(), semaphore_aborted);
     }
 }
 
@@ -339,7 +339,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_nothrow_move_func) {
     auto expected = 42;
     auto res = with_shared(sm, [expected] {
         return expected;
-    }).get0();
+    }).get();
     BOOST_REQUIRE_EQUAL(res, expected);
 
     try {
@@ -383,7 +383,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_nothrow_move_func) {
     auto expected = 42;
     auto res = with_lock(sm, [expected] {
         return expected;
-    }).get0();
+    }).get();
     BOOST_REQUIRE_EQUAL(res, expected);
 
     try {

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -148,9 +148,9 @@ public:
         return _buffer->pop().then_wrapped([this] (future<temporary_buffer<char>>&& b) {
             _eof = b.failed();
             if (!_eof) {
-                // future::get0() is destructive, so we have to play these games
-                // FIXME: make future::get0() non-destructive
-                auto&& tmp = b.get0();
+                // future::get() is destructive, so we have to play these games
+                // FIXME: make future::get() non-destructive
+                auto&& tmp = b.get();
                 _eof = tmp.empty();
                 b = make_ready_future<temporary_buffer<char>>(std::move(tmp));
             }

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -83,7 +83,7 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
 
     static const char* name1 = "A";
     static const char* name2 = "B";
-    scheduling_group sg =  create_scheduling_group("hello", 111).get0();
+    scheduling_group sg =  create_scheduling_group("hello", 111).get();
     boost::integer_range<int> rng(0, 1000);
     // repeatedly change the group name back and forth in
     // decresing time intervals to see if it generate double

--- a/tests/unit/pipe_test.cc
+++ b/tests/unit/pipe_test.cc
@@ -42,10 +42,10 @@ SEASTAR_THREAD_TEST_CASE(simple_pipe_test) {
     auto f0 = p.reader.read();
     BOOST_CHECK(!f0.available());
     p.writer.write(17).get();
-    BOOST_REQUIRE_EQUAL(*f0.get0(), 17);
+    BOOST_REQUIRE_EQUAL(*f0.get(), 17);
 
     p.writer.write(42).get();
     auto f2 = p.reader.read();
     BOOST_CHECK(f2.available());
-    BOOST_REQUIRE_EQUAL(*f2.get0(), 42);
+    BOOST_REQUIRE_EQUAL(*f2.get(), 42);
 }

--- a/tests/unit/request_parser_test.cc
+++ b/tests/unit/request_parser_test.cc
@@ -63,7 +63,7 @@ SEASTAR_TEST_CASE(test_header_parsing) {
     http_request_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get0().has_value());
+        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto req = parser.get_parsed_request();

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -49,7 +49,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
     const int num_scheduling_groups = 4;
     std::vector<scheduling_group> sgs;
     for (int i = 0; i < num_scheduling_groups; i++) {
-        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get0());
+        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get());
     }
 
     const auto destroy_scheduling_groups = defer([&sgs] () noexcept {
@@ -58,10 +58,10 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
        }
     });
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<int>();
-    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get0();
+    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get();
 
     scheduling_group_key_config key2_conf = make_scheduling_group_key_config<ivec>();
-    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get0();
+    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get();
 
     smp::invoke_on_all([key1, key2, &sgs] () {
         int factor = this_shard_id() + 1;
@@ -112,13 +112,13 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
        }
     });
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<int>();
-    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get0();
+    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get();
 
     scheduling_group_key_config key2_conf = make_scheduling_group_key_config<ivec>();
-    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get0();
+    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get();
 
     for (int i = 0; i < num_scheduling_groups; i++) {
-        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get0());
+        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get());
     }
 
     smp::invoke_on_all([key1, key2, &sgs] () {
@@ -171,16 +171,16 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
     });
 
     for (int i = 0; i < num_scheduling_groups/2; i++) {
-        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get0());
+        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get());
     }
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<int>();
-    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get0();
+    scheduling_group_key key1 = scheduling_group_key_create(key1_conf).get();
 
     scheduling_group_key_config key2_conf = make_scheduling_group_key_config<ivec>();
-    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get0();
+    scheduling_group_key key2 = scheduling_group_key_create(key2_conf).get();
 
     for (int i = num_scheduling_groups/2; i < num_scheduling_groups; i++) {
-        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get0());
+        sgs.push_back(create_scheduling_group(format("sg{}", i).c_str(), 100).get());
     }
 
     smp::invoke_on_all([key1, key2, &sgs] () {
@@ -221,7 +221,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
  * Test that current scheduling group is inherited by seastar::async()
  */
 SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) {
-    scheduling_group sg = create_scheduling_group("sg0", 100).get0();
+    scheduling_group sg = create_scheduling_group("sg0", 100).get();
     auto cleanup = defer([&] () noexcept { destroy_scheduling_group(sg).get(); });
     thread_attributes attr = {};
     attr.sched_group = sg;
@@ -242,7 +242,7 @@ SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) 
 
 
 SEASTAR_THREAD_TEST_CASE(yield_preserves_sg) {
-    scheduling_group sg = create_scheduling_group("sg", 100).get0();
+    scheduling_group sg = create_scheduling_group("sg", 100).get();
     auto cleanup = defer([&] () noexcept { destroy_scheduling_group(sg).get(); });
     with_scheduling_group(sg, [&] {
         return yield().then([&] {
@@ -310,17 +310,17 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
 
     std::vector<scheduling_group_key> keys;
     for (size_t i = 0; i < 3; ++i) {
-        keys.push_back(scheduling_group_key_create(key_conf).get0());
+        keys.push_back(scheduling_group_key_create(key_conf).get());
     }
 
     std::vector<scheduling_group> sgs;
     const auto destroy_sgs = defer([&sgs] () noexcept {
         for (auto sg : sgs) {
-           destroy_scheduling_group(sg).get0();
+           destroy_scheduling_group(sg).get();
         }
     });
     for (size_t s = 0; s < 3; ++s) {
-        sgs.push_back(create_scheduling_group(fmt::format("sg-old-{}", s), 1000).get0());
+        sgs.push_back(create_scheduling_group(fmt::format("sg-old-{}", s), 1000).get());
     }
 
     smp::invoke_on_all([&sgs, &keys] () {
@@ -330,10 +330,10 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
                 sgs[s].get_specific<value>(keys[k])._id = 1;
             }
         }
-    }).get0();
+    }).get();
 
     for (size_t s = 0; s < std::size(sgs); ++s) {
-        rename_scheduling_group(sgs[s], fmt::format("sg-new-{}", s)).get0();
+        rename_scheduling_group(sgs[s], fmt::format("sg-new-{}", s)).get();
     }
 
     smp::invoke_on_all([&sgs, &keys] () {
@@ -344,7 +344,7 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
                 BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._id, 1);
             }
         }
-    }).get0();
+    }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(sg_create_with_destroy_tasks) {
@@ -371,13 +371,13 @@ SEASTAR_THREAD_TEST_CASE(sg_create_check_unique_constructor_invocation) {
 
     smp::invoke_on_all([] () {
         groups.clear();
-    }).get0();
+    }).get();
 
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<check>();
-    scheduling_group_key_create(key1_conf).get0();
+    scheduling_group_key_create(key1_conf).get();
 
     // clean out data for ASAN.
     smp::invoke_on_all([] () {
         groups = {};
-    }).get0();
+    }).get();
 }

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -264,7 +264,7 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_valid_splitting) {
     auto sm = semaphore(2);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto units = get_units(sm, 2, 1min).get();
     {
         BOOST_REQUIRE_EQUAL(units.count(), 2);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
@@ -276,7 +276,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_valid_splitting) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_invalid_splitting) {
     auto sm = semaphore(2);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto units = get_units(sm, 2, 1min).get();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
@@ -285,7 +285,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_invalid_splitting) {
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return_when_destroyed) {
     auto sm = semaphore(3);
   {
-    auto units = get_units(sm, 3, 1min).get0();
+    auto units = get_units(sm, 3, 1min).get();
     BOOST_REQUIRE_EQUAL(units.count(), 3);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
@@ -297,7 +297,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return_when_destroyed) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return_all) {
     auto sm = semaphore(3);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto units = get_units(sm, 2, 1min).get();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     BOOST_REQUIRE_THROW(units.return_units(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
@@ -329,7 +329,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_try_get_units) {
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_abort) {
     auto sm = semaphore(3);
-    auto units = get_units(sm, 3, 1min).get0();
+    auto units = get_units(sm, 3, 1min).get();
     BOOST_REQUIRE_EQUAL(units.count(), 3);
 
     abort_source as;
@@ -349,7 +349,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_bool_operator) {
     semaphore_units u0;
     BOOST_REQUIRE(!bool(u0));
 
-    u0 = get_units(sem, 2).get0();
+    u0 = get_units(sem, 2).get();
     BOOST_REQUIRE(bool(u0));
 
     u0.return_units(1);
@@ -359,7 +359,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_bool_operator) {
     BOOST_REQUIRE(!bool(u0));
     sem.signal(n);
 
-    u0 = get_units(sem, 2).get0();
+    u0 = get_units(sem, 2).get();
     BOOST_REQUIRE(bool(u0));
     auto u1 = std::move(u0);
     BOOST_REQUIRE(bool(u1));
@@ -368,7 +368,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_bool_operator) {
     u1.return_all();
     BOOST_REQUIRE(!bool(u1));
 
-    u0 = get_units(sem, 2).get0();
+    u0 = get_units(sem, 2).get();
     BOOST_REQUIRE(bool(u0));
     u1 = u0.split(1);
     BOOST_REQUIRE(bool(u1));

--- a/tests/unit/sharded_test.cc
+++ b/tests/unit/sharded_test.cc
@@ -90,8 +90,8 @@ SEASTAR_THREAD_TEST_CASE(test_const_map_reduces) {
     sharded<peering_counter> c;
     c.start().get();
 
-    BOOST_REQUIRE_EQUAL(c.local().count().get0(), smp::count);
-    BOOST_REQUIRE_EQUAL(c.local().count_from(1).get0(), smp::count + 1);
+    BOOST_REQUIRE_EQUAL(c.local().count().get(), smp::count);
+    BOOST_REQUIRE_EQUAL(c.local().count_from(1).get(), smp::count + 1);
 
     c.stop().get();
 }
@@ -100,10 +100,10 @@ SEASTAR_THREAD_TEST_CASE(test_member_map_reduces) {
     sharded<peering_counter> c;
     c.start().get();
 
-    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_const().get0(), smp::count);
-    BOOST_REQUIRE_EQUAL(c.local().count_mutate().get0(), smp::count);
-    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_from_const(1).get0(), smp::count + 1);
-    BOOST_REQUIRE_EQUAL(c.local().count_from_mutate(1).get0(), smp::count + 1);
+    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_const().get(), smp::count);
+    BOOST_REQUIRE_EQUAL(c.local().count_mutate().get(), smp::count);
+    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_from_const(1).get(), smp::count + 1);
+    BOOST_REQUIRE_EQUAL(c.local().count_from_mutate(1).get(), smp::count + 1);
     c.stop().get();
 }
 

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -125,7 +125,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
         bool client_notified = false;
 
         auto client = seastar::async([&] {
-            connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get0();
+            connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get();
 
             auto close_wait_fiber = cln.wait_input_shutdown().then([&] {
                 BOOST_REQUIRE_EQUAL(server_closed, true);
@@ -142,7 +142,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
                 out.flush().get();
                 seastar::sleep(std::chrono::milliseconds(250)).get();
                 fmt::print("Client: <- message\n");
-                auto buf = in.read().get0();
+                auto buf = in.read().get();
                 if (!buf) {
                     fmt::print("Client: server eof\n");
                     break;
@@ -156,7 +156,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
         });
 
         auto server = seastar::async([&] {
-            accept_result acc = ss.accept().get0();
+            accept_result acc = ss.accept().get();
             auto out = acc.connection.output();
             auto in = acc.connection.input();
 
@@ -188,7 +188,7 @@ SEASTAR_TEST_CASE(socket_on_close_local_shutdown_test) {
         bool client_notified = false;
 
         auto client = seastar::async([&] {
-            connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get0();
+            connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get();
 
             auto close_wait_fiber = cln.wait_input_shutdown().then([&] {
                 BOOST_REQUIRE_EQUAL(server_closed, false);
@@ -213,7 +213,7 @@ SEASTAR_TEST_CASE(socket_on_close_local_shutdown_test) {
         });
 
         auto server = seastar::async([&] {
-            accept_result acc = ss.accept().get0();
+            accept_result acc = ss.accept().get();
             auto in = acc.connection.input();
             auto buf = in.read().get();
             server_closed = true;

--- a/tests/unit/stream_reader_test.cc
+++ b/tests/unit/stream_reader_test.cc
@@ -64,7 +64,7 @@ public:
 SEASTAR_TEST_CASE(test_read_all) {
     return async([] {
         auto check_read_all = [] (input_stream<char>& strm, const char* test) {
-            auto all = read_entire_stream(strm).get0();
+            auto all = read_entire_stream(strm).get();
             sstring s;
             for (auto&& buf: all) {
                 s += seastar::to_sstring(std::move(buf));
@@ -82,13 +82,13 @@ SEASTAR_TEST_CASE(test_read_all) {
         BOOST_REQUIRE(empty_inp.eof());
 
         input_stream<char> inp_cont(data_source(std::make_unique<test_source_impl>(5, 15)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont).get0()), "abcdefghijklmno");
+        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont).get()), "abcdefghijklmno");
         BOOST_REQUIRE(inp_cont.eof());
         input_stream<char> inp_cont2(data_source(std::make_unique<test_source_impl>(5, 16)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont2).get0()), "abcdefghijklmnop");
+        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont2).get()), "abcdefghijklmnop");
         BOOST_REQUIRE(inp_cont2.eof());
         input_stream<char> empty_inp_cont(data_source(std::make_unique<test_source_impl>(5, 0)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(empty_inp_cont).get0()), "");
+        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(empty_inp_cont).get()), "");
         BOOST_REQUIRE(empty_inp_cont.eof());
     });
 }
@@ -98,14 +98,14 @@ SEASTAR_TEST_CASE(test_skip_all) {
         input_stream<char> inp(data_source(std::make_unique<test_source_impl>(5, 15)));
         skip_entire_stream(inp).get();
         BOOST_REQUIRE(inp.eof());
-        BOOST_REQUIRE(to_sstring(inp.read().get0()).empty());
+        BOOST_REQUIRE(to_sstring(inp.read().get()).empty());
         input_stream<char> inp2(data_source(std::make_unique<test_source_impl>(5, 16)));
         skip_entire_stream(inp2).get();
         BOOST_REQUIRE(inp2.eof());
-        BOOST_REQUIRE(to_sstring(inp2.read().get0()).empty());
+        BOOST_REQUIRE(to_sstring(inp2.read().get()).empty());
         input_stream<char> empty_inp(data_source(std::make_unique<test_source_impl>(5, 0)));
         skip_entire_stream(empty_inp).get();
         BOOST_REQUIRE(empty_inp.eof());
-        BOOST_REQUIRE(to_sstring(empty_inp.read().get0()).empty());
+        BOOST_REQUIRE(to_sstring(empty_inp.read().get()).empty());
     });
 }

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -97,7 +97,7 @@ SEASTAR_TEST_CASE(test_thread_async_nested) {
     return async([] {
         return async([] {
             return 3;
-        }).get0();
+        }).get();
     }).then([] (int three) {
         BOOST_REQUIRE_EQUAL(three, 3);
     });

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -94,8 +94,8 @@ struct timer_test {
 
     future<> test_timer_with_scheduling_groups() {
         return async([] {
-            auto sg1 = create_scheduling_group("sg1", 100).get0();
-            auto sg2 = create_scheduling_group("sg2", 100).get0();
+            auto sg1 = create_scheduling_group("sg1", 100).get();
+            auto sg2 = create_scheduling_group("sg2", 100).get();
             thread_attributes t1attr;
             t1attr.sched_group = sg1;
             auto expirations = 0;

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -132,15 +132,15 @@ future<> ud_server_client::init_server() {
 // Runs in a seastar::thread.
 void ud_server_client::client_round() {
     auto cc = client_path ? 
-        engine().net().connect(server_addr, socket_address{unix_domain_addr{*client_path}}).get0() :
-        engine().net().connect(server_addr).get0();
+        engine().net().connect(server_addr, socket_address{unix_domain_addr{*client_path}}).get() :
+        engine().net().connect(server_addr).get();
 
     auto inp = cc.input();
     auto out = cc.output();
 
     out.write(test_message).get();
     out.flush().get();
-    auto bb = inp.read().get0();
+    auto bb = inp.read().get();
     BOOST_REQUIRE_EQUAL(std::string_view(bb.begin(), bb.size()), "+"s+test_message);
     inp.close().get();
     out.close().get();
@@ -257,7 +257,7 @@ SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_autobind) {
     auto chan2 = make_bound_datagram_channel(autobind());
 
     chan1.send(chan2.local_address(), "hello").get();
-    net::datagram dgram = chan2.receive().get0();
+    net::datagram dgram = chan2.receive().get();
 
     string received = to_string(std::move(dgram.get_data()));
     BOOST_REQUIRE_EQUAL(received, "hello");
@@ -281,7 +281,7 @@ SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_named_bound) {
     auto sender = make_unbound_datagram_channel(AF_UNIX);
     sender.send(socket_address{unix_domain_addr{socket_path}}, "hihi").get();
 
-    net::udp_datagram dgram = named_receiver.receive().get0();
+    net::udp_datagram dgram = named_receiver.receive().get();
     string received = to_string(std::move(dgram.get_data()));
     BOOST_REQUIRE_EQUAL(received, "hihi");
 

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -27,7 +27,7 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
 
         auto acceptor = factory.get_server_socket().accept();
         auto connector = lsi.connect(socket_address(), socket_address());
-        connected_socket sock = connector.get0();
+        connected_socket sock = connector.get();
         auto input = sock.input();
         auto output = sock.output();
 
@@ -49,7 +49,7 @@ SEASTAR_TEST_CASE(test_websocket_handshake) {
                     });
                 });
             });
-        websocket::connection conn(dummy, acceptor.get0().connection);
+        websocket::connection conn(dummy, acceptor.get().connection);
         future<> serve = conn.process();
         auto close = defer([&conn, &input, &output, &serve] () noexcept {
             conn.close().get();
@@ -90,7 +90,7 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
 
         auto acceptor = factory.get_server_socket().accept();
         auto connector = lsi.connect(socket_address(), socket_address());
-        connected_socket sock = connector.get0();
+        connected_socket sock = connector.get();
         auto input = sock.input();
         auto output = sock.output();
 
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration) {
                 });
             });
         });
-        websocket::connection conn(ws, acceptor.get0().connection);
+        websocket::connection conn(ws, acceptor.get().connection);
         future<> serve = conn.process();
 
         auto close = defer([&conn, &input, &output, &serve] () noexcept {


### PR DESCRIPTION
get0() is a remnant of the days of variadic futures.

To prepare for its deprecation, stop using it internally.