### PR TITLE
code-cleanup: explicitly depend on io_desc.hh

### DIFF
--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <cassert>
 #include <cstdint>

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -23,7 +23,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
-#include <seastar/core/internal/io_desc.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -31,6 +31,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/idle_cpu_handler.hh>
+#include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/io_request.hh>
 #include <seastar/core/internal/io_sink.hh>
 #include <seastar/core/iostream.hh>
@@ -140,7 +141,6 @@ void increase_thrown_exceptions_counter() noexcept;
 
 }
 
-class kernel_completion;
 class io_queue;
 SEASTAR_MODULE_EXPORT
 class io_intent;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/core/internal/poll.hh>
 #include <seastar/core/linux-aio.hh>


### PR DESCRIPTION
The mentioned header file contains 'kernel_completion' interface.
Multiple classes implement it. However, the files in which the
derived classes are defined very often do not explicitly include
the header file in which the base class is defined. Therefore,
they can be easily broken.

In some places like reactor.hh the dependency was implicit.
The mentioned header pulled 'kernel_completion' via 'pollable_fd.hh'.
The file with the definition of an interface was included implicitly
-- by another header file. Therefore, if anybody removed 'io_desc.hh'
include from 'pollable_fd.hh', then 'reactor.hh' would stop to compile.

This change ensures that the header which contains the definition of
'kernel_completion' interface is explicilty included in places that need
it. This patch also removes the includes of the mentioned header from
files that do not need it.