### PR TITLE
include: add missing modules.hh import to shard_id.hh

### DIFF
--- a/include/seastar/core/shard_id.hh
+++ b/include/seastar/core/shard_id.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <seastar/util/modules.hh>
+
 /// \file
 
 namespace seastar {


### PR DESCRIPTION
The seastar/core/shard_id.hh header does not import other headers, but it requires SEASTAR_MODULE_EXPORT_BEGIN and SEASTAR_MODULE_EXPORT_END macros which are defined in seastar/util/modules.hh.

Make the header self-contained by adding the missing import.