### PR TITLE
treewide: do not check for SEASTAR_COROUTINES_ENABLED

### DIFF
--- a/demos/coroutines_demo.cc
+++ b/demos/coroutines_demo.cc
@@ -23,15 +23,6 @@
 
 #include <seastar/util/std-compat.hh>
 
-#ifndef SEASTAR_COROUTINES_ENABLED
-
-int main(int argc, char** argv) {
-    std::cout << "coroutines not available\n";
-    return 0;
-}
-
-#else
-
 #include <seastar/core/app-template.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/fstream.hh>
@@ -68,5 +59,3 @@ int main(int argc, char** argv) {
         std::cout << "done\n";
     });
 }
-
-#endif

--- a/include/seastar/core/condition-variable.hh
+++ b/include/seastar/core/condition-variable.hh
@@ -28,10 +28,8 @@
 #include <functional>
 #endif
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/timer.hh>
-#ifdef SEASTAR_COROUTINES_ENABLED
-#   include <seastar/core/coroutine.hh>
-#endif
 #include <seastar/core/loop.hh>
 #include <seastar/util/modules.hh>
 
@@ -102,7 +100,6 @@ private:
         }
     };
 
-#ifdef SEASTAR_COROUTINES_ENABLED
     struct [[nodiscard("must co_await a when() call")]] awaiter : public waiter {
         condition_variable* _cv;
         promise<> _p;
@@ -183,7 +180,6 @@ private:
             }
         }
     };
-#endif
 
     boost::intrusive::list<waiter, boost::intrusive::constant_time_size<false>> _waiters;
     std::exception_ptr _ex; //"broken" exception
@@ -298,7 +294,6 @@ public:
         return wait(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }
 
-#ifdef SEASTAR_COROUTINES_ENABLED
     /// Coroutine/co_await only waiter.
     /// Waits until condition variable is signaled, may wake up without condition been met
     ///
@@ -380,8 +375,6 @@ public:
     auto when(std::chrono::duration<Rep, Period> timeout, Pred&& pred) noexcept {
         return when(timer<>::clock::now() + timeout, std::forward<Pred>(pred));
     }
-
-#endif
 
     /// Whether or not the condition variable currently has pending waiter(s)
     /// The returned answer is valid until next continuation/fiber switch.

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -29,9 +29,6 @@
 
 
 #ifndef SEASTAR_MODULE
-#ifndef SEASTAR_COROUTINES_ENABLED
-#error Coroutines support disabled.
-#endif
 #include <coroutine>
 #endif
 

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -22,10 +22,8 @@
 #pragma once
 
 #include <seastar/util/std-compat.hh>
-#ifdef SEASTAR_COROUTINES_ENABLED
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/generator.hh>
-#endif
 #include <seastar/core/do_with.hh>
 #include <seastar/core/stream.hh>
 #include <seastar/core/sstring.hh>
@@ -170,11 +168,9 @@ public:
     virtual future<> close() = 0;
     virtual std::unique_ptr<file_handle_impl> dup();
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) = 0;
-#ifdef SEASTAR_COROUTINES_ENABLED
     // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
     // buffered generator yet.
     virtual coroutine::experimental::generator<directory_entry> experimental_list_directory();
-#endif
 };
 
 future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int oflags, struct stat st) noexcept;
@@ -688,12 +684,10 @@ public:
     /// Returns a directory listing, given that this file object is a directory.
     subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next);
 
-#ifdef SEASTAR_COROUTINES_ENABLED
     /// Returns a directory listing, given that this file object is a directory.
     // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
     // buffered generator yet.
     coroutine::experimental::generator<directory_entry> experimental_list_directory();
-#endif
 
 #if SEASTAR_API_LEVEL < 7
     /**

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1142,9 +1142,7 @@ protected:
 
     void do_wait() noexcept;
 
-#ifdef SEASTAR_COROUTINES_ENABLED
     void set_coroutine(task& coroutine) noexcept;
-#endif
 
     friend class promise_base;
 };
@@ -1769,9 +1767,8 @@ public:
         _state.ignore();
     }
 
-#ifdef SEASTAR_COROUTINES_ENABLED
     using future_base::set_coroutine;
-#endif
+
 private:
     void set_task(task& t) noexcept {
         assert(_promise);

--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -26,13 +26,10 @@
 
 #include <fmt/format.h>
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/testing/linux_perf_event.hh>
-
-#ifdef SEASTAR_COROUTINES_ENABLED
-#include <seastar/core/coroutine.hh>
-#endif
 
 using namespace seastar;
 
@@ -362,7 +359,6 @@ void do_not_optimize(const T& v)
     test_##test_group##_##test_case##_registrar(#test_group, #test_case); \
     [[gnu::always_inline]] auto test_##test_group##_##test_case::run()
 
-#ifdef SEASTAR_COROUTINES_ENABLED
 
 #define PERF_TEST_C(test_group, test_case) \
     struct test_##test_group##_##test_case : test_group { \
@@ -379,5 +375,3 @@ void do_not_optimize(const T& v)
     static ::perf_tests::internal::test_registrar<test_##test_group##_##test_case> \
     test_##test_group##_##test_case##_registrar(#test_group, #test_case); \
     future<size_t> test_##test_group##_##test_case::run()
-
-#endif // SEASTAR_COROUTINES_ENABLED

--- a/include/seastar/util/std-compat.hh
+++ b/include/seastar/util/std-compat.hh
@@ -40,14 +40,6 @@ namespace std::pmr {
 }
 #endif
 
-#if defined(__cpp_impl_coroutine) || defined(__cpp_coroutines)
-#if __has_include(<coroutine>)
-#define SEASTAR_COROUTINES_ENABLED
-#else
-#error Please use a C++ compiler with C++20 coroutines support
-#endif
-#endif
-
 // Defining SEASTAR_ASAN_ENABLED in here is a bit of a hack, but
 // convenient since it is build system independent and in practice
 // everything includes this header.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,6 @@ target_compile_definitions (seastar-module
     $<$<BOOL:${Seastar_SSTRING}>:SEASTAR_SSTRING>
     SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
     SEASTAR_SCHEDULING_GROUPS_COUNT=${Seastar_SCHEDULING_GROUPS_COUNT}
-    SEASTAR_COROUTINES_ENABLED
   PRIVATE
     SEASTAR_MODULE)
 target_compile_options (seastar-module

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -104,9 +104,7 @@ public:
     virtual future<> close() noexcept override;
     virtual std::unique_ptr<seastar::file_handle_impl> dup() override;
     virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)> next) override;
-#ifdef SEASTAR_COROUTINES_ENABLED
     virtual coroutine::experimental::generator<directory_entry> experimental_list_directory() override;
-#endif
 
 #if SEASTAR_API_LEVEL >= 7
     virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept override = 0;

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -275,11 +275,9 @@ void internal::future_base::do_wait() noexcept {
     thread_impl::switch_out(thread);
 }
 
-#ifdef SEASTAR_COROUTINES_ENABLED
 void internal::future_base::set_coroutine(task& coroutine) noexcept {
     assert(_promise);
     _promise->set_task(&coroutine);
 }
-#endif
 
 }

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -21,8 +21,6 @@
 
 #include <seastar/testing/perf_tests.hh>
 
-#ifdef SEASTAR_COROUTINES_ENABLED
-
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -48,5 +46,3 @@ PERF_TEST_C(coroutine_test, maybe_yield)
 {
     co_await coroutine::maybe_yield();
 }
-
-#endif // SEASTAR_COROUTINES_ENABLED

--- a/tests/perf/future_util_perf.cc
+++ b/tests/perf/future_util_perf.cc
@@ -23,13 +23,10 @@
 #include <boost/range/irange.hpp>
 
 #include <seastar/testing/perf_tests.hh>
-#include <seastar/core/loop.hh>
-#include <seastar/util/later.hh>
-
-#ifdef SEASTAR_COROUTINES_ENABLED
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
-#endif
+#include <seastar/core/loop.hh>
+#include <seastar/util/later.hh>
 
 struct parallel_for_each {
     std::vector<int> empty_range;
@@ -156,8 +153,6 @@ PERF_TEST_F(parallel_for_each, suspend_100)
         return range.size();
     });
 }
-
-#ifdef SEASTAR_COROUTINES_ENABLED
 
 PERF_TEST_C(parallel_for_each, cor_empty)
 {
@@ -352,5 +347,3 @@ PERF_TEST_CN(parallel_for_each, cor_pfe_suspend_100)
     perf_tests::do_not_optimize(value);
     co_return range.size();
 }
-
-#endif // SEASTAR_COROUTINES_ENABLED

--- a/tests/unit/condition_variable_test.cc
+++ b/tests/unit/condition_variable_test.cc
@@ -222,8 +222,6 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_has_waiter) {
     BOOST_REQUIRE_EQUAL(cv.has_waiters(), false);
 }
 
-#ifdef SEASTAR_COROUTINES_ENABLED
-
 SEASTAR_TEST_CASE(test_condition_variable_signal_consume_coroutine) {
     condition_variable cv;
 
@@ -365,5 +363,3 @@ SEASTAR_TEST_CASE(test_condition_variable_when_timeout) {
 
     co_await std::move(f);
 }
-
-#endif

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -24,25 +24,10 @@
 #include <ranges>
 
 #include <seastar/core/circular_buffer.hh>
-#include <seastar/core/future-util.hh>
-#include <seastar/testing/test_case.hh>
-#include <seastar/core/sleep.hh>
-#include <seastar/util/later.hh>
-#include <seastar/core/thread.hh>
-#include <seastar/testing/random.hh>
-
-using namespace seastar;
-using namespace std::chrono_literals;
-
-#ifndef SEASTAR_COROUTINES_ENABLED
-
-SEASTAR_TEST_CASE(test_coroutines_not_compiled_in) {
-    return make_ready_future<>();
-}
-
-#else
-
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
 #include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>
@@ -50,6 +35,12 @@ SEASTAR_TEST_CASE(test_coroutines_not_compiled_in) {
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/generator.hh>
+#include <seastar/testing/random.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/util/later.hh>
+
+using namespace seastar;
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -520,7 +511,7 @@ SEASTAR_TEST_CASE(test_maybe_yield) {
     BOOST_REQUIRE(true); // the test will hang if it doesn't work.
 }
 
-#if __has_include(<coroutine>) && !defined(__clang__)
+#ifndef __clang__
 
 #include "tl-generator.hh"
 tl::generator<int> simple_generator(int max)
@@ -917,5 +908,3 @@ SEASTAR_TEST_CASE(test_lambda_coroutine_in_continuation) {
     }));
     BOOST_REQUIRE_EQUAL(sin1, sin2);
 }
-
-#endif

--- a/tests/unit/directory_test.cc
+++ b/tests/unit/directory_test.cc
@@ -86,7 +86,6 @@ future<> lister_test() {
     });
 }
 
-#ifdef SEASTAR_COROUTINES_ENABLED
 future<> lister_generator_test(file f) {
     auto lister = f.experimental_list_directory();
     while (auto de = co_await lister()) {
@@ -134,12 +133,6 @@ future<> lister_generator_test() {
     auto f2 = file(std::move(tf));
     co_await lister_generator_test(std::move(f2));
 }
-#else
-future<> lister_generator_test() {
-    fmt::print("Generator lister test skipped, coroutines not enabled\n");
-    return make_ready_future<>();
-}
-#endif
 
 int main(int ac, char** av) {
     return app_template().run(ac, av, [] {


### PR DESCRIPTION
since we've dropped the support for C++17, and we even started using C++20 coroutines in 1d56a1d17a unconditionally in the implementation of Seastar, there is no need to check the support of coroutine anymore.

so, in this change, we

* stop check and define SEASTAR_COROUTINES_ENABLED
* do not check SEASTAR_COROUTINES_ENABLED
* drop the code for handling the case where SEASTAR_COROUTINES_ENABLED is not defined.