### PR TITLE
code-cleanup: remove unneeded includes of fair_queue.hh

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -27,7 +27,6 @@
 #include <seastar/core/circular_buffer_fixed_capacity.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/enum.hh>
-#include <seastar/core/fair_queue.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/idle_cpu_handler.hh>

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -41,7 +41,6 @@ module;
 module seastar;
 #else
 #include <seastar/core/file.hh>
-#include <seastar/core/fair_queue.hh>
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/io_intent.hh>
 #include <seastar/core/reactor.hh>


### PR DESCRIPTION
Neither 'reactor.hh' nor 'reactor.cc' need to include 'fair_queue.hh'.

Moreover, inclusion of 'fair_queue.hh' does not need to be repeated
in 'io_queue.cc' -- the mentioned header is already included in 'io_queue.hh'.