### PR TITLE
gate: add try_hold

### DIFF
--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -280,6 +280,13 @@ public:
         return holder(*this);
     }
 
+    /// Try getting an optional RAII-based gate::holder object that \ref enter "enter()s"
+    /// the gate when constructed and \ref leave "leave()s" it when destroyed.
+    /// Returns std::nullopt iff the gate is closed.
+    std::optional<holder> try_hold() noexcept {
+        return is_closed() ? std::nullopt : std::make_optional<holder>(*this);
+    }
+
 private:
 #ifdef SEASTAR_GATE_HOLDER_DEBUG
     using holders_list_t = boost::intrusive::list<holder,

--- a/tests/unit/closeable_test.cc
+++ b/tests/unit/closeable_test.cc
@@ -378,3 +378,19 @@ SEASTAR_TEST_CASE(gate_holder_parallel_copy_test) {
         });
     });
 }
+
+SEASTAR_THREAD_TEST_CASE(gate_holder_try_close_test) {
+    gate g;
+    auto gh0 = g.try_hold();
+    BOOST_CHECK(gh0.has_value());
+    auto fut = g.close();
+    BOOST_CHECK(g.is_closed());
+    auto failed_gh = g.try_hold();
+    BOOST_CHECK(!failed_gh.has_value());
+    auto gh1 = std::move(gh0);
+    BOOST_CHECK(!fut.available());
+    gh0.reset();
+    BOOST_CHECK(!fut.available());
+    gh1.reset();
+    fut.get();
+}


### PR DESCRIPTION
Add a method to try acquiring a gate holder
that gracefully returns nullopt if the gate
is already closed, rather than throwing an exception.