### PR TITLE
scripts/perftune.py: clock source tweaking: special case Amazon and Google KVM virtualizations

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1157,8 +1157,10 @@ class ClocksourceManager:
     def _get_arch(self):
         try:
             virt = run_read_only_command(['systemd-detect-virt']).strip()
-            if virt == "kvm":
-                return virt
+            # According to https://www.freedesktop.org/software/systemd/man/latest/systemd-detect-virt.html
+            # 'amazon' and 'google' are returned for KVM guests.
+            if virt in ["kvm", "amazon", "google"]:
+                return "kvm"
         except:
             pass
         return platform.machine()


### PR DESCRIPTION
According to https://www.freedesktop.org/software/systemd/man/latest/systemd-detect-virt.html systemd-detect-virt is going to return 'amazon' for AWS Nitro-based VMs and may return 'google' for GCE VMs (which uses a KVM hypervisor).

In both these cases we want to use 'kvm-clock' as a clock source.

Fixes #2363