### PR TITLE
file: document that close() returns the file object to uninitialized state

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -677,7 +677,8 @@ public:
     /// Closes the file.
     ///
     /// Flushes any pending operations and release any resources associated with
-    /// the file (except for stable storage).
+    /// the file (except for stable storage). Resets the file object back to
+    /// uninitialized state as if by assigning file() to it.
     ///
     /// \note
     /// \c close() never fails. It just reports errors and swallows them.


### PR DESCRIPTION
`file::close()` in `src/core/file.cc` empties `_file_impl` by moving it to a local shared pointer object, effectively reverting the file object to its default-constructed state. Document this fact as a part of the public API.

[Suggested](https://github.com/scylladb/scylladb/pull/19624#discussion_r1679973548) by @bhalevy.