### PR TITLE
future: correctly document nested exception type emitted by `finally()`

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1632,7 +1632,7 @@ public:
      * If the original return value or the callback return value is an
      * exceptional future it will be propagated.
      *
-     * If both of them are exceptional - the std::nested_exception exception
+     * If both of them are exceptional - the seastar::nested_exception exception
      * with the callback exception on top and the original future exception
      * nested will be propagated.
      */


### PR DESCRIPTION
Since commit 73e3fbc1bc51 ("future: Use a new seastar::nested_exception in finally", 2020-06-23), `future::finally()` propagates a `seastar::nested_exception` instance rather than an `std::nested_exception` instance, in case both the original future, and the cleanup appended by `finally()`, resolve with exceptions. Update the documentation.

Fixes: 73e3fbc1bc51