### PR TITLE
core: fix -Wunused-but-set-variable

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1865,9 +1865,9 @@ configure(std::vector<resource::memory> m, bool mbind,
         get_cpu_mem().replace_memory_backing(sys_alloc);
     }
     get_cpu_mem().resize(total, sys_alloc);
+#ifdef SEASTAR_HAVE_NUMA
     size_t pos = 0;
     for (auto&& x : m) {
-#ifdef SEASTAR_HAVE_NUMA
         unsigned long nodemask = 1UL << x.nodeid;
         if (mbind) {
             auto start = get_cpu_mem().mem() + pos;
@@ -1888,9 +1888,9 @@ configure(std::vector<resource::memory> m, bool mbind,
             }
             ret_layout.ranges.push_back({.start = start, .end = start + x.bytes, .numa_node_id = x.nodeid});
         }
-#endif
         pos += x.bytes;
     }
+#endif
     return ret_layout;
 }
 


### PR DESCRIPTION
When configured with -DSeastar_NUMA=OFF, fix -Wunused-but-set-variable that triggers with clang-16.

```
seastar/src/core/memory.cc:1868:12: error: variable 'pos' set but not used [-Werror,-Wunused-but-set-variable]
    size_t pos = 0;
```