### PR TITLE
rpc: add fmt::formatter for rpc::error classes and rpc::optional

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -432,7 +432,29 @@ struct tuple_element<I, seastar::rpc::tuple<T...>> : tuple_element<I, tuple<T...
 template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_formatter {};
 #endif
 
-#if FMT_VERSION >= 100000
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <std::derived_from<seastar::rpc::error> T>
+struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+    auto format(const T& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif
+
+#if FMT_VERSION < 100000
+template <typename T>
+struct fmt::formatter<seastar::rpc::optional<T>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::rpc::optional<T>& opt, fmt::format_context& ctx) const {
+        if (opt) {
+            return fmt::format_to(ctx.out(), "optional({})", *opt);
+        } else {
+            return fmt::format_to(ctx.out(), "none");
+        }
+    }
+};
+#else
 template <typename T>
 struct fmt::formatter<seastar::rpc::optional<T>> : private fmt::formatter<std::optional<T>> {
     using fmt::formatter<std::optional<T>>::parse;


### PR DESCRIPTION
this change addresses the formatting with fmtlib < 10, and without `FMT_DEPRECATED_OSTREAM` defined. please note, in {fmt} v10 and up, it defines formatter for classes derived from `std::exception`, so our formatter is only added when compiled with {fmt} < 10.

{fmt} introduced its builtin `fmt::formatter` for std::optional in v10, so to enable applications to print `rpc::optional<T>`, we also implement `fmt::formatter<rpc::optional<T>>`, it's behavior mimics the one provided by {fmt} v10 with minor difference, for the sake of simplicity, the homebrew version does not call `maybe_set_debug_format(.., true)` for the underlying type. so when printing types with debug_format support, their formattings might be different.

Refs https://github.com/scylladb/scylladb/issues/13245