### PR TITLE
github: encode matrix.enables in cache key

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.compiler }}-${{ matrix.standard }}-${{ matrix.mode }}
+          key: ${{ matrix.compiler }}-${{ matrix.standard }}-${{ matrix.mode }}-${{ matrix.enables }}
 
       - name: Configure
         run: >


### PR DESCRIPTION
as matrix.enables controls how the tree is configured, so we should take it into consideration, otherwise the hit rate of cache would be lower than expected.