### PR TITLE
docker: fix mount of install-dependencies

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:mantic
 
-RUN --mount=type=bind,source=./install-dependencies.sh,target=./install-dependencies.sh \
+RUN --mount=type=bind,source=./install-dependencies.sh,target=/install-dependencies.sh \
     apt-get update && apt-get install -y \
     curl \
     gnupg \


### PR DESCRIPTION
`podman build` complains that the target path must be absolute; make it so. With this I can use `podman build` to build the dev container image.