### PR TITLE
code-cleanup: remove redundant includes of linux-aio.hh

### DIFF
--- a/include/seastar/core/internal/io_desc.hh
+++ b/include/seastar/core/internal/io_desc.hh
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <seastar/core/linux-aio.hh>
 #include <exception>
 
 namespace seastar {

--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/linux-aio.hh>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <cassert>

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -60,12 +60,6 @@ class io_intent;
 
 namespace internal {
 class io_sink;
-namespace linux_abi {
-
-struct io_event;
-struct iocb;
-
-}
 }
 
 using shard_id = unsigned;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -34,7 +34,6 @@
 #include <seastar/core/internal/io_request.hh>
 #include <seastar/core/internal/io_sink.hh>
 #include <seastar/core/iostream.hh>
-#include <seastar/core/linux-aio.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/make_task.hh>
 #include <seastar/core/manual_clock.hh>

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -63,7 +63,6 @@ module seastar;
 #include <seastar/core/reactor.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/report_exception.hh>
-#include <seastar/core/linux-aio.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/internal/magic.hh>
 #include <seastar/util/internal/iovec_utils.hh>

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -47,7 +47,6 @@ module seastar;
 #include <seastar/core/reactor.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/metrics.hh>
-#include <seastar/core/linux-aio.hh>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/io_sink.hh>
 #include <seastar/core/io_priority_class.hh>
@@ -59,7 +58,6 @@ namespace seastar {
 logger io_log("io");
 
 using namespace std::chrono_literals;
-using namespace internal::linux_abi;
 using io_direction_and_length = internal::io_direction_and_length;
 static constexpr auto io_direction_read = io_direction_and_length::read_idx;
 static constexpr auto io_direction_write = io_direction_and_length::write_idx;


### PR DESCRIPTION
There were places in the code where linux-aio.hh was included but not used.

This patch removes the redundant includes.