### PR TITLE
metrics: Use this_shard_id unconditionally

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -392,11 +392,7 @@ foreign_ptr<values_reference> get_values() {
 
 
 instance_id_type shard() {
-    if (engine_is_ready()) {
-        return to_sstring(this_shard_id());
-    }
-
-    return sstring("0");
+    return to_sstring(this_shard_id());
 }
 
 void impl::update_metrics_if_needed() {


### PR DESCRIPTION
https://github.com/scylladb/seastar/commit/a57b17c8f4cba96aa8ac09741f0ca8f07a208e0a changed the way `local_engine`
gets set. It's now only being set after the reactor has been fully
constructed.

This breaks a bunch of metrics that are being registered from the
reactor constructor (main scheduling group metrics, stall detector,
possibly more) as the metrics subsystem uses `engine_is_ready` which
internally checks whether `local_engine` is set. With this not being the
case it would set the shard id to 0 for all shards.

Remove the extra check to `engine_is_ready` as the shard id is
initialized before the reactor is being constructed so this is safe to
use directly.