### PR TITLE
core/app_template: return status code 0 for --help

### DIFF
--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -212,15 +212,15 @@ app_template::run_deprecated(int ac, char ** av, std::function<void ()>&& func) 
             std::cout << _opts.description << "\n";
         }
         std::cout << _app_opts << "\n";
-        return 1;
+        return 0;
     }
     if (configuration.count("help-seastar")) {
         std::cout << _seastar_opts << "\n";
-        return 1;
+        return 0;
     }
     if (configuration.count("help-loggers")) {
         log_cli::print_available_loggers(std::cout);
-        return 1;
+        return 0;
     }
 
     try {


### PR DESCRIPTION
if user queries the usage of an seastar application using `--help`, `--help-seastar` or `--help-loggers`, he/she should not be greeted with a non-zero status code, which implies an error in general. but in this case, there is no errors. so we should return 0 as the status code.