### PR TITLE
core/sleep: Use more raii-sh aproach to maintain sleeper

### DIFF
--- a/include/seastar/core/sleep.hh
+++ b/include/seastar/core/sleep.hh
@@ -55,9 +55,9 @@ future<> sleep(std::chrono::duration<Rep, Period> dur) {
             tmr.arm(dur);
         }
     };
-    sleeper *s = new sleeper(dur);
+    auto s = std::make_unique<sleeper>(dur);
     future<> fut = s->done.get_future();
-    return fut.then([s] { delete s; });
+    return fut.finally([s = std::move(s)] {});
 }
 
 /// exception that is thrown when application is in process of been stopped


### PR DESCRIPTION
The sleeper helper struct is allocated and deleted by hand. Using unique_ptr is the same.

Also replace .then() with .finally(). The future in question never fails, but finally is more idiomatic to guard object lifetime