### PR TITLE
util/log: add formatter for log_level

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -66,6 +66,12 @@ std::istream& operator>>(std::istream& in, log_level& level);
 SEASTAR_MODULE_EXPORT_END
 }
 
+template <>
+struct fmt::formatter<seastar::log_level> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(seastar::log_level level, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
 // Boost doesn't auto-deduce the existence of the streaming operators for some reason
 
 namespace boost {

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -72,6 +72,14 @@ struct wrapped_log_level {
     seastar::log_level level;
 };
 
+static const std::map<seastar::log_level, std::string_view> log_level_names = {
+        { seastar::log_level::trace, "trace" },
+        { seastar::log_level::debug, "debug" },
+        { seastar::log_level::info, "info" },
+        { seastar::log_level::warn, "warn" },
+        { seastar::log_level::error, "error" },
+};
+
 namespace fmt {
 template <> struct formatter<wrapped_log_level> {
     using log_level = seastar::log_level;
@@ -110,6 +118,12 @@ template <> struct formatter<wrapped_log_level> {
     }
 };
 bool formatter<wrapped_log_level>::colored = true;
+
+auto formatter<seastar::log_level>::format(seastar::log_level level, format_context& ctx) const
+    -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", log_level_names.at(level));
+}
+
 }
 
 namespace seastar {
@@ -261,13 +275,6 @@ static internal::log_buf::inserter_iterator print_real_timestamp(internal::log_b
 
 static internal::log_buf::inserter_iterator (*print_timestamp)(internal::log_buf::inserter_iterator) = print_no_timestamp;
 
-const std::map<log_level, std::string_view> log_level_names = {
-        { log_level::trace, "trace" },
-        { log_level::debug, "debug" },
-        { log_level::info, "info" },
-        { log_level::warn, "warn" },
-        { log_level::error, "error" },
-};
 
 std::ostream& operator<<(std::ostream& out, log_level level) {
     return out << log_level_names.at(level);

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -261,7 +261,7 @@ static internal::log_buf::inserter_iterator print_real_timestamp(internal::log_b
 
 static internal::log_buf::inserter_iterator (*print_timestamp)(internal::log_buf::inserter_iterator) = print_no_timestamp;
 
-const std::map<log_level, sstring> log_level_names = {
+const std::map<log_level, std::string_view> log_level_names = {
         { log_level::trace, "trace" },
         { log_level::debug, "debug" },
         { log_level::info, "info" },
@@ -534,7 +534,7 @@ logger_registry& global_logger_registry() {
 }
 
 sstring level_name(log_level level) {
-    return  log_level_names.at(level);
+    return sstring(log_level_names.at(level));
 }
 
 namespace log_cli {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, we define formatters for `seastar::log_level`, its
operator<< is preserved for backward compatibility.

Refs https://github.com/scylladb/scylladb/issues/13245