### PR TITLE
native-stack: use queue::pop_eventually() in listener::accept()

### DIFF
--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -738,9 +738,7 @@ public:
             }
         }
         future<connection> accept() {
-            return _q.not_empty().then([this] {
-                return make_ready_future<connection>(_q.pop());
-            });
+            return _q.pop_eventually();
         }
         void abort_accept() {
             _q.abort(std::make_exception_ptr(std::system_error(ECONNABORTED, std::system_category())));


### PR DESCRIPTION
we could have following sequence:

1. listener.accept():
   1. `_q.not_empty()`
   2. the lambda passed to then() is scheduled, but not invoked yet
2. listener.abort_accept()
   1. `_q.abort()`, so `_q` is cleared
3. the lambda passed to `listener.accept()` is invoked
   1. in `queue<T>::pop()`, as the queue is empty, the application aborts, because of `assert(!_q.empty())`.

so, in this change, to address the potential racing between `accept()` and  `abort_accept()`, let's use `_q.pop_eventually()`, which checks for `_ex` when the future returned by `not_empty()` is fulfilled. this propagate the exception to the caller of `accept()`.

Fixes #2351
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>