### PR TITLE
util: add formatter for optimized_optional<>

### DIFF
--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <memory>
 #include <type_traits>
+#include <fmt/core.h>
 #endif
 
 namespace seastar {
@@ -99,3 +100,13 @@ public:
 };
 
 }
+
+template <typename T>
+struct fmt::formatter<seastar::optimized_optional<T>> : fmt::formatter<std::string_view> {
+    auto format(const seastar::optimized_optional<T>& opt, fmt::format_context& ctx) const {
+        if (opt) {
+            return fmt::format_to(ctx.out(), "{}", *opt);
+        }
+        return fmt::format_to(ctx.out(), "null");
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `seastar::optimized_optional`, its operator<< is preserved for backward compatibility.

Refs scylladb/scylladb#13245