### PR TITLE
reactor: add missing includes of noncopyable_function.hh

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -55,8 +55,9 @@
 #include <seastar/net/api.hh>
 #include <seastar/util/eclipse.hh>
 #include <seastar/util/log.hh>
-#include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/std-compat.hh>
 #include "internal/pollable_fd.hh"
 
 #ifndef SEASTAR_MODULE

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -167,6 +167,7 @@ module seastar;
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/memory_diagnostics.hh>
+#include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/print_safe.hh>
 #include <seastar/util/process.hh>
 #include <seastar/util/read_first_line.hh>


### PR DESCRIPTION
Add missing include of noncopyable_function.hh in reactor.hh and reactor.cc, and fix lexical order.