### PR TITLE
Fix incorrect class name in documentation.

### DIFF
--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -35,7 +35,7 @@ typedef const http::request& const_req;
 
 /**
  * handlers holds the logic for serving an incoming request.
- * All handlers inherit from the base httpserver_handler and
+ * All handlers inherit from the base handler_base and
  * implement the handle method.
  *
  */


### PR DESCRIPTION
The httpserver_handler class does not exist.
All handlers inherit from this class instead.