### PR TITLE
include/seastar: do not include unused headers

### DIFF
--- a/include/seastar/http/handlers.hh
+++ b/include/seastar/http/handlers.hh
@@ -26,7 +26,6 @@
 #include <seastar/http/exception.hh>
 #include <seastar/http/reply.hh>
 
-#include <unordered_map>
 
 namespace seastar {
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -22,11 +22,6 @@
 #pragma once
 
 #ifndef SEASTAR_MODULE
-#include <iostream>
-#include <algorithm>
-#include <unordered_map>
-#include <queue>
-#include <bitset>
 #include <limits>
 #include <cctype>
 #include <vector>

--- a/include/seastar/http/json_path.hh
+++ b/include/seastar/http/json_path.hh
@@ -23,8 +23,6 @@
 
 #ifndef SEASTAR_MODULE
 #include <vector>
-#include <unordered_map>
-#include <tuple>
 #endif
 
 #include <seastar/http/common.hh>

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -32,8 +32,6 @@
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/sstring.hh>
-#include <string>
-#include <vector>
 #include <strings.h>
 #include <seastar/http/common.hh>
 #include <seastar/http/mime_types.hh>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.