### PR TITLE
circular_buffer: make the iterator default constructible

### DIFF
--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -194,9 +194,10 @@ private:
        difference_type operator-(const cbiterator<CB, ValueType>& rhs) const noexcept {
             return idx - rhs.idx;
         }
+        cbiterator() = default;
     private:
-        CB* cb;
-        size_t idx;
+        CB* cb{nullptr};
+        size_t idx{0};
         cbiterator(CB* b, size_t i) noexcept : cb(b), idx(i) {}
         friend class circular_buffer;
     };

--- a/tests/unit/circular_buffer_test.cc
+++ b/tests/unit/circular_buffer_test.cc
@@ -27,9 +27,20 @@
 #include <chrono>
 #include <deque>
 #include <random>
+#if __has_include(<ranges>)
+#include <ranges>
+#endif
+#if __has_include(<version>)
+#include <version>
+#endif
+
 #include <seastar/core/circular_buffer.hh>
 
 using namespace seastar;
+
+#ifdef __cpp_lib_ranges
+static_assert(std::ranges::range<circular_buffer<int>>);
+#endif
 
 BOOST_AUTO_TEST_CASE(test_erasing) {
     circular_buffer<int> buf;


### PR DESCRIPTION
this pr makes circular_buffer::iterator default constructible, 
It is needed to make circular_buffer a regular range.

this check is added to circular_buffer_test.cc as a compile-time test:
```cpp
static_assert(std::ranges::range<circular_buffer<int>>);
```
