### PR TITLE
seastar.cc: include fmt/ranges.h

### DIFF
--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -116,6 +116,7 @@ module;
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <fmt/printf.h>
 #include <gnutls/crypto.h>
 #ifdef SEASTAR_HAVE_HWLOC


### PR DESCRIPTION
this change address the build failure with C++20 modules and fmt 11.

this change is a follow up of b8fc54d68a, which includes fmt/ranges.hh, and references `fmt::range_format_kind` in `sstring.hh`, but we failed to include this header in `src/seastar.cc`, hence we have following FTBFS when compiling the tree with C++20 modules support on a system with fmt 11 installed:
```
FAILED: src/CMakeFiles/seastar-module.dir/seastar.cc.o src/CMakeFiles/seastar-module.dir/seastar.pcm
/home/kefu/.local/bin/clang++ -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_HAVE_URING -DSEASTAR_MODULE -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -Dseastar_module_EXPORTS -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/debug/gen/include -I/home/kefu/dev/seastar/src -g -std=c++23 -fPIC -U_FORTIFY_SOURCE -Wno-include-angled-in-module-purview -MD -MT src/CMakeFiles/seastar-module.dir/seastar.cc.o -MF src/CMakeFiles/seastar-module.dir/seastar.cc.o.d @src/CMakeFiles/seastar-module.dir/seastar.cc.o.modmap -o src/CMakeFiles/seastar-module.dir/seastar.cc.o -c /home/kefu/dev/seastar/src/seastar.cc
In file included from /home/kefu/dev/seastar/src/seastar.cc:157:
In file included from /home/kefu/dev/seastar/include/seastar/core/abortable_fifo.hh:25:
In file included from /home/kefu/dev/seastar/include/seastar/core/future.hh:36:
In file included from /home/kefu/dev/seastar/include/seastar/core/task.hh:24:
In file included from /home/kefu/dev/seastar/include/seastar/core/scheduling.hh:30:
/home/kefu/dev/seastar/include/seastar/core/sstring.hh:889:13: error: explicit specialization of non-template struct 'range_format_kind'
  889 | struct fmt::range_format_kind<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>, char_type> : std::integral_constant<fmt::range_format, fmt::range_format::disabled>
      |             ^                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/seastar/include/seastar/core/sstring.hh:889:13: error: out-of-line definition of 'range_format_kind' does not match any declaration in namespace 'fmt'
  889 | struct fmt::range_format_kind<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>, char_type> : std::integral_constant<fmt::range_format, fmt::range_format::disabled>
      |        ~~~~~^
/home/kefu/dev/seastar/include/seastar/core/sstring.hh:889:137: error: no member named 'range_format' in namespace 'fmt'
  889 | struct fmt::range_format_kind<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>, char_type> : std::integral_constant<fmt::range_format, fmt::range_format::disabled>
      |                                                                                                                                    ~~~~~^
3 errors generated.
```