### PR TITLE
code-cleanup: remove redundant includes of 'smp hh'

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -46,7 +46,6 @@
 #include <seastar/core/scheduling_specific.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread_cputime_clock.hh>

--- a/src/core/program_options.cc
+++ b/src/core/program_options.cc
@@ -35,7 +35,6 @@ module seastar;
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/resource.hh>
-#include <seastar/core/smp.hh>
 #endif
 
 namespace seastar::program_options {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -146,6 +146,7 @@ module seastar;
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/scheduling_specific.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/smp_options.hh>
 #include <seastar/core/stall_sampler.hh>
 #include <seastar/core/systemwide_memory_barrier.hh>

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -57,6 +57,7 @@ module seastar;
 #include <seastar/core/internal/uname.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
 #endif

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -54,7 +54,6 @@ module;
 module seastar;
 #else
 #include <seastar/util/log.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/util/log-cli.hh>
 
 #include <seastar/core/array_map.hh>

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -33,6 +33,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/stream.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/core/do_with.hh>

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -26,7 +26,6 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/io_queue.hh>


### PR DESCRIPTION
There were places in the code where 'smp.hh' was
included in spite of the fact, that it wasn't needed.

Moreover, 'reactor.hh' could have utilized only forward
declaration. It did not need to know the definitions
from 'smp.hh'.

This change adjusts the inclusion of 'smp.hh'.