### PR TITLE
timer-set: Add missing sanity headers

### DIFF
--- a/include/seastar/core/timer-set.hh
+++ b/include/seastar/core/timer-set.hh
@@ -14,8 +14,10 @@
 #pragma once
 
 #include <seastar/core/bitset-iter.hh>
+#include <seastar/core/scheduling.hh>
 #ifndef SEASTAR_MODULE
 #include <boost/intrusive/list.hpp>
+#include <exception>
 #include <array>
 #include <bitset>
 #include <limits>


### PR DESCRIPTION
The checkheaders target somehow stepped on recently merged #2269, while the PR itself passed CI when it was created

```
FAILED: CMakeFiles/checkheaders-seastar.dir/checkheaders/include/seastar/core/timer-set.hh.cc.o /usr/lib64/ccache/g++ -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_DEPRECATED_OSTREAM_FORMATTERS -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_PTHREAD_ATTR_SETAFFINITY_NP -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -Dcheckheaders_seastar_EXPORTS -I/home/xemul/src/seastar-2/include/seastar/core -I/home/xemul/src/seastar-2/include/seastar/util -I/home/xemul/src/seastar-2/include/seastar/http -I/home/xemul/src/seastar-2/include/seastar/json -I/home/xemul/src/seastar-2/include/seastar/net -I/home/xemul/src/seastar-2/include/seastar/rpc -I/home/xemul/src/seastar-2/include/seastar/websocket -I/home/xemul/src/seastar-2/src/core -I/home/xemul/src/seastar-2/include -I/home/xemul/src/seastar-2/build/dev/gen/include -I/home/xemul/src/seastar-2/build/dev/gen/src -I/home/xemul/src/seastar-2/src -O1 -std=gnu++23 -fPIC -U_FORTIFY_SOURCE -Wno-maybe-uninitialized -Wno-error=unused-result -fstack-clash-protection -UNDEBUG -Wall -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -Wno-error=stringop-overflow -Wno-error=array-bounds -Wdeprecated-declarations -Wno-error=deprecated-declarations -ftls-model=initial-exec -gz -Wno-unused-const-variable -Wno-unused-function -Wno-unused-variable -MD -MT CMakeFiles/checkheaders-seastar.dir/checkheaders/include/seastar/core/timer-set.hh.cc.o -MF CMakeFiles/checkheaders-seastar.dir/checkheaders/include/seastar/core/timer-set.hh.cc.o.d -o CMakeFiles/checkheaders-seastar.dir/checkheaders/include/seastar/core/timer-set.hh.cc.o -c /home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc /home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:27:6: error: variable or field ‘log_timer_callback_exception’ declared void
   27 | void log_timer_callback_exception(std::exception_ptr) noexcept;
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:27:40: error: ‘exception_ptr’ is not a member of ‘std’
   27 | void log_timer_callback_exception(std::exception_ptr) noexcept;
      |                                        ^~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:20:1: note: ‘std::exception_ptr’ is defined in header ‘<exception>’; did you forget to ‘#include <exception>’?
   19 | #include <array>
  +++ |+#include <exception>
   20 | #include <bitset>
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc: In member function ‘void seastar::timer_set<Timer, link>::complete(timer_list_t&, EnableFunc&&)’:
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:236:30: error: there are no arguments to ‘current_scheduling_group’ that depend on a template parameter, so a declaration of ‘current_scheduling_group’ must be available [-fpermissive]
  236 |         const auto prev_sg = current_scheduling_group();
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:236:30: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:247:32: error: ‘current_scheduling_group_ptr’ is not a member of ‘seastar::internal’
  247 |                     *internal::current_scheduling_group_ptr() = t->_sg;
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:250:31: error: ‘log_timer_callback_exception’ is not a member of ‘seastar::internal’
  250 |                     internal::log_timer_callback_exception(std::current_exception());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:250:65: error: ‘current_exception’ is not a member of ‘std’
  250 |                     internal::log_timer_callback_exception(std::current_exception());
      |                                                                 ^~~~~~~~~~~~~~~~~
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:250:65: note: ‘std::current_exception’ is defined in header ‘<exception>’; did you forget to ‘#include <exception>’?
/home/xemul/src/seastar-2/build/dev/checkheaders/include/seastar/core/timer-set.hh.cc:256:20: error: ‘current_scheduling_group_ptr’ is not a member of ‘seastar::internal’
  256 |         *internal::current_scheduling_group_ptr() = prev_sg;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```