### PR TITLE
code-cleanup: add missing header guards

### DIFF
--- a/include/seastar/core/internal/read_state.hh
+++ b/include/seastar/core/internal/read_state.hh
@@ -19,6 +19,8 @@
  * Copyright 2021 ScyllaDB
  */
 
+#pragma once
+
 #ifndef SEASTAR_MODULE
 #include <cstring>
 #endif

--- a/include/seastar/core/relabel_config.hh
+++ b/include/seastar/core/relabel_config.hh
@@ -18,6 +18,9 @@
 /*
  * Copyright 2022 ScyllaDB
  */
+
+#pragma once
+
 #ifndef SEASTAR_MODULE
 #include <regex>
 #endif

--- a/include/seastar/http/short_streams.hh
+++ b/include/seastar/http/short_streams.hh
@@ -19,6 +19,8 @@
  * Copyright (C) 2021 ScyllaDB
  */
 
+#pragma once
+
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -19,6 +19,8 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
+#pragma once
+
 #include <seastar/core/sstring.hh>
 
 namespace seastar {

--- a/include/seastar/util/short_streams.hh
+++ b/include/seastar/util/short_streams.hh
@@ -19,6 +19,8 @@
  * Copyright (C) 2021 ScyllaDB
  */
 
+#pragma once
+
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/src/core/program_options.hh
+++ b/src/core/program_options.hh
@@ -19,6 +19,8 @@
  * Copyright (C) 2021 Cloudius Systems, Ltd.
  */
 
+#pragma once
+
 #ifndef SEASTAR_MODULE
 #include <boost/program_options.hpp>
 #include <optional>

--- a/tests/unit/tmpdir.hh
+++ b/tests/unit/tmpdir.hh
@@ -20,6 +20,8 @@
  * Copyright (C) 2020 ScyllaDB Ltd.
  */
 
+#pragma once
+
 #include <seastar/util/tmp_file.hh>
 
 namespace seastar {


### PR DESCRIPTION
The following command was executed to get
a list of headers that did not contain header guards:
'grep -rnw . -e "#pragma once" --include *.hh -L'

This change adds missing '#pragma once' to headers
that did not contain it.