### PR TITLE
file: Add directory_entry::is_hidden() helper

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -61,6 +61,9 @@ struct directory_entry {
     sstring name;
     /// Type of the directory entry, if known.
     std::optional<directory_entry_type> type;
+
+    /// Checks if the file is hidden or not
+    bool is_hidden() const noexcept { return name.starts_with("."); }
 };
 
 /// Filesystem object stat information


### PR DESCRIPTION
It checks if the file is "hidden" i.e. has its name starting with a dot. Scylla code checks that in some places and this helper is just for verbosity of those