### PR TITLE
docker: install clang-tools-18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2023-12-28 "$@"' > run; chmod +x run
+      - run: echo 'docker run --pids-limit -1 --security-opt seccomp=unconfined --network host --user "$(id -u):$(id -g)" --rm -v $PWD:$PWD -w $PWD  docker.io/scylladb/seastar-toolchain:2024-02-01 "$@"' > run; chmod +x run
       - when:
           condition:
             equal: [ "enable-dpdk", << parameters.with_dpdk >> ]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,11 @@
 FROM ubuntu:mantic
+RUN apt-get -y update
+RUN apt-get -y install gnupg curl
+RUN echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-17 main" \
+    >> /etc/apt/sources.list.d/llvm.list
+RUN echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main" \
+    >> /etc/apt/sources.list.d/llvm.list
+RUN curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 RUN apt -y update \
     && apt -y install build-essential \
     && apt -y install gcc-12 g++-12 gcc-13 g++-13 pandoc \
@@ -6,11 +13,11 @@ RUN apt -y update \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13 \
-    && apt -y install clang-16 clang-17 clang-tools-17 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 16 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 16 \
+    && apt -y install clang-17 clang-18 clang-tools-18 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 17 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 17
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 17 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 18 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 18
 COPY install-dependencies.sh /tmp/
 RUN bash /tmp/install-dependencies.sh
 CMD /bin/bash


### PR DESCRIPTION
to address the build failure caused by
https://github.com/llvm/llvm-project/issues/59827, and to test the build with C++23, we need to use clang-18. which will be released in March 2023.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

Closes scylladb/seastar#2058

[avi: regenerate toolchain]