### PR TITLE
tls: s/get0()/get()/

### DIFF
--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1538,10 +1538,10 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         fout.get();
         fin.get();
 
-        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get0()); // no resume data
+        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get()); // no resume data
 
         // get ticket data
-        sess_data = tls::get_session_resume_data(c).get0();
+        sess_data = tls::get_session_resume_data(c).get();
         BOOST_REQUIRE(!sess_data.empty());
 
         in.close().get();
@@ -1581,7 +1581,7 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         fout.get();
         fin.get();
 
-        BOOST_REQUIRE(f.get0()); // Should work
+        BOOST_REQUIRE(f.get()); // Should work
 
         in.close().get();
         out.close().get();


### PR DESCRIPTION
`future::get0()` was deprecated. so let's use `future::get()` instead. this addresses following build failure:

```
FAILED: tests/unit/CMakeFiles/test_unit_tls.dir/tls_test.cc.o
/usr/bin/g++-13 -DBOOST_ALL_DYN_LINK -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TESTING_MAIN -DSEASTAR_TESTING_WITH_NETWORKING=1 -DSEASTAR_TYPE_ERASE_MORE -I/home/circleci/project/tests/unit -I/home/circleci/project/src -I/home/circleci/project/include -I/home/circleci/project/build/debug/gen/include -I/home/circleci/project/build/debug/gen/src -g -std=gnu++20 -U_FORTIFY_SOURCE -Wno-maybe-uninitialized -Wno-error=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -UNDEBUG -Wall -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -Wno-error=stringop-overflow -Wno-error=array-bounds -gz -MD -MT tests/unit/CMakeFiles/test_unit_tls.dir/tls_test.cc.o -MF tests/unit/CMakeFiles/test_unit_tls.dir/tls_test.cc.o.d -o tests/unit/CMakeFiles/test_unit_tls.dir/tls_test.cc.o -c /home/circleci/project/tests/unit/tls_test.cc
In file included from /usr/include/boost/test/test_tools.hpp:45,
                 from /usr/include/boost/test/unit_test.hpp:18,
                 from /home/circleci/project/include/seastar/testing/seastar_test.hh:27,
                 from /home/circleci/project/include/seastar/testing/test_case.hh:31,
                 from /home/circleci/project/tests/unit/tls_test.cc:40:
/home/circleci/project/tests/unit/tls_test.cc: In member function 'void test_tls13_session_tickets::do_run_test_case() const':
/home/circleci/project/tests/unit/tls_test.cc:1541:61: error: 'seastar::future<T>::get0_return_type seastar::future<T>::get0() [with T = bool; get0_return_type = bool]' is deprecated: Use get() instead [-Werror=deprecated-declarations]
 1541 |         BOOST_REQUIRE(!tls::check_session_is_resumed(c).get0()); // no resume data
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/circleci/project/include/seastar/core/do_with.hh:25,
                 from /home/circleci/project/tests/unit/tls_test.cc:25:
/home/circleci/project/include/seastar/core/future.hh:1376:22: note: declared here
 1376 |     get0_return_type get0() {
      |                      ^~~~
/home/circleci/project/tests/unit/tls_test.cc:1544:57: error: 'seastar::future<T>::get0_return_type seastar::future<T>::get0() [with T = std::vector<unsigned char>; get0_return_type = std::vector<unsigned char>]' is deprecated: Use get() instead [-Werror=deprecated-declarations]
 1544 |         sess_data = tls::get_session_resume_data(c).get0();
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/circleci/project/include/seastar/core/future.hh:1376:22: note: declared here
 1376 |     get0_return_type get0() {
      |                      ^~~~
/home/circleci/project/tests/unit/tls_test.cc:1584:29: error: 'seastar::future<T>::get0_return_type seastar::future<T>::get0() [with T = bool; get0_return_type = bool]' is deprecated: Use get() instead [-Werror=deprecated-declarations]
 1584 |         BOOST_REQUIRE(f.get0()); // Should work
      |                       ~~~~~~^~
/home/circleci/project/include/seastar/core/future.hh:1376:22: note: declared here
 1376 |     get0_return_type get0() {
      |                      ^~~~
cc1plus: all warnings being treated as errors
```

Refs c224fe09f055a7c500a5fa22a8e115e8d1d64641
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>