### PR TITLE
internal::io_request: add discard operation

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -523,6 +523,8 @@ sstring io_request::opname() const {
         return "poll remove";
     case io_request::operation::cancel:
         return "cancel";
+    case io_request::operation::discard:
+        return "discard";
     }
     std::abort();
 }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1471,6 +1471,7 @@ private:
             case o::poll_add:
             case o::poll_remove:
             case o::cancel:
+            case o::discard:
                 // The reactor does not generate these types of I/O requests yet, so
                 // this path is unreachable. As more features of io_uring are exploited,
                 // we'll utilize more of these opcodes.

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -509,3 +509,25 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_create_internal_discard_request) {
+    // Given discard request data.
+    const int fd{77};
+    const uint64_t offset{8192u};
+    const uint64_t length{4096u};
+
+    // When creating internal::io_request for it.
+    internal::io_request req = internal::io_request::make_discard(fd, offset, length);
+
+    // Then its operation name is correct.
+    const std::string expected_name{"discard"};
+    BOOST_REQUIRE_EQUAL(req.opname(), expected_name);
+
+    // And then discard request can be accessed and has properly set fields.
+    auto& discard_req = req.as<internal::io_request::operation::discard>();
+    BOOST_REQUIRE_EQUAL(discard_req.fd, fd);
+    BOOST_REQUIRE_EQUAL(discard_req.offset, offset);
+    BOOST_REQUIRE_EQUAL(discard_req.length, length);
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
This patch is a part of the preparation to route discard requests
via I/O scheduler. In spite of the fact that 'fallocate()' is
not supported by Linux AIO and thus reactor backend will not
support it, the existing infrastructure around io_queue is
going to use internal::io_request with the fields related to
discard operation.
    
This change extends internal::io_request with 'discard' operation type.