### PR TITLE
timed_out_error: add fmt::formatter for timed_out_error

### DIFF
--- a/include/seastar/core/timed_out_error.hh
+++ b/include/seastar/core/timed_out_error.hh
@@ -23,6 +23,7 @@
 #pragma once
 
 #ifndef SEASTAR_MODULE
+#include <fmt/core.h>
 #include <exception>
 #include <seastar/util/modules.hh>
 #endif
@@ -45,3 +46,13 @@ struct default_timeout_exception_factory {
 };
 
 } // namespace seastar
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<std::string_view> {
+    auto format(const seastar::timed_out_error& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif


### PR DESCRIPTION
this change is added in the same spirit of cd8a9133d2.

this change addresses the formatting with fmtlib < 10, and without `FMT_DEPRECATED_OSTREAM` defined. please note, in {fmt} v10 and up, it defines formatter for classes derived from `std::exception`, so our formatter is only added when compiled with {fmt} < 10.

please note, unlike the operator<< based formatter of `operator<<(std::ostream&, const std::exception&)` defined in log.hh and log.cc, this formatter does not include the exception's type when formatting an instance of `timed_out_error`.

Refs https://github.com/scylladb/scylladb/issues/13245