### PR TITLE
include: include used headers

### DIFF
--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <memory>
 #include <cassert>
-#include <seastar/util/std-compat.hh>
+#include <optional>
 #include <seastar/util/modules.hh>
 #include <seastar/core/future.hh>
 #endif


### PR DESCRIPTION
in b822c94b2b, we removed some "#include":s in std-compat.hh. despite that the Seastar library and all tests still compile. some header are not self-contained anymore.

otherwise, we could have following build failure
```
Error: /home/runner/work/scylladb/scylladb/seastar/include/seastar/core/ragel.hh:130:39: error: no template named 'optional' in namespace 'std' [clang-diagnostic-error]
  130 |     using unconsumed_remainder = std::optional<temporary_buffer<char>>;
      |                                  ~~~~~^
```