### PR TITLE
util/source_location-compat: use __cpp_consteval

### DIFF
--- a/include/seastar/util/source_location-compat.hh
+++ b/include/seastar/util/source_location-compat.hh
@@ -44,7 +44,7 @@ public:
         , _col(0)
     { }
     static
-#if __cplusplus >= 202002L
+#ifdef __cpp_consteval
     consteval
 #endif
     source_location current(const char* file = __builtin_FILE(), const char* func = __builtin_FUNCTION(), int line = __builtin_LINE(), int col = 0) noexcept {


### PR DESCRIPTION
we should use `__cpp_consteval` for checking the availability of `consteval` instead of using `__cplusplus`. the former is more specific than the later.