### PR TITLE
Revert remove duplicate of metric family

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -338,11 +338,9 @@ using metric_metadata_fifo = std::deque<metric_info>;
  * and all metrics related to them. Second, it only contains enabled metrics,
  * making disabled metrics more efficient.
  * The struct is recreated when impl._value_map changes
- * Using a pointer to the family_info metadata is an efficient way to get
- * from a metric_family to its metadata based on its name.
  */
 struct metric_family_metadata {
-    metric_family_info& mf; //This points to impl._value_map
+    metric_family_info mf;
     metric_metadata_fifo metrics;
 };
 


### PR DESCRIPTION
This PR reverts d2929c2ade5bd0125a73d53280c82ae5da86218e.
The optimization added in that patch broke the independence between the currently registered metrics and the reported metrics.

The metric layer takes a snapshot of the registered metrics before start reporting and will report that snapshot even if metrics are added or removed during that reporting time.
This is the expected behavior, making all the metrics values to be reported automatically.

Because the two data structures are now independent (_value_map that holds the registered metrics by name and _metadata that holds the meta-data optimized for reporting), set_metric_family_configs should now change both of them.

Fixes #2184 