### PR TITLE
Cleanup rpc FrameType:: API

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -370,10 +370,10 @@ public:
     }
 
     template <typename FrameType>
-    typename FrameType::return_type read_frame(socket_address info, input_stream<char>& in);
+    future<typename FrameType::return_type> read_frame(socket_address info, input_stream<char>& in);
 
     template <typename FrameType>
-    typename FrameType::return_type read_frame_compressed(socket_address info, std::unique_ptr<compressor>& compressor, input_stream<char>& in);
+    future<typename FrameType::return_type> read_frame_compressed(socket_address info, std::unique_ptr<compressor>& compressor, input_stream<char>& in);
     friend class client;
     template<typename Serializer, typename... Out>
     friend class sink_impl;


### PR DESCRIPTION
There are several frame types declared in rpc.cc, each with a certain API that's used by read helpers. This set makes the API a bit shorter as preparation to RPC round-trip-time measurement and as continuation of #1687 