### PR TITLE
Replace recursion by iteration in input_stream::read_exactly_part

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/net/packet.hh>
@@ -152,26 +153,29 @@ future<> output_stream<CharType>::write(temporary_buffer<CharType> p) noexcept {
 template <typename CharType>
 future<temporary_buffer<CharType>>
 input_stream<CharType>::read_exactly_part(size_t n, tmp_buf out, size_t completed) noexcept {
-    if (available()) {
-        auto now = std::min(n - completed, available());
-        std::copy(_buf.get(), _buf.get() + now, out.get_write() + completed);
-        _buf.trim_front(now);
-        completed += now;
-    }
-    if (completed == n) {
-        return make_ready_future<tmp_buf>(std::move(out));
-    }
+    while (completed < n) {
+        size_t avail = available();
+        if (avail) {
+            auto now = std::min(n - completed, avail);
+            std::copy_n(_buf.get(), now, out.get_write() + completed);
+            _buf.trim_front(now);
+            completed += now;
+        }
 
-    // _buf is now empty
-    return _fd.get().then([this, n, out = std::move(out), completed] (auto buf) mutable {
+        if (completed == n) {
+            break;
+        }
+
+        // _buf is now empty
+        temporary_buffer<CharType> buf = co_await _fd.get();
         if (buf.size() == 0) {
             _eof = true;
             out.trim(completed);
-            return make_ready_future<tmp_buf>(std::move(out));
+            break;
         }
         _buf = std::move(buf);
-        return this->read_exactly_part(n, std::move(out), completed);
-    });
+    }
+    co_return out;
 }
 
 template <typename CharType>

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -355,7 +355,7 @@ public:
     /// \returns the data_source
     data_source detach() &&;
 private:
-    future<temporary_buffer<CharType>> read_exactly_part(size_t n, tmp_buf buf, size_t completed) noexcept;
+    future<temporary_buffer<CharType>> read_exactly_part(size_t n) noexcept;
 };
 
 struct output_stream_options {


### PR DESCRIPTION
Currently `read_exactly_part` (found in the iostream-impl.hh header) uses recursion, which can lead to stack overflow. This commit rewrites `read_exactly_part` into a coroutine that does not use recursion. Fixes https://github.com/scylladb/seastar/issues/202