### PR TITLE
net: Modify the listen_backlog parameter, because this parameter is s…

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -393,7 +393,7 @@ struct listen_options {
     bool reuse_address = false;
     server_socket::load_balancing_algorithm lba = server_socket::load_balancing_algorithm::default_;
     transport proto = transport::TCP;
-    int listen_backlog = 100;
+    int listen_backlog = 150;
     unsigned fixed_cpu = 0u;
     std::optional<file_permissions> unix_domain_socket_permissions;
     void set_fixed_cpu(unsigned cpu) {


### PR DESCRIPTION
Modify the listen_backlog parameter, because this parameter is small and causes a connect timeout error on the client.