### PR TITLE
github: build with fedora 40 and add 2 build combinations back

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,84 @@
+name: Test
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      compiler:
+        # only the compilers supported by setup-cpp can be used
+        description: 'the C++ compiler to use'
+        type: string
+        required: true
+      standard:
+        description: 'the C++ standard to use'
+        type: number
+        required: true
+      mode:
+        description: 'build mode (debug, dev or release)'
+        type: string
+        required: true
+      enables:
+        description: 'the --enable-* option passed to configure.py'
+        type: string
+        default: ''
+        required: false
+      options:
+        description: 'additional options passed to configure.py'
+        type: string
+        default: ''
+        required: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "${{ contains(inputs.enables, 'dpdk') }}"
+
+      - name: Install build dependencies
+        run: |
+          sudo ./install-dependencies.sh
+
+      - name: Install ${{ inputs.compiler }}
+        uses: aminya/setup-cpp@master
+        with:
+          compiler: ${{ inputs.compiler }}
+          ccache: true
+          # ubuntu:latest comes with CMake 3.29, so we just need to install
+          # ninja. see
+          # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
+          ninja: "${{ contains(inputs.enables, 'cxx-modules') }}"
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ inputs.compiler }}-${{ inputs.standard }}-${{ inputs.mode }}-${{ inputs.enables }}
+
+      - name: Configure
+        run: >
+          ./configure.py
+          --ccache
+          --c++-standard ${{ inputs.standard }}
+          --compiler $CXX
+          --c-compiler $CC
+          --mode ${{ inputs.mode }}
+          ${{ inputs.options }}
+          ${{ inputs.enables }} ;
+
+      - name: Build
+        run: cmake --build build/${{inputs.mode}}
+
+      - name: Check Header
+        if: ${{ inputs.mode == 'dev' && inputs.compiler == 'clang++-18' }}
+        run: cmake --build build/${{ inputs.mode }} --target checkheaders
+
+      - name: Build with C++20 modules
+        if: ${{ contains(inputs.enables, 'cxx-modules') }}
+        run: cmake --build build/${{ inputs.mode }} --target hello_cxx_module
+
+      - name: Test
+        if: ${{ ! contains(inputs.enables, 'cxx-modules') }}
+        run: ./test.py --mode=${{ inputs.mode }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,6 @@ on:
   workflow_call:
     inputs:
       compiler:
-        # only the compilers supported by setup-cpp can be used
         description: 'the C++ compiler to use'
         type: string
         required: true
@@ -33,7 +32,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: fedora:40
     steps:
+      - name: Install Git
+        run: |
+          sudo dnf -y install git
+
       - uses: actions/checkout@v4
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
@@ -42,15 +46,19 @@ jobs:
         run: |
           sudo ./install-dependencies.sh
 
-      - name: Install ${{ inputs.compiler }}
-        uses: aminya/setup-cpp@master
-        with:
-          compiler: ${{ inputs.compiler }}
-          ccache: true
-          # ubuntu:latest comes with CMake 3.29, so we just need to install
-          # ninja. see
-          # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
-          ninja: "${{ contains(inputs.enables, 'cxx-modules') }}"
+      - name: Install clang++
+        if: ${{ inputs.compiler == 'clang++' }}
+        run: |
+          sudo dnf -y install clang
+
+      - name: Install clang-scan-deps
+        if: ${{ contains(inputs.enables, 'cxx-modules') }}
+        run: |
+          sudo dnf -y install clang-tools-extra
+
+      - name: Install ccache
+        run: |
+          sudo dnf -y install ccache
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
@@ -58,15 +66,20 @@ jobs:
           key: ${{ inputs.compiler }}-${{ inputs.standard }}-${{ inputs.mode }}-${{ inputs.enables }}
 
       - name: Configure
-        run: >
-          ./configure.py
-          --ccache
-          --c++-standard ${{ inputs.standard }}
-          --compiler $CXX
-          --c-compiler $CC
-          --mode ${{ inputs.mode }}
-          ${{ inputs.options }}
-          ${{ inputs.enables }} ;
+        run: |
+          if [ ${{ inputs.compiler }} = "clang++" ]; then
+            CC=clang
+          else
+            CC=gcc
+          fi
+          ./configure.py                          \
+            --ccache                              \
+            --c++-standard ${{ inputs.standard }} \
+            --compiler ${{ inputs.compiler }}     \
+            --c-compiler $CC                      \
+            --mode ${{ inputs.mode }}             \
+            ${{ inputs.options }}                 \
+            ${{ inputs.enables }}
 
       - name: Build
         run: cmake --build build/${{inputs.mode}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  test:
-    name: "Tests (${{ matrix.compiler }}, C++${{ matrix.standard}}, ${{ matrix.mode }}, ${{ matrix.enables }})"
+  regular_test:
+    name: "Test (${{ matrix.compiler }}, C++${{ matrix.standard}}, ${{ matrix.mode }})"
     uses: ./.github/workflows/test.yaml
     strategy:
       fail-fast: false
@@ -20,55 +20,30 @@ jobs:
         compiler: [clang++-18, gcc-13]
         standard: [20, 23]
         mode: [dev, debug, release]
-        include:
-          - compiler: clang++-18
-            standard: 20
-            mode: dev
-          - compiler: clang++-18
-            standard: 20
-            mode: debug
-          - compiler: clang++-18
-            standard: 20
-            mode: release
-          - compiler: clang++-18
-            standard: 23
-            mode: dev
-          - compiler: clang++-18
-            standard: 23
-            mode: debug
-          - compiler: clang++-18
-            standard: 23
-            mode: release
-          - compiler: gcc-13
-            standard: 20
-            mode: dev
-          - compiler: gcc-13
-            standard: 20
-            mode: debug
-          - compiler: gcc-13
-            standard: 20
-            mode: release
-          - compiler: gcc-13
-            standard: 23
-            mode: dev
-          - compiler: gcc-13
-            standard: 23
-            mode: debug
-          - compiler: gcc-13
-            standard: 23
-            mode: release
-          - compiler: clang++-18
-            standard: 23
-            mode: release
-            options: --cook dpdk --dpdk-machine haswell
-            enables: --enable-dpdk
-          - compiler: clang++-18
-            standard: 23
-            mode: debug
-            enables: --enable-cxx-modules
     with:
       compiler: ${{ matrix.compiler }}
       standard: ${{ matrix.standard }}
       mode: ${{ matrix.mode }}
       enables: ${{ matrix.enables }}
       options: ${{ matrix.options }}
+  build_with_dpdk:
+    name: "Test with DPDK enabled"
+    uses: ./.github/workflows/test.yaml
+    strategy:
+      fail-fast: false
+    with:
+      compiler: clang++-18
+      standard: 23
+      mode: release
+      enables: --enable-dpdk
+      options: --cook dpdk --dpdk-machine haswell
+  build_with_cxx_modules:
+    name: "Test with C++20 modules enabled"
+    uses: ./.github/workflows/test.yaml
+    strategy:
+      fail-fast: false
+    with:
+      compiler: clang++-18
+      standard: 23
+      mode: debug
+      enables: --enable-cxx-modules

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     name: "Tests (${{ matrix.compiler }}, C++${{ matrix.standard}}, ${{ matrix.mode }}, ${{ matrix.enables }})"
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/test.yaml
     strategy:
       fail-fast: false
       matrix:
@@ -66,52 +66,9 @@ jobs:
             standard: 23
             mode: debug
             enables: --enable-cxx-modules
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "${{ contains(matrix.enables, 'dpdk') }}"
-
-      - name: Install build dependencies
-        run: |
-          sudo ./install-dependencies.sh
-
-      - name: Install ${{ matrix.compiler }}
-        uses: aminya/setup-cpp@master
-        with:
-          compiler: ${{ matrix.compiler }}
-          ccache: true
-          # ubuntu:latest comes with CMake 3.29, so we just need to install
-          # ninja. see
-          # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
-          ninja: "${{ contains(matrix.enables, 'cxx-modules') }}"
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: ${{ matrix.compiler }}-${{ matrix.standard }}-${{ matrix.mode }}-${{ matrix.enables }}
-
-      - name: Configure
-        run: >
-          ./configure.py
-          --ccache
-          --c++-standard ${{ matrix.standard }}
-          --compiler $CXX
-          --c-compiler $CC
-          --mode ${{ matrix.mode }}
-          ${{ matrix.options }}
-          ${{ matrix.enables }} ;
-
-      - name: Build
-        run: cmake --build build/${{matrix.mode}}
-
-      - name: Check Header
-        if: ${{ matrix.mode == 'dev' && matrix.compiler == 'clang++-18' }}
-        run: cmake --build build/${{ matrix.mode }} --target checkheaders
-
-      - name: Build with C++20 modules
-        if: ${{ contains(matrix.enables, 'cxx-modules') }}
-        run: cmake --build build/${{ matrix.mode }} --target hello_cxx_module
-
-      - name: Test
-        if: ${{ ! contains(matrix.enables, 'cxx-modules') }}
-        run: ./test.py --mode=${{ matrix.mode }}
+    with:
+      compiler: ${{ matrix.compiler }}
+      standard: ${{ matrix.standard }}
+      mode: ${{ matrix.mode }}
+      enables: ${{ matrix.enables }}
+      options: ${{ matrix.options }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # only the compilers supported by setup-cpp
-        compiler: [clang++-18, gcc-13]
+        compiler: [clang++, g++]
         standard: [20, 23]
         mode: [dev, debug, release]
     with:
@@ -32,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      compiler: clang++-18
+      compiler: clang++
       standard: 23
       mode: release
       enables: --enable-dpdk
@@ -43,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      compiler: clang++-18
+      compiler: clang++
       standard: 23
       mode: debug
       enables: --enable-cxx-modules


### PR DESCRIPTION
in order to address the infra issues caused by unreliable connection to llvm's apt repo, and to bring the two missing build combinations back, in this series, we switch from `setup-cpp` action to fedora 40, and extract the test job into a reusable workflow.