### PR TITLE
Move output IO throttler to IO queue level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ add_library (seastar
   src/core/alien.cc
   src/core/file.cc
   src/core/fair_queue.cc
+  src/core/throttle.cc
   src/core/reactor_backend.cc
   src/core/thread_pool.cc
   src/core/app-template.cc

--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -74,7 +74,7 @@ int main(int ac, char** av) {
                             }
                             out << YAML::EndMap;
 
-                            const auto& fg = internal::get_fair_group(ioq, internal::io_direction_and_length::write_idx);
+                            const auto& fg = internal::io_throttle(ioq, internal::io_direction_and_length::write_idx);
                             out << YAML::Key << "per_tick_grab_threshold" << YAML::Value << fg.per_tick_grab_threshold();
 
                             const auto& tb = fg.token_bucket();

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -216,8 +216,8 @@ private:
     void unplug_priority_class(priority_class_data& pc) noexcept;
 
     enum class grab_result { grabbed, cant_preempt, pending };
-    grab_result grab_capacity(const fair_queue_entry& ent) noexcept;
-    grab_result grab_pending_capacity(const fair_queue_entry& ent) noexcept;
+    grab_result grab_capacity(capacity_t) noexcept;
+    grab_result grab_pending_capacity(capacity_t) noexcept;
 public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -116,6 +116,7 @@ private:
 
 protected:
     ~fair_queue_entry() = default;
+    void cancel() noexcept { _capacity = 0; }
 
 public:
     fair_queue_entry(capacity_t c) noexcept
@@ -234,11 +235,6 @@ public:
 
     void plug_class(class_id c) noexcept;
     void unplug_class(class_id c) noexcept;
-
-    /// Notifies that ont request finished
-    /// \param desc an instance of \c fair_queue_ticket structure describing the request that just finished.
-    void notify_request_finished(fair_queue_entry::capacity_t cap) noexcept;
-    void notify_request_cancelled(fair_queue_entry& ent) noexcept;
 
     /// Try to execute new requests if there is capacity left in the queue.
     void dispatch_requests();

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -26,7 +26,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/util/shared_token_bucket.hh>
+#include <seastar/core/internal/throttle.hh>
 
 #include <chrono>
 #include <cstdint>
@@ -125,148 +125,6 @@ public:
     capacity_t capacity() const noexcept { return _capacity; }
 };
 
-/// \brief Group of queues class
-///
-/// This is a fair group. It's attached by one or mode fair queues. On machines having the
-/// big* amount of shards, queues use the group to borrow/lend the needed capacity for
-/// requests dispatching.
-///
-/// * Big means that when all shards sumbit requests alltogether the disk is unable to
-/// dispatch them efficiently. The inability can be of two kinds -- either disk cannot
-/// cope with the number of arriving requests, or the total size of the data withing
-/// the given time frame exceeds the disk throughput.
-class shared_throttle {
-public:
-    using capacity_t = fair_queue_entry::capacity_t;
-    using clock_type = std::chrono::steady_clock;
-
-    /*
-     * tldr; The math
-     *
-     *    Bw, Br -- write/read bandwidth (bytes per second)
-     *    Ow, Or -- write/read iops (ops per second)
-     *
-     *    xx_max -- their maximum values (configured)
-     *
-     * Throttling formula:
-     *
-     *    Bw/Bw_max + Br/Br_max + Ow/Ow_max + Or/Or_max <= K
-     *
-     * where K is the scalar value <= 1.0 (also configured)
-     *
-     * Bandwidth is bytes time derivatite, iops is ops time derivative, i.e.
-     * Bx = d(bx)/dt, Ox = d(ox)/dt. Then the formula turns into
-     *
-     *   d(bw/Bw_max + br/Br_max + ow/Ow_max + or/Or_max)/dt <= K
-     *
-     * Fair queue tickets are {w, s} weight-size pairs that are
-     *
-     *   s = read_base_count * br, for reads
-     *       Br_max/Bw_max * read_base_count * bw, for writes
-     *
-     *   w = read_base_count, for reads
-     *       Or_max/Ow_max * read_base_count, for writes
-     *
-     * Thus the formula turns into
-     *
-     *   d(sum(w/W + s/S))/dr <= K
-     *
-     * where {w, s} is the ticket value if a request and sum summarizes the
-     * ticket values from all the requests seen so far, {W, S} is the ticket
-     * value that corresonds to a virtual summary of Or_max requests of
-     * Br_max size total.
-     */
-
-    /*
-     * The normalization results in a float of the 2^-30 seconds order of
-     * magnitude. Not to invent float point atomic arithmetics, the result
-     * is converted to an integer by multiplying by a factor that's large
-     * enough to turn these values into a non-zero integer.
-     *
-     * Also, the rates in bytes/sec when adjusted by io-queue according to
-     * multipliers become too large to be stored in 32-bit ticket value.
-     * Thus the rate resolution is applied. The t.bucket is configured with a
-     * time period for which the speeds from F (in above formula) are taken.
-     */
-
-    static constexpr float fixed_point_factor = float(1 << 24);
-    using rate_resolution = std::milli;
-    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::no>;
-
-private:
-
-    /*
-     * The dF/dt <= K limitation is managed by the modified token bucket
-     * algo where tokens are ticket.normalize(cost_capacity), the refill
-     * rate is K.
-     *
-     * The token bucket algo must have the limit on the number of tokens
-     * accumulated. Here it's configured so that it accumulates for the
-     * latency_goal duration.
-     *
-     * The replenish threshold is the minimal number of tokens to put back.
-     * It's reserved for future use to reduce the load on the replenish
-     * timestamp.
-     *
-     * The timestamp, in turn, is the time when the bucket was replenished
-     * last. Every time a shard tries to get tokens from bucket it first
-     * tries to convert the time that had passed since this timestamp
-     * into more tokens in the bucket.
-     */
-
-    token_bucket_t _token_bucket;
-    const capacity_t _per_tick_threshold;
-
-public:
-
-    // Convert internal capacity value back into the real token
-    static double capacity_tokens(capacity_t cap) noexcept {
-        return (double)cap / fixed_point_factor / token_bucket_t::rate_cast(std::chrono::seconds(1)).count();
-    }
-
-    // Convert floating-point tokens into the token bucket capacity
-    static capacity_t tokens_capacity(double tokens) noexcept {
-        return tokens * token_bucket_t::rate_cast(std::chrono::seconds(1)).count() * fixed_point_factor;
-    }
-
-    auto capacity_duration(capacity_t cap) const noexcept {
-        return _token_bucket.duration_for(cap);
-    }
-
-    struct config {
-        sstring label = "";
-        /*
-         * There are two "min" values that can be configured. The former one
-         * is the minimal weight:size pair that the upper layer is going to
-         * submit. However, it can submit _larger_ values, and the fair queue
-         * must accept those as large as the latter pair (but it can accept
-         * even larger values, of course)
-         */
-        double min_tokens = 0.0;
-        double limit_min_tokens = 0.0;
-        std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
-    };
-
-    explicit shared_throttle(config cfg, unsigned nr_queues);
-    shared_throttle(shared_throttle&&) = delete;
-
-    capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
-    capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
-    capacity_t grab_capacity(capacity_t cap) noexcept;
-    clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
-    void replenish_capacity(clock_type::time_point now) noexcept;
-    void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
-
-    capacity_t capacity_deficiency(capacity_t from) const noexcept;
-
-    std::chrono::duration<double> rate_limit_duration() const noexcept {
-        std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
-        return std::chrono::duration_cast<std::chrono::duration<double>>(dur);
-    }
-
-    const token_bucket_t& token_bucket() const noexcept { return _token_bucket; }
-};
-
 /// \brief Fair queuing class
 ///
 /// This is a fair queue, allowing multiple request producers to queue requests
@@ -299,7 +157,7 @@ public:
 
     using class_id = unsigned int;
     class priority_class_data;
-    using capacity_t = shared_throttle::capacity_t;
+    using capacity_t = fair_queue_entry::capacity_t;
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -135,7 +135,7 @@ public:
 /// dispatch them efficiently. The inability can be of two kinds -- either disk cannot
 /// cope with the number of arriving requests, or the total size of the data withing
 /// the given time frame exceeds the disk throughput.
-class fair_group {
+class shared_throttle {
 public:
     using capacity_t = fair_queue_entry::capacity_t;
     using clock_type = std::chrono::steady_clock;
@@ -247,8 +247,8 @@ public:
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };
 
-    explicit fair_group(config cfg, unsigned nr_queues);
-    fair_group(fair_group&&) = delete;
+    explicit shared_throttle(config cfg, unsigned nr_queues);
+    shared_throttle(shared_throttle&&) = delete;
 
     capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
@@ -299,7 +299,7 @@ public:
 
     using class_id = unsigned int;
     class priority_class_data;
-    using capacity_t = fair_group::capacity_t;
+    using capacity_t = shared_throttle::capacity_t;
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:
@@ -322,7 +322,7 @@ private:
     };
 
     config _config;
-    fair_group& _group;
+    shared_throttle& _group;
     clock_type::time_point _group_replenish;
     fair_queue_ticket _resources_executing;
     fair_queue_ticket _resources_queued;
@@ -364,7 +364,7 @@ public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///
     /// \param cfg an instance of the class \ref config
-    explicit fair_queue(fair_group& shared, config cfg);
+    explicit fair_queue(shared_throttle& shared, config cfg);
     fair_queue(fair_queue&&) = delete;
     ~fair_queue();
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -114,6 +114,9 @@ private:
     capacity_t _capacity;
     bi::slist_member_hook<> _hook;
 
+protected:
+    ~fair_queue_entry() = default;
+
 public:
     fair_queue_entry(capacity_t c) noexcept
         : _capacity(c) {}
@@ -123,6 +126,7 @@ public:
             bi::member_hook<fair_queue_entry, bi::slist_member_hook<>, &fair_queue_entry::_hook>>;
 
     capacity_t capacity() const noexcept { return _capacity; }
+    virtual void dispatch() = 0;
 };
 
 /// \brief Fair queuing class
@@ -247,7 +251,7 @@ public:
     void notify_request_cancelled(fair_queue_entry& ent) noexcept;
 
     /// Try to execute new requests if there is capacity left in the queue.
-    void dispatch_requests(std::function<void(fair_queue_entry&)> cb);
+    void dispatch_requests();
 
     clock_type::time_point next_pending_aio() const noexcept;
 

--- a/include/seastar/core/internal/throttle.hh
+++ b/include/seastar/core/internal/throttle.hh
@@ -1,0 +1,171 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2016 ScyllaDB
+ */
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/shared_token_bucket.hh>
+
+namespace seastar {
+
+/// \brief Group of queues class
+///
+/// This is a fair group. It's attached by one or mode fair queues. On machines having the
+/// big* amount of shards, queues use the group to borrow/lend the needed capacity for
+/// requests dispatching.
+///
+/// * Big means that when all shards sumbit requests alltogether the disk is unable to
+/// dispatch them efficiently. The inability can be of two kinds -- either disk cannot
+/// cope with the number of arriving requests, or the total size of the data withing
+/// the given time frame exceeds the disk throughput.
+class shared_throttle {
+public:
+    using capacity_t = uint64_t; // XXX -- this could be a template parameter
+    using clock_type = std::chrono::steady_clock;
+
+    /*
+     * tldr; The math
+     *
+     *    Bw, Br -- write/read bandwidth (bytes per second)
+     *    Ow, Or -- write/read iops (ops per second)
+     *
+     *    xx_max -- their maximum values (configured)
+     *
+     * Throttling formula:
+     *
+     *    Bw/Bw_max + Br/Br_max + Ow/Ow_max + Or/Or_max <= K
+     *
+     * where K is the scalar value <= 1.0 (also configured)
+     *
+     * Bandwidth is bytes time derivatite, iops is ops time derivative, i.e.
+     * Bx = d(bx)/dt, Ox = d(ox)/dt. Then the formula turns into
+     *
+     *   d(bw/Bw_max + br/Br_max + ow/Ow_max + or/Or_max)/dt <= K
+     *
+     * Fair queue tickets are {w, s} weight-size pairs that are
+     *
+     *   s = read_base_count * br, for reads
+     *       Br_max/Bw_max * read_base_count * bw, for writes
+     *
+     *   w = read_base_count, for reads
+     *       Or_max/Ow_max * read_base_count, for writes
+     *
+     * Thus the formula turns into
+     *
+     *   d(sum(w/W + s/S))/dr <= K
+     *
+     * where {w, s} is the ticket value if a request and sum summarizes the
+     * ticket values from all the requests seen so far, {W, S} is the ticket
+     * value that corresonds to a virtual summary of Or_max requests of
+     * Br_max size total.
+     */
+
+    /*
+     * The normalization results in a float of the 2^-30 seconds order of
+     * magnitude. Not to invent float point atomic arithmetics, the result
+     * is converted to an integer by multiplying by a factor that's large
+     * enough to turn these values into a non-zero integer.
+     *
+     * Also, the rates in bytes/sec when adjusted by io-queue according to
+     * multipliers become too large to be stored in 32-bit ticket value.
+     * Thus the rate resolution is applied. The t.bucket is configured with a
+     * time period for which the speeds from F (in above formula) are taken.
+     */
+
+    static constexpr float fixed_point_factor = float(1 << 24);
+    using rate_resolution = std::milli;
+    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::no>;
+
+private:
+
+    /*
+     * The dF/dt <= K limitation is managed by the modified token bucket
+     * algo where tokens are ticket.normalize(cost_capacity), the refill
+     * rate is K.
+     *
+     * The token bucket algo must have the limit on the number of tokens
+     * accumulated. Here it's configured so that it accumulates for the
+     * latency_goal duration.
+     *
+     * The replenish threshold is the minimal number of tokens to put back.
+     * It's reserved for future use to reduce the load on the replenish
+     * timestamp.
+     *
+     * The timestamp, in turn, is the time when the bucket was replenished
+     * last. Every time a shard tries to get tokens from bucket it first
+     * tries to convert the time that had passed since this timestamp
+     * into more tokens in the bucket.
+     */
+
+    token_bucket_t _token_bucket;
+    const capacity_t _per_tick_threshold;
+
+public:
+
+    // Convert internal capacity value back into the real token
+    static double capacity_tokens(capacity_t cap) noexcept {
+        return (double)cap / fixed_point_factor / token_bucket_t::rate_cast(std::chrono::seconds(1)).count();
+    }
+
+    // Convert floating-point tokens into the token bucket capacity
+    static capacity_t tokens_capacity(double tokens) noexcept {
+        return tokens * token_bucket_t::rate_cast(std::chrono::seconds(1)).count() * fixed_point_factor;
+    }
+
+    auto capacity_duration(capacity_t cap) const noexcept {
+        return _token_bucket.duration_for(cap);
+    }
+
+    struct config {
+        sstring label = "";
+        /*
+         * There are two "min" values that can be configured. The former one
+         * is the minimal weight:size pair that the upper layer is going to
+         * submit. However, it can submit _larger_ values, and the fair queue
+         * must accept those as large as the latter pair (but it can accept
+         * even larger values, of course)
+         */
+        double min_tokens = 0.0;
+        double limit_min_tokens = 0.0;
+        std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
+    };
+
+    explicit shared_throttle(config cfg, unsigned nr_queues);
+    shared_throttle(shared_throttle&&) = delete;
+
+    capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
+    capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
+    capacity_t grab_capacity(capacity_t cap) noexcept;
+    clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
+    void replenish_capacity(clock_type::time_point now) noexcept;
+    void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
+
+    capacity_t capacity_deficiency(capacity_t from) const noexcept;
+
+    std::chrono::duration<double> rate_limit_duration() const noexcept {
+        std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
+        return std::chrono::duration_cast<std::chrono::duration<double>>(dur);
+    }
+
+    const token_bucket_t& token_bucket() const noexcept { return _token_bucket; }
+};
+
+} // seastar namespace

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -171,7 +171,6 @@ public:
     throttle::grab_result can_dispatch_request(const queued_io_request& rq) noexcept;
     void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;
-    void complete_cancelled_request(queued_io_request& req) noexcept;
     void complete_request(io_desc_read_write& desc) noexcept;
 
     [[deprecated("I/O queue users should not track individual requests, but resources (weight, size) passing through the queue")]]

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -95,6 +95,7 @@ private:
     io_group_ptr _group;
     struct stream {
         fair_queue fq;
+        throttle thr;
         stream(shared_throttle&, fair_queue::config);
     };
     boost::container::static_vector<stream, 2> _streams;
@@ -167,6 +168,7 @@ public:
     future<size_t> submit_io_write(internal::priority_class priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
+    throttle::grab_result can_dispatch_request(const queued_io_request& rq) noexcept;
     void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -43,7 +43,7 @@ namespace seastar {
 
 class io_queue;
 namespace internal {
-const fair_group& get_fair_group(const io_queue& ioq, unsigned stream);
+const shared_throttle& io_throttle(const io_queue& ioq, unsigned stream);
 }
 
 #if SEASTAR_API_LEVEL < 7
@@ -97,7 +97,7 @@ private:
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;
-    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const shared_throttle& internal::io_throttle(const io_queue& ioq, unsigned stream);
 
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
@@ -218,16 +218,16 @@ public:
 private:
     friend class io_queue;
     friend struct ::io_queue_for_tests;
-    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const shared_throttle& internal::io_throttle(const io_queue& ioq, unsigned stream);
 
     const io_queue::config _config;
     size_t _max_request_length[2];
-    boost::container::static_vector<fair_group, 2> _fgs;
+    boost::container::static_vector<shared_throttle, 2> _fgs;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;
 
-    static fair_group::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
+    static shared_throttle::config make_throttle_config(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);
 };
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -93,7 +93,11 @@ public:
 private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     io_group_ptr _group;
-    boost::container::static_vector<fair_queue, 2> _streams;
+    struct stream {
+        fair_queue fq;
+        stream(shared_throttle&, fair_queue::config);
+    };
+    boost::container::static_vector<stream, 2> _streams;
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -222,7 +222,7 @@ private:
 
     const io_queue::config _config;
     size_t _max_request_length[2];
-    boost::container::static_vector<shared_throttle, 2> _fgs;
+    boost::container::static_vector<shared_throttle, 2> _throttle;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources (seastar-module
     core/exception_hacks.cc
     core/execution_stage.cc
     core/fair_queue.cc
+    core/throttle.cc
     core/file.cc
     core/fsnotify.cc
     core/fstream.cc

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -247,7 +247,7 @@ fair_queue::clock_type::time_point fair_queue::next_pending_aio() const noexcept
     return _throttle.next_pending();
 }
 
-void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
+void fair_queue::dispatch_requests() {
     capacity_t dispatched = 0;
     boost::container::small_vector<priority_class_ptr, 2> preempt;
 
@@ -297,7 +297,7 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         h._pure_accumulated += req_cap;
         dispatched += req_cap;
 
-        cb(req);
+        req.dispatch();
 
         if (h._plugged && !h._queue.empty()) {
             push_priority_class(h);

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -235,13 +235,6 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
     pc._queue.push_back(ent);
 }
 
-void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
-}
-
-void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {
-    ent._capacity = 0;
-}
-
 void fair_queue::dispatch_requests() {
     capacity_t dispatched = 0;
     boost::container::small_vector<priority_class_ptr, 2> preempt;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -102,41 +102,6 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
             std::max<int32_t>(a._size - b._size, 0));
 }
 
-shared_throttle::shared_throttle(config cfg, unsigned nr_queues)
-        : _token_bucket(fixed_point_factor,
-                        std::max<capacity_t>(fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
-                        tokens_capacity(cfg.min_tokens)
-                       )
-        , _per_tick_threshold(_token_bucket.limit() / nr_queues)
-{
-    if (tokens_capacity(cfg.min_tokens) > _token_bucket.threshold()) {
-        throw std::runtime_error("Fair-group replenisher limit is lower than threshold");
-    }
-}
-
-auto shared_throttle::grab_capacity(capacity_t cap) noexcept -> capacity_t {
-    assert(cap <= _token_bucket.limit());
-    return _token_bucket.grab(cap);
-}
-
-void shared_throttle::replenish_capacity(clock_type::time_point now) noexcept {
-    _token_bucket.replenish(now);
-}
-
-void shared_throttle::maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept {
-    auto now = clock_type::now();
-    auto extra = _token_bucket.accumulated_in(now - local_ts);
-
-    if (extra >= _token_bucket.threshold()) {
-        local_ts = now;
-        replenish_capacity(now);
-    }
-}
-
-auto shared_throttle::capacity_deficiency(capacity_t from) const noexcept -> capacity_t {
-    return _token_bucket.deficiency(from);
-}
-
 // Priority class, to be used with a given fair_queue
 class fair_queue::priority_class_data {
     friend class fair_queue;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -528,7 +528,7 @@ sstring io_request::opname() const {
 }
 
 const shared_throttle& io_throttle(const io_queue& ioq, unsigned stream) {
-    return ioq._group->_fgs[stream];
+    return ioq._group->_throttle[stream];
 }
 
 } // internal namespace
@@ -569,11 +569,11 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     auto& cfg = get_config();
     if (cfg.duplex) {
         static_assert(internal::io_direction_and_length::write_idx == 0);
-        _streams.emplace_back(_group->_fgs[0], make_fair_queue_config(cfg, "write"));
+        _streams.emplace_back(_group->_throttle[0], make_fair_queue_config(cfg, "write"));
         static_assert(internal::io_direction_and_length::read_idx == 1);
-        _streams.emplace_back(_group->_fgs[1], make_fair_queue_config(cfg, "read"));
+        _streams.emplace_back(_group->_throttle[1], make_fair_queue_config(cfg, "read"));
     } else {
-        _streams.emplace_back(_group->_fgs[0], make_fair_queue_config(cfg, "rw"));
+        _streams.emplace_back(_group->_throttle[0], make_fair_queue_config(cfg, "rw"));
     }
     _flow_ratio_update.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(_group->io_latency_goal() * cfg.flow_ratio_ticks));
 
@@ -602,7 +602,7 @@ shared_throttle::config io_group::make_throttle_config(const io_queue::config& q
 }
 
 std::chrono::duration<double> io_group::io_latency_goal() const noexcept {
-    return _fgs.front().rate_limit_duration();
+    return _throttle.front().rate_limit_duration();
 }
 
 io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
@@ -610,9 +610,9 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
     , _allocated_on(this_shard_id())
 {
     auto fg_cfg = make_throttle_config(_config);
-    _fgs.emplace_back(fg_cfg, nr_queues);
+    _throttle.emplace_back(fg_cfg, nr_queues);
     if (_config.duplex) {
-        _fgs.emplace_back(fg_cfg, nr_queues);
+        _throttle.emplace_back(fg_cfg, nr_queues);
     }
 
     auto goal = io_latency_goal();
@@ -629,10 +629,10 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
      */
     auto update_max_size = [this] (unsigned idx) {
         auto g_idx = _config.duplex ? idx : 0;
-        auto max_cap = _fgs[g_idx].maximum_capacity();
+        auto max_cap = _throttle[g_idx].maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
             auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
-            auto cap = _fgs[g_idx].tokens_capacity(tokens);
+            auto cap = _throttle[g_idx].tokens_capacity(tokens);
             if (cap > max_cap) {
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -304,7 +304,6 @@ public:
 
     virtual void dispatch() noexcept override {
         if (is_cancelled()) {
-            _ioq.complete_cancelled_request(*this);
             delete this;
             return;
         }
@@ -1053,9 +1052,6 @@ throttle::grab_result io_queue::can_dispatch_request(const queued_io_request& rq
 
 void io_queue::cancel_request(queued_io_request& req) noexcept {
     _queued_requests--;
-}
-
-void io_queue::complete_cancelled_request(queued_io_request& req) noexcept {
 }
 
 io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -317,6 +317,7 @@ public:
 
     void cancel() noexcept {
         _ioq.cancel_request(*this);
+        fair_queue_entry::cancel();
         _desc.release()->cancel();
     }
 
@@ -555,7 +556,6 @@ void
 io_queue::complete_request(io_desc_read_write& desc) noexcept {
     _requests_executing--;
     _requests_completed++;
-    _streams[desc.stream()].fq.notify_request_finished(desc.capacity());
 }
 
 fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring label) {
@@ -1053,11 +1053,9 @@ throttle::grab_result io_queue::can_dispatch_request(const queued_io_request& rq
 
 void io_queue::cancel_request(queued_io_request& req) noexcept {
     _queued_requests--;
-    _streams[req.stream()].fq.notify_request_cancelled(req);
 }
 
 void io_queue::complete_cancelled_request(queued_io_request& req) noexcept {
-    _streams[req.stream()].fq.notify_request_finished(req.capacity());
 }
 
 io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -211,6 +211,10 @@ public:
     metrics::metric_groups metric_groups;
 };
 
+io_queue::stream::stream(shared_throttle& st, fair_queue::config cfg)
+        : fq(st, std::move(cfg))
+{ }
+
 class io_desc_read_write final : public io_completion {
     io_queue& _ioq;
     io_queue::priority_class_data& _pclass;
@@ -551,7 +555,7 @@ void
 io_queue::complete_request(io_desc_read_write& desc) noexcept {
     _requests_executing--;
     _requests_completed++;
-    _streams[desc.stream()].notify_request_finished(desc.capacity());
+    _streams[desc.stream()].fq.notify_request_finished(desc.capacity());
 }
 
 fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring label) {
@@ -661,7 +665,7 @@ io_queue::~io_queue() {
     for (auto&& pc_data : _priority_classes) {
         if (pc_data) {
             for (auto&& s : _streams) {
-                s.unregister_priority_class(pc_data->fq_class());
+                s.fq.unregister_priority_class(pc_data->fq_class());
             }
         }
     }
@@ -833,8 +837,8 @@ void io_queue::register_stats(sstring name, priority_class_data& pc) {
     }
 
     for (auto&& s : _streams) {
-        for (auto&& m : s.metrics(pc.fq_class())) {
-            m(owner_l)(mnt_l)(class_l)(group_l)(sm::label("stream")(s.label()));
+        for (auto&& m : s.fq.metrics(pc.fq_class())) {
+            m(owner_l)(mnt_l)(class_l)(group_l)(sm::label("stream")(s.fq.label()));
             metrics.emplace_back(std::move(m));
         }
     }
@@ -866,7 +870,7 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         // This conveys all the information we need and allows one to easily group all classes from
         // the same I/O queue (by filtering by shard)
         for (auto&& s : _streams) {
-            s.register_priority_class(id, shares);
+            s.fq.register_priority_class(id, shares);
         }
         auto& pg = _group->find_or_create_class(pc);
         auto pc_data = std::make_unique<priority_class_data>(pc, shares, *this, pg);
@@ -920,12 +924,12 @@ fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length 
     const auto& cfg = get_config();
     auto tokens = internal::request_tokens(dnl, cfg);
     if (_flow_ratio <= cfg.flow_ratio_backpressure_threshold) {
-        return _streams[request_stream(dnl)].tokens_capacity(tokens);
+        return _streams[request_stream(dnl)].fq.tokens_capacity(tokens);
     }
 
     auto stream = request_stream(dnl);
-    auto cap = _streams[stream].tokens_capacity(tokens * _flow_ratio);
-    auto max_cap = _streams[stream].maximum_capacity();
+    auto cap = _streams[stream].fq.tokens_capacity(tokens * _flow_ratio);
+    auto max_cap = _streams[stream].fq.maximum_capacity();
     return std::min(cap, max_cap);
 }
 
@@ -949,7 +953,7 @@ future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direc
             queued_req->set_intent(cq);
         }
 
-        _streams[queued_req->stream()].queue(pclass.fq_class(), queued_req->queue_entry());
+        _streams[queued_req->stream()].fq.queue(pclass.fq_class(), queued_req->queue_entry());
         queued_req.release();
         pclass.on_queue();
         _queued_requests++;
@@ -1032,7 +1036,7 @@ future<size_t> io_queue::submit_io_write(internal::priority_class pc, size_t len
 
 void io_queue::poll_io_queue() {
     for (auto&& st : _streams) {
-        st.dispatch_requests([] (fair_queue_entry& fqe) {
+        st.fq.dispatch_requests([] (fair_queue_entry& fqe) {
             queued_io_request::from_fq_entry(fqe).dispatch();
         });
     }
@@ -1047,18 +1051,18 @@ void io_queue::submit_request(io_desc_read_write* desc, internal::io_request req
 
 void io_queue::cancel_request(queued_io_request& req) noexcept {
     _queued_requests--;
-    _streams[req.stream()].notify_request_cancelled(req.queue_entry());
+    _streams[req.stream()].fq.notify_request_cancelled(req.queue_entry());
 }
 
 void io_queue::complete_cancelled_request(queued_io_request& req) noexcept {
-    _streams[req.stream()].notify_request_finished(req.queue_entry().capacity());
+    _streams[req.stream()].fq.notify_request_finished(req.queue_entry().capacity());
 }
 
 io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {
     clock_type::time_point next = clock_type::time_point::max();
 
     for (const auto& s : _streams) {
-        clock_type::time_point n = s.next_pending_aio();
+        clock_type::time_point n = s.fq.next_pending_aio();
         if (n < next) {
             next = std::move(n);
         }
@@ -1072,7 +1076,7 @@ io_queue::update_shares_for_class(internal::priority_class pc, size_t new_shares
     auto& pclass = find_or_create_class(pc);
     pclass.update_shares(new_shares);
     for (auto&& s : _streams) {
-        s.update_shares_for_class(pclass.fq_class(), new_shares);
+        s.fq.update_shares_for_class(pclass.fq_class(), new_shares);
     }
 }
 
@@ -1102,13 +1106,13 @@ io_queue::rename_priority_class(internal::priority_class pc, sstring new_name) {
 
 void io_queue::throttle_priority_class(const priority_class_data& pc) noexcept {
     for (auto&& s : _streams) {
-        s.unplug_class(pc.fq_class());
+        s.fq.unplug_class(pc.fq_class());
     }
 }
 
 void io_queue::unthrottle_priority_class(const priority_class_data& pc) noexcept {
     for (auto&& s : _streams) {
-        s.plug_class(pc.fq_class());
+        s.fq.plug_class(pc.fq_class());
     }
 }
 

--- a/src/core/throttle.cc
+++ b/src/core/throttle.cc
@@ -1,0 +1,66 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2024 ScyllaDB
+ */
+
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <seastar/core/internal/throttle.hh>
+
+namespace seastar {
+
+shared_throttle::shared_throttle(config cfg, unsigned nr_queues)
+        : _token_bucket(fixed_point_factor,
+                        std::max<capacity_t>(fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
+                        tokens_capacity(cfg.min_tokens)
+                       )
+        , _per_tick_threshold(_token_bucket.limit() / nr_queues)
+{
+    if (tokens_capacity(cfg.min_tokens) > _token_bucket.threshold()) {
+        throw std::runtime_error("Fair-group replenisher limit is lower than threshold");
+    }
+}
+
+auto shared_throttle::grab_capacity(capacity_t cap) noexcept -> capacity_t {
+    assert(cap <= _token_bucket.limit());
+    return _token_bucket.grab(cap);
+}
+
+void shared_throttle::replenish_capacity(clock_type::time_point now) noexcept {
+    _token_bucket.replenish(now);
+}
+
+void shared_throttle::maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept {
+    auto now = clock_type::now();
+    auto extra = _token_bucket.accumulated_in(now - local_ts);
+
+    if (extra >= _token_bucket.threshold()) {
+        local_ts = now;
+        replenish_capacity(now);
+    }
+}
+
+auto shared_throttle::capacity_deficiency(capacity_t from) const noexcept -> capacity_t {
+    return _token_bucket.deficiency(from);
+}
+
+
+} // seastar namespace

--- a/src/core/throttle.cc
+++ b/src/core/throttle.cc
@@ -62,5 +62,53 @@ auto shared_throttle::capacity_deficiency(capacity_t from) const noexcept -> cap
     return _token_bucket.deficiency(from);
 }
 
+auto throttle::grab_pending_capacity(shared_throttle::capacity_t cap) noexcept -> grab_result {
+    _group.maybe_replenish_capacity(_group_replenish);
+
+    if (_group.capacity_deficiency(_pending->head)) {
+        return grab_result::pending;
+    }
+
+    if (cap > _pending->cap) {
+        return grab_result::cant_preempt;
+    }
+
+    _pending.reset();
+    return grab_result::grabbed;
+}
+
+auto throttle::grab_capacity(shared_throttle::capacity_t cap) noexcept -> grab_result {
+    if (_pending) {
+        return grab_pending_capacity(cap);
+    }
+
+    auto want_head = _group.grab_capacity(cap);
+    if (_group.capacity_deficiency(want_head)) {
+        _pending.emplace(want_head, cap);
+        return grab_result::pending;
+    }
+
+    return grab_result::grabbed;
+}
+
+throttle::clock_type::time_point throttle::next_pending() const noexcept {
+    if (_pending) {
+        /*
+         * We expect the disk to release the ticket within some time,
+         * but it's ... OK if it doesn't -- the pending wait still
+         * needs the head rover value to be ahead of the needed value.
+         *
+         * It may happen that the capacity gets released before we think
+         * it will, in this case we will wait for the full value again,
+         * which's sub-optimal. The expectation is that we think disk
+         * works faster, than it really does.
+         */
+        auto over = _group.capacity_deficiency(_pending->head);
+        auto ticks = _group.capacity_duration(over);
+        return std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::microseconds>(ticks);
+    }
+
+    return std::chrono::steady_clock::time_point::max();
+}
 
 } // seastar namespace

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -94,7 +94,6 @@ future<> perf_fair_queue::test(bool loc) {
         return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
             auto req = std::make_unique<local_fq_entry>(100, [&local, loc] {
                 local.executed++;
-                local.queue(loc).notify_request_finished(100);
             });
             local.queue(loc).queue(cid, *req);
             req.release();

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -32,19 +32,19 @@
 static constexpr fair_queue::class_id cid = 0;
 
 struct local_fq_and_class {
-    seastar::fair_group fg;
+    seastar::shared_throttle fg;
     seastar::fair_queue fq;
     seastar::fair_queue sfq;
     unsigned executed = 0;
 
-    static fair_group::config fg_config() {
-        fair_group::config cfg;
+    static shared_throttle::config fg_config() {
+        shared_throttle::config cfg;
         return cfg;
     }
 
     seastar::fair_queue& queue(bool local) noexcept { return local ? fq : sfq; }
 
-    local_fq_and_class(seastar::fair_group& sfg)
+    local_fq_and_class(seastar::shared_throttle& sfg)
         : fg(fg_config(), 1)
         , fq(fg, seastar::fair_queue::config())
         , sfq(sfg, seastar::fair_queue::config())
@@ -75,10 +75,10 @@ struct perf_fair_queue {
 
     seastar::sharded<local_fq_and_class> local_fq;
 
-    seastar::fair_group shared_fg;
+    seastar::shared_throttle shared_fg;
 
-    static fair_group::config fg_config() {
-        fair_group::config cfg;
+    static shared_throttle::config fg_config() {
+        shared_throttle::config cfg;
         return cfg;
     }
 

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -55,15 +55,15 @@ struct request {
 };
 
 class test_env {
-    fair_group _fg;
+    shared_throttle _fg;
     fair_queue _fq;
     std::vector<int> _results;
     std::vector<std::vector<std::exception_ptr>> _exceptions;
     fair_queue::class_id _nr_classes = 0;
     std::vector<request> _inflight;
 
-    static fair_group::config fg_config(unsigned cap) {
-        fair_group::config cfg;
+    static shared_throttle::config fg_config(unsigned cap) {
+        shared_throttle::config cfg;
         cfg.rate_limit_duration = std::chrono::microseconds(cap);
         return cfg;
     }

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -99,7 +99,6 @@ public:
                 if (processed < n) {
                     _results[req.index]++;
                 }
-                _fq.notify_request_finished(req.capacity());
                 processed++;
             }
             if (processed >= n) {
@@ -131,7 +130,6 @@ public:
             } catch (...) {
                 auto eptr = std::current_exception();
                 _exceptions[index].push_back(eptr);
-                _fq.notify_request_finished(req.capacity());
             }
         });
 

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -85,7 +85,7 @@ struct io_queue_for_tests {
     }
 
     void kick() {
-        for (auto&& fg : group->_fgs) {
+        for (auto&& fg : group->_throttle) {
             fg.replenish_capacity(std::chrono::steady_clock::now());
         }
     }


### PR DESCRIPTION
IO queue is responsible for two things:
- cross-class shares-based fair balancing
- throttling the flow of dispatching requests to obey disk model

The former is done with the help of fair_queue that implements rather simple "virtual capacity" model. The latter is done with the help of shared token bucket, but historically the throttling code was implemented as a part of fair_queue. That's not correct, fair queue has nothing to do with output flow control. This PR moves the throttling code out of fair_queue and makes IO-queue own it and use.