### PR TITLE
util: add fmt::formatter for bool_class<Tag>

### DIFF
--- a/include/seastar/util/bool_class.hh
+++ b/include/seastar/util/bool_class.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <ostream>
+#include <fmt/core.h>
 
 namespace seastar {
 
@@ -108,3 +109,12 @@ const bool_class<Tag> bool_class<Tag>::no { false };
 /// @}
 
 }
+
+template<typename Tag>
+struct fmt::formatter<seastar::bool_class<Tag>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(seastar::bool_class<Tag> v, FormatContext& ctx) const{
+        return fmt::format_to(ctx.out(), "{}", bool(v));
+    }
+};


### PR DESCRIPTION
this change addresses the formatting with fmtlib v10, which stopped creating the default-generated formatter even if FMT_DEPRECATED_OSTREAM preprocess macro is defined. so to enable Seastar applications to print bool_class<Tag> using {fmt} without defining the formatter by themselves, we provide the formatter for this class in Seastar.

the operator<< for bool_class<Tag> is preserved for backward compatibility. please note, {fmt} format a `bool` variable as "true" or "false" based on its value, so we don't have to put "true" or "false" explicitly as we do in the implementation of operator<<.

Refs https://github.com/scylladb/scylladb/issues/13245
