### PR TITLE
sstring: declare nested type with typename

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -716,7 +716,7 @@ string_type uninitialized_string(size_t size) {
     } else {
         string_type ret;
 #ifdef __cpp_lib_string_resize_and_overwrite
-        ret.resize_and_overwrite(size, [](string_type::value_type*, string_type::size_type n) { return n; });
+        ret.resize_and_overwrite(size, [](typename string_type::value_type*, typename string_type::size_type n) { return n; });
 #else
         ret.resize(size);
 #endif


### PR DESCRIPTION
per [temp.dep.type](https://eel.is/c++draft/temp.dep.type#5), `string_type::value_type` is considered a qualified name, and is a dependent type, so we have to prefix it with `typename` to make sure the compiler consider it as a type.

Fixes #2327
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>