### PR TITLE
XFS: ensure proper alignment of extent allocation size hint

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -64,6 +64,8 @@ using namespace seastar;
 using namespace std::chrono_literals;
 using namespace boost::accumulators;
 
+static constexpr uint64_t extent_size_hint_alignment{1u << 20}; // 1MB
+
 static auto random_seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 static thread_local std::default_random_engine random_generator(random_seed);
 
@@ -770,7 +772,7 @@ private:
 
         return max_concurrent_for_each(boost::irange(UINT64_C(0), files_count()), max_concurrency(), [this] (uint64_t file_id) {
             const auto fname = get_filename(file_id);
-            const auto fsize = _config.file_size / files_count();
+            const auto fsize = align_up<uint64_t>(_config.file_size / files_count(), extent_size_hint_alignment);
             const auto flags = open_flags::rw | open_flags::create;
 
             file_open_options options;
@@ -984,7 +986,8 @@ struct convert<job_config> {
         // constant) disk space between workloads. Each shard inside the
         // workload thus uses its portion of the assigned space.
         if (node["data_size"]) {
-            cl.file_size = node["data_size"].as<byte_size>().size / smp::count;
+            const uint64_t per_shard_bytes = node["data_size"].as<byte_size>().size / smp::count;
+            cl.file_size = align_up<uint64_t>(per_shard_bytes, extent_size_hint_alignment);
         } else {
             cl.file_size = 1ull << 30; // 1G by default
         }

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -103,7 +103,8 @@ future<std::pair<file, uint64_t>> create_and_fill_file(sstring name, uint64_t fs
                     }
 
                     const uint64_t buffer_size{256ul << 10};
-                    const uint64_t buffers_count{static_cast<uint64_t>(fsize / buffer_size) + 1u};
+                    const uint64_t additional_iteration = (fsize % buffer_size == 0) ? 0 : 1;
+                    const uint64_t buffers_count{static_cast<uint64_t>(fsize / buffer_size) + additional_iteration};
                     const uint64_t last_buffer_id = (buffers_count - 1u);
                     const uint64_t last_write_position = buffer_size * last_buffer_id;
 

--- a/doc/io-tester.md
+++ b/doc/io-tester.md
@@ -45,7 +45,9 @@ For example:
 * `type`: mandatory property, one of seqread, seqwrite, randread, randwrite, append, cpu, unlink
 * `shards`: mandatory property, either the string "all" or a list of shards where this class should place jobs.
 * `data_size`: optional property, used to divide the available disk space between workloads. Each shard inside the workload uses its portion of the assigned space. If not specified 1GB is used.
-* `files_count`: optional property, relevant only for unlink job class - in such case it is required. Describes the number of files that need to be created during startup to be unlinked during evaluation.
+* `files_count`: optional property, relevant only for unlink job class - in such case it is required. Describes the number of files that need to be created during startup to be unlinked during evaluation. Describes files count per shard.
+
+> **_NOTE:_** the actual file size is always aligned to 1MB.
 
 The properties under `shard_info` represent properties of the job that will
 be replicated to each shard. All properties under `shard_info` are optional, and in case not specified, defaults are used.

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -94,6 +94,10 @@ struct file_open_options {
 
     // The fsxattr.fsx_extsize is 32-bit
     static constexpr uint64_t max_extent_allocation_size_hint = 1 << 31;
+
+    // XFS ignores hints that are not aligned to the logical block size.
+    // To fulfill the requirement, we ensure that hint is aligned to 128KB (best guess).
+    static constexpr uint32_t min_extent_size_hint_alignment{128u << 10}; // 128KB
 };
 
 class file;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1905,6 +1905,8 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
                     attr.fsx_extsize = std::min(options.extent_allocation_size_hint,
                                         file_open_options::max_extent_allocation_size_hint);
 
+                    attr.fsx_extsize = align_up<uint32_t>(attr.fsx_extsize, file_open_options::min_extent_size_hint_alignment);
+
                     // Ignore error; may be !xfs, and just a hint anyway
                     ::ioctl(fd, XFS_IOC_FSSETXATTR, &attr);
                 }


### PR DESCRIPTION
If the extent size is not aligned to logical block
size then XFS ignores it and returns an error from
ioctl() function call.

These patches ensure that the hint passed by a user
is properly aligned.