### PR TITLE
net: Expose DNS error category

### DIFF
--- a/include/seastar/net/dns.hh
+++ b/include/seastar/net/dns.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <system_error>
 #include <vector>
 #include <unordered_map>
 #include <memory>
@@ -148,6 +149,13 @@ future<sstring> resolve_addr(const inet_address&);
 future<std::vector<srv_record>> get_srv_records(dns_resolver::srv_proto proto,
                                                 const sstring& service,
                                                 const sstring& domain);
+
+/**
+ * Error handling.
+ *
+ * The error_category instance used by exceptions thrown by DNS
+ */
+ const std::error_category& error_category();
 
 }
 

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -37,7 +37,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/print.hh>
-#include <system_error>
 
 namespace seastar::net {
 
@@ -117,11 +116,9 @@ public:
     }
 };
 
-static const ares_error_category ares_errorc;
-
 static void check_ares_error(int error) {
     if (error != ARES_SUCCESS) {
-        throw std::system_error(error, ares_errorc);
+        throw std::system_error(error, net::dns::error_category());
     }
 }
 
@@ -296,7 +293,7 @@ public:
             switch (status) {
             default:
                 dns_log.debug("Query failed: {}", status);
-                p->set_exception(std::system_error(status, ares_errorc, p->name));
+                p->set_exception(std::system_error(status, net::dns::error_category(), p->name));
                 break;
             case ARES_SUCCESS:
                 p->set_value(make_hostent(*host));
@@ -337,7 +334,7 @@ public:
             switch (status) {
             default:
                 dns_log.debug("Query failed: {}", status);
-                p->set_exception(std::system_error(status, ares_errorc, boost::lexical_cast<std::string>(p->addr)));
+                p->set_exception(std::system_error(status, net::dns::error_category(), boost::lexical_cast<std::string>(p->addr)));
                 break;
             case ARES_SUCCESS:
                 p->set_value(make_hostent(*host));
@@ -417,14 +414,14 @@ public:
                 reinterpret_cast<promise<srv_records> *>(arg));
             if (status != ARES_SUCCESS) {
                 dns_log.debug("Query failed: {}", status);
-                p->set_exception(std::system_error(status, ares_errorc));
+                p->set_exception(std::system_error(status, net::dns::error_category()));
                 return;
             }
             ares_srv_reply* start = nullptr;
             status = ares_parse_srv_reply(buf, len, &start);
             if (status != ARES_SUCCESS) {
                 dns_log.debug("Parse failed: {}", status);
-                p->set_exception(std::system_error(status, ares_errorc));
+                p->set_exception(std::system_error(status, net::dns::error_category()));
                 return;
             }
             try {
@@ -1216,6 +1213,12 @@ future<std::vector<net::inet_address>> net::inet_address::find_all(
     return dns::get_host_by_name(name, f).then([](hostent e) {
         return make_ready_future<std::vector<net::inet_address>>(std::move(e.addr_list));
     });
+}
+
+const std::error_category& net::dns::error_category() {
+    static const ares_error_category ares_errorc;
+
+    return ares_errorc;
 }
 
 }


### PR DESCRIPTION
In case user applications wish to examine and react to specific DNS errors, make `ares_error_category` accessible via
`seastar::net::dns::error_category()` in a similar fashion to `seastar::tls::error_category()`.