### PR TITLE
linux_perf_event: exclude_idle only on x86_64

### DIFF
--- a/tests/perf/linux_perf_event.cc
+++ b/tests/perf/linux_perf_event.cc
@@ -90,7 +90,11 @@ make_linux_perf_event(unsigned config, pid_t pid = 0, int cpu = -1, int group_fd
             .disabled = 1,
             .exclude_kernel = 1,
             .exclude_hv = 1,
+#if defined(__x86_64__)
+            // exclude_idle is not supported on all architectures (e.g. aarch64)
+            // so enable it selectively only on architectures that support it.
             .exclude_idle = 1,
+#endif
             }, pid, cpu, group_fd, flags);
 }
 

--- a/tests/perf/linux_perf_event.cc
+++ b/tests/perf/linux_perf_event.cc
@@ -81,28 +81,25 @@ linux_perf_event::disable() {
     ::ioctl(_fd, PERF_EVENT_IOC_DISABLE, 0);
 }
 
-linux_perf_event
-linux_perf_event::user_instructions_retired() {
+static linux_perf_event
+make_linux_perf_event(unsigned config, pid_t pid = 0, int cpu = -1, int group_fd = -1, unsigned long flags = 0) {
     return linux_perf_event(perf_event_attr{
             .type = PERF_TYPE_HARDWARE,
             .size = sizeof(struct perf_event_attr),
-            .config = PERF_COUNT_HW_INSTRUCTIONS,
+            .config = config,
             .disabled = 1,
             .exclude_kernel = 1,
             .exclude_hv = 1,
             .exclude_idle = 1,
-            }, 0, -1, -1, 0);
+            }, pid, cpu, group_fd, flags);
+}
+
+linux_perf_event
+linux_perf_event::user_instructions_retired() {
+    return make_linux_perf_event(PERF_COUNT_HW_INSTRUCTIONS);
 }
 
 linux_perf_event
 linux_perf_event::user_cpu_cycles_retired() {
-    return linux_perf_event(perf_event_attr{
-            .type = PERF_TYPE_HARDWARE,
-            .size = sizeof(struct perf_event_attr),
-            .config = PERF_COUNT_HW_CPU_CYCLES,
-            .disabled = 1,
-            .exclude_kernel = 1,
-            .exclude_hv = 1,
-            .exclude_idle = 1,
-            }, 0, -1, -1, 0);
+    return make_linux_perf_event(PERF_COUNT_HW_CPU_CYCLES);
 }


### PR DESCRIPTION
Commit 93f19d39526c68defac6860a15c77160da273606
added `exclude_idle = 1` to `linux_perf_event`.
However, as reported in
https://github.com/scylladb/scylladb/issues/19227#issuecomment-2165577271, `exclude_idle` is not supported on ARM platforms.

This change sets `exclude_idle` only on known-to-work architectures
(presently, it's only x86_64), assuming it is initialized to 0 as all
other unset bitfields in `perf_event_attr`.

Fixes scylladb/seastar#2298