### PR TITLE
[RFC] Scatter IO request among shards evenly

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -105,9 +105,12 @@ private:
     friend struct ::io_queue_for_tests;
     friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
+    unsigned get_request_target(const internal::io_request&) const noexcept;
+
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
     future<size_t> queue_one_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
+    future<size_t> queue_one_request_locally(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
 
     // The fields below are going away, they are just here so we can implement deprecated
     // functions that used to be provided by the fair_queue and are going away (from both
@@ -157,6 +160,7 @@ public:
         unsigned flow_ratio_ticks = 100;
         double flow_ratio_ema_factor = 0.95;
         double flow_ratio_backpressure_threshold = 1.1;
+        unsigned request_fanout_block_bits = 24; // 16MB
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -232,6 +232,7 @@ private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;
+    std::vector<io_queue*> _io_queues;
 
     static fair_group::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -569,6 +569,7 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     , _sink(sink)
     , _flow_ratio_update([this] { update_flow_ratio(); })
 {
+    _group->_io_queues[this_shard_id()] = this;
     auto& cfg = get_config();
     if (cfg.duplex) {
         static_assert(internal::io_direction_and_length::write_idx == 0);
@@ -611,6 +612,7 @@ std::chrono::duration<double> io_group::io_latency_goal() const noexcept {
 io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
     : _config(std::move(io_cfg))
     , _allocated_on(this_shard_id())
+    , _io_queues(smp::count, nullptr)
 {
     auto fg_cfg = make_fair_group_config(_config);
     _fgs.emplace_back(fg_cfg, nr_queues);


### PR DESCRIPTION
Current IO queues design assumes that IO workload is very uniform on different shards in a sense that -- all classes are more-or-less equally loaded on different shards. In reality that's not true and some shards can easily get more requests in one of its class than the others.

This leads to a very nasty consequence. Consider a corner case -- two classes, A and B, with shares 100 and 1000 respectively, two shards. Class A is active on shard-0 only, while class B is active on shard-1 only. We expect, that they share disk ~~bandwidth~~ capacity in 1:10 proportion, but in reality it's going to be 1:1, because cross-shard queue doesn't preempt (it doesn't, because load is expected to be even on all shards).

The solution below is far from being ideal, but it demonstrates (and proves) one of the approaches -- when requests get queued into a class, scatter them evenly across all shards on the node in plain round robin manner. This brings the aforementioned assumption back true, and the described corner case start working as expected.

One of the immediate problem with it -- intents (IO cancellation) stops working
Another problem -- smp::submit_to() can slow things down #1017 . This has chance to be solved by introducing more sophisticated logic around scattering, that would e.g. take into account imbalance of class queues on different shards.

fixes: #1430 
fixes: #1083

Tested with io_tester on 2-shards setup

```
- name: shard_0
  shard_info:
    parallelism: 32
    reqsize: 4kB
    shares: 100
  shards:
  - '0'
  type: randread
- name: shard_1
  shard_info:
    parallelism: 32
    reqsize: 4kB
    shares: 800
  shards:
  - '1'
  type: randread
```

Without the patch the result is

```
---
- shard: 0
  shard_0:
    throughput: 354812.719  # kB/s
    IOPS: 88703.375
    latencies:  # usec
      average: 359
      p0.5: 358
      p0.95: 387
      p0.99: 408
      p0.999: 455
      max: 2704
    stats:
      total_requests: 887065
      io_queue_total_exec_sec: 50.380561289002046
      io_queue_total_delay_sec: 268.07659966000335
      io_queue_total_operations: 887097
      io_queue_starvation_time_sec: 8.5391000000000023e-05
      io_queue_consumption: 4.9869152042269711
      io_queue_adjusted_consumption: 0.051574149906635287
- shard: 1
  shard_1:
    throughput: 356593.031  # kB/s
    IOPS: 89148.4531
    latencies:  # usec
      average: 358
      p0.5: 357
      p0.95: 385
      p0.99: 406
      p0.999: 444
      max: 2768
    stats:
      total_requests: 891511
      io_queue_total_exec_sec: 50.404540082000388
      io_queue_total_delay_sec: 268.12554203199409
      io_queue_total_operations: 891543
      io_queue_starvation_time_sec: 5.6404000000000004e-05
      io_queue_consumption: 5.0119088914990426
      io_queue_adjusted_consumption: 0.0079740712642669669
...
```

With it the result is


```
---
- shard: 0
  shard_0:
    throughput: 79122.1875  # kB/s
    IOPS: 19780.5469
    latencies:  # usec
      average: 1616
      p0.5: 671
      p0.95: 3134
      p0.99: 3164
      p0.999: 3214
      max: 11612
    stats:
      total_requests: 197817
      io_queue_total_exec_sec: 5.8829173029999913
      io_queue_total_delay_sec: 16.473880899999962
      io_queue_total_operations: 98925
      io_queue_starvation_time_sec: 5.0897572340000377
      io_queue_consumption: 0.55611797422170639
      io_queue_adjusted_consumption: 0.0072732244133949277
- shard: 1
  shard_1:
    throughput: 632085.812  # kB/s
    IOPS: 158021.547
    latencies:  # usec
      average: 201
      p0.5: 232
      p0.95: 334
      p0.99: 359
      p0.999: 400
      max: 8257
    stats:
      total_requests: 1580247
      io_queue_total_exec_sec: 46.343612493998329
      io_queue_total_delay_sec: 199.64613740399747
      io_queue_total_operations: 790139
      io_queue_starvation_time_sec: 0.0068174949999999963
      io_queue_consumption: 4.4418549409508703
      io_queue_adjusted_consumption: 0.0072718314528465271
...
```