### PR TITLE
io_queue: make queued I/O requests more generic

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -163,7 +163,7 @@ public:
     future<size_t> submit_io_write(internal::priority_class priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
-    void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
+    void request_dispatched() noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;
     void complete_request(io_desc_read_write& desc) noexcept;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -65,7 +65,6 @@ class io_sink;
 using shard_id = unsigned;
 using stream_id = unsigned;
 
-class io_desc_read_write;
 class queued_io_request;
 class io_group;
 
@@ -166,7 +165,7 @@ public:
     void request_dispatched() noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;
-    void complete_request(io_desc_read_write& desc) noexcept;
+    void complete_request(queued_io_request& req) noexcept;
 
     [[deprecated("I/O queue users should not track individual requests, but resources (weight, size) passing through the queue")]]
     size_t queued_requests() const {


### PR DESCRIPTION
Before this patch 'io_queue' was strongly oriented on read and write operations.
The top-level class called 'queued_io_request' depended on implementation details related
to 'io_sink' and 'internal::io_request' -- there was an assumption that all requests are routed
via the mentioned sink.

The interface of 'io_queue' contained four functions related to managing the execution of I/O requests.
1. 'void cancel_request(queued_io_request& req)'
2. 'void complete_cancelled_request(queued_io_request& req)'
3. 'void submit_request(io_desc_read_write* desc, internal::io_request req)'
4. 'void complete_request(io_desc_read_write& desc)'

Although the names of mentioned functions suggest that 'request' is a parameter, in two cases
an implementation detail related to 'io_sink' that is derived from 'io_completion' was used -- 'io_desc_read_write'.

The idea of this series of changes is to make 'io_queue' more generic to allow routing discard requests via it.
Unfortunately, discard requests cannot be routed via 'io_sink', because 'fallocate()' is not supported by Linux AIO.

This pull request:
- Removes the implementation details related to read and write operations from
'queued_io_request' class and makes it an abstract base for more specialized request types.
- Cleans the interface of 'io_queue' from the usage of types derived from 'io_completion'. A request
type may not use 'io_sink'. Therefore, 'io_queue' should not force the request types to use 'io_completion'
to finish the execution of a request.
- Allows request types derived from 'queued_io_request' to select the means to submit the
actual work to be performed - the assumption about routing each request via 'io_sink' is removed.
- Introduces a new type derived from 'queued_io_request' that is called 'queued_read_write_request'.
It encapsulates the logic required to handle read and write I/O requests.
- Moves the code of 'io_desc_read_write' to 'queued_read_write_request' to allow exclusive usage of
'queue_io_request' in the interface of 'io_queue'.

Refs: https://github.com/scylladb/scylladb/issues/14940