### PR TITLE
reactor: Reset one-shot signal to DFL before handling

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3992,8 +3992,8 @@ void install_oneshot_signal_handler() {
         std::lock_guard<util::spinlock> g(lock);
         if (!handled) {
             handled = true;
-            Func();
             signal(sig, SIG_DFL);
+            Func();
         }
     };
     sigfillset(&sa.sa_mask);


### PR DESCRIPTION
While handling SEGV/ABRT signal yet another one (of the same kind) may pop up. In that case it will call the same handler again, dead-locking on the guard lock.