### PR TITLE
Unfriend reactor from scheduling_group_key

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -409,7 +409,7 @@ private:
     void insert_activating_task_queues();
     void account_runtime(task_queue& tq, sched_clock::duration runtime);
     void account_idle(sched_clock::duration idletime);
-    void allocate_scheduling_group_specific_data(scheduling_group sg, scheduling_group_key key);
+    void allocate_scheduling_group_specific_data(scheduling_group sg, unsigned long key_id);
     future<> rename_scheduling_group_specific_data(scheduling_group sg);
     future<> init_scheduling_group(scheduling_group sg, sstring name, sstring shortname, float shares);
     future<> init_new_scheduling_group_key(scheduling_group_key key, scheduling_group_key_config cfg);

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -192,7 +192,6 @@ private:
     unsigned long id() const noexcept {
         return _id;
     }
-    friend class reactor;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
     template<typename T>
     friend T* internal::scheduling_group_get_specific_ptr(scheduling_group sg, scheduling_group_key key) noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4862,17 +4862,18 @@ deallocate_scheduling_group_id(unsigned id) noexcept {
 
 void
 reactor::allocate_scheduling_group_specific_data(scheduling_group sg, scheduling_group_key key) {
+    auto key_id = key.id();
     auto& sg_data = _scheduling_group_specific_data;
     auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
-    this_sg.specific_vals.resize(std::max<size_t>(this_sg.specific_vals.size(), key.id()+1));
-    this_sg.specific_vals[key.id()] =
-        aligned_alloc(sg_data.scheduling_group_key_configs[key.id()].alignment,
-                sg_data.scheduling_group_key_configs[key.id()].allocation_size);
-    if (!this_sg.specific_vals[key.id()]) {
+    this_sg.specific_vals.resize(std::max<size_t>(this_sg.specific_vals.size(), key_id+1));
+    this_sg.specific_vals[key_id] =
+        aligned_alloc(sg_data.scheduling_group_key_configs[key_id].alignment,
+                sg_data.scheduling_group_key_configs[key_id].allocation_size);
+    if (!this_sg.specific_vals[key_id]) {
         std::abort();
     }
-    if (sg_data.scheduling_group_key_configs[key.id()].constructor) {
-        sg_data.scheduling_group_key_configs[key.id()].constructor(this_sg.specific_vals[key.id()]);
+    if (sg_data.scheduling_group_key_configs[key_id].constructor) {
+        sg_data.scheduling_group_key_configs[key_id].constructor(this_sg.specific_vals[key_id]);
     }
 }
 


### PR DESCRIPTION
The scheduling_group_key is assumed to be only copy-able and move-able by its users. However, reactor wants to mess with its ID for its maintenance purposes, but there's dedicated internal:: helper for that. Also rector wants to construct a temporary key object out of id, but that's just the way how internal reactor helper works, it can go with plain integral id value.