### PR TITLE
reactor: print scheduling group along with backtrace

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -143,6 +143,7 @@ module seastar;
 #include <seastar/core/reactor.hh>
 #include <seastar/core/report_exception.hh>
 #include <seastar/core/resource.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/scheduling_specific.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp_options.hh>
@@ -848,6 +849,9 @@ static void print_with_backtrace(backtrace_buffer& buf, bool oneline) noexcept {
     if (local_engine) {
         buf.append(" on shard ");
         buf.append_decimal(this_shard_id());
+
+        buf.append(", in scheduling group ");
+        buf.append(current_scheduling_group().name().c_str());
     }
 
   if (!oneline) {


### PR DESCRIPTION
reactor: print scheduling group along with backtrace

Backtraces are printed in at least 2 cases:
  1) during segfaults,
  2) during reactor stalls.
Extra context is always helpful in identifying the exact circumstances
during which the above happen. E.g. in a server application where user
requests are processed in one (or more) scheduling group(s), background
processes are split between different scheduling groups as well, knowing
the scheduling group narrows the search space.

Prior to this commit:

```
Segmentation fault on shard 0.
Backtrace:
  ...
```

With this commit:

```
Segmentation fault on shard 0, in scheduling group main.
Backtrace:
  ...
```

Ref https://github.com/scylladb/seastar/issues/2216