### PR TITLE
treewide: put std::invocable<> constraints in template param list

### DIFF
--- a/include/seastar/core/alien.hh
+++ b/include/seastar/core/alien.hh
@@ -200,8 +200,7 @@ template <typename Func> using return_type_t = typename return_type_of<Func>::ty
 /// \return whatever \c func returns, as a \c std::future<>
 /// \note the caller must keep the returned future alive until \c func returns
 SEASTAR_MODULE_EXPORT
-template<typename Func, typename T = internal::return_type_t<Func>>
-requires std::invocable<Func>
+template<std::invocable Func, typename T = internal::return_type_t<Func>>
 std::future<T> submit_to(instance& instance, unsigned shard, Func func) {
     std::promise<T> pr;
     auto fut = pr.get_future();

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -792,8 +792,8 @@ private:
 /// \param file_fut A future that produces a file
 /// \param func A function that uses a file
 /// \returns the future returned by \c func, or an exceptional future if either \c file_fut or closing the file failed.
-template <typename Func>
-requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func>
+template <std::invocable<file&> Func>
+requires std::is_nothrow_move_constructible_v<Func>
 auto with_file(future<file> file_fut, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>, "Func's move constructor must not throw");
     return file_fut.then([func = std::move(func)] (file f) mutable {
@@ -819,8 +819,8 @@ auto with_file(future<file> file_fut, Func func) noexcept {
 /// \param file_fut A future that produces a file
 /// \param func A function that uses a file
 /// \returns the future returned by \c func, or an exceptional future if \c file_fut failed or a nested exception if closing the file failed.
-template <typename Func>
-requires std::invocable<Func, file&> && std::is_nothrow_move_constructible_v<Func>
+template <std::invocable<file&> Func>
+requires std::is_nothrow_move_constructible_v<Func>
 auto with_file_close_on_failure(future<file> file_fut, Func func) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<Func>, "Func's move constructor must not throw");
     return file_fut.then([func = std::move(func)] (file f) mutable {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1509,15 +1509,13 @@ public:
     /// \param func - function to be called when the future becomes available,
     /// \return a \c future representing the return value of \c func, applied
     ///         to the eventual value of this future.
-    template <typename Func, typename FuncResult = std::invoke_result_t<Func, future>>
-    requires std::invocable<Func, future>
+    template <std::invocable<future> Func, typename FuncResult = std::invoke_result_t<Func, future>>
     futurize_t<FuncResult>
     then_wrapped(Func&& func) & noexcept {
         return then_wrapped_maybe_erase<false, FuncResult>(std::forward<Func>(func));
     }
 
-    template <typename Func, typename FuncResult = std::invoke_result_t<Func, future&&>>
-    requires std::invocable<Func, future&&>
+    template <std::invocable<future&&> Func, typename FuncResult = std::invoke_result_t<Func, future&&>>
     futurize_t<FuncResult>
     then_wrapped(Func&& func) && noexcept {
         return then_wrapped_maybe_erase<true, FuncResult>(std::forward<Func>(func));
@@ -1627,8 +1625,7 @@ public:
      * with the callback exception on top and the original future exception
      * nested will be propagated.
      */
-    template <typename Func>
-    requires std::invocable<Func>
+    template <std::invocable Func>
     future<T> finally(Func&& func) noexcept {
         return then_wrapped(finally_body<Func, is_future<std::invoke_result_t<Func>>::value>(std::forward<Func>(func)));
     }
@@ -1901,8 +1898,7 @@ private:
     /// Forwards the result of, or exception thrown by, func() to the
     /// promise. This avoids creating a future if func() doesn't
     /// return one.
-    template<typename Func>
-    requires std::invocable<Func>
+    template<std::invocable Func>
     static void satisfy_with_result_of(promise_base_with_type&&, Func&& func);
 
     template <typename U>
@@ -2001,8 +1997,7 @@ typename futurize<T>::type futurize<T>::apply(Func&& func, std::tuple<FuncArgs..
 }
 
 template<typename T>
-template<typename Func>
-requires std::invocable<Func>
+template<std::invocable Func>
 void futurize<T>::satisfy_with_result_of(promise_base_with_type&& pr, Func&& func) {
     using ret_t = decltype(func());
     if constexpr (std::is_void_v<ret_t>) {

--- a/include/seastar/core/shared_mutex.hh
+++ b/include/seastar/core/shared_mutex.hh
@@ -161,8 +161,8 @@ private:
 /// \return whatever \c func returns, as a future
 ///
 /// \relates shared_mutex
-template <typename Func>
-    requires (std::invocable<Func> && std::is_nothrow_move_constructible_v<Func>)
+template <std::invocable Func>
+    requires std::is_nothrow_move_constructible_v<Func>
     inline
     futurize_t<std::invoke_result_t<Func>>
 with_shared(shared_mutex& sm, Func&& func) noexcept {
@@ -173,8 +173,8 @@ with_shared(shared_mutex& sm, Func&& func) noexcept {
     });
 }
 
-template <typename Func>
-    requires (std::invocable<Func> && !std::is_nothrow_move_constructible_v<Func>)
+template <std::invocable Func>
+    requires (!std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
 with_shared(shared_mutex& sm, Func&& func) noexcept {
@@ -202,8 +202,8 @@ with_shared(shared_mutex& sm, Func&& func) noexcept {
 /// \return whatever \c func returns, as a future
 ///
 /// \relates shared_mutex
-template <typename Func>
-    requires (std::invocable<Func> && std::is_nothrow_move_constructible_v<Func>)
+template <std::invocable Func>
+    requires std::is_nothrow_move_constructible_v<Func>
     inline
     futurize_t<std::invoke_result_t<Func>>
 with_lock(shared_mutex& sm, Func&& func) noexcept {
@@ -215,8 +215,8 @@ with_lock(shared_mutex& sm, Func&& func) noexcept {
 }
 
 
-template <typename Func>
-    requires (std::invocable<Func> && !std::is_nothrow_move_constructible_v<Func>)
+template <std::invocable Func>
+    requires (!std::is_nothrow_move_constructible_v<Func>)
     inline
     futurize_t<std::invoke_result_t<Func>>
 with_lock(shared_mutex& sm, Func&& func) noexcept {

--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -182,8 +182,8 @@ requires (std::same_as<Sentinel, Iterator> || std::sentinel_for<Sentinel, Iterat
     && std::same_as<future<>, futurize_t<std::invoke_result_t<Func, typename std::iterator_traits<Iterator>::reference>>>
 parallel_for_each(Iterator begin, Sentinel end, Func&& func) -> parallel_for_each<Func>;
 
-template <std::ranges::range Range, typename Func>
-requires std::invocable<Func, std::ranges::range_reference_t<Range>>
+template <std::ranges::range Range,
+          std::invocable<std::ranges::range_reference_t<Range>> Func>
 parallel_for_each(Range&& range, Func&& func) -> parallel_for_each<Func>;
 
 

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -183,8 +183,7 @@ class client {
     future<> put_connection(connection_ptr con);
     future<> shrink_connections();
 
-    template <typename Fn>
-    requires std::invocable<Fn, connection&>
+    template <std::invocable<connection&> Fn>
     auto with_connection(Fn&& fn);
 
 public:

--- a/include/seastar/util/closeable.hh
+++ b/include/seastar/util/closeable.hh
@@ -90,9 +90,8 @@ public:
     }
 };
 
-template <typename Closeable, typename Func>
-requires closeable<Closeable> && std::invocable<Func, Closeable&> &&
-        std::is_nothrow_move_constructible_v<Closeable> && std::is_nothrow_move_constructible_v<Func>
+template <closeable Closeable, std::invocable<Closeable&> Func>
+requires std::is_nothrow_move_constructible_v<Closeable> && std::is_nothrow_move_constructible_v<Func>
 inline futurize_t<std::invoke_result_t<Func, Closeable&>>
 with_closeable(Closeable&& obj, Func func) noexcept {
     return do_with(std::move(obj), [func = std::move(func)] (Closeable& obj) mutable {
@@ -160,9 +159,8 @@ public:
     }
 };
 
-template <typename Stoppable, typename Func>
-requires stoppable<Stoppable> && std::invocable<Func, Stoppable&> &&
-        std::is_nothrow_move_constructible_v<Stoppable> && std::is_nothrow_move_constructible_v<Func>
+template <stoppable Stoppable, std::invocable<Stoppable&> Func>
+requires std::is_nothrow_move_constructible_v<Stoppable> && std::is_nothrow_move_constructible_v<Func>
 inline futurize_t<std::invoke_result_t<Func, Stoppable&>>
 with_stoppable(Stoppable&& obj, Func func) noexcept {
     return do_with(std::move(obj), [func = std::move(func)] (Stoppable& obj) mutable {

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -300,8 +300,7 @@ future<> client::set_maximum_connections(unsigned nr) {
     return shrink_connections();
 }
 
-template <typename Fn>
-requires std::invocable<Fn, connection&>
+template <std::invocable<connection&> Fn>
 auto client::with_connection(Fn&& fn) {
     return get_connection().then([this, fn = std::move(fn)] (connection_ptr con) mutable {
         return fn(*con).finally([this, con = std::move(con)] () mutable {


### PR DESCRIPTION
so that the template definition is more compact.