### PR TITLE
circleci: quote literal in condition with `"`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             - run: ./run ./configure.py --compiler << parameters.compiler >> --c++-standard << parameters.standard >>
       - when:
           condition:
-            equal: [ dev, << parameters.mode >> ]
+            equal: [ "dev", << parameters.mode >> ]
           steps:
             - run: ./run ninja -C build/<< parameters.mode >> checkheaders
       - when:


### PR DESCRIPTION
this should bring the checkheader back to the CI

the regression was introduced by e3fce16653