### PR TITLE
Add missing include in tests/unit/rpc_test.cc

### DIFF
--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -41,6 +41,8 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/later.hh>
 
+#include <span>
+
 using namespace seastar;
 
 struct serializer {


### PR DESCRIPTION
This change fixes compilation issue that was
visible on Linux Ubuntu 22.04 in release mode.
The code uses types and functions defined in
span header.