### PR TITLE
reactor: io_uring: poll first on send/recv

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1441,21 +1441,25 @@ private:
             case o::recv: {
                 const auto& op = req.as<io_request::operation::recv>();
                 ::io_uring_prep_recv(sqe, op.fd, op.addr, op.size, op.flags);
+                sqe->ioprio |= IORING_RECVSEND_POLL_FIRST;
                 break;
             }
             case o::recvmsg: {
                 const auto& op = req.as<io_request::operation::recvmsg>();
                 ::io_uring_prep_recvmsg(sqe, op.fd, op.msghdr, op.flags);
+                sqe->ioprio |= IORING_RECVSEND_POLL_FIRST;
                 break;
             }
             case o::send: {
                 const auto& op = req.as<io_request::operation::send>();
                 ::io_uring_prep_send(sqe, op.fd, op.addr, op.size, op.flags);
+                sqe->ioprio |= IORING_RECVSEND_POLL_FIRST;
                 break;
             }
             case o::sendmsg: {
                 const auto& op = req.as<io_request::operation::sendmsg>();
                 ::io_uring_prep_sendmsg(sqe, op.fd, op.msghdr, op.flags);
+                sqe->ioprio |= IORING_RECVSEND_POLL_FIRST;
                 break;
             }
             case o::accept: {


### PR DESCRIPTION
Our speculation mechanism tries to predict if data is available in the socket (recv) or if there is room in the write buffer (send) and issues the syscall directly if so. It may make more sense to change it later, but for now, the expectation is that the request will not be completed immediately.

Make use of this information by setting the IORING_RECVSEND_POLL_FIRST flag. This tells io_uring not to try to complete the request immediately, and instead issue a poll first.