### PR TITLE
memory: Ensure thread locals etc are minimally initialized even with non-seastar reactor options for alloc

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -165,6 +165,8 @@ internal::numa_layout configure(std::vector<resource::memory> m, bool mbind,
         bool transparent_hugepages,
         std::optional<std::string> hugetlbfs_path = {});
 
+void configure_minimal();
+
 // A deprecated alias for set_abort_on_allocation_failure(true).
 [[deprecated("use set_abort_on_allocation_failure(true) instead")]]
 void enable_abort_on_allocation_failure();

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -139,6 +139,13 @@ future<> destroy_smp_service_group(smp_service_group ssg) noexcept {
 }
 
 void init_default_smp_service_group(shard_id cpu) {
+    // default_smp_service_group == smp_service_group(0) -> we assume service groups are empty
+    // at this point. If they are not, it is quite possibly because we are running repeated 
+    // reactors in the program. Probably a test (see #2148). 
+    // This would be fine, we just create extra junk here, _but_ it is quite possible
+    // that we actually run with different cpu count (see smp_options::smp), in which case
+    // the `get_smp_service_groups_semaphore` below can cause us to return uninitialized memory.
+    smp_service_groups.clear();
     smp_service_groups.emplace_back();
     auto& ssg0 = smp_service_groups.back();
     ssg0.clients.reserve(smp::count);


### PR DESCRIPTION
Fixes #2148

When using the seastar allocator, there are numerous implicit reliances on cpu_mem_ptr having been set up. Previously, this just happened to be true, due to #2137.

Fixed by adding a minimal memory setup call to smp::configure, even if using non-seastar allocator reactor options (not compile flags).

Fixed the test for the feature (allocator options) so that it 
* Actually runs. regardlerss of dpdk
* Actually catches the issue