### PR TITLE
http: add missing decoding of path part of URL

### DIFF
--- a/src/http/matcher.cc
+++ b/src/http/matcher.cc
@@ -29,6 +29,7 @@ module;
 module seastar;
 #else
 #include <seastar/http/matcher.hh>
+#include <seastar/http/url.hh>
 #endif
 
 namespace seastar {
@@ -65,7 +66,12 @@ size_t param_matcher::match(const sstring& url, size_t ind, parameters& param) {
         }
         return sstring::npos;
     }
-    param.set(_name, url.substr(ind, last - ind));
+    sstring path;
+    if (http::internal::url_decode(url.substr(ind, last - ind), path)) {
+        param.set(_name, path);
+    } else {
+        param.set(_name, url.substr(ind, last - ind));
+    }
     return last;
 }
 

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -82,10 +82,19 @@ void request::add_param(const std::string_view& param) {
 
 }
 
+static sstring decode_path(std::string_view path) {
+    sstring out;
+    if (http::internal::url_decode(path, out)) {
+        return out;
+    } else {
+        return sstring(path);
+    }
+}
+
 sstring request::parse_query_param() {
     size_t pos = _url.find('?');
     if (pos == sstring::npos) {
-        return _url;
+        return decode_path(_url);
     }
     size_t curr = pos + 1;
     size_t end_param;
@@ -95,7 +104,7 @@ sstring request::parse_query_param() {
         curr = end_param + 1;
     }
     add_param(url.substr(curr));
-    return _url.substr(0, pos);
+    return decode_path(_url.substr(0, pos));
 }
 
 void request::write_body(const sstring& content_type, sstring content) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -81,6 +81,12 @@ SEASTAR_TEST_CASE(test_match_rule)
     res = mr.get("/hell/val1", param);
     httpd::handler_base* nl = nullptr;
     BOOST_REQUIRE_EQUAL(res, nl);
+
+    // Test that URL decoding happens correctly on the path part of
+    // the URL. Reproduces issue #725.
+    res = mr.get("/hello/hello%21hi", param);
+    BOOST_REQUIRE_EQUAL(param["param"], "hello!hi");
+
     return make_ready_future<>();
 }
 
@@ -202,6 +208,12 @@ SEASTAR_TEST_CASE(test_decode_url) {
     req.parse_query_param();
     BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "#$#");
     BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "\"&\"");
+    // Test that URL decoding happens correctly on the path part of
+    // the URL too. Reproduces issue #725.
+    req._url = "/a%21b?q=%23%24%23";
+    url = req.parse_query_param();
+    BOOST_REQUIRE_EQUAL(url, "/a!b");
+    BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "#$#");
     return make_ready_future<>();
 }
 


### PR DESCRIPTION
Seastar's HTTP server implementation correctly does percent decoding (e.g., "%21" to "!") on the individual pieces of the query part of the URL (i.e., after the "?"). However, we forgot to do the same decoding also on the path part of the URL (before the "?"). This patch fixes this oversight.

The patch fixes two places: The more important place is the code which splits the URL to the path and the different query parameters. This is the fix most users will need. The other place is the code which allows a rule matching a specific path to also match an encoded version. This patch also adds simple test cases for both.

I also verified that this fix fixes a bug for one user of this HTTP server (the ScyllaDB project), which did not get correctly-decoded paths before this patch, and works as expected afterwards.

Fixes #725