### PR TITLE
abort_source: add fmt::formatter for abort_requested_exception

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -197,3 +197,13 @@ public:
 SEASTAR_MODULE_EXPORT_END
 
 }
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<seastar::abort_requested_exception> : fmt::formatter<std::string_view> {
+    auto format(const seastar::abort_requested_exception& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif


### PR DESCRIPTION
this change addresses the formatting with fmtlib < 10, and without `FMT_DEPRECATED_OSTREAM` defined. please note, in {fmt} v10 and up, it defines formatter for classes derived from `std::exception`, so our formatter is only added when compiled with {fmt} < 10.

Refs https://github.com/scylladb/scylladb/issues/13245wip