### PR TITLE
std-compat: remove #include:s which were added for pre C++17

### DIFF
--- a/include/seastar/core/internal/uname.hh
+++ b/include/seastar/core/internal/uname.hh
@@ -23,8 +23,8 @@
 #pragma once
 
 #include <seastar/util/modules.hh>
-#include <seastar/util/std-compat.hh>
 #ifndef SEASTAR_MODULE
+#include <optional>
 #include <string>
 #include <initializer_list>
 #include <iosfwd>

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -21,12 +21,13 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
 #include <seastar/util/spinlock.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cstdlib>
+#include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 #include <set>

--- a/include/seastar/net/config.hh
+++ b/include/seastar/net/config.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
+#include <optional>
 #include <istream>
 #include <string>
 #include <unordered_map>

--- a/include/seastar/util/exceptions.hh
+++ b/include/seastar/util/exceptions.hh
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
+#include <filesystem>
 
 namespace seastar {
 

--- a/include/seastar/util/read_first_line.hh
+++ b/include/seastar/util/read_first_line.hh
@@ -1,4 +1,4 @@
-#include <seastar/util/std-compat.hh>
+#include <filesystem>
 #include <seastar/core/sstring.hh>
 #ifndef SEASTAR_MODULE
 #include <boost/lexical_cast.hpp>

--- a/include/seastar/util/std-compat.hh
+++ b/include/seastar/util/std-compat.hh
@@ -25,12 +25,6 @@
 
 #ifndef SEASTAR_MODULE
 
-#include <optional>
-#include <string_view>
-#include <variant>
-
-#include <filesystem>
-
 #if __has_include(<memory_resource>)
 #include <memory_resource>
 #else

--- a/include/seastar/util/variant_utils.hh
+++ b/include/seastar/util/variant_utils.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
+#include <variant>
 
 namespace seastar {
 

--- a/src/net/config.cc
+++ b/src/net/config.cc
@@ -29,6 +29,7 @@ module;
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
 #include <istream>
+#include <optional>
 #include <unordered_map>
 #include <string>
 


### PR DESCRIPTION
these `#include`s were introduced by 0bbcbbae and 79e846e9, for backward compatibility with pre-C++17 era. since we've dropped C++17 support, and now only support C++20 and up. let's remove these cruft.