### PR TITLE
build: add shard_id.hh to seastar library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,7 @@ add_library (seastar
   include/seastar/core/scollectd_api.hh
   include/seastar/core/seastar.hh
   include/seastar/core/semaphore.hh
+  include/seastar/core/shard_id.hh
   include/seastar/core/sharded.hh
   include/seastar/core/shared_future.hh
   include/seastar/core/shared_mutex.hh


### PR DESCRIPTION
in 949053b9, we extracted this header out of `smp.hh`, but we didn't add the new header to seastar library. we use the build dependency to deduce which headers should be checked for self-containness, and run checkheaders against them. so this change practically disabled us from performing checkheaders on the new header.

in this change, we bring shard_id.hh to the club. so we can run checkheaders on it again.

see also cb78f9e372325fcc06f5ba39f4419c7e3a2e329d