### PR TITLE
resource: move includes to the top of the source file

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -28,10 +28,13 @@ module;
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
+#include <boost/range/irange.hpp>
 #include <regex>
 #include <stdlib.h>
+#include <unistd.h>
 #include <limits>
 #include <filesystem>
+#include <unordered_map>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -39,9 +42,11 @@ module seastar;
 #include <seastar/core/resource.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/print.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/io_queue.hh>
+#include <seastar/core/print.hh>
 #include "cgroup.hh"
 
 #if SEASTAR_HAVE_HWLOC
@@ -284,11 +289,6 @@ io_queue_topology::io_queue_topology(io_queue_topology&& o)
 }
 
 #ifdef SEASTAR_HAVE_HWLOC
-
-#include <seastar/util/defer.hh>
-#include <seastar/core/print.hh>
-#include <unordered_map>
-#include <boost/range/irange.hpp>
 
 namespace seastar {
 
@@ -703,9 +703,6 @@ unsigned nr_processing_units(configuration& c) {
 }
 
 #else
-
-#include <seastar/core/resource.hh>
-#include <unistd.h>
 
 namespace seastar {
 


### PR DESCRIPTION
so we don't have `export` files in the module purview. this addresses the FTBFS with C++20, like
```
FAILED: src/CMakeFiles/seastar-module.dir/core/resource.cc.o
/usr/bin/clang++-18 -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_COROUTINES_ENABLED -DSEASTAR_MODULE -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -Dseastar_module_EXPORTS -I/home/circleci/project/include -I/home/circleci/project/build/debug/gen/include -I/home/circleci/project/src -g -std=c++20 -fPIC -U_FORTIFY_SOURCE -Wno-include-angled-in-module-purview -MD -MT src/CMakeFiles/seastar-module.dir/core/resource.cc.o -MF src/CMakeFiles/seastar-module.dir/core/resource.cc.o.d @src/CMakeFiles/seastar-module.dir/core/resource.cc.o.modmap -o src/CMakeFiles/seastar-module.dir/core/resource.cc.o -c /home/circleci/project/src/core/resource.cc
In file included from /home/circleci/project/src/core/resource.cc:707:
In file included from /home/circleci/project/include/seastar/core/resource.hh:24:
/home/circleci/project/include/seastar/util/std-compat.hh:79:1: error: export declaration can only be used within a module purview
   79 | SEASTAR_MODULE_EXPORT_BEGIN
      | ^
/home/circleci/project/include/seastar/util/modules.hh:26:39: note: expanded from macro 'SEASTAR_MODULE_EXPORT_BEGIN'
   26 | #  define SEASTAR_MODULE_EXPORT_BEGIN export {
      |                                       ^
/home/circleci/project/src/core/resource.cc:37:1: note: add 'export' here if this is intended to be a module interface unit
   37 | module seastar;
      | ^
      | export
```