### PR TITLE
reactor: fix crash during metrics gathering

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2545,7 +2545,9 @@ uint64_t
 reactor::pending_task_count() const {
     uint64_t ret = 0;
     for (auto&& tq : _task_queues) {
-        ret += tq->_q.size();
+        if (tq) {
+            ret += tq->_q.size();
+        }
     }
     return ret;
 }


### PR DESCRIPTION
The crash is caused by statistics request while scheduling_group is removed. The tasks_pending metric gathering triggers reactor::pending_task_count() call. This call causes null pointer derefence as the task queue pointer has been reset in reactor::destroy_scheduling_group()