### PR TITLE
abort_source: add method to get exception pointer

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -185,6 +185,11 @@ public:
         }
     }
 
+    /// Returns an exception with which an abort was requested.
+    const std::exception_ptr& abort_requested_exception_ptr() const noexcept {
+        return _ex;
+    }
+
     /// Returns the default exception type (\ref abort_requested_exception) for this abort source.
     /// Overridable by derived classes.
     virtual std::exception_ptr get_default_exception() const noexcept {


### PR DESCRIPTION
Currently to check the exact type of an exception in abort_source, we need to rethrow it.

Add method to get abort_source exception_ptr.