### PR TITLE
scripts/perftune.py: aRFS should be disabled by default in non-MQ mode

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -694,7 +694,7 @@ class NetPerfTuner(PerfTunerBase):
         op = "Enable"
         value = 'on'
 
-        if (self.args.enable_arfs is None and self.irqs_cpu_mask == self.cpu_mask) or self.args.enable_arfs is False:
+        if (self.args.enable_arfs is None and self.irqs_cpu_mask != self.cpu_mask) or self.args.enable_arfs is False:
             op = "Disable"
             value = 'off'
 


### PR DESCRIPTION
Commit 661367668f1e459bfd2f82450057d3944da7e20 introduced a regression by enabling ntuples by default for a configuration when the applicaiton CPUs and IRQ cpus are not the same.

Let's fix that.