### PR TITLE
seastar-json2code: extract Parameter class and cleanups

### DIFF
--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -275,14 +275,14 @@ def add_operation(hfile, ccfile, path, oper):
         vals.reverse()
         base_url = path[:param_starts]
 
-    varname = getitem(oper, "nickname", oper)
+    nickname = getitem(oper, "nickname", oper)
     if config.create_cc:
-        fprintln(hfile, 'extern const path_description ', varname, ';')
+        fprintln(hfile, 'extern const path_description ', nickname, ';')
         maybe_static = ''
     else:
         maybe_static = 'static '
-    fprintln(ccfile, maybe_static, 'const path_description ', varname, '("', clear_path_ending(base_url),
-           '",', oper["method"], ',"', oper["nickname"], '",')
+    fprintln(ccfile, maybe_static, 'const path_description ', nickname, '("', clear_path_ending(base_url),
+           '",', oper["method"], ',"', nickname, '",')
     fprint(ccfile, '{')
     first = True
     while vals:
@@ -305,7 +305,6 @@ def add_operation(hfile, ccfile, path, oper):
     fprint(ccfile, ',{')
     enum_definitions = ""
     if "enum" in oper:
-        nickname = oper["nickname"]
         enum_wrapper = create_enum_wrapper(nickname, "return_type", oper["enum"])
         enum_definitions = Template('''
 namespace ns_$nickname {
@@ -318,7 +317,7 @@ $enum_wrapper
         if is_required_query_param(param):
             required_query_params.append(param["name"])
         if "enum" in param:
-            enum_decl, parse_func = generate_code_from_enum(oper["nickname"],
+            enum_decl, parse_func = generate_code_from_enum(nickname,
                                                             param["name"],
                                                             param["enum"])
             enum_definitions += enum_decl
@@ -326,7 +325,7 @@ $enum_wrapper
     fprint(ccfile, '\n,'.join(f'"{name}"' for name in required_query_params))
     fprintln(ccfile, '});')
     fprintln(hfile, enum_definitions)
-    open_namespace(ccfile, 'ns_' + oper["nickname"])
+    open_namespace(ccfile, 'ns_' + nickname)
     fprintln(ccfile, funcs)
     close_namespace(ccfile)
 

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -294,14 +294,13 @@ def add_operation(hfile, ccfile, path, oper):
         else:
             fprint(ccfile, "\n,")
         if is_url:
-            fprint(ccfile, '{', '"/', path_param , '", path_description::url_component_type::FIXED_STRING', '}')
+            component_type = 'FIXED_STRING'
+        elif get_parameter_by_name(oper, path_param).get("allowMultiple",
+                                                         False):
+            component_type = 'PARAM_UNTIL_END_OF_PATH'
         else:
-            path_param_type = get_parameter_by_name(oper, path_param)
-            if ("allowMultiple" in path_param_type and
-                path_param_type["allowMultiple"]):
-                fprint(ccfile, '{', '"', path_param , '", path_description::url_component_type::PARAM_UNTIL_END_OF_PATH', '}')
-            else:
-                fprint(ccfile, '{', '"', path_param , '", path_description::url_component_type::PARAM', '}')
+            component_type = 'PARAM'
+        fprint(ccfile, f'{{"/{path_param}", path_description::url_component_type::{component_type}}}')
     fprint(ccfile, '}')
     fprint(ccfile, ',{')
     enum_definitions = ""

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -277,12 +277,13 @@ def add_operation(hfile, ccfile, path, oper):
 
     nickname = getitem(oper, "nickname", oper)
     if config.create_cc:
-        fprintln(hfile, 'extern const path_description ', nickname, ';')
+        fprintln(hfile, f'extern const path_description {nickname};')
         maybe_static = ''
     else:
         maybe_static = 'static '
-    fprintln(ccfile, maybe_static, 'const path_description ', nickname, '("', clear_path_ending(base_url),
-           '",', oper["method"], ',"', nickname, '",')
+    normalized_path = clear_path_ending(base_url)
+    http_method = oper["method"]
+    fprintln(ccfile, f'{maybe_static}const path_description {nickname}("{normalized_path}",{http_method},"{nickname}",')
     fprint(ccfile, '{')
     first = True
     while vals:
@@ -325,7 +326,7 @@ $enum_wrapper
     fprint(ccfile, '\n,'.join(f'"{name}"' for name in required_query_params))
     fprintln(ccfile, '});')
     fprintln(hfile, enum_definitions)
-    open_namespace(ccfile, 'ns_' + nickname)
+    open_namespace(ccfile, f'ns_{nickname}')
     fprintln(ccfile, funcs)
     close_namespace(ccfile)
 


### PR DESCRIPTION
this change paves the road to https://github.com/scylladb/seastar/issues/2082. so that we can store more
properties in the Parameter class in this python script and then
translate them into a C++ class which is used to verify and expose
the content and schema of a parameter. so that they can be used
in `handler_base::verify_mandatory_params()` in a follow-up
change.

Refs https://github.com/scylladb/seastar/issues/2082