### PR TITLE
http: `to_reply()` from `redirect_exception`

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -24,6 +24,9 @@
 #include <seastar/util/log.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/json/json_elements.hh>
+#include <initializer_list>
+#include <utility>
+#include <vector>
 
 namespace seastar {
 
@@ -59,14 +62,33 @@ private:
 };
 
 /**
- * Throwing this exception will result in a redirect to the given url
+ * Throwing this exception will result in a redirect to the given url.
+ * Optional extra headers can be included in the redirect response.
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url, http::reply::status_type status = http::reply::status_type::moved_permanently)
-            : base_exception("", status), url(url) {
+    using header_list = std::initializer_list<std::pair<std::string, std::string>>;
+
+    redirect_exception(const std::string& url,
+                       http::reply::status_type status = http::reply::status_type::moved_permanently,
+                       header_list extra_headers = {})
+            : base_exception("", status), url(url), _extra_headers(extra_headers) {
     }
+
+    /// Construct an http::reply for this redirect, with Location header and status set.
+    http::reply to_reply() const {
+        http::reply reply{};
+        reply.add_header("Location", url);
+        for (const auto& [name, value] : _extra_headers) {
+            reply.add_header(name, value);
+        }
+        reply.set_status(status());
+        return reply;
+    }
+
     std::string url;
+private:
+    std::vector<std::pair<std::string, std::string>> _extra_headers;
 };
 
 /**

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -75,8 +75,7 @@ std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
         }
         std::rethrow_exception(eptr);
     } catch (const redirect_exception& _e) {
-       rep.reset(new http::reply());
-       rep->add_header("Location", _e.url).set_status(_e.status());
+      *rep = _e.to_reply();
     } catch (const base_exception& e) {
         rep->set_status(e.status(), internal::to_json(e));
     } catch (...) {
@@ -96,6 +95,10 @@ future<std::unique_ptr<http::reply> > routes::handle(const sstring& path, std::u
             handler->verify_mandatory_params(*req);
             auto r =  handler->handle(path, std::move(req), std::move(rep));
             return r.handle_exception(_general_handler);
+        } catch (const redirect_exception& _e) {
+            // rep may have been moved into handler->handle(), so create a fresh one
+            rep = std::make_unique<http::reply>(_e.to_reply());
+            rep->set_content_type("json");
         } catch (...) {
             rep = exception_reply(std::current_exception());
         }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2128,6 +2128,67 @@ SEASTAR_TEST_CASE(test_redirect_exception) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_redirect_exception_to_reply) {
+    // Basic redirect: Location header and status set correctly
+    httpd::redirect_exception e("/new-loc");
+    auto rep = e.to_reply();
+    BOOST_REQUIRE_EQUAL(rep.get_header("Location"), "/new-loc");
+    BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::moved_permanently);
+
+    // Extra headers are included in the reply
+    httpd::redirect_exception e2("/other", http::reply::status_type::moved_temporarily,
+            {{"Retry-After", "120"}, {"X-Custom", "val"}});
+    auto rep2 = e2.to_reply();
+    BOOST_REQUIRE_EQUAL(rep2.get_header("Location"), "/other");
+    BOOST_REQUIRE_EQUAL(rep2.get_header("Retry-After"), "120");
+    BOOST_REQUIRE_EQUAL(rep2.get_header("X-Custom"), "val");
+    BOOST_REQUIRE_EQUAL(rep2._status, http::reply::status_type::moved_temporarily);
+}
+
+SEASTAR_TEST_CASE(test_redirect_exception_sync_throw) {
+    // Verify that a handler which throws redirect_exception synchronously
+    // (i.e. before returning a future) is handled correctly by routes::handle().
+    // This exercises the catch(redirect_exception) block added alongside to_reply().
+    return seastar::async([] {
+        class sync_redirect_handle : public httpd::handler_base {
+        public:
+            virtual future<std::unique_ptr<http::reply>> handle(const sstring& path,
+                    std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
+                throw httpd::redirect_exception("/sync_dest", http::reply::status_type::moved_temporarily,
+                        {{"Retry-After", "30"}});
+            }
+        };
+
+        loopback_connection_factory lcf(1);
+        http_server server("test");
+        httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
+
+        future<> client = seastar::async([&lcf] {
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
+            auto req = http::request::make("GET", "test", "/sync");
+            std::optional<http::reply::status_type> status;
+            sstring location;
+            sstring retry_after;
+            cln.make_request(std::move(req), [&](const http::reply& rep, input_stream<char>&& in) {
+                status = rep._status;
+                location = rep.get_header("Location");
+                retry_after = rep.get_header("Retry-After");
+                return make_ready_future<>();
+            }).get();
+            BOOST_REQUIRE(status.has_value());
+            BOOST_REQUIRE_EQUAL(status.value(), http::reply::status_type::moved_temporarily);
+            BOOST_REQUIRE_EQUAL(location, "/sync_dest");
+            BOOST_REQUIRE_EQUAL(retry_after, "30");
+            cln.close().get();
+        });
+
+        server._routes.put(GET, "/sync", new sync_redirect_handle());
+        server.do_accepts(0).get();
+        client.get();
+        server.stop().get();
+    });
+}
+
 BOOST_AUTO_TEST_CASE(test_path_decode_unchanged) {
     auto unchanged_chars = seastar::sstring{
       "~abcdefghijklmnopqrstuvwhyz-ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789.+"};


### PR DESCRIPTION
This PR adds `redirect_exception::to_reply()` for construction of a `http::reply` from a redirect case, with a `Location` header and optionally a `Retry-After` header.