### PR TITLE
Update supported C++ standards to C++23 and C++20 (dropping C++17)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ workflows:
       - build_and_test:
           matrix:
             parameters:
-              compiler: ["clang++-17", "g++-13"]
-              standard: ["20", "17"]
+              compiler: ["clang++-18", "g++-13"]
+              standard: ["23", "20"]
               mode: ["dev", "debug", "release"]
       # only build this combination with dpdk enabled, so we don't double
       # the size of the test matrix, and can at least test the build with
@@ -79,8 +79,8 @@ workflows:
       - build_and_test:
           matrix:
             parameters:
-              compiler: ["clang++-17"]
-              standard: ["20"]
+              compiler: ["clang++-18"]
+              standard: ["23"]
               mode: ["release"]
               with_dpdk: [ "enable-dpdk" ]
       # only build this combination with C++20 moduels enabled, so we don't double
@@ -90,6 +90,6 @@ workflows:
           matrix:
             parameters:
               compiler: ["clang++-18"]
-              standard: ["20"]
+              standard: ["23"]
               mode: ["debug"]
               with_modules: [ "enable-modules" ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ set (CMAKE_CXX_FLAGS_SANITIZE
   FORCE)
 
 set (CMAKE_CXX_STANDARD
-  "20"
+  "23"
   CACHE
   STRING
   "C++ standard to build with.")

--- a/configure.py
+++ b/configure.py
@@ -159,7 +159,7 @@ def identify_best_standard(cpp_standards, compiler):
 
 
 if args.cpp_standard == '':
-    cpp_standards = ['23', '20', '17']
+    cpp_standards = ['23', '20']
     args.cpp_standard = identify_best_standard(cpp_standards, compiler=args.cxx)
 
 


### PR DESCRIPTION
C++23 has passed all the ballots [1]. We can therefore support it now formally. This means that C++17 is no longer supported, and C++20 is supported until C++26 is released.

The primary benefit of C++23 support is that we can now use coroutines in core Seastar code, as all supported C++ versions have them.

[1] https://lists.isocpp.org/std-proposals/2024/01/8880.php