### PR TITLE
tls: add fmt::formatter for tls::subject_alt_name

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -496,3 +496,26 @@ namespace tls {
     extern const int ERROR_PREMATURE_TERMINATION;
 }
 }
+
+template <> struct fmt::formatter<seastar::tls::subject_alt_name_type> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(seastar::tls::subject_alt_name_type type, FormatContext& ctx) const {
+        return formatter<std::string_view>::format(format_as(type), ctx);
+    }
+};
+
+template <> struct fmt::formatter<seastar::tls::subject_alt_name::value_type> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const seastar::tls::subject_alt_name::value_type& value, FormatContext& ctx) const {
+        return std::visit([&](const auto& v) {
+            return fmt::format_to(ctx.out(), "{}", v);
+        }, value);
+    }
+};
+
+template <> struct fmt::formatter<seastar::tls::subject_alt_name> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const seastar::tls::subject_alt_name& name, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}={}", name.type, name.value);
+    }
+};

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -39,6 +39,7 @@ module;
 #include <boost/range/adaptor/map.hpp>
 
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -2001,12 +2002,13 @@ std::ostream& tls::operator<<(std::ostream& os, subject_alt_name_type type) {
 }
 
 std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name::value_type& v) {
-    std::visit([&](auto& vv) { os << vv; }, v);
+    fmt::print(os, "{}", v);
     return os;
 }
 
 std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
-    return os << a.type << "=" << a.value;
+    fmt::print(os, "{}", a);
+    return os;
 }
 
 


### PR DESCRIPTION
this change addresses the formatting with fmtlib v10, which stopped creating the default-generated formatter even if FMT_DEPRECATED_OSTREAM preprocess macro is defined. so to enable Seastar applications to print tls::subject_alt_name using {fmt} without defining the formatter by themselves, we provide the formatter for this class in Seastar.

Refs https://github.com/scylladb/scylladb/issues/13245