### PR TITLE
github: cancel a job if it takes longer than 40 minutes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     container: fedora:40
     steps:


### PR DESCRIPTION
in general, it takes less than 34 minutes to build the tree from scratch and to test all tests, even with DPDK enabled. but to be on the safe side, let's add 6 more minutes.

this helps to stop if we run into some unexpected infra issues, or to identify some very time consuming tests.

see also
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes