### PR TITLE
Unfriend reactor from message queues

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -368,6 +368,8 @@ public:
     /// Register a user-defined signal handler
     void handle_signal(int signo, noncopyable_function<void ()>&& handler);
     void wakeup();
+    /// @private
+    bool stopped() const noexcept { return _stopped; }
 
 private:
     class signals {

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -97,7 +97,6 @@ namespace seastar {
 using shard_id = unsigned;
 
 namespace alien {
-class message_queue;
 class instance;
 }
 SEASTAR_MODULE_EXPORT
@@ -632,7 +631,6 @@ private:
 
     future<> run_exit_tasks();
     void stop();
-    friend class alien::message_queue;
     friend class pollable_fd;
     friend class pollable_fd_state;
     friend class posix_file_impl;
@@ -641,7 +639,6 @@ private:
     friend class timer<lowres_clock>;
     friend class timer<manual_clock>;
     friend class smp;
-    friend class smp_message_queue;
     friend class internal::poller;
     friend class scheduling_group;
     friend void internal::add_to_flush_poller(output_stream<char>& os) noexcept;

--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -54,10 +54,7 @@ void
 message_queue::lf_queue::maybe_wakeup() {
     // see also smp_message_queue::lf_queue::maybe_wakeup()
     std::atomic_signal_fence(std::memory_order_seq_cst);
-    if (remote->_sleeping.load(std::memory_order_relaxed)) {
-        remote->_sleeping.store(false, std::memory_order_relaxed);
-        remote->wakeup();
-    }
+    remote->wakeup();
 }
 
 void message_queue::submit_item(std::unique_ptr<message_queue::work_item> item) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3602,7 +3602,7 @@ void smp_message_queue::submit_item(shard_id t, smp_timeout_clock::time_point ti
 
 void smp_message_queue::respond(work_item* item) {
     _completed_fifo.push_back(item);
-    if (_completed_fifo.size() >= batch_size || engine()._stopped) {
+    if (_completed_fifo.size() >= batch_size || engine().stopped()) {
         flush_response_batch();
     }
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2975,6 +2975,13 @@ public:
 
 void
 reactor::wakeup() {
+    if (!_sleeping.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    // We are free to clear it, because we're sending a signal now
+    _sleeping.store(false, std::memory_order_relaxed);
+
     uint64_t one = 1;
     ::write(_notify_eventfd.get(), &one, sizeof(one));
 }
@@ -3633,11 +3640,7 @@ smp_message_queue::lf_queue::maybe_wakeup() {
     //
     // However, we do need a compiler barrier:
     std::atomic_signal_fence(std::memory_order_seq_cst);
-    if (remote->_sleeping.load(std::memory_order_relaxed)) {
-        // We are free to clear it, because we're sending a signal now
-        remote->_sleeping.store(false, std::memory_order_relaxed);
-        remote->wakeup();
-    }
+    remote->wakeup();
 }
 
 smp_message_queue::lf_queue::~lf_queue() {


### PR DESCRIPTION
The alien and smp ones need _sleeping and _stopped. Both can be patched to be part of the public API.