### PR TITLE
test/unit: do not check if __cplusplus > 201703L

### DIFF
--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -301,11 +301,9 @@ BOOST_AUTO_TEST_CASE(test_resize_and_overwrite) {
 
 BOOST_AUTO_TEST_CASE(test_compares_left_hand_not_string) {
     // mostly a compile test for non-sstring left-hand-side
-#if __cplusplus > 201703L
     BOOST_REQUIRE("a" == sstring("a"));
     BOOST_REQUIRE(std::string("a") == sstring("a"));
     BOOST_REQUIRE(std::string_view("a") == sstring("a"));
-#endif
 
 #ifdef __cpp_lib_three_way_comparison
     BOOST_REQUIRE("a" < sstring("b"));


### PR DESCRIPTION
now that we've dropped C++17 support in 01257e6058, there is no need to check `__cplusplus > 201703L`, as it's always true now.