### PR TITLE
memory: drop support for compilers that don't support aligned new

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2492,8 +2492,6 @@ void operator delete[](void* ptr, size_t size, std::nothrow_t) noexcept {
     seastar::memory::free(ptr, size);
 }
 
-#ifdef __cpp_aligned_new
-
 extern "C++"
 [[gnu::visibility("default")]]
 void* operator new(size_t size, std::align_val_t a) {
@@ -2567,8 +2565,6 @@ extern "C++"
 void operator delete[](void* ptr, std::align_val_t a, const std::nothrow_t&) noexcept {
     seastar::memory::free(ptr);
 }
-
-#endif
 
 namespace seastar {
 

--- a/tests/unit/allocator_test.cc
+++ b/tests/unit/allocator_test.cc
@@ -62,8 +62,6 @@ struct allocation {
     }
 };
 
-#ifdef __cpp_aligned_new
-
 template <size_t N>
 struct alignas(N) cpp17_allocation final {
     char v;
@@ -145,13 +143,6 @@ void test_cpp17_aligned_allocator() {
         }
     }
 }
-
-#else
-
-void test_cpp17_aligned_allocator() {
-}
-
-#endif
 
 int main(int ac, char** av) {
     namespace bpo = boost::program_options;


### PR DESCRIPTION
Aligned new (__cpp_aligned_new) was introduced in C++17 and compilers support it since 2018. Remove the conditional compilation and refuse to build on compilers that are too old to support it (we require C++20+ anyway).