### PR TITLE
include: include used headers

### DIFF
--- a/include/seastar/core/report_exception.hh
+++ b/include/seastar/core/report_exception.hh
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
+#include <exception>
+#include <string_view>
 
 namespace seastar {
 

--- a/include/seastar/core/timer.hh
+++ b/include/seastar/core/timer.hh
@@ -29,6 +29,7 @@
 #ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
 #include <chrono>
+#include <optional>
 #endif
 
 /// \file

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
-#include <concepts>
 #include <iostream>
-#include <memory>
+#include <optional>
 #include <type_traits>
 #include <fmt/core.h>
 #endif


### PR DESCRIPTION
in b822c94b2b, we removed some "#include":s in std-compat.hh. despite that the Seastar library and all tests still compile. some headers are not self-contained anymore.