### PR TITLE
build: run socket test with linux-aio reactor backend

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -420,7 +420,9 @@ seastar_add_test (app-template
   SOURCES app-template_test.cc)
 
 seastar_add_test (socket
-  SOURCES socket_test.cc)
+  SOURCES socket_test.cc
+  # https://github.com/scylladb/seastar/issues/2302
+  RUN_ARGS --reactor-backend linux-aio)
 
 seastar_add_test (sstring
   KIND BOOST


### PR DESCRIPTION
to workaround #2302, before it is fixed.

Refs #2302