### PR TITLE
github: s/ubuntu-latest/ubuntu-24.04/

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,16 +32,14 @@ on:
 jobs:
   test:
     timeout-minutes: 40
-    runs-on: ubuntu-latest
-    container: fedora:40
+    runs-on: ubuntu-24.04
     steps:
-      - name: Install Git
-        run: |
-          sudo dnf -y install git
-
       - uses: actions/checkout@v4
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
+
+      - run: |
+          sudo apt-get update
 
       - name: Install build dependencies
         run: |
@@ -50,16 +48,16 @@ jobs:
       - name: Install clang++
         if: ${{ inputs.compiler == 'clang++' }}
         run: |
-          sudo dnf -y install clang
+          sudo apt-get -y install clang
 
       - name: Install clang-scan-deps
         if: ${{ contains(inputs.enables, 'cxx-modules') }}
         run: |
-          sudo dnf -y install clang-tools-extra
+          sudo apt-get -y install clang-tools
 
       - name: Install ccache
         run: |
-          sudo dnf -y install ccache
+          sudo apt-get -y install ccache
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1


### PR DESCRIPTION
Ubuntu 24.04 is now available, see
https://github.com/actions/runner-images/issues/9848

so instead of building and running the tests in a fedora 40 container, let's do the CI with the shinny ubuntu runner image, which preinstalls some of the necessary building dependencies, so in theory, it should be relatively faster than installing every package on fedora 40.

and since we are now using an image with git pre-installed, there is no need to install `git` anymore. so, in this change, we drop the step to install `git`.

because we are switching to a debian derivative distro, let's use apt-get instead of dnf to install packages.