### PR TITLE
treewide: expand SEASTAR_CONCEPT macro

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -137,9 +137,8 @@ public:
     ///          the lifetime of the callback \c f, if \ref abort_requested() is \c false. Otherwise,
     ///          returns a disengaged \ref optimized_optional.
     template <typename Func>
-    SEASTAR_CONCEPT(
         requires (std::is_nothrow_invocable_r_v<void, Func, const std::optional<std::exception_ptr>&> ||
-                  std::is_nothrow_invocable_r_v<void, Func>))
+                  std::is_nothrow_invocable_r_v<void, Func>)
     [[nodiscard]]
     optimized_optional<subscription> subscribe(Func&& f) {
         if (abort_requested()) {

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
@@ -29,6 +28,7 @@
 
 #ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
+#include <concepts>
 #include <exception>
 #include <optional>
 #include <type_traits>

--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -36,8 +36,8 @@ namespace seastar {
 
 namespace internal {
 
-    template <typename Aborter, typename T>
-    concept aborter = std::is_nothrow_invocable_r_v<void, Aborter, T&>;
+template <typename Aborter, typename T>
+concept aborter = std::is_nothrow_invocable_r_v<void, Aborter, T&>;
 
 // This class satisfies 'aborter' concept and is used by default
 template<typename... T>

--- a/include/seastar/core/abortable_fifo.hh
+++ b/include/seastar/core/abortable_fifo.hh
@@ -36,10 +36,8 @@ namespace seastar {
 
 namespace internal {
 
-SEASTAR_CONCEPT(
     template <typename Aborter, typename T>
     concept aborter = std::is_nothrow_invocable_r_v<void, Aborter, T&>;
-)
 
 // This class satisfies 'aborter' concept and is used by default
 template<typename... T>
@@ -57,7 +55,7 @@ struct noop_aborter {
 /// The container can only be moved before any elements are pushed.
 ///
 template <typename T, typename OnAbort = noop_aborter<T>>
-SEASTAR_CONCEPT( requires aborter<OnAbort, T> )
+requires aborter<OnAbort, T>
 class abortable_fifo {
 private:
     struct entry {

--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -24,6 +24,7 @@
 
 #ifndef SEASTAR_MODULE
 #include <atomic>
+#include <concepts>
 #include <future>
 #include <memory>
 #include <type_traits>
@@ -34,7 +35,6 @@
 #include <seastar/core/cacheline.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 
 /// \file

--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -145,7 +145,7 @@ extern instance* default_instance;
 ///          \c func throws.
 SEASTAR_MODULE_EXPORT
 template <typename Func>
-SEASTAR_CONCEPT(requires std::is_nothrow_invocable_r_v<void, Func>)
+requires std::is_nothrow_invocable_r_v<void, Func>
 void run_on(instance& instance, unsigned shard, Func func) {
     instance._qs[shard].submit(std::move(func));
 }
@@ -201,7 +201,7 @@ template <typename Func> using return_type_t = typename return_type_of<Func>::ty
 /// \note the caller must keep the returned future alive until \c func returns
 SEASTAR_MODULE_EXPORT
 template<typename Func, typename T = internal::return_type_t<Func>>
-SEASTAR_CONCEPT(requires std::invocable<Func>)
+requires std::invocable<Func>
 std::future<T> submit_to(instance& instance, unsigned shard, Func func) {
     std::promise<T> pr;
     auto fut = pr.get_future();

--- a/include/seastar/core/bitops.hh
+++ b/include/seastar/core/bitops.hh
@@ -63,7 +63,7 @@ constexpr unsigned count_trailing_zeros(unsigned long long x) {
 }
 
 template<typename T>
-SEASTAR_CONCEPT( requires std::is_integral_v<T> )
+requires std::is_integral_v<T>
 inline constexpr unsigned log2ceil(T n) {
     if (n == 1) {
         return 0;
@@ -72,7 +72,7 @@ inline constexpr unsigned log2ceil(T n) {
 }
 
 template<typename T>
-SEASTAR_CONCEPT( requires std::is_integral_v<T> )
+requires std::is_integral_v<T>
 inline constexpr unsigned log2floor(T n) {
     return std::numeric_limits<T>::digits - count_leading_zeros(n) - 1;
 }

--- a/include/seastar/core/bitops.hh
+++ b/include/seastar/core/bitops.hh
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <limits>
 #include <type_traits>
 #endif

--- a/include/seastar/core/checked_ptr.hh
+++ b/include/seastar/core/checked_ptr.hh
@@ -63,11 +63,9 @@ namespace internal {
 /// \param ptr A smart pointer object
 /// \return A pointer to the underlying object
 template <typename T>
-/// cond SEASTAR_CONCEPT_DOC - nested '\ cond' doesn't seem to work (bug 736553), so working it around
-SEASTAR_CONCEPT( requires requires (T ptr) {
+requires requires (T ptr) {
     ptr.get();
-})
-/// endcond
+}
 inline typename std::pointer_traits<std::remove_const_t<T>>::element_type* checked_ptr_do_get(T& ptr) {
     return ptr.get();
 }
@@ -100,11 +98,9 @@ inline T* checked_ptr_do_get(T* ptr) noexcept {
 ///
 SEASTAR_MODULE_EXPORT
 template<typename Ptr, typename NullDerefAction = default_null_deref_action>
-/// \cond SEASTAR_CONCEPT_DOC
-SEASTAR_CONCEPT( requires std::is_default_constructible_v<NullDerefAction> && requires (NullDerefAction action) {
+requires std::is_default_constructible_v<NullDerefAction> && requires (NullDerefAction action) {
     NullDerefAction();
-})
-/// \endcond
+}
 class checked_ptr {
 public:
     /// Underlying element type

--- a/include/seastar/core/checked_ptr.hh
+++ b/include/seastar/core/checked_ptr.hh
@@ -24,9 +24,9 @@
 /// \file
 /// \brief Contains a seastar::checked_ptr class implementation.
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <exception>
 #include <memory>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 #endif
 

--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -88,7 +88,7 @@ public:
     using const_reference = const T&;
     using const_pointer = const T*;
 public:
-    circular_buffer() noexcept SEASTAR_CONCEPT(requires std::default_initializable<Alloc>) : circular_buffer(Alloc()) {}
+    circular_buffer() noexcept requires std::default_initializable<Alloc> : circular_buffer(Alloc()) {}
     circular_buffer(Alloc alloc) noexcept;
     circular_buffer(circular_buffer&& X) noexcept;
     circular_buffer(const circular_buffer& X) = delete;

--- a/include/seastar/core/circular_buffer.hh
+++ b/include/seastar/core/circular_buffer.hh
@@ -23,9 +23,9 @@
 
 #include <seastar/core/transfer.hh>
 #include <seastar/core/bitops.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <memory>
 #include <algorithm>
 #endif

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -259,7 +259,7 @@ public:
     /// \return a future that becomes ready when \ref signal() is called
     ///         If the condition variable was \ref broken(), may contain an exception.
     template<typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     future<> wait(Pred&& pred) noexcept {
         return do_until(std::forward<Pred>(pred), [this] {
             return wait();
@@ -276,7 +276,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is reached will return \ref condition_variable_timed_out exception.
     template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration, typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     future<> wait(std::chrono::time_point<Clock, Duration> timeout, Pred&& pred) noexcept {
         return do_until(std::forward<Pred>(pred), [this, timeout] {
             return wait(timeout);
@@ -293,7 +293,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is passed will return \ref condition_variable_timed_out exception.
     template<typename Rep, typename Period, typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     future<> wait(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return wait(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }
@@ -344,7 +344,7 @@ public:
     /// \return a future that becomes ready when \ref signal() is called
     ///         If the condition variable was \ref broken(), may contain an exception.
     template<typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     auto when(Pred&& pred) noexcept {
         return predicate_awaiter<Pred, awaiter>{std::forward<Pred>(pred), when()};
     }
@@ -360,7 +360,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is reached will return \ref condition_variable_timed_out exception.
     template<typename Clock = typename timer<>::clock, typename Duration = typename Clock::duration, typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     auto when(std::chrono::time_point<Clock, Duration> timeout, Pred&& pred) noexcept {
         return predicate_awaiter<Pred, timeout_awaiter<Clock, Duration>>{std::forward<Pred>(pred), when(timeout)};
     }
@@ -376,7 +376,7 @@ public:
     ///         If the condition variable was \ref broken() will return \ref broken_condition_variable
     ///         exception. If timepoint is passed will return \ref condition_variable_timed_out exception.
     template<typename Rep, typename Period, typename Pred>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Pred> )
+    requires std::is_invocable_r_v<bool, Pred>
     auto when(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return when(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -28,13 +28,13 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/reference_wrapper.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
 #include <fmt/format.h>
+#include <concepts>
 #include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -208,7 +208,7 @@ public:
 /// \tparam Args  argument pack containing arguments to the function object, needs
 ///                   to have move constructor that doesn't throw
 template<typename ReturnType, typename... Args>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>)
+requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>
 class concrete_execution_stage final : public execution_stage {
     using args_tuple = std::tuple<Args...>;
     static_assert(std::is_nothrow_move_constructible_v<args_tuple>,
@@ -321,7 +321,7 @@ public:
 /// \tparam Args  argument pack containing arguments to the function object, needs
 ///                   to have move constructor that doesn't throw
 template<typename ReturnType, typename... Args>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>)
+requires std::is_nothrow_move_constructible_v<std::tuple<Args...>>
 class inheriting_concrete_execution_stage final : public inheriting_execution_stage {
     using return_type = futurize_t<ReturnType>;
     using args_tuple = std::tuple<Args...>;

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -793,7 +793,7 @@ private:
 /// \param func A function that uses a file
 /// \returns the future returned by \c func, or an exceptional future if either \c file_fut or closing the file failed.
 template <typename Func>
-SEASTAR_CONCEPT( requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func> )
+requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func>
 auto with_file(future<file> file_fut, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>, "Func's move constructor must not throw");
     return file_fut.then([func = std::move(func)] (file f) mutable {
@@ -820,7 +820,7 @@ auto with_file(future<file> file_fut, Func func) noexcept {
 /// \param func A function that uses a file
 /// \returns the future returned by \c func, or an exceptional future if \c file_fut failed or a nested exception if closing the file failed.
 template <typename Func>
-SEASTAR_CONCEPT( requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func> )
+requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func>
 auto with_file_close_on_failure(future<file> file_fut, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>, "Func's move constructor must not throw");
     return file_fut.then([func = std::move(func)] (file f) mutable {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1045,8 +1045,6 @@ SEASTAR_MODULE_EXPORT
 template <typename T>
 struct futurize;
 
-SEASTAR_CONCEPT(
-
 template <typename T>
 concept Future = is_future<T>::value;
 
@@ -1080,8 +1078,6 @@ concept InvokeReturnsAnyFuture = Future<std::invoke_result_t<Func, T...>>;
 // Deprecated alias
 template <typename Func, typename... T>
 concept ApplyReturnsAnyFuture = InvokeReturnsAnyFuture<Func, T...>;
-
-)
 
 /// \endcond
 
@@ -1412,8 +1408,8 @@ public:
     /// \return a \c future representing the return value of \c func, applied
     ///         to the eventual value of this future.
     template <typename Func, typename Result = typename internal::future_result<Func, T>::future_type>
-    SEASTAR_CONCEPT( requires std::invocable<Func, T>
-                 || (std::same_as<void, T> && std::invocable<Func>) )
+    requires std::invocable<Func, T>
+                 || (std::same_as<void, T> && std::invocable<Func>)
     Result
     then(Func&& func) noexcept {
 #ifndef SEASTAR_TYPE_ERASE_MORE
@@ -1451,7 +1447,7 @@ public:
     /// \return a \c future representing the return value of \c func, applied
     ///         to the eventual value of this future.
     template <typename Func, typename Result = futurize_t<internal::result_of_apply_t<Func, T>>>
-    SEASTAR_CONCEPT( requires ::seastar::CanApplyTuple<Func, T>)
+    requires ::seastar::CanApplyTuple<Func, T>
     Result
     then_unpack(Func&& func) noexcept {
         return then([func = std::forward<Func>(func)] (T&& tuple) mutable {
@@ -1514,14 +1510,14 @@ public:
     /// \return a \c future representing the return value of \c func, applied
     ///         to the eventual value of this future.
     template <typename Func, typename FuncResult = std::invoke_result_t<Func, future>>
-    SEASTAR_CONCEPT( requires std::invocable<Func, future> )
+    requires std::invocable<Func, future>
     futurize_t<FuncResult>
     then_wrapped(Func&& func) & noexcept {
         return then_wrapped_maybe_erase<false, FuncResult>(std::forward<Func>(func));
     }
 
     template <typename Func, typename FuncResult = std::invoke_result_t<Func, future&&>>
-    SEASTAR_CONCEPT( requires std::invocable<Func, future&&> )
+    requires std::invocable<Func, future&&>
     futurize_t<FuncResult>
     then_wrapped(Func&& func) && noexcept {
         return then_wrapped_maybe_erase<true, FuncResult>(std::forward<Func>(func));
@@ -1632,7 +1628,7 @@ public:
      * nested will be propagated.
      */
     template <typename Func>
-    SEASTAR_CONCEPT( requires std::invocable<Func> )
+    requires std::invocable<Func>
     future<T> finally(Func&& func) noexcept {
         return then_wrapped(finally_body<Func, is_future<std::invoke_result_t<Func>>::value>(std::forward<Func>(func)));
     }
@@ -1714,11 +1710,10 @@ public:
     /// successful value; Because handle_exception() is used here on a
     /// future<>, the handler function does not need to return anything.
     template <typename Func>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<future<T> ,Func, std::exception_ptr>
+    requires std::is_invocable_r_v<future<T> ,Func, std::exception_ptr>
                     || (std::tuple_size_v<tuple_type> == 0 && std::is_invocable_r_v<void, Func, std::exception_ptr>)
                     || (std::tuple_size_v<tuple_type> == 1 && std::is_invocable_r_v<T, Func, std::exception_ptr>)
                     || (std::tuple_size_v<tuple_type> > 1 && std::is_invocable_r_v<tuple_type ,Func, std::exception_ptr>)
-    )
     future<T> handle_exception(Func&& func) noexcept {
         return then_wrapped([func = std::forward<Func>(func)]
                              (auto&& fut) mutable -> future<T> {
@@ -1907,7 +1902,7 @@ private:
     /// promise. This avoids creating a future if func() doesn't
     /// return one.
     template<typename Func>
-    SEASTAR_CONCEPT( requires std::invocable<Func> )
+    requires std::invocable<Func>
     static void satisfy_with_result_of(promise_base_with_type&&, Func&& func);
 
     template <typename U>
@@ -2007,7 +2002,7 @@ typename futurize<T>::type futurize<T>::apply(Func&& func, std::tuple<FuncArgs..
 
 template<typename T>
 template<typename Func>
-SEASTAR_CONCEPT( requires std::invocable<Func> )
+requires std::invocable<Func>
 void futurize<T>::satisfy_with_result_of(promise_base_with_type&& pr, Func&& func) {
     using ret_t = decltype(func());
     if constexpr (std::is_void_v<ret_t>) {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -23,6 +23,7 @@
 
 #ifndef SEASTAR_MODULE
 #include <cassert>
+#include <concepts>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
@@ -37,7 +38,6 @@
 #include <seastar/core/function_traits.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/util/critical_alloc_section.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/std-compat.hh>

--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -56,7 +56,7 @@ public:
     template <typename Fn>
     // Fn should return whether the request was consumed and
     // draining should try to drain more
-    SEASTAR_CONCEPT( requires std::is_invocable_r<bool, Fn, internal::io_request&, io_completion*>::value )
+    requires std::is_invocable_r<bool, Fn, internal::io_request&, io_completion*>::value
     size_t drain(Fn&& consume) {
         size_t pending = _pending_io.size();
         size_t drained = 0;

--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -23,8 +23,8 @@
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/internal/io_request.hh>
-#include <seastar/util/concepts.hh>
 
+#include <concepts>
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/include/seastar/core/internal/poll.hh
+++ b/include/seastar/core/internal/poll.hh
@@ -59,7 +59,7 @@ struct simple_pollfn : public pollfn {
 namespace internal {
 
 template <typename Func>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
+requires std::is_invocable_r_v<bool, Func>
 inline
 std::unique_ptr<seastar::pollfn> make_pollfn(Func&& func) {
     struct the_pollfn : simple_pollfn<false> {
@@ -79,7 +79,7 @@ class poller {
     registration_task* _registration_task = nullptr;
 public:
     template <typename Func>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, Func> )
+    requires std::is_invocable_r_v<bool, Func>
     static poller simple(Func&& poll) {
         return poller(make_pollfn(std::forward<Func>(poll)));
     }

--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -208,7 +208,7 @@ input_stream<CharType>::read_exactly(size_t n) noexcept {
 
 template <typename CharType>
 template <typename Consumer>
-SEASTAR_CONCEPT(requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>)
+requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>
 future<>
 input_stream<CharType>::consume(Consumer&& consumer) noexcept(std::is_nothrow_move_constructible_v<Consumer>) {
     return repeat([consumer = std::move(consumer), this] () mutable {
@@ -244,7 +244,7 @@ input_stream<CharType>::consume(Consumer&& consumer) noexcept(std::is_nothrow_mo
 
 template <typename CharType>
 template <typename Consumer>
-SEASTAR_CONCEPT(requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>)
+requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>
 future<>
 input_stream<CharType>::consume(Consumer& consumer) noexcept(std::is_nothrow_move_constructible_v<Consumer>) {
     return consume(std::ref(consumer));

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -243,7 +243,7 @@ private:
 };
 
 // Consumer concept, for consume() method
-SEASTAR_CONCEPT(
+
 // The consumer should operate on the data given to it, and
 // return a future "consumption result", which can be
 //  - continue_consuming, if the consumer has consumed all the input given
@@ -271,7 +271,6 @@ template <typename Consumer, typename CharType>
 concept ObsoleteInputStreamConsumer = requires (Consumer c) {
     { c(temporary_buffer<CharType>{}) } -> std::same_as<future<std::optional<temporary_buffer<CharType>>>>;
 };
-)
 
 /// Buffers data from a data_source and provides a stream interface to the user.
 ///
@@ -310,10 +309,10 @@ public:
     /// prematurely reaching the end of stream is *not* an I/O error.
     future<temporary_buffer<CharType>> read_exactly(size_t n) noexcept;
     template <typename Consumer>
-    SEASTAR_CONCEPT(requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>)
+    requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>
     future<> consume(Consumer&& c) noexcept(std::is_nothrow_move_constructible_v<Consumer>);
     template <typename Consumer>
-    SEASTAR_CONCEPT(requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>)
+    requires InputStreamConsumer<Consumer, CharType> || ObsoleteInputStreamConsumer<Consumer, CharType>
     future<> consume(Consumer& c) noexcept(std::is_nothrow_move_constructible_v<Consumer>);
     /// Returns true if the end-of-file flag is set on the stream.
     /// Note that the eof flag is only set after a previous attempt to read

--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -116,7 +116,7 @@ future<> repeat(AsyncAction& action) noexcept = delete;
 /// \return a ready future if we stopped successfully, or a failed future if
 ///         a call to to \c action failed.
 template<typename AsyncAction>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<stop_iteration, AsyncAction> || std::is_invocable_r_v<future<stop_iteration>, AsyncAction> )
+requires std::is_invocable_r_v<stop_iteration, AsyncAction> || std::is_invocable_r_v<future<stop_iteration>, AsyncAction>
 inline
 future<> repeat(AsyncAction&& action) noexcept {
     using futurator = futurize<std::invoke_result_t<AsyncAction>>;
@@ -229,10 +229,10 @@ public:
 /// \return a ready future if we stopped successfully, or a failed future if
 ///         a call to to \c action failed.  The \c optional's value is returned.
 template<typename AsyncAction>
-SEASTAR_CONCEPT( requires requires (AsyncAction aa) {
+requires requires (AsyncAction aa) {
     bool(futurize_invoke(aa).get());
     futurize_invoke(aa).get().value();
-} )
+}
 repeat_until_value_return_type<AsyncAction>
 repeat_until_value(AsyncAction action) noexcept {
     using futurator = futurize<std::invoke_result_t<AsyncAction>>;
@@ -334,7 +334,7 @@ public:
 /// \return a ready future if we stopped successfully, or a failed future if
 ///         a call to to \c action or a call to \c stop_cond failed.
 template<typename AsyncAction, typename StopCondition>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<bool, StopCondition> && std::is_invocable_r_v<future<>, AsyncAction> )
+requires std::is_invocable_r_v<bool, StopCondition> && std::is_invocable_r_v<future<>, AsyncAction>
 inline
 future<> do_until(StopCondition stop_cond, AsyncAction action) noexcept {
     using namespace internal;
@@ -370,7 +370,7 @@ future<> do_until(StopCondition stop_cond, AsyncAction action) noexcept {
 ///        that becomes ready when you wish it to be called again.
 /// \return a future<> that will resolve to the first failure of \c action
 template<typename AsyncAction>
-SEASTAR_CONCEPT( requires std::is_invocable_r_v<future<>, AsyncAction> )
+requires std::is_invocable_r_v<future<>, AsyncAction>
 inline
 future<> keep_doing(AsyncAction action) noexcept {
     return repeat([action = std::move(action)] () mutable {
@@ -455,9 +455,9 @@ future<> do_for_each_impl(Iterator begin, Iterator end, AsyncAction action) {
 /// \return a ready future on success, or the first failed future if
 ///         \c action failed.
 template<typename Iterator, typename AsyncAction>
-SEASTAR_CONCEPT( requires requires (Iterator i, AsyncAction aa) {
+requires requires (Iterator i, AsyncAction aa) {
     { futurize_invoke(aa, *i) } -> std::same_as<future<>>;
-} )
+}
 inline
 future<> do_for_each(Iterator begin, Iterator end, AsyncAction action) noexcept {
     try {
@@ -479,10 +479,10 @@ future<> do_for_each(Iterator begin, Iterator end, AsyncAction action) noexcept 
 /// \return a ready future on success, or the first failed future if
 ///         \c action failed.
 template<typename Container, typename AsyncAction>
-SEASTAR_CONCEPT( requires requires (Container c, AsyncAction aa) {
+requires requires (Container c, AsyncAction aa) {
     { futurize_invoke(aa, *std::begin(c)) } -> std::same_as<future<>>;
     std::end(c);
-} )
+}
 inline
 future<> do_for_each(Container& c, AsyncAction action) noexcept {
     try {
@@ -556,7 +556,7 @@ public:
 ///       current shard. If you want to run a function on all shards in parallel,
 ///       have a look at \ref smp::invoke_on_all() instead.
 template <typename Iterator, typename Sentinel, typename Func>
-SEASTAR_CONCEPT( requires (requires (Func f, Iterator i) { { f(*i) } -> std::same_as<future<>>; { i++ }; } && (std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>)))
+requires (requires (Func f, Iterator i) { { f(*i) } -> std::same_as<future<>>; { i++ }; } && (std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>))
 // We use a conjunction with std::same_as<Sentinel, Iterator> because std::sentinel_for requires Sentinel to be semiregular,
 // which implies that it requires Sentinel to be default-constructible, which is unnecessarily strict in below's context and could
 // break legacy code, for which it holds that Sentinel equals Iterator.
@@ -629,10 +629,10 @@ parallel_for_each_impl(Range&& range, Func&& func) {
 } // namespace internal
 
 template <typename Range, typename Func>
-SEASTAR_CONCEPT( requires requires (Func f, Range r) {
+requires requires (Func f, Range r) {
     { f(*std::begin(r)) } -> std::same_as<future<>>;
     std::end(r);
-} )
+}
 inline
 future<>
 parallel_for_each(Range&& range, Func&& func) noexcept {
@@ -662,7 +662,7 @@ parallel_for_each(Range&& range, Func&& func) noexcept {
 ///       current shard. If you want to run a function on all shards in parallel,
 ///       have a look at \ref smp::invoke_on_all() instead.
 template <typename Iterator, typename Sentinel, typename Func>
-SEASTAR_CONCEPT( requires (requires (Func f, Iterator i) { { f(*i) } -> std::same_as<future<>>; { ++i }; } && (std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>) ) )
+requires (requires (Func f, Iterator i) { { f(*i) } -> std::same_as<future<>>; { ++i }; } && (std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterator>) )
 // We use a conjunction with std::same_as<Sentinel, Iterator> because std::sentinel_for requires Sentinel to be semiregular,
 // which implies that it requires Sentinel to be default-constructible, which is unnecessarily strict in below's context and could
 // break legacy code, for which it holds that Sentinel equals Iterator.
@@ -743,10 +743,10 @@ max_concurrent_for_each(Iterator begin, Sentinel end, size_t max_concurrent, Fun
 ///       current shard. If you want to run a function on all shards in parallel,
 ///       have a look at \ref smp::invoke_on_all() instead.
 template <typename Range, typename Func>
-SEASTAR_CONCEPT( requires requires (Func f, Range r) {
+requires requires (Func f, Range r) {
     { f(*std::begin(r)) } -> std::same_as<future<>>;
     std::end(r);
-} )
+}
 inline
 future<>
 max_concurrent_for_each(Range&& range, size_t max_concurrent, Func&& func) noexcept {

--- a/include/seastar/core/map_reduce.hh
+++ b/include/seastar/core/map_reduce.hh
@@ -96,12 +96,12 @@ struct reducer_traits<T, Ptr, decltype(std::declval<T>().get(), void())> : publi
 
 // TODO: specialize for non-deferring reducer
 template <typename Iterator, typename Mapper, typename Reducer>
-SEASTAR_CONCEPT( requires requires (Iterator i, Mapper mapper, Reducer reduce) {
+requires requires (Iterator i, Mapper mapper, Reducer reduce) {
      *i++;
      { i != i } -> std::convertible_to<bool>;
      mapper(*i);
      reduce(futurize_invoke(mapper, *i).get());
-} )
+}
 inline
 auto
 map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&& r)
@@ -171,13 +171,13 @@ map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&& r)
 ///       Sharded services have their own \ref sharded::map_reduce() which
 ///       map-reduces across all shards.
 template <typename Iterator, typename Mapper, typename Initial, typename Reduce>
-SEASTAR_CONCEPT( requires requires (Iterator i, Mapper mapper, Initial initial, Reduce reduce) {
+requires requires (Iterator i, Mapper mapper, Initial initial, Reduce reduce) {
      *i++;
      { i != i} -> std::convertible_to<bool>;
      mapper(*i);
      requires is_future<decltype(mapper(*i))>::value;
      { reduce(std::move(initial), mapper(*i).get()) } -> std::convertible_to<Initial>;
-} )
+}
 inline
 future<Initial>
 map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Initial initial, Reduce reduce) {
@@ -249,13 +249,13 @@ map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Initial initial, Reduc
 ///       Sharded services have their own \ref sharded::map_reduce() which
 ///       map-reduces across all shards.
 template <typename Range, typename Mapper, typename Initial, typename Reduce>
-SEASTAR_CONCEPT( requires requires (Range range, Mapper mapper, Initial initial, Reduce reduce) {
+requires requires (Range range, Mapper mapper, Initial initial, Reduce reduce) {
      std::begin(range);
      std::end(range);
      mapper(*std::begin(range));
      requires is_future<std::remove_reference_t<decltype(mapper(*std::begin(range)))>>::value;
      { reduce(std::move(initial), mapper(*std::begin(range)).get()) } -> std::convertible_to<Initial>;
-} )
+}
 inline
 future<Initial>
 map_reduce(Range&& range, Mapper&& mapper, Initial initial, Reduce reduce) {

--- a/include/seastar/core/queue.hh
+++ b/include/seastar/core/queue.hh
@@ -40,7 +40,7 @@ namespace seastar {
 /// are required to be nothrow move-constructible.
 SEASTAR_MODULE_EXPORT
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 class queue {
     std::queue<T, circular_buffer<T>> _q;
     size_t _max;
@@ -155,14 +155,14 @@ public:
 };
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 queue<T>::queue(size_t size)
     : _max(size) {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 void queue<T>::notify_not_empty() noexcept {
     if (_not_empty) {
@@ -172,7 +172,7 @@ void queue<T>::notify_not_empty() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 void queue<T>::notify_not_full() noexcept {
     if (_not_full) {
@@ -182,7 +182,7 @@ void queue<T>::notify_not_full() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 bool queue<T>::push(T&& data) {
     if (_q.size() < _max) {
@@ -195,7 +195,7 @@ bool queue<T>::push(T&& data) {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 T& queue<T>::front() noexcept {
     // std::queue::front() has no reason to throw
@@ -203,7 +203,7 @@ T& queue<T>::front() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 T queue<T>::pop() noexcept {
     if (_q.size() == _max) {
@@ -220,7 +220,7 @@ T queue<T>::pop() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 future<T> queue<T>::pop_eventually() noexcept {
     // seastar allows only nothrow_move_constructible types
@@ -245,7 +245,7 @@ future<T> queue<T>::pop_eventually() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 future<> queue<T>::push_eventually(T&& data) noexcept {
     if (_ex) {
@@ -268,7 +268,7 @@ future<> queue<T>::push_eventually(T&& data) noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 template <typename Func>
 inline
 bool queue<T>::consume(Func&& func) {
@@ -287,7 +287,7 @@ bool queue<T>::consume(Func&& func) {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 bool queue<T>::empty() const noexcept {
     // std::queue::empty() has no reason to throw
@@ -295,7 +295,7 @@ bool queue<T>::empty() const noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 bool queue<T>::full() const noexcept {
     // std::queue::size() has no reason to throw
@@ -303,7 +303,7 @@ bool queue<T>::full() const noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 future<> queue<T>::not_empty() noexcept {
     if (_ex) {
@@ -318,7 +318,7 @@ future<> queue<T>::not_empty() noexcept {
 }
 
 template <typename T>
-SEASTAR_CONCEPT(requires std::is_nothrow_move_constructible_v<T>)
+requires std::is_nothrow_move_constructible_v<T>
 inline
 future<> queue<T>::not_full() noexcept {
     if (_ex) {

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -23,12 +23,12 @@
 
 #ifndef SEASTAR_MODULE
 #include <chrono>
+#include <concepts>
 #include <functional>
 #include <typeindex>
 #endif
 #include <seastar/core/sstring.hh>
 #include <seastar/core/function_traits.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 
 /// \file

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -346,16 +346,16 @@ public:
     friend scheduling_group internal::scheduling_group_from_index(unsigned index) noexcept;
 
     template<typename SpecificValType, typename Mapper, typename Reducer, typename Initial>
-    SEASTAR_CONCEPT( requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
+    requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
         {reducer(initial, mapper(specific_val))} -> std::convertible_to<Initial>;
-    })
+    }
     friend future<typename function_traits<Reducer>::return_type>
     map_reduce_scheduling_group_specific(Mapper mapper, Reducer reducer, Initial initial_val, scheduling_group_key key);
 
     template<typename SpecificValType, typename Reducer, typename Initial>
-    SEASTAR_CONCEPT( requires requires(SpecificValType specific_val, Reducer reducer, Initial initial) {
+    requires requires(SpecificValType specific_val, Reducer reducer, Initial initial) {
         {reducer(initial, specific_val)} -> std::convertible_to<Initial>;
-    })
+    }
     friend future<typename function_traits<Reducer>::return_type>
         reduce_scheduling_group_specific(Reducer reducer, Initial initial_val, scheduling_group_key key);
 

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -143,9 +143,9 @@ T& scheduling_group_get_specific(scheduling_group_key key) noexcept {
  * SpecificValType.
  */
 template<typename SpecificValType, typename Mapper, typename Reducer, typename Initial>
-SEASTAR_CONCEPT( requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
+requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
     {reducer(initial, mapper(specific_val))} -> std::convertible_to<Initial>;
-})
+}
 future<typename function_traits<Reducer>::return_type>
 map_reduce_scheduling_group_specific(Mapper mapper, Reducer reducer,
         Initial initial_val, scheduling_group_key key) {
@@ -177,9 +177,9 @@ map_reduce_scheduling_group_specific(Mapper mapper, Reducer reducer,
  * SpecificValType.
  */
 template<typename SpecificValType, typename Reducer, typename Initial>
-SEASTAR_CONCEPT( requires requires(SpecificValType specific_val, Reducer reducer, Initial initial) {
+requires requires(SpecificValType specific_val, Reducer reducer, Initial initial) {
     {reducer(initial, specific_val)} -> std::convertible_to<Initial>;
-})
+}
 future<typename function_traits<Reducer>::return_type>
 reduce_scheduling_group_specific(Reducer reducer, Initial initial_val, scheduling_group_key key) {
     using per_scheduling_group = internal::scheduling_group_specific_thread_local_data::per_scheduling_group;

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -288,7 +288,7 @@ public:
     ///        to be invoked on all shards
     /// \return Future that becomes ready once all calls have completed
     template <typename Func, typename... Args>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>)
+    requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>
     future<> invoke_on_all(smp_submit_to_options options, Func func, Args... args) noexcept;
 
     /// Invoke a function on all instances of `Service`.
@@ -297,7 +297,7 @@ public:
     /// Passes the default \ref smp_submit_to_options to the
     /// \ref smp::submit_to() called behind the scenes.
     template <typename Func, typename... Args>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>)
+    requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>
     future<> invoke_on_all(Func func, Args... args) noexcept {
       try {
         return invoke_on_all(smp_submit_to_options{}, std::move(func), std::move(args)...);
@@ -317,7 +317,7 @@ public:
     /// \return a `future<>` that becomes ready when all cores but the current one have
     ///         processed the message.
     template <typename Func, typename... Args>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, Args...>)
+    requires std::invocable<Func, Service&, Args...>
     future<> invoke_on_others(smp_submit_to_options options, Func func, Args... args) noexcept;
 
     /// Invoke a callable on all instances of  \c Service except the instance
@@ -332,7 +332,7 @@ public:
     /// Passes the default \ref smp_submit_to_options to the
     /// \ref smp::submit_to() called behind the scenes.
     template <typename Func, typename... Args>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, Args...>)
+    requires std::invocable<Func, Service&, Args...>
     future<> invoke_on_others(Func func, Args... args) noexcept {
       try {
         return invoke_on_others(smp_submit_to_options{}, std::move(func), std::move(args)...);
@@ -467,7 +467,7 @@ public:
     ///
     /// \return result of calling `func(instance)` on the designated instance
     template <typename Func, typename... Args, typename Ret = futurize_t<std::invoke_result_t<Func, Service&, Args...>>>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, Args&&...>)
+    requires std::invocable<Func, Service&, Args&&...>
     Ret
     invoke_on(unsigned id, smp_submit_to_options options, Func&& func, Args&&... args) {
         return smp::submit_to(id, options, [this, func = std::forward<Func>(func), args = std::tuple(std::move(args)...)] () mutable {
@@ -485,7 +485,7 @@ public:
     /// \param args parameters to the callable
     /// \return result of calling `func(instance)` on the designated instance
     template <typename Func, typename... Args, typename Ret = futurize_t<std::invoke_result_t<Func, Service&, Args&&...>>>
-    SEASTAR_CONCEPT(requires std::invocable<Func, Service&, Args&&...>)
+    requires std::invocable<Func, Service&, Args&&...>
     Ret
     invoke_on(unsigned id, Func&& func, Args&&... args) {
         return invoke_on(id, smp_submit_to_options(), std::forward<Func>(func), std::forward<Args>(args)...);
@@ -547,7 +547,7 @@ public:
     ///                  instance will be passed. Anything else
     ///                  will be passed by value unchanged.
     explicit sharded_parameter(Func func, Params... params)
-            SEASTAR_CONCEPT(requires std::invocable<Func, internal::sharded_unwrap_evaluated_t<Params>...>)
+            requires std::invocable<Func, internal::sharded_unwrap_evaluated_t<Params>...>
             : _func(std::move(func)), _params(std::make_tuple(std::move(params)...)) {
     }
 private:
@@ -757,7 +757,7 @@ sharded<Service>::invoke_on_all(smp_submit_to_options options, std::function<fut
 
 template <typename Service>
 template <typename Func, typename... Args>
-SEASTAR_CONCEPT(requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>)
+requires std::invocable<Func, Service&, internal::sharded_unwrap_t<Args>...>
 inline
 future<>
 sharded<Service>::invoke_on_all(smp_submit_to_options options, Func func, Args... args) noexcept {
@@ -776,7 +776,7 @@ sharded<Service>::invoke_on_all(smp_submit_to_options options, Func func, Args..
 
 template <typename Service>
 template <typename Func, typename... Args>
-SEASTAR_CONCEPT(requires std::invocable<Func, Service&, Args...>)
+requires std::invocable<Func, Service&, Args...>
 inline
 future<>
 sharded<Service>::invoke_on_others(smp_submit_to_options options, Func func, Args... args) noexcept {
@@ -841,7 +841,7 @@ SEASTAR_MODULE_EXPORT_BEGIN
 /// \c foreign_ptr<> is a move-only object; it cannot be copied.
 ///
 template <typename PtrType>
-SEASTAR_CONCEPT( requires (!std::is_pointer_v<PtrType>) )
+requires (!std::is_pointer_v<PtrType>)
 class foreign_ptr {
 private:
     PtrType _value;

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -28,16 +28,13 @@
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/core/do_with.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE
 #include <boost/iterator/counting_iterator.hpp>
-#include <functional>
-#if __has_include(<concepts>)
 #include <concepts>
-#endif
+#include <functional>
 #endif
 
 /// \defgroup smp-module Multicore

--- a/include/seastar/core/shared_mutex.hh
+++ b/include/seastar/core/shared_mutex.hh
@@ -162,15 +162,9 @@ private:
 ///
 /// \relates shared_mutex
 template <typename Func>
-SEASTAR_CONCEPT(
     requires (std::invocable<Func> && std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
-)
-SEASTAR_NO_CONCEPT(
-    inline
-    std::enable_if_t<std::is_nothrow_move_constructible_v<Func>, futurize_t<std::result_of_t<Func ()>>>
-)
 with_shared(shared_mutex& sm, Func&& func) noexcept {
     return sm.lock_shared().then([&sm, func = std::forward<Func>(func)] () mutable {
         return futurize_invoke(func).finally([&sm] {
@@ -180,15 +174,9 @@ with_shared(shared_mutex& sm, Func&& func) noexcept {
 }
 
 template <typename Func>
-SEASTAR_CONCEPT(
     requires (std::invocable<Func> && !std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
-)
-SEASTAR_NO_CONCEPT(
-    inline
-    std::enable_if_t<!std::is_nothrow_move_constructible_v<Func>, futurize_t<std::result_of_t<Func ()>>>
-)
 with_shared(shared_mutex& sm, Func&& func) noexcept {
     // FIXME: use a coroutine when c++17 support is dropped
     try {
@@ -215,15 +203,9 @@ with_shared(shared_mutex& sm, Func&& func) noexcept {
 ///
 /// \relates shared_mutex
 template <typename Func>
-SEASTAR_CONCEPT(
     requires (std::invocable<Func> && std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
-)
-SEASTAR_NO_CONCEPT(
-    inline
-    std::enable_if_t<std::is_nothrow_move_constructible_v<Func>, futurize_t<std::result_of_t<Func ()>>>
-)
 with_lock(shared_mutex& sm, Func&& func) noexcept {
     return sm.lock().then([&sm, func = std::forward<Func>(func)] () mutable {
         return futurize_invoke(func).finally([&sm] {
@@ -234,15 +216,9 @@ with_lock(shared_mutex& sm, Func&& func) noexcept {
 
 
 template <typename Func>
-SEASTAR_CONCEPT(
     requires (std::invocable<Func> && !std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
-)
-SEASTAR_NO_CONCEPT(
-    inline
-    std::enable_if_t<!std::is_nothrow_move_constructible_v<Func>, futurize_t<std::result_of_t<Func ()>>>
-)
 with_lock(shared_mutex& sm, Func&& func) noexcept {
     // FIXME: use a coroutine when c++17 support is dropped
     try {

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -407,7 +407,7 @@ public:
     ///         of \c func.
     /// \returns a future that resolves when all async invocations finish.
     template<typename Func>
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+     requires std::is_nothrow_move_constructible_v<Func>
     static future<> invoke_on_all(smp_submit_to_options options, Func&& func) noexcept {
         static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
@@ -438,8 +438,8 @@ public:
     ///         of \c func.
     /// \returns a future that resolves when all async invocations finish.
     template<typename Func>
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> &&
-            std::is_nothrow_copy_constructible_v<Func> )
+    requires std::is_nothrow_move_constructible_v<Func> &&
+            std::is_nothrow_copy_constructible_v<Func>
     static future<> invoke_on_others(unsigned cpu_id, smp_submit_to_options options, Func func) noexcept {
         static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
@@ -458,7 +458,7 @@ public:
     /// Passes the default \ref smp_submit_to_options to the
     /// \ref smp::submit_to() called behind the scenes.
     template<typename Func>
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+    requires std::is_nothrow_move_constructible_v<Func>
     static future<> invoke_on_others(unsigned cpu_id, Func func) noexcept {
         return invoke_on_others(cpu_id, smp_submit_to_options{}, std::move(func));
     }
@@ -469,7 +469,7 @@ public:
     ///         of \c func.
     /// \returns a future that resolves when all async invocations finish.
     template<typename Func>
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+    requires std::is_nothrow_move_constructible_v<Func>
     static future<> invoke_on_others(Func func) noexcept {
         return invoke_on_others(this_shard_id(), std::move(func));
     }

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -354,7 +354,7 @@ public:
      *  @param op the function object used for setting the new content of the string
      */
     template <class Operation>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<size_t, Operation, char_type*, size_t> )
+    requires std::is_invocable_r_v<size_t, Operation, char_type*, size_t>
     void resize_and_overwrite(size_t n, Operation op) {
         if (n > size()) {
             *this = basic_sstring(initialized_later(), n);

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -28,6 +28,7 @@
 #if __has_include(<compare>)
 #include <compare>
 #endif
+#include <concepts>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -40,7 +41,6 @@
 #include <type_traits>
 #include <fmt/ostream.h>
 #endif
-#include <seastar/util/concepts.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -188,7 +188,6 @@ public:
 } // namespace internal
 
 /// \cond internal
-SEASTAR_CONCEPT(
 
 namespace impl {
 
@@ -211,8 +210,6 @@ struct is_tuple_of_futures<std::tuple<future<T...>, Rest...>> : is_tuple_of_futu
 template <typename... Futs>
 concept AllAreFutures = impl::is_tuple_of_futures<std::tuple<Futs...>>::value;
 
-)
-
 template<typename Fut, std::enable_if_t<is_future<Fut>::value, int> = 0>
 auto futurize_invoke_if_func(Fut&& fut) noexcept {
     return std::forward<Fut>(fut);
@@ -227,7 +224,7 @@ auto futurize_invoke_if_func(Func&& func) noexcept {
 namespace internal {
 
 template <typename... Futs>
-SEASTAR_CONCEPT( requires seastar::AllAreFutures<Futs...> )
+requires seastar::AllAreFutures<Futs...>
 inline
 future<std::tuple<Futs...>>
 when_all_impl(Futs&&... futs) noexcept {
@@ -321,7 +318,7 @@ do_when_all(FutureIterator begin, FutureIterator end) noexcept {
 ///         ready, all contained futures will be ready as well.
 SEASTAR_MODULE_EXPORT
 template <typename FutureIterator>
-SEASTAR_CONCEPT( requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; } )
+requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; }
 inline
 future<std::vector<typename std::iterator_traits<FutureIterator>::value_type>>
 when_all(FutureIterator begin, FutureIterator end) noexcept {
@@ -476,7 +473,7 @@ struct extract_values_from_futures_vector<future<>> {
 };
 
 template<typename... Futures>
-SEASTAR_CONCEPT( requires seastar::AllAreFutures<Futures...> )
+requires seastar::AllAreFutures<Futures...>
 inline auto when_all_succeed_impl(Futures&&... futures) noexcept {
     using state = when_all_state<extract_values_from_futures_tuple<Futures...>, Futures...>;
     return state::wait_all(std::forward<Futures>(futures)...);
@@ -512,11 +509,11 @@ inline auto when_all_succeed(FutOrFuncs&&... fut_or_funcs) noexcept {
 /// \return an \c std::vector<> of all the valus in the input
 SEASTAR_MODULE_EXPORT
 template <typename FutureIterator, typename = typename std::iterator_traits<FutureIterator>::value_type>
-SEASTAR_CONCEPT( requires requires (FutureIterator i) {
+requires requires (FutureIterator i) {
      *i++;
      { i != i } -> std::convertible_to<bool>;
      requires is_future<std::remove_reference_t<decltype(*i)>>::value;
-} )
+}
 inline auto
 when_all_succeed(FutureIterator begin, FutureIterator end) noexcept {
     using itraits = std::iterator_traits<FutureIterator>;

--- a/include/seastar/core/when_any.hh
+++ b/include/seastar/core/when_any.hh
@@ -75,7 +75,7 @@ public:
 ///         ready, at least one of the contained futures (the one indicated by index) will be ready.
 SEASTAR_MODULE_EXPORT
 template <class FutureIterator>
-SEASTAR_CONCEPT( requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; } )
+requires requires (FutureIterator i) { { *i++ }; requires is_future<std::remove_reference_t<decltype(*i)>>::value; }
 auto when_any(FutureIterator begin, FutureIterator end) noexcept
   -> future<when_any_result<std::vector<std::decay_t<typename std::iterator_traits<FutureIterator>::value_type>>>>
 {

--- a/include/seastar/core/with_scheduling_group.hh
+++ b/include/seastar/core/with_scheduling_group.hh
@@ -39,7 +39,7 @@ namespace seastar {
 namespace internal {
 
 template <typename Func>
-SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+requires std::is_nothrow_move_constructible_v<Func>
 auto
 schedule_in_group(scheduling_group sg, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>);
@@ -63,7 +63,7 @@ schedule_in_group(scheduling_group sg, Func func) noexcept {
 ///             to force passing references
 SEASTAR_MODULE_EXPORT
 template <typename Func, typename... Args>
-SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+requires std::is_nothrow_move_constructible_v<Func>
 inline
 auto
 with_scheduling_group(scheduling_group sg, Func func, Args&&... args) noexcept {

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -184,7 +184,7 @@ class client {
     future<> shrink_connections();
 
     template <typename Fn>
-    SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
+    requires std::invocable<Fn, connection&>
     auto with_connection(Fn&& fn);
 
 public:

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -329,7 +329,7 @@ struct json_return_type {
  * return make_ready_future<json::json_return_type>(stream_range_as_array(res, [](const auto&i) {return i.first}));
  */
 template<typename Container, typename Func>
-SEASTAR_CONCEPT( requires requires (Container c, Func aa, output_stream<char> s) { { formatter::write(s, aa(*c.begin())) } -> std::same_as<future<>>; } )
+requires requires (Container c, Func aa, output_stream<char> s) { { formatter::write(s, aa(*c.begin())) } -> std::same_as<future<>>; }
 std::function<future<>(output_stream<char>&&)> stream_range_as_array(Container val, Func fun) {
     return [val = std::move(val), fun = std::move(fun)](output_stream<char>&& s) mutable {
         return do_with(output_stream<char>(std::move(s)), Container(std::move(val)), Func(std::move(fun)), true, [](output_stream<char>& s, const Container& val, const Func& f, bool& first){

--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -21,9 +21,9 @@
 
 #pragma once
 
+#include <concepts>
 #include <functional>
 #include <seastar/core/future.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/defer.hh>
 
 /// \file

--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -32,12 +32,10 @@
 
 namespace seastar {
 
-SEASTAR_CONCEPT(
 template <typename Object>
 concept closeable = requires (Object o) {
     { o.close() } SEASTAR_DEFERRED_ACTION_NOEXCEPT -> std::same_as<future<>>;
 };
-)
 
 /// Template helper to auto-close \c obj when destroyed.
 ///
@@ -47,7 +45,7 @@ concept closeable = requires (Object o) {
 /// Must be used in a seastar thread as the destructor
 /// needs to wait on the \c obj close() future.
 template <typename Object>
-SEASTAR_CONCEPT( requires closeable<Object> )
+requires closeable<Object>
 class [[nodiscard]] deferred_close {
     std::reference_wrapper<Object> _obj;
     bool _closed = false;
@@ -93,10 +91,8 @@ public:
 };
 
 template <typename Closeable, typename Func>
-SEASTAR_CONCEPT(
 requires closeable<Closeable> && std::invocable<Func, Closeable&> &&
         std::is_nothrow_move_constructible_v<Closeable> && std::is_nothrow_move_constructible_v<Func>
-)
 inline futurize_t<std::invoke_result_t<Func, Closeable&>>
 with_closeable(Closeable&& obj, Func func) noexcept {
     return do_with(std::move(obj), [func = std::move(func)] (Closeable& obj) mutable {
@@ -106,12 +102,10 @@ with_closeable(Closeable&& obj, Func func) noexcept {
     });
 }
 
-SEASTAR_CONCEPT(
 template <typename Object>
 concept stoppable = requires (Object o) {
     { o.stop() } SEASTAR_DEFERRED_ACTION_NOEXCEPT -> std::same_as<future<>>;
 };
-)
 
 /// Template helper to auto-stop \c obj when destroyed.
 ///
@@ -121,7 +115,7 @@ concept stoppable = requires (Object o) {
 /// Must be used in a seastar thread as the destructor
 /// needs to wait on the \c obj stop() future.
 template <typename Object>
-SEASTAR_CONCEPT( requires stoppable<Object> )
+requires stoppable<Object>
 class [[nodiscard]] deferred_stop {
     std::reference_wrapper<Object> _obj;
     bool _stopped = false;
@@ -167,10 +161,8 @@ public:
 };
 
 template <typename Stoppable, typename Func>
-SEASTAR_CONCEPT(
 requires stoppable<Stoppable> && std::invocable<Func, Stoppable&> &&
         std::is_nothrow_move_constructible_v<Stoppable> && std::is_nothrow_move_constructible_v<Func>
-)
 inline futurize_t<std::invoke_result_t<Func, Stoppable&>>
 with_stoppable(Stoppable&& obj, Func func) noexcept {
     return do_with(std::move(obj), [func = std::move(func)] (Stoppable& obj) mutable {

--- a/include/seastar/util/concepts.hh
+++ b/include/seastar/util/concepts.hh
@@ -20,20 +20,15 @@
  */
 #pragma once
 
-#if __has_include(<concepts>)
 #include <concepts>
-#endif
 
 #if defined(__cpp_concepts) && __cpp_concepts >= 201907 && \
     defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 201907
-
-#define SEASTAR_CONCEPT(x...) x
-#define SEASTAR_NO_CONCEPT(x...)
-
+    // good
 #else
-
-#define SEASTAR_CONCEPT(x...)
-#define SEASTAR_NO_CONCEPT(x...) x
-
+#error the language support and/or library support for concepts is missing
 #endif
 
+// provided for backward compatibility
+#define SEASTAR_CONCEPT(x...) x
+#define SEASTAR_NO_CONCEPT(x...)

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -36,17 +36,15 @@
 #define SEASTAR_DEFERRED_ACTION_NOEXCEPT
 #endif
 
-SEASTAR_CONCEPT(
 template <typename Func>
 concept deferrable_action = requires (Func func) {
     { func() } SEASTAR_DEFERRED_ACTION_NOEXCEPT -> std::same_as<void>;
 };
-)
 
 namespace seastar {
 
 template <typename Func>
-SEASTAR_CONCEPT( requires deferrable_action<Func> )
+requires deferrable_action<Func>
 class [[nodiscard]] deferred_action {
     Func _func;
     bool _cancelled = false;
@@ -70,7 +68,7 @@ public:
 
 SEASTAR_MODULE_EXPORT
 template <typename Func>
-SEASTAR_CONCEPT( requires deferrable_action<Func> )
+requires deferrable_action<Func>
 inline
 deferred_action<Func>
 defer(Func&& func) {

--- a/include/seastar/util/defer.hh
+++ b/include/seastar/util/defer.hh
@@ -23,11 +23,11 @@
 
 #include "modules.hh"
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <type_traits>
 #include <utility>
 #endif
 #include <seastar/util/modules.hh>
-#include <seastar/util/concepts.hh>
 
 
 #ifdef SEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT

--- a/include/seastar/util/file.hh
+++ b/include/seastar/util/file.hh
@@ -64,9 +64,9 @@ namespace util {
 
 SEASTAR_MODULE_EXPORT_BEGIN
 template <typename Func>
-SEASTAR_CONCEPT(requires requires(Func func, input_stream<char>& in) {
+requires requires(Func func, input_stream<char>& in) {
      { func(in) };
-})
+}
 auto with_file_input_stream(const std::filesystem::path& path, Func func, file_open_options file_opts = {}, file_input_stream_options input_stream_opts = {}) {
     static_assert(std::is_nothrow_move_constructible_v<Func>);
     return open_file_dma(path.native(), open_flags::ro, std::move(file_opts)).then(

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -110,9 +110,9 @@ public:
         virtual internal::log_buf::inserter_iterator operator()(internal::log_buf::inserter_iterator) = 0;
     };
     template <typename Func>
-    SEASTAR_CONCEPT(requires requires (Func fn, internal::log_buf::inserter_iterator it) {
+    requires requires (Func fn, internal::log_buf::inserter_iterator it) {
         it = fn(it);
-    })
+    }
     class lambda_log_writer : public log_writer {
         Func _func;
     public:

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -22,13 +22,13 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/backtrace.hh>
-#include <seastar/util/concepts.hh>
 #include <seastar/util/log-impl.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <unordered_map>
 #include <exception>
 #include <iosfwd>

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -180,7 +180,7 @@ private:
 public:
     noncopyable_function() noexcept : _vtable(&_s_empty_vtable) {}
     template <typename Func>
-    SEASTAR_CONCEPT( requires std::is_invocable_r_v<Ret, Func, Args...> )
+    requires std::is_invocable_r_v<Ret, Func, Args...>
     noncopyable_function(Func func) {
         static_assert(!Noexcept || noexcept(std::declval<Func>()(std::declval<Args>()...)));
         vtable_for<Func>::initialize(std::move(func), this);

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -23,9 +23,9 @@
 
 #include <seastar/util/modules.hh>
 #include <seastar/util/used_size.hh>
-#include <seastar/util/concepts.hh>
 
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <utility>
 #include <type_traits>
 #include <functional>

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -32,8 +32,6 @@
 
 namespace seastar {
 
-SEASTAR_CONCEPT(
-
 template<typename T>
 concept OptimizableOptional =
     std::is_default_constructible_v<T>
@@ -41,8 +39,6 @@ concept OptimizableOptional =
         && requires(const T& obj) {
             { bool(obj) } noexcept;
         };
-
-)
 
 /// \c optimized_optional<> is intended mainly for use with classes that store
 /// their data externally and expect pointer to this data to be always non-null.

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include <seastar/util/concepts.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
+#include <concepts>
 #include <iostream>
 #include <memory>
 #include <type_traits>

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -71,7 +71,7 @@ void print_safe(const char *str) noexcept {
 // and returns a pointer to the first character.
 // For example, convert_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "   c".
 template<typename Integral, char Padding = ' '>
-SEASTAR_CONCEPT( requires std::integral<Integral> )
+requires std::integral<Integral>
 char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
     const char *digits = "0123456789abcdef";
     memset(buf, Padding, bufsz);
@@ -87,7 +87,7 @@ char* convert_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
 // Fills a buffer with a zero-padded hexadecimal representation of an integer.
 // For example, convert_zero_padded_hex_safe(buf, 4, uint16_t(12)) fills the buffer with "000c".
 template<typename Integral>
-SEASTAR_CONCEPT( requires std::integral<Integral> )
+requires std::integral<Integral>
 void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept {
     convert_hex_safe<Integral, '0'>(buf, bufsz, n);
 }
@@ -96,7 +96,7 @@ void convert_zero_padded_hex_safe(char *buf, size_t bufsz, Integral n) noexcept 
 // For example, print_zero_padded_hex_safe(uint16_t(12)) prints "000c".
 // Async-signal safe.
 template<typename Integral>
-SEASTAR_CONCEPT ( requires std::unsigned_integral<Integral> )
+requires std::unsigned_integral<Integral>
 void print_zero_padded_hex_safe(Integral n) noexcept {
     char buf[sizeof(n) * 2];
     convert_zero_padded_hex_safe(buf, sizeof(buf), n);
@@ -107,7 +107,7 @@ void print_zero_padded_hex_safe(Integral n) noexcept {
 // The argument bufsz is the maximum size of the buffer.
 // For example, print_decimal_safe(buf, 16, 12) prints "12".
 template<typename Integral>
-SEASTAR_CONCEPT( requires std::unsigned_integral<Integral> )
+requires std::unsigned_integral<Integral>
 size_t convert_decimal_safe(char *buf, size_t bufsz, Integral n) noexcept {
     char tmp[sizeof(n) * 3];
     unsigned i = bufsz;

--- a/include/seastar/util/print_safe.hh
+++ b/include/seastar/util/print_safe.hh
@@ -24,12 +24,12 @@
 #ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cerrno>
+#include <concepts>
 #include <cstring>
 #include <stdio.h>
 #include <unistd.h>
 #endif
 
-#include <seastar/util/concepts.hh>
 #include <seastar/util/modules.hh>
 
 namespace seastar {

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -39,14 +39,12 @@ inline uint64_t fetch_add(std::atomic<uint64_t>& a, uint64_t b) noexcept {
     return a.fetch_add(b);
 }
 
-SEASTAR_CONCEPT(
 template <typename T>
 concept supports_wrapping_arithmetics = requires (T a, std::atomic<T> atomic_a, T b) {
     { fetch_add(atomic_a, b) } noexcept -> std::same_as<T>;
     { wrapping_difference(a, b) } noexcept -> std::same_as<T>;
     { a + b } noexcept -> std::same_as<T>;
 };
-)
 
 enum class capped_release { yes, no };
 
@@ -91,7 +89,7 @@ struct rovers<T, capped_release::no> {
 };
 
 template <typename T, typename Period, capped_release Capped, typename Clock = std::chrono::steady_clock>
-SEASTAR_CONCEPT( requires std::is_nothrow_copy_constructible_v<T> && supports_wrapping_arithmetics<T> )
+requires std::is_nothrow_copy_constructible_v<T> && supports_wrapping_arithmetics<T>
 class shared_token_bucket {
     using rate_resolution = std::chrono::duration<double, Period>;
 

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include <seastar/util/concepts.hh>
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <concepts>
 #include <cstdint>
 
 namespace seastar {

--- a/include/seastar/util/tmp_file.hh
+++ b/include/seastar/util/tmp_file.hh
@@ -133,7 +133,7 @@ public:
     future<> remove() noexcept;
 
     template <typename Func>
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+    requires std::is_nothrow_move_constructible_v<Func>
     static future<> do_with(std::filesystem::path path_template, Func&& func,
             file_permissions create_permissions = file_permissions::default_dir_permissions) noexcept {
         static_assert(std::is_nothrow_move_constructible_v<Func>,
@@ -153,8 +153,7 @@ public:
     }
 
     template <typename Func>
-
-    SEASTAR_CONCEPT( requires std::is_nothrow_move_constructible_v<Func> )
+    requires std::is_nothrow_move_constructible_v<Func>
     static future<> do_with_thread(Func&& func) noexcept {
         static_assert(std::is_nothrow_move_constructible_v<Func>,
             "Func's move constructor must not throw");

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -74,6 +74,7 @@ module;
 #endif
 
 #include <cassert>
+#include <concepts>
 #include <unordered_set>
 #include <iostream>
 #include <optional>
@@ -84,7 +85,6 @@ module;
 #include <fmt/ostream.h>
 
 #include <boost/container/static_vector.hpp>
-#include <seastar/util/concepts.hh>
 
 #include <dlfcn.h>
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1129,7 +1129,7 @@ cpu_pages::try_free_fastpath(void* ptr) {
 struct no_size {};
 
 template <typename S>
-SEASTAR_CONCEPT(requires std::same_as<S, size_t> || std::same_as<S, no_size>)
+requires std::same_as<S, size_t> || std::same_as<S, no_size>
 [[gnu::noinline]]
 static void free_slowpath(void* obj, S size) {
     if (cpu_pages::is_local_pointer(obj)) {

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -23,11 +23,11 @@
 module;
 #endif
 
+#include <concepts>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <utility>
-#include <seastar/util/concepts.hh>
 
 #ifdef SEASTAR_MODULE
 module seastar;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -301,7 +301,7 @@ future<> client::set_maximum_connections(unsigned nr) {
 }
 
 template <typename Fn>
-SEASTAR_CONCEPT( requires std::invocable<Fn, connection&> )
+requires std::invocable<Fn, connection&>
 auto client::with_connection(Fn&& fn) {
     return get_connection().then([this, fn = std::move(fn)] (connection_ptr con) mutable {
         return fn(*con).finally([this, con = std::move(con)] () mutable {

--- a/src/rpc/lz4_compressor.cc
+++ b/src/rpc/lz4_compressor.cc
@@ -78,9 +78,9 @@ public:
     // containing data that was written to the temporary buffer.
     // Output should be either snd_buf or rcv_buf.
     template<typename Output, typename Function>
-    SEASTAR_CONCEPT(requires requires (Function fn, char* ptr) {
+    requires requires (Function fn, char* ptr) {
         { fn(ptr) } -> std::convertible_to<size_t>;
-    } && (std::is_same_v<Output, snd_buf> || std::is_same_v<Output, rcv_buf>))
+    } && (std::is_same_v<Output, snd_buf> || std::is_same_v<Output, rcv_buf>)
     Output with_reserved(size_t max_size, Function&& fn) {
         if (max_size <= chunk_size) {
             auto dst = temporary_buffer<char>(max_size);

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -319,7 +319,7 @@ SEASTAR_TEST_CASE(test_diagnostics_failures) {
 }
 
 template <typename Func>
-SEASTAR_CONCEPT(requires requires (Func fn) { fn(); })
+requires requires (Func fn) { fn(); }
 void check_function_allocation(const char* name, size_t expected_allocs, Func f) {
     auto before = seastar::memory::stats();
     f();


### PR DESCRIPTION
since we dropped C++17 support in 5d3ee980730b49c2379a2728d69698ee68f5dbeb. and C++ concept is one of the import features introduced by C++20, so we can assume its presence in the language and the C++ standard library.

since `SEASTAR_CONCEPT` macro is always expanded to its parameters, there is no need to use it. in this changeset, as a cleanup, this macro is manually expanded. we could improve the use of concept in follow-up changes, by enforcing the constraints in more elegant ways.