### PR TITLE
include: do not include unuser headers

### DIFF
--- a/include/seastar/core/thread_impl.hh
+++ b/include/seastar/core/thread_impl.hh
@@ -23,7 +23,6 @@
 #pragma once
 #include <seastar/core/preempt.hh>
 #include <seastar/util/std-compat.hh>
-#include <setjmp.h>
 #include <ucontext.h>
 #include <chrono>
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.