### PR TITLE
abort_source: modify subscribe method

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -134,13 +134,14 @@ public:
     /// Delays the invocation of the callback \c f until \ref request_abort() is called.
     /// \returns an engaged \ref optimized_optional containing a \ref subscription that can be used to control
     ///          the lifetime of the callback \c f, if \ref abort_requested() is \c false. Otherwise,
-    ///          returns a disengaged \ref optimized_optional.
+    ///          triggers a callback and returns a disengaged \ref optimized_optional.
     template <typename Func>
         requires (std::is_nothrow_invocable_r_v<void, Func, const std::optional<std::exception_ptr>&> ||
                   std::is_nothrow_invocable_r_v<void, Func>)
     [[nodiscard]]
     optimized_optional<subscription> subscribe(Func&& f) {
         if (abort_requested()) {
+            f(_ex);
             return { };
         }
         if constexpr (std::is_invocable_v<Func, std::exception_ptr>) {


### PR DESCRIPTION
Currently when subscribe method is called on an abort_source on which abort has already been requested, method's arguments are ignored and std::nullopt is returned. So, behaviour of the method depends on timing and aforementioned case needs to be handled by a caller.

If subscribe is called on already aborted abort source, trigger a function passed as an argument.