### PR TITLE
thread: speed up thread creation in debug mode

### DIFF
--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -213,7 +213,7 @@ thread_context::make_stack(size_t stack_size) {
     auto stack = stack_holder(new (mem) char[stack_size], stack_deleter(valgrind_id));
 #ifdef SEASTAR_ASAN_ENABLED
     // Avoid ASAN false positive due to garbage on stack
-    std::fill_n(stack.get(), stack_size, 0);
+    std::memset(stack.get(), 0, stack_size);
 #endif
 
 #ifdef SEASTAR_THREAD_STACK_GUARDS


### PR DESCRIPTION
In debug mode, we clear the stack to avoid the address sanitizer thinking we're reading from uninitialized memory (although, typically, programs write to the stack before reading from it). The problem is that we use fill_n, which in debug mode doesn't get optimized into a memset as every write has to pass through asan. This shows up in profiles as the work to initialize the thread stack can be larger than the work the thread does.

Fix be using memset() to clear the stack. memset() is intercepted by asan and is treated as a unit.