### PR TITLE
Support mutable lambdas in sharded::invoke_on_others

### DIFF
--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -780,7 +780,7 @@ sharded<Service>::invoke_on_others(smp_submit_to_options options, Func func, Arg
     static_assert(std::is_same_v<futurize_t<std::invoke_result_t<Func, Service&, Args...>>, future<>>,
                   "invoke_on_others()'s func must return void or future<>");
   try {
-    return invoke_on_all(options, [orig = this_shard_id(), func = std::move(func), args = std::tuple(std::move(args)...)] (Service& s) -> future<> {
+    return invoke_on_all(options, [orig = this_shard_id(), func = std::move(func), args = std::tuple(std::move(args)...)] (Service& s) mutable -> future<> {
         return this_shard_id() == orig ? make_ready_future<>() : futurize_apply(func, std::tuple_cat(std::forward_as_tuple(s), args));;
     });
   } catch (...) {

--- a/tests/unit/sharded_test.cc
+++ b/tests/unit/sharded_test.cc
@@ -201,3 +201,23 @@ SEASTAR_THREAD_TEST_CASE(invoke_on_all_sharded_arg) {
     srv.stop().get();
     arg.stop().get();
 }
+
+SEASTAR_THREAD_TEST_CASE(invoke_on_modifiers) {
+    class checker {
+    public:
+        future<> fn(int a) {
+            return make_ready_future<>();
+        }
+    };
+
+    seastar::sharded<checker> srv;
+    srv.start().get();
+    int a = 42;
+
+    srv.invoke_on_all([a] (checker& s) { return s.fn(a); }).get();
+    srv.invoke_on_all([a] (checker& s) mutable { return s.fn(a); }).get();
+    srv.invoke_on_others([a] (checker& s) { return s.fn(a); }).get();
+    srv.invoke_on_others([a] (checker& s) mutable { return s.fn(a); }).get();
+
+    srv.stop().get();
+}


### PR DESCRIPTION
Currently only sharded::invoke_on_all() can call mutable lambdas, the ..._on_others fails to compile. This PR fixes it and adds test for more invoke_on_... compilation options.