### PR TITLE
HACKING.md: remove doc related to test_dist

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -75,12 +75,6 @@ Make sure you are in the "build" directory.
 ninja test_unit
 ```
 
-- Run distribution tests (these take a long time the first time, but then the dependencies are cached):
-
-```
-ninja test_dist
-```
-
 - Run all tests:
 
 ```


### PR DESCRIPTION
unfortunately, tests/dist was removed in d8b73851c2. so the document referencing it is now outdated. so let's drop it.