### PR TITLE
io_queue: do not reference moved variable

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -619,8 +619,8 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
     }
 
     auto goal = io_latency_goal();
-    auto lvl = goal > 1.1 * io_cfg.rate_limit_duration ? log_level::warn : log_level::debug;
-    seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, io_cfg.devid);
+    auto lvl = goal > 1.1 * _config.rate_limit_duration ? log_level::warn : log_level::debug;
+    seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, _config.devid);
 
     /*
      * The maximum request size shouldn't result in the capacity that would


### PR DESCRIPTION
this change is a cleanup to silence a false alarm.

clang-tidy warns like

```
Warning: /home/runner/work/scylladb/scylladb/seastar/src/core/io_queue.cc:622:29: warning: 'io_cfg' used after it was moved [bugprone-use-after-move]
  622 |     auto lvl = goal > 1.1 * io_cfg.rate_limit_duration ? log_level::warn : log_level::debug;
      |                             ^
/home/runner/work/scylladb/scylladb/seastar/src/core/io_queue.cc:612:7: note: move occurred here
  612 |     : _config(std::move(io_cfg))
      |       ^
```

despite that the default-generated move constructor of `io_queue::config` does not really move the referenced variable away, as they are plain numbers (devid) or structure holding plain numbers (rate_limit_duration). but still, would be more consistent if we always reference the config members by dereferencing `_config` instead of `io_cfg`, and less confusing this way. this also helps us silence the warning, so that the genuine move-after-move issues can stand out when clang-tidy warngs.