### PR TITLE
build: relax the version constraint for Protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,10 +417,11 @@ function (seastar_generate_protobuf)
   set (source_out ${args_OUT_DIR}/${in_file_name}.pb.cc)
 
   add_custom_command (
-    DEPENDS ${args_IN_FILE}
+    DEPENDS ${args_IN_FILE} protobuf::protoc
     OUTPUT ${header_out} ${source_out}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${args_OUT_DIR}
-    COMMAND ${Protobuf_PROTOC_EXECUTABLE} --cpp_out=${args_OUT_DIR} -I${in_file_dir} ${args_IN_FILE})
+    COMMAND protobuf::protoc
+    ARGS --cpp_out=${args_OUT_DIR} -I${in_file_dir} ${args_IN_FILE})
 
   add_custom_target (${args_TARGET}
     DEPENDS

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -159,14 +159,11 @@ macro (seastar_find_dependencies)
   # ProtobufConfig.cmake provided by protobuf defines this linkage. so we try
   # the CMake package configuration file first, and fall back to CMake's
   # FindProtobuf module.
-  find_package (Protobuf 2.5.0
-    QUIET CONFIG)
-  if (Protobuf_FOUND)
+  find_package (Protobuf QUIET CONFIG)
+  if (Protobuf_FOUND AND Protobuf_VERSION VERSION_GREATER_EQUAL 2.5.0)
     # do it again, so the message is printed when the package is found
-    find_package(Protobuf 2.5.0
-      CONFIG REQUIRED)
+    find_package(Protobuf CONFIG REQUIRED)
   else ()
-    find_package(Protobuf 2.5.0
-      REQUIRED)
+    find_package(Protobuf 2.5.0 REQUIRED)
   endif ()
 endmacro ()


### PR DESCRIPTION
as higher versions of Protobuf does not claim to be compatible with
v2.5.0, so we should not specify a version number which is acceptable
by Seastar as a parameter of `find_package()`. and instead, we just
check the version number after calling `find_package()` in config mode.
if we find the package using config mode, we search it again, for
printing out the version number to the stdout, otherwise we search
using its C++ API version.

Refs ##2113