### PR TITLE
sstring: deprecate formatters for vector and unordered_map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ option (Seastar_SSTRING
   "Use seastar's own string implementation"
   ON)
 
+option (Seastar_DEPRECATED_OSTREAM_FORMATTERS
+  "Enable operator<< for formatting standard library containers, which will be deprecated in future"
+  ON)
+
 set (Seastar_API_LEVEL
   "7"
   CACHE
@@ -925,6 +929,11 @@ endif ()
 if (Seastar_SSTRING)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_SSTRING)
+endif ()
+
+if (Seastar_DEPRECATED_OSTREAM_FORMATTERS)
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_DEPRECATED_OSTREAM_FORMATTERS)
 endif ()
 
 if (LinuxMembarrier_FOUND)

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -836,10 +836,13 @@ string_type to_sstring(T value) {
 }
 }
 
+#ifdef SEASTAR_DEPRECATED_OSTREAM_FORMATTERS
+
 namespace std {
 
 SEASTAR_MODULE_EXPORT
 template <typename T>
+[[deprecated("Use {fmt} instead")]]
 inline
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
     bool first = true;
@@ -858,6 +861,7 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
 
 SEASTAR_MODULE_EXPORT
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+[[deprecated("Use {fmt} instead")]]
 std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash, KeyEqual, Allocator>& v) {
     bool first = true;
     os << "{";
@@ -873,6 +877,8 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
     return os;
 }
 }
+
+#endif
 
 #if FMT_VERSION >= 90000
 


### PR DESCRIPTION
Seastar is an event-driven framework, not a collection of libraries for multiple purposes. also, when migrating to a {fmt} only formatting solution, the operator<< based printers can actually makes our lives more difficult. for instance, Boost.test expects operator<< and fall back to `boost_test_print_type()`, so even if we provide a templated `boost_test_print_type()` which accepts all types which can be formatted with {fmt}, if Boost.test is able to find the operator<<-based formatter for a std::vector, it just picks it, and then hits the brick wall, as the elements in the vector does not provide an operator<<-based formatter.

instead of enabling these operator<<:s to print the element with fmt::formatter support, let's just disable them on user's request.

in this change, a new option is added. so that user can disable these formatter on request. and these two formatters are marked deprecated. so in future, we can remove them when we bump up the API level or just completely drop them.

Fixes #1544
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>