### PR TITLE
perf_tests: add linux_perf_event::user_cpu_cycles_retired

### DIFF
--- a/include/seastar/testing/linux_perf_event.hh
+++ b/include/seastar/testing/linux_perf_event.hh
@@ -45,5 +45,6 @@ public:
     void disable();
 public:
     static linux_perf_event user_instructions_retired();
+    static linux_perf_event user_cpu_cycles_retired();
 };
 

--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -45,6 +45,7 @@ public:
     uint64_t allocations = 0;
     uint64_t tasks_executed = 0;
     uint64_t instructions_retired = 0;
+    uint64_t cpu_cycles_retired = 0;
 
 private:
     static uint64_t perf_mallocs();
@@ -52,15 +53,17 @@ private:
 
 public:
     perf_stats() = default;
-    perf_stats(uint64_t allocations_, uint64_t tasks_executed_, uint64_t instructions_retired_ = 0)
+    perf_stats(uint64_t allocations_, uint64_t tasks_executed_, uint64_t instructions_retired_ = 0, uint64_t cpu_cycles_retired_ = 0)
         : allocations(allocations_)
         , tasks_executed(tasks_executed_)
         , instructions_retired(instructions_retired_)
+        , cpu_cycles_retired(cpu_cycles_retired_)
     {}
     perf_stats(perf_stats&& o) noexcept
         : allocations(std::exchange(o.allocations, 0))
         , tasks_executed(std::exchange(o.tasks_executed, 0))
         , instructions_retired(std::exchange(o.instructions_retired, 0))
+        , cpu_cycles_retired(std::exchange(o.cpu_cycles_retired, 0))
     {}
     perf_stats(const perf_stats& o) = default;
 
@@ -70,7 +73,7 @@ public:
     perf_stats& operator+=(perf_stats b);
     perf_stats& operator-=(perf_stats b);
 
-    static perf_stats snapshot(linux_perf_event* instructions_retired_counter = nullptr);
+    static perf_stats snapshot(linux_perf_event* instructions_retired_counter = nullptr, linux_perf_event* cpu_cycles_retired_counter = nullptr);
 };
 
 inline
@@ -79,6 +82,7 @@ operator+(perf_stats a, perf_stats b) {
     a.allocations += b.allocations;
     a.tasks_executed += b.tasks_executed;
     a.instructions_retired += b.instructions_retired;
+    a.cpu_cycles_retired += b.cpu_cycles_retired;
     return a;
 }
 
@@ -88,6 +92,7 @@ operator-(perf_stats a, perf_stats b) {
     a.allocations -= b.allocations;
     a.tasks_executed -= b.tasks_executed;
     a.instructions_retired -= b.instructions_retired;
+    a.cpu_cycles_retired -= b.cpu_cycles_retired;
     return a;
 }
 
@@ -95,6 +100,7 @@ inline perf_stats& perf_stats::operator+=(perf_stats b) {
     allocations += b.allocations;
     tasks_executed += b.tasks_executed;
     instructions_retired += b.instructions_retired;
+    cpu_cycles_retired += b.cpu_cycles_retired;
     return *this;
 }
 
@@ -102,6 +108,7 @@ inline perf_stats& perf_stats::operator-=(perf_stats b) {
     allocations -= b.allocations;
     tasks_executed -= b.tasks_executed;
     instructions_retired -= b.instructions_retired;
+    cpu_cycles_retired -= b.cpu_cycles_retired;
     return *this;
 }
 
@@ -113,6 +120,7 @@ class performance_test {
     std::atomic<uint64_t> _max_single_run_iterations;
 protected:
     linux_perf_event _instructions_retired_counter = linux_perf_event::user_instructions_retired();
+    linux_perf_event _cpu_cycles_retired_counter = linux_perf_event::user_cpu_cycles_retired();
 private:
     void do_run(const config&);
 public:
@@ -165,17 +173,19 @@ class time_measurement {
     perf_stats _total_stats;
 
     linux_perf_event* _instructions_retired_counter = nullptr;
+    linux_perf_event* _cpu_cycles_retired_counter = nullptr;
 
 public:
     [[gnu::always_inline]] [[gnu::hot]]
-    void start_run(linux_perf_event* instructions_retired_counter = nullptr) {
+    void start_run(linux_perf_event* instructions_retired_counter = nullptr, linux_perf_event* cpu_cycles_retired_counter = nullptr) {
         _instructions_retired_counter = instructions_retired_counter;
+        _cpu_cycles_retired_counter = cpu_cycles_retired_counter;
         _total_time = { };
         _total_stats = {};
         auto t = clock_type::now();
         _run_start_time = t;
         _start_time = t;
-        _start_stats = perf_stats::snapshot(_instructions_retired_counter);
+        _start_stats = perf_stats::snapshot(_instructions_retired_counter, _cpu_cycles_retired_counter);
     }
 
     [[gnu::always_inline]] [[gnu::hot]]
@@ -184,20 +194,21 @@ public:
         performance_test::run_result ret;
         if (_start_time == _run_start_time) {
             ret.duration = t - _start_time;
-            auto stats = perf_stats::snapshot(_instructions_retired_counter);
+            auto stats = perf_stats::snapshot(_instructions_retired_counter, _cpu_cycles_retired_counter);
             ret.stats = stats - _start_stats;
         } else {
             ret.duration = _total_time;
             ret.stats = _total_stats;
         }
         _instructions_retired_counter = nullptr;
+        _cpu_cycles_retired_counter = nullptr;
         return ret;
     }
 
     [[gnu::always_inline]] [[gnu::hot]]
     void start_iteration() {
         _start_time = clock_type::now();
-        _start_stats = perf_stats::snapshot(_instructions_retired_counter);
+        _start_stats = perf_stats::snapshot(_instructions_retired_counter, _cpu_cycles_retired_counter);
     }
 
     [[gnu::always_inline]] [[gnu::hot]]
@@ -205,7 +216,7 @@ public:
         auto t = clock_type::now();
         _total_time += t - _start_time;
         perf_stats stats;
-        stats = perf_stats::snapshot(_instructions_retired_counter);
+        stats = perf_stats::snapshot(_instructions_retired_counter, _cpu_cycles_retired_counter);
         _total_stats += stats - _start_stats;
     }
 };
@@ -259,6 +270,7 @@ protected:
     virtual future<run_result> do_single_run() override {
         // Redundant 'this->'s courtesy of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61636
         _instructions_retired_counter.enable();
+        _cpu_cycles_retired_counter.enable();
         return if_constexpr_<is_future<decltype(_test->run())>::value>([&] (auto&&...) {
             measure_time.start_run(&_instructions_retired_counter);
             return do_until([this] { return this->stop_iteration(); }, [this] {
@@ -276,9 +288,10 @@ protected:
                 return measure_time.stop_run();
             }).finally([this] {
                 _instructions_retired_counter.disable();
+                _cpu_cycles_retired_counter.disable();
             });
         }, [&] (auto&&...) {
-            measure_time.start_run(&_instructions_retired_counter);
+            measure_time.start_run(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
             while (!stop_iteration()) {
                 if_constexpr_<std::is_void_v<decltype(_test->run())>>([&] (auto&&...) {
                     (void)_test->run();
@@ -291,6 +304,7 @@ protected:
             }
             auto ret = measure_time.stop_run();
             _instructions_retired_counter.disable();
+            _cpu_cycles_retired_counter.disable();
             return make_ready_future<run_result>(std::move(ret));
         })();
     }

--- a/tests/perf/linux_perf_event.cc
+++ b/tests/perf/linux_perf_event.cc
@@ -90,5 +90,6 @@ linux_perf_event::user_instructions_retired() {
             .disabled = 1,
             .exclude_kernel = 1,
             .exclude_hv = 1,
+            .exclude_idle = 1,
             }, 0, -1, -1, 0);
 }

--- a/tests/perf/linux_perf_event.cc
+++ b/tests/perf/linux_perf_event.cc
@@ -93,3 +93,16 @@ linux_perf_event::user_instructions_retired() {
             .exclude_idle = 1,
             }, 0, -1, -1, 0);
 }
+
+linux_perf_event
+linux_perf_event::user_cpu_cycles_retired() {
+    return linux_perf_event(perf_event_attr{
+            .type = PERF_TYPE_HARDWARE,
+            .size = sizeof(struct perf_event_attr),
+            .config = PERF_COUNT_HW_CPU_CYCLES,
+            .disabled = 1,
+            .exclude_kernel = 1,
+            .exclude_hv = 1,
+            .exclude_idle = 1,
+            }, 0, -1, -1, 0);
+}


### PR DESCRIPTION
This series adds a new linux_perf_event: user_cpu_cycles_retired
and makes use of it in the general perf tests framework.

Example output for `tests/perf/allocator_perf --blocked-reactor-notify-ms=1000000`:
```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              3842059098

test                                                                iterations      median         mad         min         max      allocs       tasks        inst      cycles
alloc_bench.malloc_only                                               63527000     8.893ns     0.255ns     8.632ns     9.497ns       1.000       0.000        43.3        13.6
alloc_bench.free_only                                                 65545000     5.820ns     0.038ns     5.765ns     6.009ns       0.000       0.000        27.3         7.8
alloc_bench.malloc_free                                               51283000    14.776ns     0.145ns    14.593ns    14.993ns       1.000       0.000        70.6        22.0
alloc_bench.op_new_only                                               68012000     8.630ns     0.126ns     8.445ns     8.836ns       1.000       0.000        41.3        13.7
alloc_bench.op_delete_only                                            68054000     5.877ns     0.050ns     5.797ns     5.927ns       0.000       0.000        27.3         7.9
alloc_bench.op_new_delete                                             52444000    14.442ns     0.082ns    14.132ns    14.526ns       1.000       0.000        68.6        21.3
alloc_bench.new_array_only                                            68676000     8.692ns     0.007ns     8.651ns     8.748ns       1.000       0.000        42.3        13.7
alloc_bench.delete_array_only                                         69221000     5.765ns     0.028ns     5.727ns     5.864ns       0.000       0.000        29.3         7.6
alloc_bench.array_new_delete                                          50895000    14.952ns     0.071ns    14.684ns    15.023ns       1.000       0.000        71.6        21.3
alloc_bench.alloc_only_large                                          20392000    28.326ns     0.090ns    27.729ns    28.481ns       1.000       0.000       201.2        53.5
alloc_bench.free_only_large                                           20668000    20.227ns     0.269ns    19.434ns    20.497ns       0.000       0.000       137.2        36.6
alloc_bench.alloc_free_large                                          18993000    47.542ns     0.230ns    47.312ns    48.205ns       1.000       0.000       338.3        90.1
alloc_bench.single_alloc_and_free_small_many                          10790191    92.200ns     0.203ns    91.839ns    92.479ns      10.000       0.000       710.0       192.1
alloc_bench.single_alloc_and_free_small_many_cross_page               21399784    47.149ns     1.048ns    45.682ns    48.197ns       5.000       0.000       360.0        98.1
alloc_bench.single_alloc_and_free_small_many_cross_page_alloc_more      557930     1.772us     6.331ns     1.751us     1.785us     101.000       0.000     12837.0      3704.1
random_sampling.exp_dist                                              41050000    24.108ns     0.039ns    23.847ns    24.218ns       0.000       0.000       120.8        50.5
random_sampling.geo_dist                                              37260000    26.713ns     0.044ns    26.564ns    26.896ns       0.000       0.000       129.8        55.9
```
