### PR TITLE
Fix compilation failure on Ubuntu 22.04

### DIFF
--- a/include/seastar/core/queue.hh
+++ b/include/seastar/core/queue.hh
@@ -23,9 +23,9 @@
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future.hh>
-#include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
+#include <optional>
 #include <queue>
 #endif
 

--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <memory>
 #include <cassert>
-#include <seastar/util/std-compat.hh>
+#include <optional>
 #include <seastar/util/modules.hh>
 #include <seastar/core/future.hh>
 #endif

--- a/include/seastar/net/inet_address.hh
+++ b/include/seastar/net/inet_address.hh
@@ -25,6 +25,7 @@
 #include <iosfwd>
 #include <sys/types.h>
 #include <netinet/in.h>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 #endif

--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -33,7 +33,9 @@
 
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
+#include <optional>
 #include <set>
 #endif
 

--- a/src/core/program_options.hh
+++ b/src/core/program_options.hh
@@ -21,6 +21,7 @@
 
 #ifndef SEASTAR_MODULE
 #include <boost/program_options.hpp>
+#include <optional>
 #include <stack>
 #endif
 


### PR DESCRIPTION
Fix compilation failure on Ubuntu 22.04
    
When the code was built according to the
README.md on Ubuntu 22.04 it failed due
to missing includes of `<optional>` and
`<variant>`.
    
Commit b822c94b2bb5860003995ff3fa197709dfc46c2c
seemed to be the first for which the issue
occurred.
    
This change adds missing includes and removes
usage of "std-compat.hh" in modified files when
possible.