### PR TITLE
sstring: include <fmt/format.h> instead of <fmt/ostream.h> 

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -33,6 +33,7 @@
 #include <functional>
 #include <optional>
 #include <queue>
+#include <fmt/ostream.h>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -37,7 +37,7 @@
 #include <ostream>
 #include <functional>
 #include <type_traits>
-#include <fmt/ostream.h>
+#include <fmt/format.h>
 #endif
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>


### PR DESCRIPTION
<fmt/ostream.h> was include in 2975b612 so we can use ostream_formatter, but later in bef98ab0, we stopped using ostream_formatter. so this header is not necessary anymore.

in this change, we trade this include with a smaller dependency.