### PR TITLE
rpc: cast rpc::tuple to std::tuple when passing it to std::apply()

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -241,7 +241,11 @@ struct marshall_one {
             auto do_do_marshall = [&serializer, &out] (const auto&... args) {
                 do_marshall(serializer, out, args...);
             };
-            std::apply(do_do_marshall, arg);
+            // since C++23, std::apply() only accepts tuple-like types, while
+            // rpc::tuple is not a tuple-like type from the tuple-like C++
+            // concept's perspective. so we have to cast it to std::tuple to
+            // appease std::apply()
+            std::apply(do_do_marshall, static_cast<const std::tuple<T...>&>(arg));
         }
     };
 };


### PR DESCRIPTION
before this change, we implement rpc::tuple by inheriting it from
std::tuple, and following the tuple-like protocol, by implementing
`tuple_size<seastar::rpc::tuple<T...>>` and
`tuple_element<I,seastar::rpc::tuple<T...>>`. but in C++23, the
tuple-like constraints are tightened, quote from libstdc++ shipped
along with GCC-14

```c++
  template<typename _Tp>
    inline constexpr bool __is_tuple_v = false;

  template<typename... _Ts>
    inline constexpr bool __is_tuple_v<tuple<_Ts...>> = true;

  // TODO: Reuse __is_tuple_like from <type_traits>?
  template<typename _Tp>
    inline constexpr bool __is_tuple_like_v = false;

  template<typename... _Elements>
    inline constexpr bool __is_tuple_like_v<tuple<_Elements...>> = true;

  template<typename _T1, typename _T2>
    inline constexpr bool __is_tuple_like_v<pair<_T1, _T2>> = true;

  template<typename _Tp, size_t _Nm>
    inline constexpr bool __is_tuple_like_v<array<_Tp, _Nm>> = true;
// ...
```

which is a loyal translation of the C++23 standard.

apparently, `rpc::tuple` cannot fulfill this constraint, hence
`rpc_test.cc` fails to compile with GCC-14 and C++23. fortunately,
`rpc::tuple` is derived from `std::tuple`.

so, in this change, we cast `rpc::tuple` to `std::tuple` when passing
it to `std::apply` to satisfy the more picky critera in C++23.

Fixes https://github.com/scylladb/seastar/issues/2158