### PR TITLE
circular_buffer_fixed_capacity: arrow operator instead of . operator

### DIFF
--- a/include/seastar/core/circular_buffer_fixed_capacity.hh
+++ b/include/seastar/core/circular_buffer_fixed_capacity.hh
@@ -348,7 +348,7 @@ circular_buffer_fixed_capacity<T, Capacity>::erase(iterator first, iterator last
         auto new_start = std::move_backward(begin(), first, last);
         auto i = begin();
         while (i < new_start) {
-            *i++.~T();
+            i++->~T();
         }
         _begin = new_start.idx;
         return last;
@@ -357,7 +357,7 @@ circular_buffer_fixed_capacity<T, Capacity>::erase(iterator first, iterator last
         auto i = new_end;
         auto e = end();
         while (i < e) {
-            *i++.~T();
+            i++->~T();
         }
         _end = new_end.idx;
         return first;


### PR DESCRIPTION
before this change, we use `*i++.~T()` to implement following sequence:
```c++
auto p = i++;
auto& v = *p;
v.~T();
```

but the associativity of `.` and `++` (suffix increment) operator is left-to-right. so from compiler's perspective, it emits:

```c++
auto p = i++;
auto v = p.~T();
*v;
```

that's why Clang-19 complains that we are dereferencing a `void`:
```
/home/kefu/.local/bin/clang -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_DEPRECATED_OSTREAM_FORMATTERS -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_PTHREAD_ATTR_SETAFFINITY_NP -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -Dseastar_EXPORTS -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/debug/gen/include -I/home/kefu/dev/seastar/build/debug/gen/src -I/home/kefu/dev/seastar/src -g -std=gnu++23 -fPIC -U_FORTIFY_SOURCE -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -UNDEBUG -Wall -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -gz -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT CMakeFiles/seastar.dir/src/core/app-template.cc.o -MF CMakeFiles/seastar.dir/src/core/app-template.cc.o.d -o CMakeFiles/seastar.dir/src/core/app-template.cc.o -c /home/kefu/dev/seastar/src/core/app-template.cc
In file included from /home/kefu/dev/seastar/src/core/app-template.cc:38:
In file included from /home/kefu/dev/seastar/include/seastar/core/reactor.hh:27:
/home/kefu/dev/seastar/include/seastar/core/circular_buffer_fixed_capacity.hh:351:13: error: indirection requires pointer operand ('void' invalid)
  351 |             *i++.~T();
      |             ^~~~~~~~~
/home/kefu/dev/seastar/include/seastar/core/circular_buffer_fixed_capacity.hh:360:13: error: indirection requires pointer operand ('void' invalid)
  360 |             *i++.~T();
      |             ^~~~~~~~~
2 errors generated.
```

in this change, we trade the `.` operator with `->` operator, to ensure that compiler generates:
```c++
auto p = i++;
p->~T();
```