### PR TITLE
tls: add assignment operator for gnutls_datum

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -339,6 +339,18 @@ struct gnutls_datum : public gnutls_datum_t {
         data = nullptr;
         size = 0;
     }
+    gnutls_datum(const gnutls_datum&) = delete;
+    gnutls_datum& operator=(gnutls_datum&& other) {
+        if (this == &other) {
+            return *this;
+        }
+        if (data != nullptr) {
+            ::gnutls_free(data);
+        }
+        data = std::exchange(other.data, nullptr);
+        size = std::exchange(other.size, 0);
+        return *this;
+    }
     ~gnutls_datum() {
         if (data != nullptr) {
             ::gnutls_free(data);


### PR DESCRIPTION
when compiling the tree with GCC, it warns like:
```
[77/92] Building CXX object CMakeFiles/seastar.dir/src/net/tls.cc.o
/var/ssd/seastar/src/net/tls.cc:342:5: warning: definition of implicit copy assignment operator for 'gnutls_datum' is deprecated because it has a user-provided destructor [-Wdeprecated-copy-with-user-provided-dtor]
  342 |     ~gnutls_datum() {
      |     ^
/var/ssd/seastar/src/net/tls.cc:425:33: note: in implicit copy assignment operator for 'seastar::gnutls_datum' first required here
  425 |             _session_resume_key = {};
      |                                 ^
```

it rightly pointed out that we are using an implicitly defined copy assignment operator of `gnutls_datum`. since the lhs operator of the assignment operator could contain a resource which is supposed to be freed using `gnutls_free()` if it is reset by the instance by the default constructor, and we don't explicitly define one, so this would result in a leakage.

in this change

- define the move assignment operator, so that the copy constructor and assignment operators are not generated.
- explicit disable the copy constructor. this is not necessary, because the move assignment operator is already defined. but it makes it more obvious that this class is not copyable, and is only moveable.

Refs c224fe09f055a7c500a5fa22a8e115e8d1d64641