### PR TITLE
fix the behavour of sstring::starts_with and ends_with for two equal strings

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -597,7 +597,7 @@ public:
     }
 
     constexpr bool starts_with(std::basic_string_view<char_type, traits_type> sv) const noexcept {
-        return size() > sv.size() && compare(0, sv.size(), sv) == 0;
+        return size() >= sv.size() && compare(0, sv.size(), sv) == 0;
     }
 
     constexpr bool starts_with(char_type c) const noexcept {
@@ -609,7 +609,7 @@ public:
     }
 
     constexpr bool ends_with(std::basic_string_view<char_type, traits_type> sv) const noexcept {
-        return size() > sv.size() && compare(size() - sv.size(), npos, sv) == 0;
+        return size() >= sv.size() && compare(size() - sv.size(), npos, sv) == 0;
     }
 
     constexpr bool ends_with(char_type c) const noexcept {

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -113,6 +113,8 @@ BOOST_AUTO_TEST_CASE(test_str_not_find_sstring) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_starts_with) {
+    BOOST_CHECK(std::string("abcdefg").starts_with("abcdefg"));
+    BOOST_CHECK(sstring("abcdefg").starts_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").starts_with("ab"sv));
     BOOST_CHECK(sstring("abcde").starts_with('a'));
     BOOST_CHECK(sstring("abcde").starts_with("ab"));
@@ -125,6 +127,8 @@ BOOST_AUTO_TEST_CASE(test_str_starts_with) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_ends_with) {
+    BOOST_CHECK(std::string("abcdefg").ends_with("abcdefg"));
+    BOOST_CHECK(sstring("abcdefg").ends_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").ends_with("efg"sv));
     BOOST_CHECK(sstring("abcde").ends_with('e'));
     BOOST_CHECK(sstring("abcde").ends_with("de"));


### PR DESCRIPTION
In c++20, 

```
std::string same_str{"seastar"};
auto eq_str{same_str};
assert(same_str.starts_with(eq_str));
assert(same_str.ends_with(eq_str));
```

but, seastar::sstring::starts_with and ends_withs can not support same string.