### PR TITLE
io_tester: ensure that file object is valid when closing it

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -784,7 +784,9 @@ private:
             options.append_is_unlikely = true;
 
             return create_and_fill_file(fname, fsize, flags, options).then([](std::pair<file, uint64_t> p) {
-                return p.first.close();
+                return do_with(std::move(p.first), [] (auto& f) {
+                    return f.close();
+                });
             });
         });
     }


### PR DESCRIPTION
In the case of unlink workloads they create and fill
files and then close them right away.

This change ensures that the file object is valid
until close() finishes.