### PR TITLE
stall-analyser: use itertools.dropwhile when appropriate

### DIFF
--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -5,6 +5,7 @@ import sys
 import re
 
 import addr2line
+from itertools import dropwhile
 from typing import Self
 
 
@@ -368,12 +369,7 @@ def main():
         #  (inlined by) seastar::reactor::block_notifier(int) at ./build/release/seastar/./seastar/src/core/reactor.cc:1240
         # ?? ??:0
         if address_threshold:
-            for i in range(0, len(trace)):
-                if int(trace[i], 0) >= address_threshold:
-                    while int(trace[i], 0) >= address_threshold:
-                        i += 1
-                    trace = trace[i:]
-                    break
+            trace = list(dropwhile(lambda addr: int(addr, 0) >= address_threshold, trace))
         tmin = args.minimum or 0
         if t >= tmin:
             graph.process_trace(trace, t)


### PR DESCRIPTION
for better readability