### PR TITLE
github: do not set --dpdk-machine haswell

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
       standard: 23
       mode: release
       enables: --enable-dpdk
-      options: --cook dpdk --dpdk-machine haswell
+      options: --cook dpdk
   build_with_cxx_modules:
     name: "Test with C++20 modules enabled"
     uses: ./.github/workflows/test.yaml


### PR DESCRIPTION
in ba395a22, in order to workaround a bug in clang-18, we hardwired --dpdk-machine to haswell, but now that LLVM 18.1.6 has released, and fedora 40 has received the new LLVM package built from LLVM 18.1.6, we can now partially drop this change.

Fixes #2259
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>