### PR TITLE
io_queue: rename io_desc_read_write to queued_io_request_completion

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -65,7 +65,7 @@ class io_sink;
 using shard_id = unsigned;
 using stream_id = unsigned;
 
-class io_desc_read_write;
+class queued_io_request_completion;
 class queued_io_request;
 class io_group;
 
@@ -163,10 +163,10 @@ public:
     future<size_t> submit_io_write(internal::priority_class priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
-    void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
+    void submit_request(queued_io_request_completion* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;
-    void complete_request(io_desc_read_write& desc) noexcept;
+    void complete_request(queued_io_request_completion& desc) noexcept;
 
     [[deprecated("I/O queue users should not track individual requests, but resources (weight, size) passing through the queue")]]
     size_t queued_requests() const {


### PR DESCRIPTION
This patch is a part of the preparation to route discard requests via I/O scheduler.

The mentioned 'io_desc_read_write' is used to track the completion of read and write requests submitted to 'io_sink'. It implements 'io_completion' interface -- its functions are invoked when the processing of a request via 'reactor_backend' is finished.

In spite of the fact that 'fallocate()' is not supported by Linux AIO and therefore, discards will not be submitted to 'io_sink' and processed by 'reactor_backend', discard requests will need to notify 'io_queue' about completion in the same way that reads and writes do. Thus, to avoid code duplication 'io_desc_read_write' is renamed to 'queued_io_request_completion' as it will be used by discard requests.