### PR TITLE
metrics: support relabel aggregate

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -192,6 +192,7 @@ struct metric_info {
     labels_type original_labels;
     bool enabled;
     skip_when_empty should_skip_when_empty;
+    std::vector<std::string> aggregate_labels;
 };
 
 
@@ -216,7 +217,7 @@ class registered_metric final {
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
-    registered_metric(metric_id id, metric_function f, bool enabled=true, skip_when_empty skip=skip_when_empty::no);
+    registered_metric(metric_id id, metric_function f, bool enabled=true, skip_when_empty skip=skip_when_empty::no, std::vector<std::string> aggregate_labels = {});
     metric_value operator()() const {
         return _f();
     }

--- a/include/seastar/core/relabel_config.hh
+++ b/include/seastar/core/relabel_config.hh
@@ -89,7 +89,7 @@ public:
  *
  */
 struct relabel_config {
-    enum class relabel_action {skip_when_empty, report_when_empty, replace, keep, drop, drop_label};
+    enum class relabel_action {skip_when_empty, report_when_empty, replace, keep, drop, drop_label, aggregate_label};
     std::vector<std::string> source_labels;
     std::string target_label;
     std::string replacement = "${1}";


### PR DESCRIPTION
inorder to aggregate metrics to node (or others) level, here add an optional to action, which is "aggregate_label". the usage is similar to action "drop_label". For example:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '[ \
   { \
     "source_labels": [ \
       "__name__" \
     ], \
     "action": "aggregate_label", \
     "target_label": "shard", \
     "regex": "column_family_live_sstable" \
   } \
 ]' 'http://localhost:10000/v2/metrics-config/'
```
Signed-off-by: qiulijuan2<qiulijuan2_yewu@cmss.chinamobile.com>