### PR TITLE
posix-file-impl: Do not keep device-id on board

### DIFF
--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -72,7 +72,6 @@ public:
 
 class posix_file_impl : public file_impl {
     std::atomic<unsigned>* _refcount = nullptr;
-    const dev_t _device_id;
     const bool _nowait_works;
     io_queue& _io_queue;
     const open_flags _open_flags;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -121,9 +121,8 @@ file_handle::to_file() && {
 }
 
 posix_file_impl::posix_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, bool nowait_works)
-        : _device_id(device_id)
-        , _nowait_works(nowait_works)
-        , _io_queue(engine().get_io_queue(_device_id))
+        : _nowait_works(nowait_works)
+        , _io_queue(engine().get_io_queue(device_id))
         , _open_flags(f)
         , _fd(fd)
 {
@@ -172,7 +171,7 @@ posix_file_impl::dup() {
     if (!_refcount) {
         _refcount = new std::atomic<unsigned>(1u);
     }
-    auto ret = std::make_unique<posix_file_handle_impl>(_fd, _open_flags, _refcount, _device_id,
+    auto ret = std::make_unique<posix_file_handle_impl>(_fd, _open_flags, _refcount, _io_queue.dev_id(),
             _memory_dma_alignment, _disk_read_dma_alignment, _disk_write_dma_alignment, _disk_overwrite_dma_alignment,
             _nowait_works);
     _refcount->fetch_add(1, std::memory_order_relaxed);
@@ -186,9 +185,8 @@ posix_file_impl::posix_file_impl(int fd, open_flags f, std::atomic<unsigned>* re
         uint32_t disk_overwrite_dma_alignment,
         bool nowait_works)
         : _refcount(refcount)
-        , _device_id(device_id)
         , _nowait_works(nowait_works)
-        , _io_queue(engine().get_io_queue(_device_id))
+        , _io_queue(engine().get_io_queue(device_id))
         , _open_flags(f)
         , _fd(fd) {
     _memory_dma_alignment = memory_dma_alignment;


### PR DESCRIPTION
This number is needed in two places

- construction-time, to find the io-queue object to use
- run-time, to construct file handle

File handle uses device id to create another posix_file_impl object on another shard, so it needs device id to find io-queue for it. However, when creating handle, the deivce-id can be obtained by file from the io-queue it references.