### PR TITLE
http: add handler_base::verify_mandatory_params()

### DIFF
--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/http/request.hh>
 #include <seastar/http/common.hh>
+#include <seastar/http/exception.hh>
 #include <seastar/http/reply.hh>
 
 #include <unordered_map>
@@ -40,6 +41,7 @@ typedef const http::request& const_req;
  *
  */
 class handler_base {
+    std::vector<sstring> _mandatory_param;
 protected:
     handler_base() = default;
     handler_base(const handler_base&) = default;
@@ -66,8 +68,18 @@ public:
         return *this;
     }
 
-    std::vector<sstring> _mandatory_param;
-
+    /**
+     * Check if all mandatory parameters exist in the request. if any param
+     * does not exist, the function would throw a @c missing_param_exception
+     * @param params req the http request
+     */
+    void verify_mandatory_params(const http::request& req) const {
+        for (auto& param : _mandatory_param) {
+            if (req.get_query_param(param) == "") {
+                throw missing_param_exception(param);
+            }
+        }
+    }
 };
 
 }

--- a/include/seastar/http/routes.hh
+++ b/include/seastar/http/routes.hh
@@ -242,14 +242,6 @@ public:
 };
 
 /**
- * A helper function that check if a parameter is found in the params object
- * if it does not the function would throw a parameter not found exception
- * @param params the parameters object
- * @param param the parameter to look for
- */
-void verify_param(const http::request& req, const sstring& param);
-
-/**
  * The handler_registration object facilitates registration and auto
  * unregistration of an exact-match handler_base into \ref routes "routes"
  */

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -38,11 +38,6 @@ namespace httpd {
 
 using namespace std;
 
-void verify_param(const http::request& req, const sstring& param) {
-    if (req.get_query_param(param) == "") {
-        throw missing_param_exception(param);
-    }
-}
 routes::routes() : _general_handler([this](std::exception_ptr eptr) mutable {
     return exception_reply(eptr);
 }) {}
@@ -96,9 +91,7 @@ future<std::unique_ptr<http::reply> > routes::handle(const sstring& path, std::u
             normalize_url(path), req->param);
     if (handler != nullptr) {
         try {
-            for (auto& i : handler->_mandatory_param) {
-                verify_param(*req.get(), i);
-            }
+            handler->verify_mandatory_params(*req);
             auto r =  handler->handle(path, std::move(req), std::move(rep));
             return r.handle_exception(_general_handler);
         } catch (...) {


### PR DESCRIPTION
before this change, this member function was a free function called
by `routes::handle()`, but since `handler_base` is closer to the
`_mandatory_param` and in the following change, we will store
the expected param types in `_mandatory_param`, this makes
`handler_base` a better home for the verification function. so to
prepare for the change, let's move this free function into handler_base.

also, let's mark `_mandatory_param` private, allows us to store the
typing of the params into `_mandatory_param`. as this variable should
not be visible from the outer world. and the typing information should
be opaque from the caller.

Refs #2082
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>