### PR TITLE
src/core: revise some grammar warnings

### DIFF
--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -117,7 +117,7 @@ struct io_queue_topology {
 
     io_queue_topology();
     io_queue_topology(const io_queue_topology&) = delete;
-    io_queue_topology(io_queue_topology&&);
+    io_queue_topology(io_queue_topology&&) noexcept;
     ~io_queue_topology();
 };
 

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -66,7 +66,7 @@ auto unwrap_sharded_arg(sharded_parameter<Func, Param...> sp);
 
 using on_each_shard_func = std::function<future<> (unsigned shard)>;
 
-future<> sharded_parallel_for_each(unsigned nr_shards, on_each_shard_func on_each_shard) noexcept(std::is_nothrow_move_constructible_v<on_each_shard_func>);
+future<> sharded_parallel_for_each(unsigned nr_shards, const on_each_shard_func& on_each_shard) noexcept(std::is_nothrow_move_constructible_v<on_each_shard_func>);
 
 template <typename Service>
 class either_sharded_or_local {

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -43,6 +43,7 @@ module seastar;
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
 #include <seastar/net/native-stack.hh>
+#include <utility>
 #include "program_options.hh"
 #endif
 
@@ -58,7 +59,7 @@ seastar_options_from_config(app_template::config cfg) {
     app_template::seastar_options opts;
     opts.name = std::move(cfg.name);
     opts.description = std::move(cfg.description);
-    opts.auto_handle_sigint_sigterm = std::move(cfg.auto_handle_sigint_sigterm);
+    opts.auto_handle_sigint_sigterm = cfg.auto_handle_sigint_sigterm;
     opts.reactor_opts.task_quota_ms.set_default_value(cfg.default_task_quota / 1ms);
     opts.reactor_opts.max_networking_io_control_blocks.set_default_value(cfg.max_networking_aio_io_control_blocks);
     opts.smp_opts.reserve_additional_memory_per_shard = cfg.reserve_additional_memory_per_shard;
@@ -132,7 +133,7 @@ app_template::configuration_reader app_template::get_default_configuration_reade
 }
 
 void app_template::set_configuration_reader(configuration_reader conf_reader) {
-    _conf_reader = conf_reader;
+    _conf_reader = std::move(conf_reader);
 }
 
 boost::program_options::options_description& app_template::get_options_description() {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4510,9 +4510,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     auto backend_selector = reactor_opts.reactor_backend.get_selected_candidate();
     seastar_logger.info("Reactor backend: {}", backend_selector);
 
-    unsigned i;
     auto smp_tmain = smp::_tmain;
-    for (i = 1; i < smp::count; i++) {
+    for (unsigned i = 1; i < smp::count; i++) {
         auto allocation = allocations[i];
         create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages] {
           try {
@@ -4536,7 +4535,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
             for (auto sig : { SIGSEGV }) {
                 sigdelset(&mask, sig);
             }
-            auto r = ::pthread_sigmask(SIG_BLOCK, &mask, NULL);
+            auto r = ::pthread_sigmask(SIG_BLOCK, &mask, nullptr);
             throw_pthread_error(r);
             init_default_smp_service_group(i);
             lowres_clock::update();
@@ -4892,7 +4891,7 @@ reactor::init_new_scheduling_group_key(scheduling_group_key key, scheduling_grou
     sg_data.scheduling_group_key_configs[key.id()] = cfg;
     return parallel_for_each(_task_queues, [this, cfg, key] (std::unique_ptr<task_queue>& tq) {
         if (tq) {
-            scheduling_group sg = scheduling_group(tq->_id);
+            auto sg = scheduling_group(tq->_id);
             if (tq.get() == _at_destroy_tasks) {
                 // fake the group by assuming it here
                 auto curr = current_scheduling_group();

--- a/src/core/sharded.cc
+++ b/src/core/sharded.cc
@@ -38,7 +38,7 @@ namespace internal {
 
 
 future<>
-sharded_parallel_for_each(unsigned nr_shards, on_each_shard_func on_each_shard) noexcept(std::is_nothrow_move_constructible_v<on_each_shard_func>) {
+sharded_parallel_for_each(unsigned nr_shards, const on_each_shard_func& on_each_shard) noexcept(std::is_nothrow_move_constructible_v<on_each_shard_func>) {
     return parallel_for_each(boost::irange<unsigned>(0, nr_shards), std::move(on_each_shard));
 }
 

--- a/src/core/syscall_work_queue.hh
+++ b/src/core/syscall_work_queue.hh
@@ -53,7 +53,7 @@ class syscall_work_queue {
         noncopyable_function<T ()> _func;
         promise<T> _promise;
         std::optional<T> _result;
-        work_item_returning(noncopyable_function<T ()> func) : _func(std::move(func)) {}
+        explicit work_item_returning(noncopyable_function<T ()> func) : _func(std::move(func)) {}
         virtual void process() override { _result = this->_func(); }
         virtual void complete() override { _promise.set_value(std::move(*_result)); }
         virtual void set_exception(std::exception_ptr eptr) override { _promise.set_exception(eptr); };


### PR DESCRIPTION
clang-tidy has raised syntax warnings for some existing code, such as using pass-by-value where pass-by-reference could be used, or renaming local variables. I have carefully revised these sections.