### PR TITLE
TLS: Add support for TLS1.3 session tickets

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -242,6 +242,14 @@ namespace tls {
     };
 
     /**
+     * Session resumption support. 
+     * We only support TLS1.3 session tickets.
+    */
+    enum class session_resume_mode {
+        NONE, TLS13_SESSION_TICKET
+    };
+
+    /**
      * Extending certificates and keys for server usage.
      * More probably goes in here...
      */
@@ -258,6 +266,14 @@ namespace tls {
         server_credentials& operator=(const server_credentials&) = delete;
 
         void set_client_auth(client_auth);
+
+        /**
+         * Sets session resume mode.
+         * If session resumption is set to TLS13 session tickets, 
+         * calling this also functions as key rotation, i.e. creates
+         * a new window of TLS session keys.
+        */
+        void set_session_resume_mode(session_resume_mode);
     };
 
     class reloadable_credentials_base;
@@ -291,6 +307,7 @@ namespace tls {
         future<> set_system_trust();
         void set_client_auth(client_auth);
         void set_priority_string(const sstring&);
+        void set_session_resume_mode(session_resume_mode);
 
         void apply_to(certificate_credentials&) const;
 
@@ -306,8 +323,11 @@ namespace tls {
 
         std::multimap<sstring, boost::any> _blobs;
         client_auth _client_auth = client_auth::NONE;
+        session_resume_mode _session_resume_mode = session_resume_mode::NONE;
         sstring _priority;
     };
+
+    using session_data = std::vector<uint8_t>;
 
     /// TLS configuration options
     struct tls_options {
@@ -315,6 +335,10 @@ namespace tls {
         bool wait_for_eof_on_shutdown = true;
         /// \brief server name to be used for the SNI TLS extension
         sstring server_name = {};
+
+        /// \brief Optional session resume data. Must be retrieved via 
+        /// get_session_resume_data below.
+        session_data session_resume_data;
     };
 
     /**
@@ -451,6 +475,28 @@ namespace tls {
      * If the socket is not a TLS socket an exception will be thrown.
     */
     future<std::vector<subject_alt_name>> get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types = {});
+
+    /**
+     * Checks if the socket was connected using session resume.
+     * Will force handshake if not already done. 
+     * 
+     * If the socket is not connected a system_error exception will be thrown.
+     * If the socket is not a TLS socket an exception will be thrown.
+    */
+    future<bool> check_session_is_resumed(connected_socket& socket);
+
+    /**
+     * Get session resume data from a connected client socket. Will force handshake if not already done.
+     * 
+     * If the socket is not connected a system_error exception will be thrown.
+     * If the socket is not a TLS socket an exception will be thrown.
+     * If no session resumption data is available, returns empty buffer.
+     * 
+     * Note: TLS13 session tickets most of the time require data to have been transferred
+     * between client/server. To ensure getting the session data, it is advisable to 
+     * delay this call to sometime before shutting down/closing the socket.
+    */
+    future<session_data> get_session_resume_data(connected_socket&);
 
     std::ostream& operator<<(std::ostream&, const subject_alt_name::value_type&);
     std::ostream& operator<<(std::ostream&, const subject_alt_name&);

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -332,6 +332,19 @@ future<tls::x509_cert> tls::x509_cert::from_file(
     });
 }
 
+// wrapper for gnutls_datum, with raii free
+struct gnutls_datum : public gnutls_datum_t {
+    gnutls_datum() {
+        data = nullptr;
+        size = 0;
+    }
+    ~gnutls_datum() {
+        if (data != nullptr) {
+            ::gnutls_free(data);
+        }
+    }
+};
+
 class tls::certificate_credentials::impl: public gnutlsobj {
 public:
     impl()
@@ -404,6 +417,20 @@ public:
     client_auth get_client_auth() const {
         return _client_auth;
     }
+    void set_session_resume_mode(session_resume_mode m) {
+        _session_resume_mode = m;
+        // (re-)generate session key
+        if (m != session_resume_mode::NONE) {
+            _session_resume_key = {};
+            gnutls_session_ticket_key_generate(&_session_resume_key);
+        }
+    }
+    session_resume_mode get_session_resume_mode() const {
+        return _session_resume_mode;
+    }
+    const gnutls_datum_t* get_session_resume_key() const {
+        return &_session_resume_key;
+    }
     void set_priority_string(const sstring& prio) {
         const char * err = prio.c_str();
         try {
@@ -441,9 +468,11 @@ private:
     std::unique_ptr<tls::dh_params::impl> _dh_params;
     std::unique_ptr<std::remove_pointer_t<gnutls_priority_t>, void(*)(gnutls_priority_t)> _priority;
     client_auth _client_auth = client_auth::NONE;
+    session_resume_mode _session_resume_mode = session_resume_mode::NONE;
     bool _load_system_trust = false;
     semaphore _system_trust_sem {1};
     dn_callback _dn_callback;
+    gnutls_datum _session_resume_key;
 };
 
 tls::certificate_credentials::certificate_credentials()
@@ -542,6 +571,11 @@ tls::server_credentials& tls::server_credentials::operator=(
 void tls::server_credentials::set_client_auth(client_auth ca) {
     _impl->set_client_auth(ca);
 }
+
+void tls::server_credentials::set_session_resume_mode(session_resume_mode m) {
+    _impl->set_session_resume_mode(m);
+}
+
 
 static const sstring dh_level_key = "dh_level";
 static const sstring x509_trust_key = "x509_trust";
@@ -645,6 +679,10 @@ void tls::credentials_builder::set_priority_string(const sstring& prio) {
     _priority = prio;
 }
 
+void tls::credentials_builder::set_session_resume_mode(session_resume_mode m) {
+    _session_resume_mode = m;
+}
+
 template<typename Blobs, typename Visitor>
 static void visit_blobs(Blobs& blobs, Visitor&& visitor) {
     auto visit = [&](const sstring& key, auto* vt) {
@@ -692,6 +730,8 @@ void tls::credentials_builder::apply_to(certificate_credentials& creds) const {
     }
 
     creds._impl->set_client_auth(_client_auth);
+    // Note: this causes server session key rotation on cert reload
+    creds._impl->set_session_resume_mode(_session_resume_mode);
 }
 
 shared_ptr<tls::certificate_credentials> tls::credentials_builder::build_certificate_credentials() const {
@@ -1028,8 +1068,17 @@ public:
                     gnutls_certificate_server_set_request(*this, GNUTLS_CERT_REQUIRE);
                     break;
             }
+            // Maybe set up server session ticket support
+            switch (_creds->get_session_resume_mode()) {
+                case session_resume_mode::NONE: 
+                default:
+                    break;
+                case session_resume_mode::TLS13_SESSION_TICKET:
+                    gnutls_session_ticket_enable_server(*this, _creds->get_session_resume_key());
+                    break;
+            }
         }
-
+ 
         auto prio = _creds->get_priority();
         if (prio) {
             gtls_chk(gnutls_priority_set(*this, prio));
@@ -1046,6 +1095,11 @@ public:
             gnutls_session_set_verify_function(*this, &verify_wrapper);
         }
 #endif
+        // if we are a client, check if we have a session ticket to unpack.
+        if (_type == type::CLIENT && !_options.session_resume_data.empty()) {
+            gtls_chk(gnutls_session_set_data(*this, _options.session_resume_data.data(), _options.session_resume_data.size()));
+        }
+        _options.session_resume_data.clear(); // no need to keep around
     }
     session(type t, shared_ptr<certificate_credentials> creds,
             connected_socket sock,
@@ -1551,8 +1605,56 @@ public:
         });
     }
 
-    seastar::net::connected_socket_impl & socket() const {
+    seastar::net::connected_socket_impl& socket() const {
         return *_sock;
+    }
+
+    // helper routine.
+    template<typename Func, typename... Args>
+    auto state_checked_access(Func&& f, Args&& ...args) {
+        using future_type = typename futurize<std::invoke_result_t<Func, Args...>>::type;
+        using result_t = typename future_type::value_type;
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!_connected) {
+            return handshake().then([this, f = std::move(f), ...args = std::forward<Args>(args)]() mutable {
+                // always recurse, in case malicious api caller does a shutdown while the above handshake is
+                // happening. I.e. misuses the api.
+                return session::state_checked_access(std::move(f), std::forward<Args>(args)...);
+            });
+        }
+        return futurize_invoke(f, std::forward<Args>(args)...);
+    }
+
+    future<bool> is_resumed() {
+        return state_checked_access([this] {
+            return gnutls_session_is_resumed(*this) != 0;
+        });
+    }
+    future<session_data> get_session_resume_data() {
+        return state_checked_access([this] {
+            /**
+             * Session ticket data is not available just because handshake 
+             * was done. First off, of course other part must support it,
+             * but we also (mostly?) need to actually transfer data before
+             * the ticket is received.
+             * 
+             * Check session flags so we can return no data in the case
+             * none is avail. Gnutls returns a 4-byte "empty marker" 
+             * on none avail.
+            */
+            auto flags = gnutls_session_get_flags(*this);
+            if ((flags & GNUTLS_SFLAGS_SESSION_TICKET) == 0) {
+                return session_data{};
+            }
+            gnutls_datum tmp;
+            gtls_chk(gnutls_session_get_data2(*this, &tmp));
+            return session_data(tmp.data, tmp.data + tmp.size);
+        });
     }
 
     future<std::optional<session_dn>> get_distinguished_name() {
@@ -1796,6 +1898,12 @@ public:
     future<> wait_input_shutdown() override {
         return _session->socket().wait_input_shutdown();
     }
+    future<bool> check_session_is_resumed() {
+        return _session->is_resumed();
+    }
+    future<session_data> get_session_resume_data() {
+        return _session->get_session_resume_data();
+    }
 };
 
 
@@ -1976,6 +2084,14 @@ future<std::optional<session_dn>> tls::get_dn_information(connected_socket& sock
 
 future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types) {
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
+}
+
+future<bool> tls::check_session_is_resumed(connected_socket& socket) {
+    return get_tls_socket(socket)->check_session_is_resumed();
+}
+
+future<tls::session_data> tls::get_session_resume_data(connected_socket& socket) {
+    return get_tls_socket(socket)->get_session_resume_data();
 }
 
 std::string_view tls::format_as(subject_alt_name_type type) {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1656,45 +1656,20 @@ public:
             return session_data(tmp.data, tmp.data + tmp.size);
         });
     }
-
     future<std::optional<session_dn>> get_distinguished_name() {
-        using result_t = std::optional<session_dn>;
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!_connected) {
-            return handshake().then([this]() mutable {
-               return get_distinguished_name();
-            });
-        }
-        result_t dn = extract_dn_information();
-        return make_ready_future<result_t>(std::move(dn));
-    }
+        return state_checked_access([this] {
+            return extract_dn_information();
+        });
+    }    
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) {
-        using result_t = std::vector<subject_alt_name>;
+        return state_checked_access([this](std::unordered_set<subject_alt_name_type> types) {
+            std::vector<subject_alt_name> res;
 
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!_connected) {
-            return handshake().then([this, types = std::move(types)]() mutable {
-               return get_alt_name_information(std::move(types));
-            });
-        }
+            auto peer = get_peer_certificate();
+            if (!peer) {
+                return res;
+            }
 
-        auto peer = get_peer_certificate();
-        if (!peer) {
-            return make_ready_future<result_t>();
-        }
-
-        return futurize_invoke([&] {
-            result_t res;
         	for (auto i = 0u; ; i++) {
                 size_t size = 0;
 
@@ -1760,7 +1735,7 @@ public:
                 res.emplace_back(std::move(v));
         	}
             return res;
-        });
+        }, std::move(types));
     }
 
     struct session_ref;

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1489,3 +1489,108 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
     }
 }
 
+/**
+ * Test TLS13 session ticket support. 
+*/
+SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
+    tls::credentials_builder b;
+
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_session_resume_mode(tls::session_resume_mode::TLS13_SESSION_TICKET);
+    b.set_priority_string("SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.3");
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    ::listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto server = tls::listen(serv, addr, opts);
+
+    tls::session_data sess_data;
+
+    {
+        auto sa = server.accept();
+        auto c = tls::connect(creds, addr).get();
+        auto s = sa.get();
+
+        auto in = s.connection.input();
+        auto cin = c.input();
+        output_stream<char> out(c.output().detach(), 1024);
+        output_stream<char> sout(s.connection.output().detach(), 1024);
+
+        // write data in both directions. Required for session data to 
+        // become available. 
+        out.write("nils").get();
+        auto fin = in.read();
+        auto fout = out.flush();
+
+        fout.get();
+        fin.get();
+
+        sout.write("banan").get();
+        fin = cin.read();
+        fout = sout.flush();
+
+        fout.get();
+        fin.get();
+
+        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get0()); // no resume data
+
+        // get ticket data
+        sess_data = tls::get_session_resume_data(c).get0();
+        BOOST_REQUIRE(!sess_data.empty());
+
+        in.close().get();
+        out.close().get();
+
+        s.connection.shutdown_input();
+        s.connection.shutdown_output();
+
+        c.shutdown_input();
+        c.shutdown_output();
+    }
+
+
+    {
+        auto sa = server.accept();
+
+        // tell client to try resuming.
+        tls::tls_options tls_opts;
+        tls_opts.session_resume_data = sess_data;
+
+        auto c = tls::connect(creds, addr, tls_opts).get();
+        auto s = sa.get();
+
+        // This is ok. Will force a handshake.
+        auto f = tls::check_session_is_resumed(c);
+
+        // But we need to force some IO to make the 
+        // handshake actually happen.
+        auto in = s.connection.input();
+        output_stream<char> out(c.output().detach(), 1024);
+
+        auto fin = in.read();
+
+        out.write("nils").get();
+        auto fout = out.flush();
+
+        fout.get();
+        fin.get();
+
+        BOOST_REQUIRE(f.get0()); // Should work
+
+        in.close().get();
+        out.close().get();
+
+        s.connection.shutdown_input();
+        s.connection.shutdown_output();
+
+        c.shutdown_input();
+        c.shutdown_output();
+    }
+
+}


### PR DESCRIPTION
Fixes #2154
    
TLS1.3 session tickets are a client-storage solution for session resume, bypassing some of the more expensive parts of a normal handshake.

Implemented by adding an optional session data parameter to tls_options, options to certificates for server keys, and query
functions for state/session data on the client side.

Note that the feature requires both client and server to handle tls1.3.

Server session keys are kept in the certificates object, and can be rotated by simply re-enabling the feature on the object.

Reloadable certificates will rotate keys on cert reload.

Simple test included.
