### PR TITLE
github: s/clang++-18/clang++/

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
         run: cmake --build build/${{inputs.mode}}
 
       - name: Check Header
-        if: ${{ inputs.mode == 'dev' && inputs.compiler == 'clang++-18' }}
+        if: ${{ inputs.mode == 'dev' && inputs.compiler == 'clang++' }}
         run: cmake --build build/${{ inputs.mode }} --target checkheaders
 
       - name: Build with C++20 modules

--- a/include/seastar/testing/exchanger.hh
+++ b/include/seastar/testing/exchanger.hh
@@ -23,7 +23,7 @@
 
 #include <mutex>
 #include <condition_variable>
-#include <seastar/util/std-compat.hh>
+#include <optional>
 
 namespace seastar {
 


### PR DESCRIPTION
in 28b05551, we switched from ubuntu:jammy to fedora:40 as the building environment of our CI workflow. and we replaced the input parameter "clang++-18" in test.yml with "clang++", because in fedora:40, the clang++ executable does not have the postfix as the clang-18 installed by the setup-cpp action.

but we failed to update all of them in that change, that's why the "check header" step was not performed after that change.

in this change, we replace that last "clang++-18" in the workflow to "clang++".