### PR TITLE
test/unit/sstring_test: do not test standard library

### DIFF
--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -113,7 +113,6 @@ BOOST_AUTO_TEST_CASE(test_str_not_find_sstring) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_starts_with) {
-    BOOST_CHECK(std::string("abcdefg").starts_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").starts_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").starts_with("ab"sv));
     BOOST_CHECK(sstring("abcde").starts_with('a'));
@@ -127,7 +126,6 @@ BOOST_AUTO_TEST_CASE(test_str_starts_with) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_ends_with) {
-    BOOST_CHECK(std::string("abcdefg").ends_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").ends_with("abcdefg"));
     BOOST_CHECK(sstring("abcdefg").ends_with("efg"sv));
     BOOST_CHECK(sstring("abcde").ends_with('e'));


### PR DESCRIPTION
according to related section of C++ standard draft at $string.ends.with, see https://eel.is/c++draft/string.ends.with, it is equivalent to
```c++
return basic_string_view(data() + (size() - rlen), rlen) == x;
```
where `rlen` is the smaller of `size()` and `x.size()`.

so, if the parameter equal to the string, this function should return true.

in existing test of sstring, we are verifying the behavior of standard library, which is not implemented by us, neither do we change its behavior. so there is no need to test it.

see also fc86e8cd, which introduced these tests.