### PR TITLE
RPC delay metrics

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -86,6 +86,14 @@ Actual negotiation looks like this:
     The server does not directly assign meaning to values of `isolation_cookie`;
     instead, the interpretation is left to user code.
 
+#### Handler duration
+    feature number: 5
+    data: none
+
+    Asks server to send "extended" response that includes the handler duration time. See
+    the response frame description for more details
+
+
 ##### Compressed frame format
     uint32_t len
     uint8_t compressed_data[len]
@@ -111,10 +119,14 @@ data is transparent for the protocol and serialized/deserialized by a user
 ## Response frame format
     int64_t msg_id
     uint32_t len
+    uint32_t handler_duration - present if handler duration is negotiated
     uint8_t data[len]
     
 if msg_id < 0 enclosed response contains an exception that came as a response to msg id abs(msg_id)
 data is transparent for the protocol and serialized/deserialized by a user 
+
+the handler_duration is in microseconds, the value of 0xffffffff means that it wasn't measured
+and should be disregarded by client
 
 ## Stream frame format
    uint32_t len

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -118,6 +118,7 @@ struct client_options {
     /// \see resource_limits::isolate_connection
     sstring isolation_cookie;
     sstring metrics_domain = "default";
+    bool send_handler_duration = true;
 };
 
 /// @}
@@ -179,6 +180,7 @@ enum class protocol_features : uint32_t {
     CONNECTION_ID = 2,
     STREAM_PARENT = 3,
     ISOLATION = 4,
+    HANDLER_DURATION = 5,
 };
 
 // internal representation of feature data
@@ -285,6 +287,7 @@ protected:
     std::unique_ptr<compressor> _compressor;
     bool _propagate_timeout = false;
     bool _timeout_negotiated = false;
+    bool _handler_duration_negotiated = false;
     // stream related fields
     bool _is_stream = false;
     connection_id _id = invalid_connection_id;
@@ -487,7 +490,11 @@ private:
 private:
     future<> negotiate_protocol(feature_map map);
     void negotiate(feature_map server_features);
-    future<std::tuple<int64_t, std::optional<rcv_buf>>>
+    // Returned future is
+    // - message id
+    // - optional server-side handler duration
+    // - message payload
+    future<std::tuple<int64_t, std::optional<uint32_t>, std::optional<rcv_buf>>>
     read_response_frame_compressed(input_stream<char>& in);
 public:
     /**

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -430,6 +430,7 @@ class client : public rpc::connection, public weakly_referencable<client> {
     struct reply_handler_base {
         timer<rpc_clock_type> t;
         cancellable* pcancel = nullptr;
+        rpc_clock_type::time_point start;
         virtual void operator()(client&, id_type, rcv_buf data) = 0;
         virtual void timeout() {}
         virtual void cancel() {}

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -592,7 +592,7 @@ public:
     public:
         connection(server& s, connected_socket&& fd, socket_address&& addr, const logger& l, void* seralizer, connection_id id);
         future<> process();
-        future<> respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout);
+        future<> respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration);
         client_info& info() { return _info; }
         const client_info& info() const { return _info; }
         stats get_stats() const {

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -502,7 +502,7 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
 }
 
 // Refer to struct response_frame for more details
-static constexpr size_t response_frame_headroom = 12;
+static constexpr size_t response_frame_headroom = 16;
 
 template<typename Serializer, typename RetTypes>
 inline future<> reply(wait_type, future<RetTypes>&& ret, int64_t msg_id, shared_ptr<server::connection> client,

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -60,6 +60,8 @@ struct stats {
     counter_type sent_messages = 0;
     counter_type wait_reply = 0;
     counter_type timeout = 0;
+    counter_type delay_samples = 0;
+    std::chrono::duration<double> delay_total = std::chrono::duration<double>(0);
 };
 
 class connection_id {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -667,6 +667,9 @@ namespace rpc {
           case protocol_features::TIMEOUT:
               _timeout_negotiated = true;
               break;
+          case protocol_features::HANDLER_DURATION:
+              _handler_duration_negotiated = true;
+              break;
           case protocol_features::CONNECTION_ID: {
               _id = deserialize_connection_id(e.second);
               break;
@@ -692,8 +695,8 @@ namespace rpc {
   //   ...  payload
   struct response_frame {
       using opt_buf_type = std::optional<rcv_buf>;
-      using return_type = std::tuple<int64_t, opt_buf_type>;
-      using header_type = std::tuple<int64_t>;
+      using return_type = std::tuple<int64_t, std::optional<uint32_t>, opt_buf_type>;
+      using header_type = std::tuple<int64_t, std::optional<uint32_t>>;
       static constexpr size_t raw_header_size = sizeof(int64_t) + sizeof(uint32_t);
       static size_t header_size() {
           static_assert(response_frame_headroom >= raw_header_size);
@@ -703,28 +706,68 @@ namespace rpc {
           return "client";
       }
       static auto empty_value() {
-          return std::make_tuple(0, std::nullopt);
+          return std::make_tuple(0, std::nullopt, std::nullopt);
       }
       static std::pair<uint32_t, header_type> decode_header(const char* ptr) {
           auto msgid = read_le<int64_t>(ptr);
           auto size = read_le<uint32_t>(ptr + 8);
-          return std::make_pair(size, std::make_tuple(msgid));
+          return std::make_pair(size, std::make_tuple(msgid, std::nullopt));
       }
-      static void encode_header(int64_t msg_id, snd_buf& data) {
+      static void encode_header(int64_t msg_id, snd_buf& data, size_t header_size = raw_header_size) {
           static_assert(snd_buf::chunk_size >= raw_header_size, "send buffer chunk size is too small");
           auto p = data.front().get_write();
           write_le<int64_t>(p, msg_id);
-          write_le<uint32_t>(p + 8, data.size - raw_header_size);
+          write_le<uint32_t>(p + 8, data.size - header_size);
       }
       static auto make_value(const header_type& t, rcv_buf data) {
-          return std::make_tuple(std::get<0>(t), std::move(data));
+          return std::make_tuple(std::get<0>(t), std::get<1>(t), std::move(data));
       }
   };
 
+  // The response frame is
+  //   le64 message ID
+  //   le32 payload size
+  //   le32 handler duration
+  //   ...  payload
+  struct response_frame_with_handler_time : public response_frame {
+      using super = response_frame;
+      static constexpr size_t raw_header_size = super::raw_header_size + sizeof(uint32_t);
+      static size_t header_size() {
+          static_assert(response_frame_headroom >= raw_header_size);
+          return raw_header_size;
+      }
+      static std::pair<uint32_t, header_type> decode_header(const char* ptr) {
+          auto p = super::decode_header(ptr);
+          auto ht = read_le<uint32_t>(ptr + 12);
+          if (ht != -1U) {
+              std::get<1>(p.second) = ht;
+          }
+          return p;
+      }
+      static uint32_t encode_handler_duration(const std::optional<rpc_clock_type::duration>& ht) noexcept {
+          if (ht.has_value()) {
+              std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(*ht);
+              if (us.count() < std::numeric_limits<uint32_t>::max()) {
+                  return us.count();
+              }
+          }
+          return -1U;
+      }
+      static void encode_header(int64_t msg_id, std::optional<rpc_clock_type::duration> ht, snd_buf& data) {
+          static_assert(snd_buf::chunk_size >= raw_header_size);
+          auto p = data.front().get_write();
+          super::encode_header(msg_id, data, raw_header_size);
+          write_le<uint32_t>(p + 12, encode_handler_duration(ht));
+      }
+  };
 
   future<response_frame::return_type>
   client::read_response_frame_compressed(input_stream<char>& in) {
-      return read_frame_compressed<response_frame>(_server_addr, _compressor, in);
+      if (_handler_duration_negotiated) {
+          return read_frame_compressed<response_frame_with_handler_time>(_server_addr, _compressor, in);
+      } else {
+          return read_frame_compressed<response_frame>(_server_addr, _compressor, in);
+      }
   }
 
   stats client::get_stats() const {
@@ -894,6 +937,9 @@ namespace rpc {
           if (_options.send_timeout_data) {
               features[protocol_features::TIMEOUT] = "";
           }
+          if (_options.send_handler_duration) {
+              features[protocol_features::HANDLER_DURATION] = "";
+          }
           if (_options.stream_parent) {
               features[protocol_features::STREAM_PARENT] = serialize_connection_id(_options.stream_parent);
           }
@@ -910,7 +956,7 @@ namespace rpc {
                   }
                   return read_response_frame_compressed(_read_buf).then([this] (response_frame::return_type msg_id_and_data) {
                       auto& msg_id = std::get<0>(msg_id_and_data);
-                      auto& data = std::get<1>(msg_id_and_data);
+                      auto& data = std::get<2>(msg_id_and_data);
                       auto it = _outstanding.find(std::abs(msg_id));
                       if (!data) {
                           _error = true;
@@ -1008,6 +1054,10 @@ namespace rpc {
               _timeout_negotiated = true;
               ret[protocol_features::TIMEOUT] = "";
               break;
+          case protocol_features::HANDLER_DURATION:
+              _handler_duration_negotiated = true;
+              ret[protocol_features::HANDLER_DURATION] = "";
+              break;
           case protocol_features::STREAM_PARENT: {
               if (!get_server()._options.streaming_domain) {
                   f = f.then([] {
@@ -1096,7 +1146,13 @@ namespace rpc {
 
   future<>
   server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
-      response_frame::encode_header(msg_id, data);
+      if (_handler_duration_negotiated) {
+          response_frame_with_handler_time::encode_header(msg_id, handler_duration, data);
+      } else {
+          data.front().trim_front(sizeof(uint32_t));
+          data.size -= sizeof(uint32_t);
+          response_frame::encode_header(msg_id, data);
+      }
       return send(std::move(data), timeout);
   }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1095,7 +1095,7 @@ namespace rpc {
   }
 
   future<>
-  server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout) {
+  server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
       response_frame::encode_header(msg_id, data);
       return send(std::move(data), timeout);
   }
@@ -1116,7 +1116,7 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
             (void)with_gate(get_server()._reply_gate, [this, timeout, msg_id, data = std::move(data), permit = std::move(permit)] () mutable {
                 // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83268
                 auto c = shared_from_this();
-                return respond(-msg_id, std::move(data), timeout).then([c = std::move(c), permit = std::move(permit)] {});
+                return respond(-msg_id, std::move(data), timeout, std::nullopt).then([c = std::move(c), permit = std::move(permit)] {});
             });
         } catch(gate_closed_exception&) {/* ignore */}
     });

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -339,6 +339,7 @@ SEASTAR_TEST_CASE(test_rpc_connect) {
 
     for (auto i = 0; i < 2; i++) {
         for (auto j = 0; j < 4; j++) {
+          for (bool with_delay : { true, false }) {
             auto factory = std::make_unique<cfactory>();
             rpc::server_options so;
             rpc::client_options co;
@@ -349,6 +350,7 @@ SEASTAR_TEST_CASE(test_rpc_connect) {
                 co.compressor_factory = factory.get();
             }
             co.send_timeout_data = j & 2;
+            co.send_handler_duration = with_delay;
             rpc_test_config cfg;
             cfg.server_options = so;
             auto f = rpc_test_env<>::do_with_thread(cfg, co, [] (rpc_test_env<>& env, test_rpc_proto::client& c1) {
@@ -368,6 +370,7 @@ SEASTAR_TEST_CASE(test_rpc_connect) {
                 }
             });
             fs.emplace_back(std::move(f));
+          }
         }
     }
     return when_all(fs.begin(), fs.end()).discard_result();


### PR DESCRIPTION
The new metrics is total time it takes an RPC message to travel back and forth between verb caller and server. It implicitly consists of the time request and response messages spend in seastar and kernel queues on both sides and classical network RTT.

Calculated for verbs that require response only. First, client negotiates with the server that response frame includes the "handler duration" value, which is the handler callback execution time. Then client notices duration between sending request and receiving response minus handler execution time received from server. This is called "delay sample". Total number of samples and their duration summary are exported as counters in the metrics domain.

refs: #323 
refs: #1753 (for what metrics domain is)