### PR TITLE
Sanitize reactor configuration on start

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -330,7 +330,6 @@ private:
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
     pthread_t _thread_id alignas(seastar::cache_line_size) = pthread_self();
     bool _strict_o_direct = true;
-    bool _bypass_fsync = false;
     std::atomic<bool> _dying{false};
     gate _background_gate;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -331,7 +331,6 @@ private:
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
     pthread_t _thread_id alignas(seastar::cache_line_size) = pthread_self();
     bool _strict_o_direct = true;
-    bool _force_io_getevents_syscall = false;
     bool _bypass_fsync = false;
     std::atomic<bool> _dying{false};
     gate _background_gate;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -334,7 +334,6 @@ private:
     bool _force_io_getevents_syscall = false;
     bool _bypass_fsync = false;
     bool _have_aio_fsync = false;
-    bool _kernel_page_cache = false;
     std::atomic<bool> _dying{false};
     gate _background_gate;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -251,7 +251,6 @@ private:
     bool _stopped = false;
     bool _finished_running_tasks = false;
     condition_variable _stop_requested;
-    bool _handle_sigint = true;
     std::optional<future<std::unique_ptr<network_stack>>> _network_stack_ready;
     int _return = 0;
     promise<> _start_promise;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -428,6 +428,7 @@ private:
     future<temporary_buffer<char>>
     do_recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 
+    void configure(const reactor_options& opts);
     int do_run();
 public:
     explicit reactor(std::shared_ptr<smp> smp, alien::instance& alien, unsigned id, reactor_backend_selector rbs, reactor_config cfg);
@@ -468,8 +469,6 @@ public:
     void rename_queues(internal::priority_class pc, sstring new_name);
     /// @private
     void update_shares_for_queues(internal::priority_class pc, uint32_t shares);
-
-    void configure(const reactor_options& opts);
 
     server_socket listen(socket_address sa, listen_options opts = {});
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -324,7 +324,6 @@ private:
     sched_clock::duration _total_idle{0};
     sched_clock::duration _total_sleep;
     sched_clock::time_point _start_time = now();
-    std::chrono::nanoseconds _max_poll_time = calculate_poll_time();
     output_stream<char>::batch_flush_list_t _flush_batching;
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
     pthread_t _thread_id alignas(seastar::cache_line_size) = pthread_self();

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -305,7 +305,6 @@ private:
     task_queue_list _active_task_queues;
     task_queue_list _activating_task_queues;
     task_queue* _at_destroy_tasks;
-    sched_clock::duration _task_quota;
     task* _current_task = nullptr;
     /// Handler that will be called when there is no task to execute on cpu.
     /// It represents a low priority work.

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -329,7 +329,6 @@ private:
     output_stream<char>::batch_flush_list_t _flush_batching;
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
     pthread_t _thread_id alignas(seastar::cache_line_size) = pthread_self();
-    bool _strict_o_direct = true;
     std::atomic<bool> _dying{false};
     gate _background_gate;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -333,7 +333,6 @@ private:
     bool _strict_o_direct = true;
     bool _force_io_getevents_syscall = false;
     bool _bypass_fsync = false;
-    bool _have_aio_fsync = false;
     std::atomic<bool> _dying{false};
     gate _background_gate;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -261,7 +261,6 @@ private:
     metrics::internal::time_estimated_histogram _stalls_histogram;
     std::unique_ptr<internal::cpu_stall_detector> _cpu_stall_detector;
 
-    unsigned _max_task_backlog = 1000;
     timer<>::set_t _timers;
     timer<>::set_t::timer_list_t _expired_timers;
     timer<lowres_clock>::set_t _lowres_timers;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -29,6 +29,7 @@ namespace seastar {
 
 /// \cond internal
 struct reactor_config {
+    bool handle_sigint = true;
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;
 };

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -24,11 +24,13 @@
 #include <seastar/util/program-options.hh>
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/util/modules.hh>
+#include <seastar/core/scheduling.hh>
 
 namespace seastar {
 
 /// \cond internal
 struct reactor_config {
+    sched_clock::duration task_quota;
     bool handle_sigint = true;
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -31,6 +31,7 @@ namespace seastar {
 /// \cond internal
 struct reactor_config {
     sched_clock::duration task_quota;
+    std::chrono::nanoseconds max_poll_time;
     bool handle_sigint = true;
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -32,6 +32,7 @@ struct reactor_config {
     bool handle_sigint = true;
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;
+    bool force_io_getevents_syscall = false;
     bool kernel_page_cache = false;
     bool have_aio_fsync = false;
 };

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -36,6 +36,7 @@ struct reactor_config {
     bool kernel_page_cache = false;
     bool have_aio_fsync = false;
     unsigned max_task_backlog = 1000;
+    bool strict_o_direct = true;
     bool bypass_fsync = false;
 };
 /// \endcond

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -33,6 +33,7 @@ struct reactor_config {
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;
     bool kernel_page_cache = false;
+    bool have_aio_fsync = false;
 };
 /// \endcond
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -35,6 +35,7 @@ struct reactor_config {
     bool force_io_getevents_syscall = false;
     bool kernel_page_cache = false;
     bool have_aio_fsync = false;
+    unsigned max_task_backlog = 1000;
 };
 /// \endcond
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -36,6 +36,7 @@ struct reactor_config {
     bool kernel_page_cache = false;
     bool have_aio_fsync = false;
     unsigned max_task_backlog = 1000;
+    bool bypass_fsync = false;
 };
 /// \endcond
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -41,6 +41,7 @@ struct reactor_config {
     unsigned max_task_backlog = 1000;
     bool strict_o_direct = true;
     bool bypass_fsync = false;
+    bool no_poll_aio = false;
 };
 /// \endcond
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -32,6 +32,7 @@ struct reactor_config {
     bool handle_sigint = true;
     bool auto_handle_sigint_sigterm = true;
     unsigned max_networking_aio_io_control_blocks = 10000;
+    bool kernel_page_cache = false;
 };
 /// \endcond
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1592,7 +1592,6 @@ void reactor::configure(const reactor_options& opts) {
         _aio_eventfd = pollable_fd(file_desc::eventfd(0, 0));
     }
     set_bypass_fsync(opts.unsafe_bypass_fsync.get_value());
-    _force_io_getevents_syscall = opts.force_aio_syscalls.get_value();
     aio_nowait_supported = opts.linux_aio_nowait.get_value();
 }
 
@@ -4396,6 +4395,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .handle_sigint = !reactor_opts.no_handle_interrupt,
         .auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm,
         .max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value()),
+        .force_io_getevents_syscall = reactor_opts.force_aio_syscalls.get_value(),
         .kernel_page_cache = reactor_opts.kernel_page_cache.get_value(),
         .have_aio_fsync = reactor_opts.aio_fsync.get_value(),
     };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4395,9 +4395,10 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         memory::set_dump_memory_diagnostics_on_alloc_failure_kind(reactor_opts.dump_memory_diagnostics_on_alloc_failure_kind.get_value());
     }
 
-    reactor_config reactor_cfg;
-    reactor_cfg.auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm;
-    reactor_cfg.max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value());
+    reactor_config reactor_cfg = {
+        .auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm,
+        .max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value()),
+    };
 
     std::mutex mtx;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1569,7 +1569,6 @@ public:
 void reactor::configure(const reactor_options& opts) {
     _network_stack_ready = opts.network_stack.get_selected_candidate()(*opts.network_stack.get_selected_candidate_opts());
 
-    _handle_sigint = !opts.no_handle_interrupt;
     auto task_quota = opts.task_quota_ms.get_value() * 1ms;
     _task_quota = std::chrono::duration_cast<sched_clock::duration>(task_quota);
 
@@ -3219,7 +3218,7 @@ int reactor::do_run() {
     start_aio_eventfd_loop();
 
     if (_id == 0 && _cfg.auto_handle_sigint_sigterm) {
-       if (_handle_sigint) {
+       if (_cfg.handle_sigint) {
           _signals.handle_signal_once(SIGINT, [this] { stop(); });
        }
        _signals.handle_signal_once(SIGTERM, [this] { stop(); });
@@ -4396,6 +4395,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 
     reactor_config reactor_cfg = {
+        .handle_sigint = !reactor_opts.no_handle_interrupt,
         .auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm,
         .max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value()),
     };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1039,7 +1039,7 @@ struct reactor::task_queue::indirect_compare {
 reactor::reactor(std::shared_ptr<smp> smp, alien::instance& alien, unsigned id, reactor_backend_selector rbs, reactor_config cfg)
     : _smp(std::move(smp))
     , _alien(alien)
-    , _cfg(cfg)
+    , _cfg(std::move(cfg))
     , _notify_eventfd(file_desc::eventfd(0, EFD_CLOEXEC))
     , _task_quota_timer(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC))
     , _id(id)

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1576,8 +1576,6 @@ void reactor::configure(const reactor_options& opts) {
     csdc.stall_detector_reports_per_minute = opts.blocked_reactor_reports_per_minute.get_value();
     csdc.oneline = opts.blocked_reactor_report_format_oneline.get_value();
     _cpu_stall_detector->update_config(csdc);
-
-    aio_nowait_supported = opts.linux_aio_nowait.get_value();
 }
 
 pollable_fd
@@ -4399,6 +4397,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .no_poll_aio = !reactor_opts.poll_aio.get_value() || (reactor_opts.poll_aio.defaulted() && reactor_opts.overprovisioned),
     };
 
+    aio_nowait_supported = reactor_opts.linux_aio_nowait.get_value();
     std::mutex mtx;
 
 #ifdef SEASTAR_HEAPPROF

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1579,7 +1579,6 @@ void reactor::configure(const reactor_options& opts) {
     csdc.oneline = opts.blocked_reactor_report_format_oneline.get_value();
     _cpu_stall_detector->update_config(csdc);
 
-    _max_task_backlog = opts.max_task_backlog.get_value();
     _max_poll_time = opts.idle_poll_time_us.get_value() * 1us;
     if (opts.poll_mode) {
         _max_poll_time = std::chrono::nanoseconds::max();
@@ -2651,7 +2650,7 @@ void reactor::run_tasks(task_queue& tq) {
         ++_global_tasks_processed;
         // check at end of loop, to allow at least one task to run
         if (internal::scheduler_need_preempt()) {
-            if (tasks.size() <= _max_task_backlog) {
+            if (tasks.size() <= _cfg.max_task_backlog) {
                 break;
             } else {
                 // While need_preempt() is set, task execution is inefficient due to
@@ -4398,6 +4397,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .force_io_getevents_syscall = reactor_opts.force_aio_syscalls.get_value(),
         .kernel_page_cache = reactor_opts.kernel_page_cache.get_value(),
         .have_aio_fsync = reactor_opts.aio_fsync.get_value(),
+        .max_task_backlog = reactor_opts.max_task_backlog.get_value(),
     };
 
     std::mutex mtx;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1594,7 +1594,6 @@ void reactor::configure(const reactor_options& opts) {
     set_bypass_fsync(opts.unsafe_bypass_fsync.get_value());
     _force_io_getevents_syscall = opts.force_aio_syscalls.get_value();
     aio_nowait_supported = opts.linux_aio_nowait.get_value();
-    _have_aio_fsync = opts.aio_fsync.get_value();
 }
 
 pollable_fd
@@ -2393,7 +2392,7 @@ reactor::fdatasync(int fd) noexcept {
     if (_bypass_fsync) {
         return make_ready_future<>();
     }
-    if (_have_aio_fsync) {
+    if (_cfg.have_aio_fsync) {
         // Does not go through the I/O queue, but has to be deleted
         struct fsync_io_desc final : public io_completion {
             promise<> _pr;
@@ -4398,6 +4397,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .auto_handle_sigint_sigterm = reactor_opts._auto_handle_sigint_sigterm,
         .max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value()),
         .kernel_page_cache = reactor_opts.kernel_page_cache.get_value(),
+        .have_aio_fsync = reactor_opts.aio_fsync.get_value(),
     };
 
     std::mutex mtx;

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -210,7 +210,7 @@ aio_storage_context::submit_work() {
         return true;
     });
 
-    if (__builtin_expect(_r._kernel_page_cache, false)) {
+    if (__builtin_expect(_r._cfg.kernel_page_cache, false)) {
         // linux-aio is not asynchronous when the page cache is used,
         // so we don't want to call io_submit() from the reactor thread.
         //

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -465,11 +465,6 @@ file_desc reactor_backend_aio::make_timerfd() {
     return file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC|TFD_NONBLOCK);
 }
 
-unsigned
-reactor_backend_aio::max_polls() const {
-    return _r._cfg.max_networking_aio_io_control_blocks;
-}
-
 bool reactor_backend_aio::await_events(int timeout, const sigset_t* active_sigmask) {
     ::timespec ts = {};
     ::timespec* tsp = [&] () -> ::timespec* {
@@ -514,6 +509,7 @@ reactor_backend_aio::reactor_backend_aio(reactor& r)
     , _hrtimer_timerfd(make_timerfd())
     , _storage_context(_r)
     , _preempting_io(_r, _r._task_quota_timer, _hrtimer_timerfd)
+    , _polling_io(_r._cfg.max_networking_aio_io_control_blocks)
     , _hrtimer_poll_completion(_r, _hrtimer_timerfd)
     , _smp_wakeup_aio_completion(_r._notify_eventfd)
 {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -289,7 +289,7 @@ void aio_storage_context::schedule_retry() {
 bool aio_storage_context::reap_completions(bool allow_retry)
 {
     struct timespec timeout = {0, 0};
-    auto n = io_getevents(_io_context, 1, max_aio, _ev_buffer, &timeout, _r._force_io_getevents_syscall);
+    auto n = io_getevents(_io_context, 1, max_aio, _ev_buffer, &timeout, _r._cfg.force_io_getevents_syscall);
     if (n == -1 && errno == EINTR) {
         n = 0;
     }

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -291,13 +291,12 @@ public:
 
 class reactor_backend_aio : public reactor_backend {
     reactor& _r;
-    unsigned max_polls() const;
     file_desc _hrtimer_timerfd;
     aio_storage_context _storage_context;
     // We use two aio contexts, one for preempting events (the timer tick and
     // signals), the other for non-preempting events (fd poll).
     preempt_io_context _preempting_io; // Used for the timer tick and the high resolution timer
-    aio_general_context _polling_io{max_polls()}; // FIXME: unify with disk aio_context
+    aio_general_context _polling_io; // FIXME: unify with disk aio_context
     hrtimer_aio_completion _hrtimer_poll_completion;
     smp_wakeup_aio_completion _smp_wakeup_aio_completion;
     static file_desc make_timerfd();


### PR DESCRIPTION
Reactor initialization is pretty dispersed, which is natural taking its complexity. However, the way reactor::configure() works has some room for improvement. In particular -- this method initializes a bunch of on-board simple bool/int/duration/etc. members soon after the reactor is constructed. And some of such members are initialized construction-time with the help of reactor_config.

This PR removes most of the re-initialization happening in reactor::configure() and de-bloats the reactor class itself. For that, those simple members onto reactor_config, the instance of reactor_config is initialized once and is copied into reactor constructor.