### PR TITLE
httpd: mark http_server_control::stop() noexcept

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -247,7 +247,7 @@ public:
     }
 
     future<> start(const sstring& name = generate_server_name());
-    future<> stop();
+    future<> stop() noexcept;
     future<> set_routes(std::function<void(routes& r)> fun);
     future<> listen(socket_address addr);
     future<> listen(socket_address addr, http_server::server_credentials_ptr credentials);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -505,7 +505,7 @@ future<> http_server_control::start(const sstring& name) {
     return _server_dist->start(name);
 }
 
-future<> http_server_control::stop() {
+future<> http_server_control::stop() noexcept {
     return _server_dist->stop();
 }
 


### PR DESCRIPTION
the only callee in `http_server_control::stop()` is `sharded<Service>::stop()`, which is `noexcept`. so we can assume that `http_server_control::stop()` is also `noexcept`.

so, in this change, we mark `http_server_control::stop()` noexcept. this allows us to use `deferred_stop` to stop an `http_server_control`.