### PR TITLE
Add Safety to the metrics layer

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -226,6 +226,7 @@ metric_value metric_value::operator+(const metric_value& c) {
     metric_value res(*this);
     switch (_type) {
     case data_type::HISTOGRAM:
+    case data_type::SUMMARY:
         std::get<histogram>(res.u) += std::get<histogram>(c.u);
         break;
     default:

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -528,6 +528,16 @@ void impl::set_metric_family_configs(const std::vector<metric_family_config>& fa
             }
         }
     }
+
+    if (!_metadata) {
+        // The metadata structure may not have been built yet,
+        // or it may rebuild right now, in this case just return
+        // and it will be updated the next time, setting the dirty to true
+        // is just in case we are somehow in the middle of rebuilding the
+        // metadata.
+        dirty();
+        return;
+    }
     for (auto& mf_metadata: *_metadata) {
         for  (const auto& fc : family_config) {
             if (fc.name == mf_metadata.mf.name || fc.regex_name.match(mf_metadata.mf.name)) {


### PR DESCRIPTION
This series addresses two corner cases in the metrics layer:
1. use the addition operator on a Summary; while this does not make sense, a user may still choose to do that; it should not throw an exception and treat the summary as a histogram.
2. There could be a situation when calling set_metric_family_configs while the _metadata object does not exist, either because it was not created yet or because it was deleted and not re-created. In this situation, we should leave it to the next time the _metadata will be created.

Fixes #2191