### PR TITLE
code-cleanup: remove redundant includes of 'reactor.hh'

### DIFF
--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -42,7 +42,6 @@ module seastar;
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/util/noncopyable_function.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
 #endif
 

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -24,7 +24,6 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sharded.hh>

--- a/tests/unit/rest_api_httpd.cc
+++ b/tests/unit/rest_api_httpd.cc
@@ -27,7 +27,6 @@
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/file_handler.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/net/inet_address.hh>

--- a/tests/unit/spawn_test.cc
+++ b/tests/unit/spawn_test.cc
@@ -19,7 +19,6 @@
 /*
  * Copyright (C) 2022 Kefu Chai ( tchaikov@gmail.com )
  */
-#include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/log.hh>


### PR DESCRIPTION
There were files that included 'reactor.hh' although they did not need it.
The mentioned header contains many dependencies.

Therefore, this change removes redundant inclusion of 'reactor.hh'.