### PR TITLE
seastar-json2code: reformat the rendered code and cleanups 

### DIFF
--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -304,7 +304,6 @@ def add_operation(hfile, ccfile, path, oper):
                 fprint(ccfile, '{', '"', path_param , '", path_description::url_component_type::PARAM', '}')
     fprint(ccfile, '}')
     fprint(ccfile, ',{')
-    first = True
     enum_definitions = ""
     if "enum" in oper:
         nickname = oper["nickname"]
@@ -315,20 +314,17 @@ $enum_wrapper
 }
 ''').substitute(nickname=nickname, enum_wrapper=enum_wrapper.rstrip())
     funcs = ""
+    required_query_params = []
     for param in oper.get("parameters", []):
         if is_required_query_param(param):
-            if first:
-                first = False
-            else:
-                fprint(ccfile, "\n,")
-            fprint(ccfile, '"', param["name"], '"')
+            required_query_params.append(param["name"])
         if "enum" in param:
             enum_decl, parse_func = generate_code_from_enum(oper["nickname"],
                                                             param["name"],
                                                             param["enum"])
             enum_definitions += enum_decl
             funcs += parse_func
-
+    fprint(ccfile, '\n,'.join(f'"{name}"' for name in required_query_params))
     fprintln(ccfile, '});')
     fprintln(hfile, enum_definitions)
     open_namespace(ccfile, 'ns_' + oper["nickname"])

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -315,20 +315,19 @@ $enum_wrapper
 }
 ''').substitute(nickname=nickname, enum_wrapper=enum_wrapper.rstrip())
     funcs = ""
-    if "parameters" in oper:
-        for param in oper["parameters"]:
-            if is_required_query_param(param):
-                if first:
-                    first = False
-                else:
-                    fprint(ccfile, "\n,")
-                fprint(ccfile, '"', param["name"], '"')
-            if "enum" in param:
-                enum_decl, parse_func = generate_code_from_enum(oper["nickname"],
-                                                                param["name"],
-                                                                param["enum"])
-                enum_definitions += enum_decl
-                funcs += parse_func
+    for param in oper.get("parameters", []):
+        if is_required_query_param(param):
+            if first:
+                first = False
+            else:
+                fprint(ccfile, "\n,")
+            fprint(ccfile, '"', param["name"], '"')
+        if "enum" in param:
+            enum_decl, parse_func = generate_code_from_enum(oper["nickname"],
+                                                            param["name"],
+                                                            param["enum"])
+            enum_definitions += enum_decl
+            funcs += parse_func
 
     fprintln(ccfile, '});')
     fprintln(hfile, enum_definitions)


### PR DESCRIPTION
this change refactors `seastar-json2code.py` by splitting `create_h_file()` into smaller pieces, and also reformats the rendered code with better formatting.

Refs #2082