### PR TITLE
stall-analyser: use raw string to avoid invalid escaping sequence

### DIFF
--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -326,7 +326,7 @@ def print_stats(tally:dict, tmin):
 
 input = open(args.file) if args.file else sys.stdin
 count = 0
-comment = re.compile('^\s*#')
+comment = re.compile(r'^\s*#')
 pattern = re.compile('Reactor stall')
 for s in input:
     if comment.search(s) or not pattern.search(s):


### PR DESCRIPTION
"\s" is not a valid escaping sequence, while "\\s" is. in this use case, what we want is a literal of "\s". so let's use raw string.