### PR TITLE
include: do not include unuser headers

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -35,7 +35,7 @@
 #include <seastar/core/io_intent.hh>
 #include <seastar/util/later.hh>
 #include <chrono>
-#include <vector>
+#include <unordered_set>
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -28,7 +28,6 @@
 
 #ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
-#include <concepts>
 #include <exception>
 #include <optional>
 #include <type_traits>

--- a/include/seastar/core/checked_ptr.hh
+++ b/include/seastar/core/checked_ptr.hh
@@ -24,7 +24,6 @@
 /// \file
 /// \brief Contains a seastar::checked_ptr class implementation.
 #ifndef SEASTAR_MODULE
-#include <concepts>
 #include <exception>
 #include <memory>
 #include <seastar/util/modules.hh>

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -34,7 +34,6 @@
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
 #include <fmt/format.h>
-#include <concepts>
 #include <vector>
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -33,7 +33,6 @@
 #include <functional>
 #include <optional>
 #include <queue>
-#include <unordered_set>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/io_priority_class.hh
+++ b/include/seastar/core/io_priority_class.hh
@@ -26,8 +26,11 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/modules.hh>
 
+#if SEASTAR_API_LEVEL < 7
 #include <array>
 #include <mutex>
+#endif
+
 #endif
 
 namespace seastar {

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -21,9 +21,6 @@
 
 #pragma once
 
-#ifndef SEASTAR_MODULE
-#include <chrono>
-#endif
 #include <seastar/util/program-options.hh>
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/util/modules.hh>

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -28,12 +28,10 @@
 #if __has_include(<compare>)
 #include <compare>
 #endif
-#include <concepts>
 #include <string>
 #include <vector>
 #include <unordered_map>
 #include <cstring>
-#include <stdexcept>
 #include <initializer_list>
 #include <istream>
 #include <ostream>

--- a/include/seastar/core/timer-set.hh
+++ b/include/seastar/core/timer-set.hh
@@ -18,9 +18,7 @@
 #include <boost/intrusive/list.hpp>
 #include <array>
 #include <bitset>
-#include <chrono>
 #include <limits>
-#include <memory>
 #endif
 
 namespace seastar {

--- a/include/seastar/core/with_scheduling_group.hh
+++ b/include/seastar/core/with_scheduling_group.hh
@@ -26,7 +26,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/make_task.hh>
 #include <seastar/util/modules.hh>
-#include <concepts>
 #include <tuple>
 #include <utility>
 #endif


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.