### PR TITLE
Simplify fs-info getting in make_file_impl()

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1132,11 +1132,11 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
         });
     }
 
-        const internal::fs_info& fsi = s_fstype[st_dev];
-        if (!fsi.append_challenged || options.append_is_unlikely || ((flags & O_ACCMODE) == O_RDONLY)) {
-            return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
-        }
-        return make_ready_future<shared_ptr<file_impl>>(make_shared<append_challenged_posix_file_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
+    const internal::fs_info& fsi = s_fstype[st_dev];
+    if (!fsi.append_challenged || options.append_is_unlikely || ((flags & O_ACCMODE) == O_RDONLY)) {
+        return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
+    }
+    return make_ready_future<shared_ptr<file_impl>>(make_shared<append_challenged_posix_file_impl>(fd, open_flags(flags), std::move(options), fsi, st_dev));
 }
 
 file::file(seastar::file_handle&& handle) noexcept


### PR DESCRIPTION
The helper looks up in the map of fs-info-s twice and returns the chain of ready futures on the common paths. This PR makes things simpler.