### PR TITLE
tests/unit/metrics_tester: use deferred_stop() when appropriate

### DIFF
--- a/tests/unit/metrics_tester.cc
+++ b/tests/unit/metrics_tester.cc
@@ -25,7 +25,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/relabel_config.hh>
 #include <seastar/core/internal/estimated_histogram.hh>
-#include <seastar/util/defer.hh>
+#include <seastar/util/closeable.hh>
 #include "../../apps/lib/stop_signal.hh"
 #include <map>
 #include <vector>
@@ -173,9 +173,7 @@ int main(int ac, char** av) {
             }
 
             prometheus_server.start("prometheus").get();
-            auto stop_server = defer([&] () noexcept {
-                prometheus_server.stop().get();
-            });
+            auto stop_server = deferred_stop(prometheus_server);
 
             prometheus::config pctx;
             pctx.allow_protobuf = true;


### PR DESCRIPTION
simpler this way.