### PR TITLE
Use staic_vector-s to keep fair_queue-s and fair_group-s

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -364,7 +364,7 @@ public:
     ///
     /// \param cfg an instance of the class \ref config
     explicit fair_queue(fair_group& shared, config cfg);
-    fair_queue(fair_queue&&);
+    fair_queue(fair_queue&&) = delete;
     ~fair_queue();
 
     sstring label() const noexcept { return _config.label; }

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -228,7 +228,7 @@ private:
 
     const io_queue::config _config;
     size_t _max_request_length[2];
-    std::vector<std::unique_ptr<fair_group>> _fgs;
+    boost::container::static_vector<fair_group, 2> _fgs;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 #ifndef SEASTAR_MODULE
-#include <boost/container/small_vector.hpp>
+#include <boost/container/static_vector.hpp>
 #include <chrono>
 #include <memory>
 #include <vector>
@@ -99,7 +99,7 @@ public:
 private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     io_group_ptr _group;
-    boost::container::small_vector<fair_queue, 2> _streams;
+    boost::container::static_vector<fair_queue, 2> _streams;
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -168,18 +168,6 @@ fair_queue::fair_queue(fair_group& group, config cfg)
 {
 }
 
-fair_queue::fair_queue(fair_queue&& other)
-    : _config(std::move(other._config))
-    , _group(other._group)
-    , _group_replenish(std::move(other._group_replenish))
-    , _resources_executing(std::exchange(other._resources_executing, fair_queue_ticket{}))
-    , _resources_queued(std::exchange(other._resources_queued, fair_queue_ticket{}))
-    , _handles(std::move(other._handles))
-    , _priority_classes(std::move(other._priority_classes))
-    , _last_accumulated(other._last_accumulated)
-{
-}
-
 fair_queue::~fair_queue() {
     for (const auto& fq : _priority_classes) {
         assert(!fq);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -531,7 +531,7 @@ sstring io_request::opname() const {
 }
 
 const fair_group& get_fair_group(const io_queue& ioq, unsigned stream) {
-    return *(ioq._group->_fgs[stream]);
+    return ioq._group->_fgs[stream];
 }
 
 } // internal namespace
@@ -572,11 +572,11 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     auto& cfg = get_config();
     if (cfg.duplex) {
         static_assert(internal::io_direction_and_length::write_idx == 0);
-        _streams.emplace_back(*_group->_fgs[0], make_fair_queue_config(cfg, "write"));
+        _streams.emplace_back(_group->_fgs[0], make_fair_queue_config(cfg, "write"));
         static_assert(internal::io_direction_and_length::read_idx == 1);
-        _streams.emplace_back(*_group->_fgs[1], make_fair_queue_config(cfg, "read"));
+        _streams.emplace_back(_group->_fgs[1], make_fair_queue_config(cfg, "read"));
     } else {
-        _streams.emplace_back(*_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
+        _streams.emplace_back(_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
     }
     _flow_ratio_update.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(_group->io_latency_goal() * cfg.flow_ratio_ticks));
 
@@ -605,7 +605,7 @@ fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg
 }
 
 std::chrono::duration<double> io_group::io_latency_goal() const noexcept {
-    return _fgs.front()->rate_limit_duration();
+    return _fgs.front().rate_limit_duration();
 }
 
 io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
@@ -613,9 +613,9 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
     , _allocated_on(this_shard_id())
 {
     auto fg_cfg = make_fair_group_config(_config);
-    _fgs.push_back(std::make_unique<fair_group>(fg_cfg, nr_queues));
+    _fgs.emplace_back(fg_cfg, nr_queues);
     if (_config.duplex) {
-        _fgs.push_back(std::make_unique<fair_group>(fg_cfg, nr_queues));
+        _fgs.emplace_back(fg_cfg, nr_queues);
     }
 
     auto goal = io_latency_goal();
@@ -632,10 +632,10 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
      */
     auto update_max_size = [this] (unsigned idx) {
         auto g_idx = _config.duplex ? idx : 0;
-        auto max_cap = _fgs[g_idx]->maximum_capacity();
+        auto max_cap = _fgs[g_idx].maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
             auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
-            auto cap = _fgs[g_idx]->tokens_capacity(tokens);
+            auto cap = _fgs[g_idx].tokens_capacity(tokens);
             if (cap > max_cap) {
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -86,7 +86,7 @@ struct io_queue_for_tests {
 
     void kick() {
         for (auto&& fg : group->_fgs) {
-            fg->replenish_capacity(std::chrono::steady_clock::now());
+            fg.replenish_capacity(std::chrono::steady_clock::now());
         }
     }
 


### PR DESCRIPTION
Both, io_queue and io_group, keep vectors with fair_... counterparts. Both use different containers for that, but static_vector works and suits better for both. More details are in individual patches.