### PR TITLE
CMakeLists.txt: Apply CXX deprecated flags conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,7 +805,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list (APPEND Seastar_PRIVATE_CXX_FLAGS
       -Wno-error=stringop-overflow
       -Wno-error=array-bounds)
-  endif()
+  endif ()
+  list (APPEND Seastar_PRIVATE_CXX_FLAGS
+    -Wdeprecated-declarations
+    -Wno-error=deprecated-declarations)
 endif ()
 
 if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
In ef941e5, we replaced the `-Wdeprecated-declarations` flag by `-Wdepracted` and` -Wno-error=deprecated`. Unfortunately, GCC and Clang interpret `-Wdeprecated` differently, compare:

* https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Warning-Options.html#index-Wno-deprecated
* https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Deprecated-Features.html

and

* https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated

As a result, `-Wno-error=deprecated` doesn't prevent GCC from turning warnings related to using functions, variables, or types marked as deprecated into errors. Clang, however, does that.

In this commit, we conditionally enable the intended options depending on which compiler is used.