### PR TITLE
include/seastar/util: fix compilation error

### DIFF
--- a/include/seastar/util/source_location-compat.hh
+++ b/include/seastar/util/source_location-compat.hh
@@ -43,11 +43,8 @@ public:
         , _line(0)
         , _col(0)
     { }
-    static
-#if __cplusplus >= 202002L
-    consteval
-#endif
-    source_location current(const char* file = __builtin_FILE(), const char* func = __builtin_FUNCTION(), int line = __builtin_LINE(), int col = 0) noexcept {
+
+    static source_location current(const char* file = __builtin_FILE(), const char* func = __builtin_FUNCTION(), int line = __builtin_LINE(), int col = 0) noexcept {
         return source_location(file, func, line, col);
     }
 


### PR DESCRIPTION
Clang 14.0.0
Full Log: https://jenkins.ceph.com/job/ceph-pull-requests/128658/consoleText

---

Revert "util/source_location-compat: mark `source_location::current() consteval"

```
../src/seastar/include/seastar/util/log.hh:191:51: error: cannot take address of consteval function 'current' outside of an immediate invocation
        format_info(compat::source_location loc = compat::source_location::current()) noexcept
                                                  ^
../src/seastar/include/seastar/util/source_location-compat.hh:50:21: note: declared here
    source_location current(const char* file = __builtin_FILE(), const char* func = __builtin_FUNCTION(), int line = __builtin_LINE(), int col = 0) noexcept {
```

This reverts commit 550da0e6750a625a171934240c9f7842ab05bc58.