### PR TITLE
cmake: suppress warnings from ragel generated headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,7 +447,8 @@ function (seastar_generate_ragel)
   target_sources(${args_TARGET}
     PRIVATE
       ${args_OUT_FILE})
-  target_include_directories(${args_TARGET} INTERFACE "${out_dir}")
+  target_include_directories(${args_TARGET} SYSTEM
+    INTERFACE "${out_dir}")
 
   set (${args_VAR} ${args_OUT_FILE} PARENT_SCOPE)
 endfunction ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,8 +443,11 @@ function (seastar_generate_ragel)
     COMMAND ${ragel_RAGEL_EXECUTABLE} -G2 -o ${args_OUT_FILE} ${args_IN_FILE}
     COMMAND sed -i -e "'1h;2,$$H;$$!d;g'" -re "'s/static const char _nfa[^;]*;//g'" ${args_OUT_FILE})
 
-  add_custom_target (${args_TARGET}
-    DEPENDS ${args_OUT_FILE})
+  add_library (${args_TARGET} INTERFACE)
+  target_sources(${args_TARGET}
+    PRIVATE
+      ${args_OUT_FILE})
+  target_include_directories(${args_TARGET} INTERFACE "${out_dir}")
 
   set (${args_VAR} ${args_OUT_FILE} PARENT_SCOPE)
 endfunction ()
@@ -777,9 +780,6 @@ add_library (seastar
 add_library (Seastar::seastar ALIAS seastar)
 
 add_dependencies (seastar
-  seastar_http_chunk_parsers
-  seastar_http_request_parser
-  seastar_http_response_parser
   seastar_proto_metrics2)
 
 target_include_directories (seastar
@@ -828,6 +828,9 @@ target_link_libraries (seastar
     lz4::lz4
     SourceLocation::source_location
   PRIVATE
+    seastar_http_chunk_parsers
+    seastar_http_request_parser
+    seastar_http_response_parser
     ${CMAKE_DL_LIBS}
     GnuTLS::gnutls
     StdAtomic::atomic

--- a/apps/memcached/CMakeLists.txt
+++ b/apps/memcached/CMakeLists.txt
@@ -38,7 +38,8 @@ seastar_add_app (memcached
 target_include_directories (app_memcached
   PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-add_dependencies (app_memcached app_memcached_ascii)
+target_link_libraries (app_memcached
+  PRIVATE app_memcached_ascii)
 
 #
 # Tests.


### PR DESCRIPTION
as ragel could generate headers which does not meet the criteria
enforced by the project, so the compiler may warn and fail the
build like:

```
/home/runner/work/scylladb/scylladb/build/gen/redis/protocol_parser.hh:110:1: error: unannotated fall-through between switch labels [clang-diagnostic-implicit-fallthrough]
  110 | case 1:
      | ^
/home/runner/work/scylladb/scylladb/build/gen/redis/protocol_parser.hh:110:1: note: insert 'FMT_FALLTHROUGH;' to silence this warning
  110 | case 1:
      | ^
      | FMT_FALLTHROUGH;
```

but the seastar application cannot control the behavior of ragel. if it is a CMake-based project, what it can do is to mark the headers as SYSTEM headers.

both Seastar and Seastar applications suffer from this. but Seastar can address by marking the exposed target with SYSTEM header. if the Seastar project chooses to include Seastar by including its CMakeLists.txt and use `seastar_generate_protobuf()` to generate its own headers using ragel, it can benefit from this as well.

so, in this series, we specify expose the generated headers as an INTERFACE target and specify `SYSTEM` for this exposed target, so that the compiler does not warn at seeing, for instance, the above switch labels.