### PR TITLE
prometheus: avoid ambiguity when calling MetricFamily.set_name()

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -78,13 +78,13 @@ static pm::Metric* add_label(pm::Metric* mt, const metrics::impl::labels_type & 
     mt->mutable_label()->Reserve(id.size() + 1);
     if (ctx.label) {
         auto label = mt->add_label();
-        label->set_name(ctx.label->key());
-        label->set_value(ctx.label->value());
+        label->set_name(std::string(ctx.label->key()));
+        label->set_value(std::string(ctx.label->value()));
     }
-    for (auto &&i : id) {
+    for (auto && [name, value] : id) {
         auto label = mt->add_label();
-        label->set_name(i.first);
-        label->set_value(i.second);
+        label->set_name(std::string(name));
+        label->set_value(std::string(value));
     }
     return mt;
 }
@@ -797,7 +797,7 @@ future<> write_protobuf_representation(output_stream<char>& out, const config& c
         auto& name = metric_family.name();
         pm::MetricFamily mtf;
         bool empty_metric = true;
-        mtf.set_name(ctx.prefix + "_" + name);
+        mtf.set_name(fmt::format("{}_{}", ctx.prefix, name));
         mtf.mutable_metric()->Reserve(metric_family.size());
         metric_family.foreach_metric([&mtf, &ctx, &filter, &aggregated_values, &empty_metric, should_aggregate](auto value, auto value_info) {
             if ((value_info.should_skip_when_empty && value.is_empty()) || !filter(value_info.id.labels())) {


### PR DESCRIPTION
in newer C++ language binding of protobuf, `ArenaStringPtr::Set()` accepts both `std::string` and `std::string_view`, while the C++ lanaguage binding genereated by protoc just fowrard the type of the parameter, so if the parameter is a `sstring`, we would run into FTBFS like

```
seastar/build/release/gen/src/proto/metrics2.pb.h:2891:20: error: call of overloaded ‘Set(const seastar::basic_sstring<char, unsigned int, 15>&, google::protobuf::Arena*)’ is ambiguous
 2891 |   _impl_.value_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
      |   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/google/protobuf/arenastring.h:478:22: note: candidate: ‘void google::protobuf::internal::ArenaStringPtr::Set(const std::string&, google::protobuf::Arena*) [with OverloadDisambiguator = {}; std::string = std::__cxx11::basic_string<char>]’
  478 | PROTOBUF_EXPORT void ArenaStringPtr::Set(const std::string& value,
      |                      ^~~~~~~~~~~~~~
/usr/include/google/protobuf/arenastring.h:295:8: note: candidate: ‘void google::protobuf::internal::ArenaStringPtr::Set(absl::lts_20230802::string_view, google::protobuf::Arena*)’
  295 |   void Set(absl::string_view value, Arena* arena);
      |        ^~~
/usr/include/google/protobuf/arenastring.h:296:8: note: candidate: ‘void google::protobuf::internal::ArenaStringPtr::Set(std::string&&, google::protobuf::Arena*)’
  296 |   void Set(std::string&& value, Arena* arena);
```

so avoid the ambiguity, let's use `fmt::format()` to set the metric family's name, as `fmt::format()` returns an `std::string`. and at the other caller sites, cast `sstring` to `std::string_view` instead.

Fixes #2111
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>