### PR TITLE
build: support enabled options when building seastar-module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -877,13 +877,6 @@ endif ()
 set( MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 --leak-check=no --trace-children=yes" )
 include (CTest)
 
-if (Seastar_MODULE)
-  if (POLICY CMP0155)
-    cmake_policy (SET CMP0155 NEW)
-  endif ()
-  include (CxxModulesRules)
-  add_subdirectory (src)
-endif ()
 #
 # We want asserts enabled on all modes, but cmake defaults to passing
 # -DNDEBUG in some modes. We add -UNDEBUG to our private options to
@@ -1182,6 +1175,14 @@ if (Seastar_INSTALL OR Seastar_TESTING)
     PUBLIC
     seastar)
 
+endif ()
+
+if (Seastar_MODULE)
+  if (POLICY CMP0155)
+    cmake_policy (SET CMP0155 NEW)
+  endif ()
+  include (CxxModulesRules)
+  add_subdirectory (src)
 endif ()
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,8 @@ target_compile_definitions (seastar-module
     SEASTAR_SCHEDULING_GROUPS_COUNT=${Seastar_SCHEDULING_GROUPS_COUNT}
     SEASTAR_COROUTINES_ENABLED
   PRIVATE
-    SEASTAR_MODULE)
+    SEASTAR_MODULE
+    ${Seastar_PRIVATE_COMPILE_DEFINITIONS})
 target_compile_options (seastar-module
   PUBLIC
     -U_FORTIFY_SOURCE)
@@ -126,6 +127,18 @@ target_link_libraries (seastar-module
     yaml-cpp::yaml-cpp
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)
+if (Seastar_NUMA)
+  target_link_libraries (seastar-module
+    PRIVATE numactl::numactl)
+endif ()
+if (Seastar_HWLOC)
+  target_link_libraries (seastar-module
+    PRIVATE hwloc::hwloc)
+endif ()
+if (Seastar_IO_URING)
+  target_link_libraries (seastar-module
+    PRIVATE URING::uring)
+endif ()
 
 install (
   TARGETS seastar-module

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -36,6 +36,7 @@ module;
 #include <sys/syscall.h>
 #include <sys/resource.h>
 #include <boost/container/small_vector.hpp>
+#include <fmt/core.h>
 
 #ifdef SEASTAR_HAVE_URING
 #include <liburing.h>

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -35,6 +35,10 @@ module;
 #include <limits>
 #include <filesystem>
 #include <unordered_map>
+#include <fmt/core.h>
+#if SEASTAR_HAVE_HWLOC
+#include <hwloc/glibc-sched.h>
+#endif
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -48,10 +52,6 @@ module seastar;
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/print.hh>
 #include "cgroup.hh"
-
-#if SEASTAR_HAVE_HWLOC
-#include <hwloc/glibc-sched.h>
-#endif
 
 #endif
 

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -118,7 +118,9 @@ module;
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <gnutls/crypto.h>
-
+#ifdef SEASTAR_HAVE_HWLOC
+#include <hwloc.h>
+#endif
 #if defined(__x86_64__) || defined(__i386__)
 #include <xmmintrin.h>
 #endif


### PR DESCRIPTION
before this change, when building seastar-module, we don't check for
the enabled features. so, for instance io uring backend is not enabled
even `Seastar_IO_URING` is set.

in this series we

* move `add_subdirectory(src)` down
* `#include` the used header files
* check for the enabled options,
* link against the related libraries, and
* add the required macro definitions

this should enable seastar-module to build with, for instance, io_uring
backend enabled. as `SEASTAR_HAVE_URING` enables this backend when
building `src/core/reactor_backend.cc`.

Fixes https://github.com/scylladb/seastar/issues/2249