### PR TITLE
reactor: Remove write-only task_queue._current

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -281,7 +281,6 @@ private:
         int64_t _vruntime = 0;
         float _shares;
         int64_t _reciprocal_shares_times_2_power_32;
-        bool _current = false;
         bool _active = false;
         uint8_t _id;
         sched_clock::time_point _ts; // to help calculating wait/starve-times

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3149,10 +3149,8 @@ reactor::run_some_tasks() {
         insert_activating_task_queues();
         task_queue* tq = pop_active_task_queue(t_run_started);
         sched_print("running tq {} {}", (void*)tq, tq->_name);
-        tq->_current = true;
         _last_vruntime = std::max(tq->_vruntime, _last_vruntime);
         run_tasks(*tq);
-        tq->_current = false;
         t_run_completed = now();
         auto delta = t_run_completed - t_run_started;
         account_runtime(*tq, delta);


### PR DESCRIPTION
It's set when reactor start running tasksk from that queue and unset when reactor stops doing it. The bit is unly used by scylla-gdb script, but active/inactive status of the queue can be found out with the help of current_scheduling_group_ptr