### PR TITLE
Change pending_io container to chunked_fifo

### DIFF
--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/internal/io_request.hh>
 
 #include <concepts>
@@ -49,7 +49,7 @@ public:
 };
 
 class io_sink {
-    circular_buffer<pending_io_request> _pending_io;
+    chunked_fifo<pending_io_request> _pending_io;
 public:
     void submit(io_completion* desc, internal::io_request req) noexcept;
 
@@ -67,7 +67,7 @@ public:
             drained++;
         }
 
-        _pending_io.erase(_pending_io.begin(), it);
+        _pending_io.pop_front_n(drained);
         return drained;
     }
 };

--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -58,19 +58,16 @@ public:
     // draining should try to drain more
     requires std::is_invocable_r<bool, Fn, internal::io_request&, io_completion*>::value
     size_t drain(Fn&& consume) {
-        size_t pending = _pending_io.size();
         size_t drained = 0;
 
-        while (pending > drained) {
-            pending_io_request& req = _pending_io[drained];
-
+        for (auto& req : _pending_io) {
             if (!consume(req, req._completion)) {
                 break;
             }
             drained++;
         }
 
-        _pending_io.erase(_pending_io.begin(), _pending_io.begin() + drained);
+        _pending_io.erase(_pending_io.begin(), it);
         return drained;
     }
 };

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -415,14 +415,15 @@ void io_sink::submit(io_completion* desc, io_request req) noexcept {
 }
 
 std::vector<io_request::part> io_request::split(size_t max_length) {
-    if (_op == operation::read || _op == operation::write) {
+    auto op = opcode();
+    if (op == operation::read || op == operation::write) {
         return split_buffer(max_length);
     }
-    if (_op == operation::readv || _op == operation::writev) {
+    if (op == operation::readv || op == operation::writev) {
         return split_iovec(max_length);
     }
 
-    seastar_logger.error("Invalid operation for split: {}", static_cast<int>(_op));
+    seastar_logger.error("Invalid operation for split: {}", static_cast<int>(op));
     std::abort();
 }
 
@@ -492,7 +493,7 @@ std::vector<io_request::part> io_request::split_iovec(size_t max_length) {
 }
 
 sstring io_request::opname() const {
-    switch (_op) {
+    switch (opcode()) {
     case io_request::operation::fdatasync:
         return "fdatasync";
     case io_request::operation::write:

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -85,3 +85,6 @@ seastar_add_test (coroutine
 
 seastar_add_test (allocator
   SOURCES allocator_perf.cc)
+
+seastar_add_test (container
+  SOURCES container_perf.cc)

--- a/tests/perf/container_perf.cc
+++ b/tests/perf/container_perf.cc
@@ -1,0 +1,235 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2020 ScyllaDB Ltd.
+ */
+
+
+#include <boost/container/deque.hpp>
+#include <boost/container/options.hpp>
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/circular_buffer.hh>
+
+using trivial_elem = int;
+
+static constexpr size_t big_size = 10000;
+static constexpr size_t small_size = 3;
+
+// test should do this many iterations, at least, inside the "measured region"
+// to defray the cost of the start/stop measuring time pairs, which are expensive
+static constexpr size_t total_iters = 10000;
+
+
+struct nontrivial_elem {
+    nontrivial_elem(int x) : x{x} { perf_tests::do_not_optimize(this->x); }
+    nontrivial_elem(const nontrivial_elem&) = default;
+    nontrivial_elem& operator=(const nontrivial_elem&) = default;
+    ~nontrivial_elem() {
+        perf_tests::do_not_optimize(x);
+    }
+    int x;
+};
+
+struct fifo_traits {
+    template <typename T>
+    using type = chunked_fifo<T>;
+};
+
+struct circ_traits {
+    template <typename T>
+    using type = circular_buffer<T>;
+};
+
+struct boost_deque_traits {
+    using deque_opts = boost::container::deque_options_t<boost::container::block_bytes<16384u>>;
+
+    template <typename T>
+    using type = boost::container::deque<T, void, deque_opts>;
+};
+
+template <typename C>
+    requires requires(C c) { c.reserve(0); }
+void reserve(C& c, size_t size) {
+    c.reserve(size);
+}
+
+template <typename C>
+void reserve(C& c, size_t size) {}
+
+template <typename Traits, typename T>
+auto make_n(size_t size) {
+    using container = Traits::template type<T>;
+
+    perf_tests::do_not_optimize(size);
+
+    container c;
+    reserve(c, size);
+
+    for (size_t i = 0; i < size; i++) {
+        auto e = trivial_elem(i);
+        c.push_back(e);
+    }
+
+    perf_tests::do_not_optimize(c);
+
+    return c;
+}
+
+struct container_perf {};
+
+
+size_t outer_loops(size_t inner_size) {
+    return total_iters / inner_size + 1;
+}
+
+template <typename Traits>
+size_t iteration_bench(size_t size) {
+    auto c = make_n<Traits, trivial_elem>(size);
+    auto outer = outer_loops(size);
+
+    perf_tests::start_measuring_time();
+    for (size_t o = 0; o < outer; o++) {
+        for (auto& e : c) {
+            perf_tests::do_not_optimize(e);
+        }
+    }
+    perf_tests::stop_measuring_time();
+    return outer * size;
+}
+
+template <typename Traits>
+size_t index_bench(size_t size) {
+    auto c = make_n<Traits, trivial_elem>(size);
+    auto outer = outer_loops(size);
+
+    perf_tests::start_measuring_time();
+    for (size_t o = 0; o < outer; o++) {
+        for (size_t i = 0; i < size; i++) {
+            perf_tests::do_not_optimize(c[i]);
+        }
+    }
+    perf_tests::stop_measuring_time();
+    return size * outer;
+}
+
+template <typename Traits, typename T>
+size_t clear_bench(size_t size) {
+    auto c = make_n<Traits, T>(size);
+
+    perf_tests::start_measuring_time();
+    c.clear();
+    perf_tests::stop_measuring_time();
+
+    return size;
+}
+
+template <typename Traits, typename T>
+size_t erase_bench(size_t size) {
+    auto c = make_n<Traits, T>(size);
+
+    perf_tests::start_measuring_time();
+    c.erase(c.begin(), c.begin() + size / 2);
+    perf_tests::stop_measuring_time();
+
+    perf_tests::do_not_optimize(c);
+
+    return size / 2;
+}
+
+template <typename Traits, typename T>
+size_t erase_front_bench(size_t size) {
+    auto c = make_n<Traits, T>(size);
+
+    perf_tests::start_measuring_time();
+    c.pop_front_n(size / 2);
+    perf_tests::stop_measuring_time();
+
+    perf_tests::do_not_optimize(c);
+
+    return size / 2;
+}
+
+PERF_TEST_F(container_perf, erase_trivial_chunked_fifo) {
+    return erase_front_bench<fifo_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, erase_trivial_circular_buffer) {
+    return erase_bench<circ_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, erase_trivial_boost_deque) {
+    return erase_bench<boost_deque_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_nontrivial_chunked_fifo) {
+    return clear_bench<fifo_traits, nontrivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_nontrivial_circular_buffer) {
+    return clear_bench<circ_traits, nontrivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_nontrivial_boost_deque) {
+    return clear_bench<boost_deque_traits, nontrivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_trivial_chunked_fifo) {
+    return clear_bench<fifo_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_trivial_circular_buffer) {
+    return clear_bench<circ_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, clear_trivial_boost_deque) {
+    return clear_bench<boost_deque_traits, trivial_elem>(big_size);
+}
+
+PERF_TEST_F(container_perf, iter_big_chunked_fifo) {
+    return iteration_bench<fifo_traits>(big_size);
+}
+
+PERF_TEST_F(container_perf, iter_big_circular_buffer) {
+    return iteration_bench<circ_traits>(big_size);
+}
+
+PERF_TEST_F(container_perf, iter_big_boost_deque) {
+    return iteration_bench<boost_deque_traits>(big_size);
+}
+
+PERF_TEST_F(container_perf, index_big_circular_buffer) {
+    return index_bench<circ_traits>(big_size);
+}
+
+PERF_TEST_F(container_perf, index_big_boost_deque) {
+    return index_bench<boost_deque_traits>(big_size);
+}
+
+PERF_TEST_F(container_perf, iter_small_chunked_fifo) {
+    return iteration_bench<fifo_traits>(small_size);
+}
+
+PERF_TEST_F(container_perf, iter_small_circular_buffer) {
+    return iteration_bench<circ_traits>(small_size);
+}
+
+PERF_TEST_F(container_perf, iter_small_boost_deque) {
+    return iteration_bench<boost_deque_traits>(small_size);
+}
+


### PR DESCRIPTION
The end goal of this series is to swap out circular_buffer for chunked_fifo in the `io_sink::_pending_io` member. 

This is to avoid the large contiguous allocation done by
circular_buffer when there many pending IOs, as such allocations can
fail on a long running system due to fragmentation.

While we are in there, we also optimize the size of the io_request structure.

See https://github.com/scylladb/seastar/issues/2355 and individual changes for more context.


