### PR TITLE
perftune.py: set clock source correctly on AWS Nitro KVM VMs to kvm-c…

### DIFF
--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1142,7 +1142,7 @@ class ClocksourceManager:
 
     def __init__(self, args):
         self.__args = args
-        self._preferred = {"x86_64": "tsc", "kvm": "kvm-clock"}
+        self._preferred = {"x86_64": "tsc", "kvm": "kvm-clock", "amazon": "kvm-clock"}
         self._arch = self._get_arch()
         self._available_clocksources_file = "/sys/devices/system/clocksource/clocksource0/available_clocksource"
         self._current_clocksource_file = "/sys/devices/system/clocksource/clocksource0/current_clocksource"
@@ -1157,7 +1157,7 @@ class ClocksourceManager:
     def _get_arch(self):
         try:
             virt = run_read_only_command(['systemd-detect-virt']).strip()
-            if virt == "kvm":
+            if virt == "kvm" or virt == "amazon":
                 return virt
         except:
             pass


### PR DESCRIPTION
…lock

If systemd-detect-virt returns 'amazon', set the clock to kvm-clock.

Ref https://www.freedesktop.org/software/systemd/man/latest/systemd-detect-virt.html Ref https://repost.aws/knowledge-center/manage-ec2-linux-clock-source

Fixes: https://github.com/scylladb/seastar/issues/2363