### PR TITLE
http: path parameter parsing convenience methods

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -27,6 +27,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/http/url.hh>
 
 namespace seastar {
 
@@ -45,6 +46,8 @@ namespace httpd {
 SEASTAR_MODULE_EXPORT_BEGIN
 
 class parameters {
+    // Note: the path matcher adds parameters with the '/' prefix into the params map (eg. "/param1"), and some getters
+    // remove this '/' to return just the path parameter value
     std::unordered_map<sstring, sstring> params;
 public:
     const sstring& path(const sstring& key) const {
@@ -57,6 +60,20 @@ public:
 
     const sstring& at(const sstring& key) const {
         return path(key);
+    }
+
+    sstring get_decoded_param(const sstring& key) const {
+        auto res = params.find(key);
+        if (res == params.end()) {
+            return "";
+        }
+        auto raw_path_param = res->second.substr(1);
+        auto decoded_path_param = sstring{};
+        auto ok = seastar::http::internal::path_decode(raw_path_param, decoded_path_param);
+        if (!ok) {
+            return "";
+        }
+        return decoded_path_param;
     }
 
     bool exists(const sstring& key) const {

--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -54,6 +54,7 @@ public:
         return params.at(key);
     }
 
+    [[deprecated("Use request::get_path_param() instead.")]]
     sstring operator[](const sstring& key) const {
         return params.at(key).substr(1);
     }

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -109,12 +109,12 @@ struct request {
     }
 
     /**
-     * Search for the first header of a given name
-     * @param name the header name
-     * @return a pointer to the header value, if it exists or empty string
+     * Search for the last query parameter of a given key
+     * @param key the query paramerter key
+     * @return the query parameter value, if it exists or empty string
      */
-    sstring get_query_param(const sstring& name) const {
-        auto res = query_parameters.find(name);
+    sstring get_query_param(const sstring& key) const {
+        auto res = query_parameters.find(key);
         if (res == query_parameters.end()) {
             return "";
         }
@@ -277,7 +277,7 @@ struct request {
     static request make(httpd::operation_type type, sstring host, sstring path);
 
 private:
-    void add_param(const std::string_view& param);
+    void add_query_param(std::string_view param);
     sstring request_line() const;
     future<> write_request_headers(output_stream<char>& out) const;
     friend class experimental::connection;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -122,6 +122,16 @@ struct request {
     }
 
     /**
+     * Search for the last path parameter of a given key
+     * @param key the path paramerter key
+     * @return the unescaped path parameter value, if it exists and can be path decoded successfully, otherwise it
+     *  returns an empty string
+     */
+    sstring get_path_param(const sstring& key) const {
+        return param.get_decoded_param(key);
+    }
+
+    /**
      * Get the request protocol name. Can be either "http" or "https".
      */
     sstring get_protocol_name() const {

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -26,7 +26,9 @@ namespace seastar {
 namespace http {
 namespace internal {
 
-bool url_decode(const std::string_view& in, sstring& out);
+bool url_decode(std::string_view in, sstring& out);
+
+bool path_decode(std::string_view in, sstring& out);
 
 /**
  * Makes a percent-encoded string out of the given parameter
@@ -36,7 +38,7 @@ bool url_decode(const std::string_view& in, sstring& out);
  * the URL into path and arguments (both names and values) and use
  * this helper to encode individual strings
  */
-sstring url_encode(const std::string_view& in);
+sstring url_encode(std::string_view in);
 
 } // internal namespace
 } // http namespace

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -50,7 +50,7 @@ directory_handler::directory_handler(const sstring& doc_root,
 
 future<std::unique_ptr<http::reply>> directory_handler::handle(const sstring& path,
         std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
-    sstring full_path = doc_root + req->param["path"];
+    sstring full_path = doc_root + req->param.get_decoded_param("path");
     auto h = this;
     return engine().file_type(full_path).then(
             [h, full_path, req = std::move(req), rep = std::move(rep)](auto val) mutable {

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -63,7 +63,7 @@ future<> request::write_request_headers(output_stream<char>& out) const {
     });
 }
 
-void request::add_param(const std::string_view& param) {
+void request::add_query_param(std::string_view param) {
     size_t split = param.find('=');
 
     if (split >= param.length() - 1) {
@@ -91,10 +91,10 @@ sstring request::parse_query_param() {
     size_t end_param;
     std::string_view url = _url;
     while ((end_param = _url.find('&', curr)) != sstring::npos) {
-        add_param(url.substr(curr, end_param - curr) );
+        add_query_param(url.substr(curr, end_param - curr) );
         curr = end_param + 1;
     }
-    add_param(url.substr(curr));
+    add_query_param(url.substr(curr));
     return _url.substr(0, pos);
 }
 

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -49,7 +49,7 @@ short hex_to_byte(char c) {
 /**
  * Convert a hex encoded 2 bytes substring to char
  */
-char hexstr_to_char(const std::string_view& in, size_t from) {
+char hexstr_to_char(std::string_view in, size_t from) {
 
     return static_cast<char>(hex_to_byte(in[from]) * 16 + hex_to_byte(in[from + 1]));
 }
@@ -67,9 +67,7 @@ inline char char_to_hex(unsigned char val) {
     return "0123456789ABCDEF"[val];
 }
 
-}
-
-bool url_decode(const std::string_view& in, sstring& out) {
+bool decode(bool replace_plus, std::string_view in, sstring& out) {
     size_t pos = 0;
     sstring buff(in.length(), 0);
     for (size_t i = 0; i < in.length(); ++i) {
@@ -80,7 +78,7 @@ bool url_decode(const std::string_view& in, sstring& out) {
             } else {
                 return false;
             }
-        } else if (in[i] == '+') {
+        } else if (replace_plus && in[i] == '+') {
             buff[pos++] = ' ';
         } else {
             buff[pos++] = in[i];
@@ -91,7 +89,18 @@ bool url_decode(const std::string_view& in, sstring& out) {
     return true;
 }
 
-sstring url_encode(const std::string_view& in) {
+}
+
+bool url_decode(std::string_view in, sstring& out) {
+    return decode(true, in, out);
+}
+
+bool path_decode(std::string_view in, sstring& out) {
+    return decode(false, in, out);
+}
+
+
+sstring url_encode(std::string_view in) {
     size_t encodable_chars = 0;
     for (size_t i = 0; i < in.length(); i++) {
         if (should_encode(in[i])) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -65,7 +65,7 @@ SEASTAR_TEST_CASE(test_param_matcher)
     parameters param;
     BOOST_REQUIRE_EQUAL(m.match("/abc/hello", 4, param), 10u);
     BOOST_REQUIRE_EQUAL(param.path("param"), "/hello");
-    BOOST_REQUIRE_EQUAL(param["param"], "hello");
+    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello");
     return make_ready_future<>();
 }
 
@@ -78,7 +78,7 @@ SEASTAR_TEST_CASE(test_match_rule)
     mr.add_str("/hello").add_param("param");
     httpd::handler_base* res = mr.get("/hello/val1", param);
     BOOST_REQUIRE_EQUAL(res, h);
-    BOOST_REQUIRE_EQUAL(param["param"], "val1");
+    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "val1");
     res = mr.get("/hell/val1", param);
     httpd::handler_base* nl = nullptr;
     BOOST_REQUIRE_EQUAL(res, nl);
@@ -295,27 +295,22 @@ SEASTAR_TEST_CASE(test_json_path) {
 
     path1.set(*route, [res1] (const_req req) {
         (*res1) = true;
-        BOOST_REQUIRE_EQUAL(req.param["param1"], "value1");
         BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value1");
         return "";
     });
 
     path2.set(*route, [res2] (const_req req) {
         (*res2) = true;
-        BOOST_REQUIRE_EQUAL(req.param["param1"], "value4+value4%20value4");
         BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value4+value4 value4");
 
-        BOOST_REQUIRE_EQUAL(req.param["param2"], "text4%2Btext4");
         BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text4+text4");
         return "";
     });
 
     path3.set(*route, [res3] (const_req req) {
         (*res3) = true;
-        BOOST_REQUIRE_EQUAL(req.param["param1"], "value3");
         BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value3");
 
-        BOOST_REQUIRE_EQUAL(req.param["param2"], "text2/text3");
         BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text2/text3");
         return "";
     });

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -16,6 +16,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include "loopback_socket.hh"
+#include "seastar/http/reply.hh"
 #include <boost/algorithm/string.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -81,6 +82,12 @@ SEASTAR_TEST_CASE(test_match_rule)
     res = mr.get("/hell/val1", param);
     httpd::handler_base* nl = nullptr;
     BOOST_REQUIRE_EQUAL(res, nl);
+
+    // Test that URL decoding happens correctly on the path part of
+    // the URL. Reproduces issue #725.
+    res = mr.get("/hello/hello%21hi", param);
+    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello!hi");
+
     return make_ready_future<>();
 }
 
@@ -205,6 +212,24 @@ SEASTAR_TEST_CASE(test_decode_url) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_decode_path) {
+    http::request req;
+    req.param = httpd::parameters();
+    req.param.set("param1", "/a+b");
+    req.param.set("param2", "/same%2Ba%2Bb");
+    req.param.set("param3", "/another_param");
+    req.param.set("param4", "/yet%20another");
+    req.param.set("invalid_param", "/%2");
+
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "a+b");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "same+a+b");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param3"), "another_param");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param4"), "yet another");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("invalid_param"), "");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("missing_param"), "");
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_routes) {
     handl* h1 = new handl();
     handl* h2 = new handl();
@@ -254,6 +279,7 @@ SEASTAR_TEST_CASE(test_json_path) {
     shared_ptr<bool> res1 = make_shared<bool>(false);
     shared_ptr<bool> res2 = make_shared<bool>(false);
     shared_ptr<bool> res3 = make_shared<bool>(false);
+    shared_ptr<bool> res4 = make_shared<bool>(false);
     shared_ptr<routes> route = make_shared<routes>();
     path_description path1("/my/path",GET,"path1",
         {{"param1", path_description::url_component_type::PARAM}
@@ -264,44 +290,62 @@ SEASTAR_TEST_CASE(test_json_path) {
     path_description path3("/my/path",GET,"path3",
             {{"param1", path_description::url_component_type::PARAM}
             ,{"param2", path_description::url_component_type::PARAM_UNTIL_END_OF_PATH}},{});
+    path_description path4("/double/encoded",GET,"path4",
+            {{"param1", path_description::url_component_type::PARAM_UNTIL_END_OF_PATH}},{});
 
     path1.set(*route, [res1] (const_req req) {
         (*res1) = true;
         BOOST_REQUIRE_EQUAL(req.param["param1"], "value1");
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value1");
         return "";
     });
 
     path2.set(*route, [res2] (const_req req) {
         (*res2) = true;
-        BOOST_REQUIRE_EQUAL(req.param["param1"], "value2");
-        BOOST_REQUIRE_EQUAL(req.param["param2"], "text1");
+        BOOST_REQUIRE_EQUAL(req.param["param1"], "value4+value4%20value4");
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value4+value4 value4");
+
+        BOOST_REQUIRE_EQUAL(req.param["param2"], "text4%2Btext4");
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text4+text4");
         return "";
     });
 
     path3.set(*route, [res3] (const_req req) {
         (*res3) = true;
         BOOST_REQUIRE_EQUAL(req.param["param1"], "value3");
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value3");
+
         BOOST_REQUIRE_EQUAL(req.param["param2"], "text2/text3");
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text2/text3");
         return "";
     });
 
-    auto f1 = route->handle("/my/path/value1/text", std::make_unique<http::request>(), std::make_unique<http::reply>()).then([res1, route] (auto f) {
-        BOOST_REQUIRE_EQUAL(*res1, true);
+    path4.set(*route, [res4] (const_req req) {
+        (*res4) = true;
+        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "example%20");
+        return "";
     });
 
-    auto f2 = route->handle("/my/path/value2/text1", std::make_unique<http::request>(), std::make_unique<http::reply>()).then([res2, route] (auto f) {
-        BOOST_REQUIRE_EQUAL(*res2, true);
-    });
+    auto check_handler = [route](auto raw_url, auto res) {
+        http::request req;
+        req._url = raw_url;
+        sstring url = req.parse_query_param();
+        return route->handle(url, std::make_unique<http::request>(), std::make_unique<http::reply>()).then([res, route] (auto f) {
+            BOOST_REQUIRE_EQUAL(*res, true);
+        });
+    };
 
-    auto f3 = route->handle("/my/path/value3/text2/text3", std::make_unique<http::request>(), std::make_unique<http::reply>()).then([res3, route] (auto f) {
-        BOOST_REQUIRE_EQUAL(*res3, true);
-    });
+    auto f1 = check_handler("/my/path/value1/text", res1);
+    auto f2 = check_handler("/my/path/value4+value4%20value4/text4%2Btext4", res2);
+    auto f3 = check_handler("/my/path/value3/text2/text3", res3);
+    auto f4 = check_handler("/double/encoded/example%2520", res4);
 
-    return when_all(std::move(f1), std::move(f2), std::move(f3))
-                .then([] (std::tuple<future<>, future<>, future<>> fs) {
+    return when_all(std::move(f1), std::move(f2), std::move(f3), std::move(f4))
+                .then([] (auto fs) {
             std::get<0>(fs).get();
             std::get<1>(fs).get();
             std::get<2>(fs).get();
+            std::get<3>(fs).get();
     });
 }
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1510,3 +1510,24 @@ SEASTAR_TEST_CASE(test_redirect_exception) {
         server.stop().get();
     });
 }
+
+BOOST_AUTO_TEST_CASE(test_path_decode_unchanged) {
+    auto unchanged_chars = seastar::sstring{
+      "~abcdefghijklmnopqrstuvwhyz-ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789.+"};
+    auto result = seastar::sstring{};
+    auto success = http::internal::path_decode(unchanged_chars, result);
+
+    BOOST_REQUIRE(success);
+    BOOST_REQUIRE_EQUAL(result, unchanged_chars);
+}
+
+BOOST_AUTO_TEST_CASE(test_path_decode_changed) {
+    auto changed_chars = seastar::sstring{"%20"};
+    auto result = seastar::sstring{};
+    auto success = http::internal::path_decode(changed_chars, result);
+
+    BOOST_REQUIRE(success);
+
+    auto expected_chars = seastar::sstring{" "};
+    BOOST_REQUIRE_EQUAL(result, expected_chars);
+}


### PR DESCRIPTION
Some REST APIs of Redpanda were incorrectly using the `seastar::http::internal::url_decode` method to url decode path parameters, ignoring the subtle difference between the rules of query parameter decoding and path parameter decoding. This caused issues for Redpanda's clients as they were unable to delete users that had a '+' in the username.

As part of solving this decoding problem, we introduced a `path_decode` method similar to seastar's `url_decode`, and it would be most convenient if this method lived next to the existing `url_decode` utility method that seastar provides both to enable code reuse and to bring it to users' attention that they should make a conscious choice between the two decode methods.

To make this even easier, this PR also adds the `get_path_param` convenience method to the http request object, similar to `get_query_param`, to expose the decoded path parameters of the http request.

Related PR: https://github.com/redpanda-data/seastar/pull/97
Fixes https://github.com/scylladb/seastar/issues/725

