### PR TITLE
treewide: inherit from formatter<string_view> not formatter<std::string_view>

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -201,7 +201,7 @@ SEASTAR_MODULE_EXPORT_END
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<seastar::abort_requested_exception> : fmt::formatter<std::string_view> {
+struct fmt::formatter<seastar::abort_requested_exception> : fmt::formatter<string_view> {
     auto format(const seastar::abort_requested_exception& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -882,12 +882,12 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
 SEASTAR_MODULE_EXPORT
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>>
-    : public fmt::formatter<std::basic_string_view<char_type>> {
-    using format_as_t = std::basic_string_view<char_type>;
+    : public fmt::formatter<basic_string_view<char_type>> {
+    using format_as_t = basic_string_view<char_type>;
     using base = fmt::formatter<format_as_t>;
     template <typename FormatContext>
     auto format(const ::seastar::basic_sstring<char_type, Size, max_size, NulTerminate>& s, FormatContext& ctx) const {
-        return base::format(format_as_t{s}, ctx);
+        return base::format(format_as_t{s.c_str(), s.size()}, ctx);
     }
 };
 

--- a/include/seastar/core/timed_out_error.hh
+++ b/include/seastar/core/timed_out_error.hh
@@ -50,7 +50,7 @@ struct default_timeout_exception_factory {
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<std::string_view> {
+struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<string_view> {
     auto format(const seastar::timed_out_error& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <map>
 #include <boost/any.hpp>
+#include <fmt/format.h>
 #endif
 
 #include <seastar/core/future.hh>
@@ -497,14 +498,14 @@ namespace tls {
 }
 }
 
-template <> struct fmt::formatter<seastar::tls::subject_alt_name_type> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<seastar::tls::subject_alt_name_type> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(seastar::tls::subject_alt_name_type type, FormatContext& ctx) const {
-        return formatter<std::string_view>::format(format_as(type), ctx);
+        return formatter<string_view>::format(format_as(type), ctx);
     }
 };
 
-template <> struct fmt::formatter<seastar::tls::subject_alt_name::value_type> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<seastar::tls::subject_alt_name::value_type> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const seastar::tls::subject_alt_name::value_type& value, FormatContext& ctx) const {
         return std::visit([&](const auto& v) {
@@ -513,7 +514,7 @@ template <> struct fmt::formatter<seastar::tls::subject_alt_name::value_type> : 
     }
 };
 
-template <> struct fmt::formatter<seastar::tls::subject_alt_name> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<seastar::tls::subject_alt_name> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const seastar::tls::subject_alt_name& name, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}={}", name.type, name.value);

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -435,7 +435,7 @@ template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_fo
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <std::derived_from<seastar::rpc::error> T>
-struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+struct fmt::formatter<T> : fmt::formatter<string_view> {
     auto format(const T& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/include/seastar/util/lazy.hh
+++ b/include/seastar/util/lazy.hh
@@ -153,7 +153,7 @@ ostream& operator<<(ostream& os, seastar::lazy_deref_wrapper<T> ld) {
 }
 
 template <typename Func>
-struct fmt::formatter<seastar::lazy_eval<Func>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<seastar::lazy_eval<Func>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const seastar::lazy_eval<Func>& lf, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", lf());
@@ -161,7 +161,7 @@ struct fmt::formatter<seastar::lazy_eval<Func>> : fmt::formatter<std::string_vie
 };
 
 template <typename T>
-struct fmt::formatter<seastar::lazy_deref_wrapper<T>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<seastar::lazy_deref_wrapper<T>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const seastar::lazy_deref_wrapper<T>& ld, FormatContext& ctx) const {
         if (ld.p) {

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -102,7 +102,7 @@ public:
 }
 
 template <typename T>
-struct fmt::formatter<seastar::optimized_optional<T>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<seastar::optimized_optional<T>> : fmt::formatter<string_view> {
     auto format(const seastar::optimized_optional<T>& opt, fmt::format_context& ctx) const {
         if (opt) {
             return fmt::format_to(ctx.out(), "{}", *opt);


### PR DESCRIPTION
before {fmt} v10, it provides the specialization of `fmt::formatter<..>` for `std::string_view` as well as the specialization of `fmt::formatter<..>` for `fmt::string_view` which is an implementation builtin in {fmt} for pre-C++17 compatibility. but this type is used even if the code is compiled with C++ stadandard greater or equal to C++17. also, before {fmt} v10, `fmt::formatter<std::string_view>::format()` is defined so it accepts `std::string_view`. that's why we can define a `fmt::formatter<Type>` for a custom type by inheriting from `fmt::formatter<std::string_view>`, and call the parent class's `format()` method by passing a variable convertible to `std::string_view`.

after v10, `fmt::formatter<std::string_view>` still exists, but it is now defined using a macro named `FMT_FORMAT_AS()`, which delegates the `format()` call to `fmt::formatter<fmt::string_view, Char>`. so, `fmt::formatter<std::string_view>::format()` does not accept `std::string_view` anymore, instead, it now accepts `fmt::string_view`. because the `fmt::string_view` can be converted to `fmt::string_view` automatically, so this arrangement still works for `fmt::formatter<std::string_view>`. however, this does not for the custom types' formatter implemented with the above technique, the compiler fails to compile them like:

```
/usr/include/fmt/core.h:2593:45: error: implicit instantiation of undefined template 'fmt::detail::type_is_unformattable_for<seastar::basic_sstring<char, unsigned int, 15>, char>'
 2593 |     type_is_unformattable_for<T, char_type> _;
      |                                             ^
/usr/include/fmt/core.h:2656:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<seastar::basic_sstring<char, unsigned int, 15>, fmt::detail::compile_parse_context<char>>' requested here
 2656 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
      |                       ^                                                                                                                                                                                                               /usr/include/fmt/core.h:2787:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, seastar::basic_sstring<char, unsigned int, 15>, seastar::basic_sstring<char, unsigned int, 15>>::format_string_checker' r
equested here
 2787 |       detail::parse_format_string<true>(str_, checker(s));
      |                                               ^                                                                                                                                                                                       /home/kefu/dev/scylladb/master/mutation/mutation.cc:292:31: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const seastar::basic_sstring<char, unsigned int, 15> &, const seastar::basic_sstring<ch
ar, unsigned int, 15> &>::basic_format_string<char[26], 0>' requested here
  292 |     out = fmt::format_to(out, "{{table: '{}.{}', key: {{", s.ks_name(), s.cf_name());
      |                               ^
/usr/include/fmt/core.h:1578:45: note: template is declared here
 1578 | template <typename T, typename Char> struct type_is_unformattable_for;
      |                                             ^
```

in this change, instead of inheriting from `fmt::formatter<std::string_view>`, we inherit from `fmt::formatter<string_view>`. this practice follows the document at  https://fmt.dev/latest/api.html#formatting-user-defined-types . and since there is less indirection under the hood -- we do not use the specialization created by FMT_FORMAT_AS which inherits from `formatter<fmt::string_view>`, hopefully this can improve the compilation speed a little bit. also, this change addresses the build failure with {fmt} v10.