### PR TITLE
shared_token_bucket: resolve FIXME

### DIFF
--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -83,9 +83,7 @@ struct rovers<T, capped_release::no> {
         return wrapping_difference(tail.load(std::memory_order_relaxed) + limit, head.load(std::memory_order_relaxed));
     }
 
-    void release(T) {
-        std::abort(); // FIXME shouldn't even be compiled
-    }
+    void release(T) = delete;
 };
 
 template <typename T, typename Period, capped_release Capped, typename Clock = std::chrono::steady_clock>


### PR DESCRIPTION
The specialization of 'struct rovers' for 'capped_release::no'
does not support 'release()' member function. If it was called,
it would call abort().

This change resolves FIXME that demanded this member function
to not be compiled. Usage of '= delete' was introduced to break the
compilation if the user tries to use release().