### PR TITLE
Avoid some in-code ifdefs in reactor.cc

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -597,13 +597,13 @@ public:
 
 thread_local task_histogram this_thread_task_histogram;
 
-#endif
-
 void task_histogram_add_task(const task& t) {
-#ifdef SEASTAR_TASK_HISTOGRAM
     this_thread_task_histogram.add(t);
-#endif
 }
+#else
+void task_histogram_add_task(const task& t) {
+}
+#endif
 
 }
 


### PR DESCRIPTION
Preprocessor conditionals (#if, #ifdef) in the middle of a function body make code harder to read and logic harder to follow. This patch re-ifdefs some of them to produce specific or stub implementations for different if/else cases. The compiler is good at not generating any code for stub calls.
