### PR TITLE
pollable_fd_state: use default-generated dtor

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -121,7 +121,7 @@ public:
 protected:
     explicit pollable_fd_state(file_desc fd, speculation speculate = speculation())
         : fd(std::move(fd)), events_known(speculate.events) {}
-    ~pollable_fd_state() {};
+    ~pollable_fd_state() = default;
 private:
     void maybe_no_more_recv();
     void maybe_no_more_send();


### PR DESCRIPTION
this is a follow-up of 97c300533994cd62d108a04b15f3d2a979472b00, which was using the default-generated dtor, but due to the build failure fixed by 2b7ee271934e4242feba658dbfe0022b3ce7a2c5, it switched to a hand-crafted one.

in this change, let's use the default-generated dtor. simpler this way.