### PR TITLE
io_tester: add parameter to force certain extent size hint value

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -249,6 +249,9 @@ struct job_config {
     // of the disk's cache. An exception to that rule is unlink_class_data, that creates files_count
     // files with file_size/files_count.
     uint64_t file_size;
+    // the value passed as a hint for allocated extent size
+    // if not specified, then file_size is used as a hint
+    std::optional<uint64_t> extent_allocation_size_hint;
     // the number of files to create and unlink by unlink_class_data per shard
     // remaining operations utilize only one file per shard
     std::optional<uint64_t> files_count;
@@ -585,7 +588,7 @@ private:
             flags |= open_flags::dsync;
         }
         file_open_options options;
-        options.extent_allocation_size_hint = _config.file_size;
+        options.extent_allocation_size_hint = _config.extent_allocation_size_hint.value_or(_config.file_size);
         options.append_is_unlikely = true;
 
         return create_and_fill_file(fname, _config.file_size, flags, options).then([this](std::pair<file, uint64_t> p) {
@@ -777,7 +780,7 @@ private:
             const auto flags = open_flags::rw | open_flags::create;
 
             file_open_options options;
-            options.extent_allocation_size_hint = fsize;
+            options.extent_allocation_size_hint = _config.extent_allocation_size_hint.value_or(fsize);
             options.append_is_unlikely = true;
 
             return create_and_fill_file(fname, fsize, flags, options).then([](std::pair<file, uint64_t> p) {
@@ -991,6 +994,12 @@ struct convert<job_config> {
             cl.file_size = align_up<uint64_t>(per_shard_bytes, extent_size_hint_alignment);
         } else {
             cl.file_size = 1ull << 30; // 1G by default
+        }
+
+        // By default the file size is used as the allocation hint.
+        // However, certain tests may require using a specific value (e.g. 32MB).
+        if (node["extent_allocation_size_hint"]) {
+            cl.extent_allocation_size_hint = node["extent_allocation_size_hint"].as<byte_size>().size;
         }
 
         // By default a job may create 0 or 1 file.

--- a/doc/io-tester.md
+++ b/doc/io-tester.md
@@ -45,9 +45,11 @@ For example:
 * `type`: mandatory property, one of seqread, seqwrite, randread, randwrite, append, cpu, unlink
 * `shards`: mandatory property, either the string "all" or a list of shards where this class should place jobs.
 * `data_size`: optional property, used to divide the available disk space between workloads. Each shard inside the workload uses its portion of the assigned space. If not specified 1GB is used.
+* `extent_allocation_size_hint`: optional property, allows setting the hint for allocation of extents for files. If not specified, then the size of file is used as hint.
 * `files_count`: optional property, relevant only for unlink job class - in such case it is required. Describes the number of files that need to be created during startup to be unlinked during evaluation. Describes files count per shard.
 
 > **_NOTE:_** the actual file size is always aligned to 1MB.
+> **_NOTE:_** if not properly aligned, then the extent allocation size hint is aligned to 128kB by seastar.
 
 The properties under `shard_info` represent properties of the job that will
 be replicated to each shard. All properties under `shard_info` are optional, and in case not specified, defaults are used.


### PR DESCRIPTION
By default io_tester uses the size of a file
as the allocation extent size hint. However,
certain tests may want to specify some exact
value for that parameter e.g. to match the
extent size hint configured for a specific product.

This change adds a new parameter to YAML job
description that enables users to explicitly
set some specific value for extent size hint.