### PR TITLE
doc/lambda-coroutine-fiasco: fix a syntax error

### DIFF
--- a/doc/lambda-coroutine-fiasco.md
+++ b/doc/lambda-coroutine-fiasco.md
@@ -1,7 +1,7 @@
 # The Lambda Coroutine Fiasco
 
 Lambda coroutines and Seastar APIs that accept continuations interact badly. This
-document explain the bad interaction and how it is mitigated.
+document explains the bad interaction and how it is mitigated.
 
 ## Lambda coroutines revisited
 


### PR DESCRIPTION
"This document" is a singular subject, so let's use singular verb by adding "s" to the base form of the verb.