### PR TITLE
WIP: route discards via the I/O queue

### DIFF
--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -425,6 +425,12 @@ private:
         return sub_req;
     }
     std::vector<part> split_iovec(size_t max_length);
+
+    io_request sub_req_discard(size_t relative_offset, size_t new_length) const {
+        auto& op = _discard;
+        return make_discard(op.fd, op.offset + relative_offset, new_length);
+    }
+    std::vector<part> split_discard(size_t max_length);
 };
 
 struct io_request::part {

--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -435,18 +435,23 @@ struct io_request::part {
 
 // Helper pair of IO direction and length
 struct io_direction_and_length {
-    size_t _directed_length; // bit 0 is R/W flag
+    size_t _directed_length; // bits 0 and 1 depict R/W/D flags
+
+    static constexpr int direction_bits_count = 2;
+    static constexpr int direction_bits_mask = (1 << direction_bits_count) - 1;
 
 public:
-    size_t length() const noexcept { return _directed_length >> 1; }
-    int rw_idx() const noexcept { return _directed_length & 0x1; }
+    size_t length() const noexcept { return _directed_length >> direction_bits_count; }
+    int rwd_idx() const noexcept { return _directed_length & direction_bits_mask; }
+
+    static constexpr int discard_idx = 2;
     static constexpr int read_idx = 1;
     static constexpr int write_idx = 0;
 
     io_direction_and_length(int idx, size_t val) noexcept
-            : _directed_length((val << 1) | idx)
+            : _directed_length((val << direction_bits_count) | idx)
     {
-        assert(idx == read_idx || idx == write_idx);
+        assert(idx == read_idx || idx == write_idx || idx == discard_idx);
     }
 };
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -65,7 +65,7 @@ class io_sink;
 using shard_id = unsigned;
 using stream_id = unsigned;
 
-class io_desc_read_write;
+class queued_io_request_completion;
 class queued_io_request;
 class io_group;
 
@@ -169,10 +169,10 @@ public:
     future<size_t> submit_io_write(internal::priority_class priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
-    void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
+    void submit_request(queued_io_request_completion* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;
     void complete_cancelled_request(queued_io_request& req) noexcept;
-    void complete_request(io_desc_read_write& desc, std::chrono::duration<double> delay) noexcept;
+    void complete_request(queued_io_request_completion& desc, std::chrono::duration<double> delay) noexcept;
 
     [[deprecated("I/O queue users should not track individual requests, but resources (weight, size) passing through the queue")]]
     size_t queued_requests() const {

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -147,6 +147,8 @@ public:
         unsigned long blocks_count_rate = std::numeric_limits<int>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;
         unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
+        unsigned disk_req_discard_to_read_multiplier = read_request_base_count;
+        unsigned disk_blocks_discard_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();
         size_t disk_write_saturation_length = std::numeric_limits<size_t>::max();
         sstring mountpoint = "undefined";

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -93,7 +93,7 @@ public:
 private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     io_group_ptr _group;
-    boost::container::static_vector<fair_queue, 2> _streams;
+    boost::container::static_vector<fair_queue, 3> _streams;
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;
@@ -205,6 +205,7 @@ public:
     struct request_limits {
         size_t max_read;
         size_t max_write;
+        size_t max_discard;
     };
 
     request_limits get_request_limits() const noexcept;
@@ -229,8 +230,8 @@ private:
     friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
     const io_queue::config _config;
-    size_t _max_request_length[2];
-    boost::container::static_vector<fair_group, 2> _fgs;
+    size_t _max_request_length[3];
+    boost::container::static_vector<fair_group, 3> _fgs;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -102,6 +102,7 @@ private:
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
     future<size_t> queue_one_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
+    void submit_blocks_discarding(queued_io_request_completion* desc, internal::io_request req) noexcept;
 
     // The fields below are going away, they are just here so we can implement deprecated
     // functions that used to be provided by the fair_queue and are going away (from both
@@ -170,6 +171,7 @@ public:
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
     future<size_t> submit_io_write(internal::priority_class priority_class,
             size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
+    future<size_t> submit_io_discard(internal::priority_class pc, size_t len, internal::io_request req, io_intent* intent) noexcept;
 
     void submit_request(queued_io_request_completion* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -505,6 +505,7 @@ public:
     future<> link_file(std::string_view oldpath, std::string_view newpath) noexcept;
     future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
+    future<> punch_hole(int fd, uint64_t offset, uint64_t length) noexcept;
     future<size_t> read_directory(int fd, char* buffer, size_t buffer_size);
 
     future<int> inotify_add_watch(int fd, std::string_view path, uint32_t flags);

--- a/include/seastar/util/file.hh
+++ b/include/seastar/util/file.hh
@@ -102,6 +102,18 @@ future<std::vector<temporary_buffer<char>>> read_entire_file(std::filesystem::pa
 /// \param path path of the file to be read.
 future<sstring> read_entire_file_contiguous(std::filesystem::path path);
 
+/// Removes a regular file via blocks discarding.
+///
+/// \param name name of the file to remove.
+///
+/// \note
+/// The removal is processed by the I/O queue according to its configuration.
+/// The removal may be delayed when the bandwidth is not available. The user
+/// must ensure, that the file is not used until the removal finishes.
+///
+/// Effectively: opens a file, unlinks it and punches holes until nothing is left.
+future<> remove_file_via_blocks_discarding(std::string_view name) noexcept;
+
 SEASTAR_MODULE_EXPORT_END
 /// @}
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -268,7 +268,9 @@ posix_file_impl::fcntl_short(int op, uintptr_t arg) noexcept {
 
 future<>
 posix_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
-    return engine().punch_hole(_fd, offset, length);
+    internal::maybe_priority_class_ref io_priority_class;
+    auto req = internal::io_request::make_discard(_fd, offset, length);
+    return _io_queue.submit_io_discard(internal::priority_class(io_priority_class), length, std::move(req), nullptr).discard_result();
 }
 
 future<>

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -268,13 +268,7 @@ posix_file_impl::fcntl_short(int op, uintptr_t arg) noexcept {
 
 future<>
 posix_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, offset, length] () mutable {
-        return wrap_syscall<int>(::fallocate(_fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE,
-            offset, length));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        return make_ready_future<>();
-    });
+    return engine().punch_hole(_fd, offset, length);
 }
 
 future<>

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -526,6 +526,8 @@ sstring io_request::opname() const {
         return "poll remove";
     case io_request::operation::cancel:
         return "cancel";
+    case io_request::operation::discard:
+        return "discard";
     }
     std::abort();
 }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -209,7 +209,7 @@ public:
     metrics::metric_groups metric_groups;
 };
 
-class io_desc_read_write final : public io_completion {
+class queued_io_request_completion final : public io_completion {
     io_queue& _ioq;
     io_queue::priority_class_data& _pclass;
     io_queue::clock_type::time_point _ts;
@@ -221,7 +221,7 @@ class io_desc_read_write final : public io_completion {
     uint64_t _dispatched_polls;
 
 public:
-    io_desc_read_write(io_queue& ioq, io_queue::priority_class_data& pc, stream_id stream, io_direction_and_length dnl, fair_queue_entry::capacity_t cap, iovec_keeper iovs)
+    queued_io_request_completion(io_queue& ioq, io_queue::priority_class_data& pc, stream_id stream, io_direction_and_length dnl, fair_queue_entry::capacity_t cap, iovec_keeper iovs)
         : _ioq(ioq)
         , _pclass(pc)
         , _ts(io_queue::clock_type::now())
@@ -279,7 +279,7 @@ class queued_io_request : private internal::io_request {
     const stream_id _stream;
     fair_queue_entry _fq_entry;
     internal::cancellable_queue::link _intent;
-    std::unique_ptr<io_desc_read_write> _desc;
+    std::unique_ptr<queued_io_request_completion> _desc;
 
     bool is_cancelled() const noexcept { return !_desc; }
 
@@ -289,7 +289,7 @@ public:
         , _ioq(q)
         , _stream(_ioq.request_stream(dnl))
         , _fq_entry(cap)
-        , _desc(std::make_unique<io_desc_read_write>(_ioq, pc, _stream, dnl, cap, std::move(iovs)))
+        , _desc(std::make_unique<queued_io_request_completion>(_ioq, pc, _stream, dnl, cap, std::move(iovs)))
     {
     }
 
@@ -558,7 +558,7 @@ void io_queue::lower_stall_threshold() noexcept {
 }
 
 void
-io_queue::complete_request(io_desc_read_write& desc, std::chrono::duration<double> delay) noexcept {
+io_queue::complete_request(queued_io_request_completion& desc, std::chrono::duration<double> delay) noexcept {
     _requests_executing--;
     _requests_completed++;
     _streams[desc.stream()].notify_request_finished(desc.capacity());
@@ -1060,7 +1060,7 @@ void io_queue::poll_io_queue() {
     }
 }
 
-void io_queue::submit_request(io_desc_read_write* desc, internal::io_request req) noexcept {
+void io_queue::submit_request(queued_io_request_completion* desc, internal::io_request req) noexcept {
     _queued_requests--;
     _requests_executing++;
     _requests_dispatched++;

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1467,6 +1467,7 @@ private:
             case o::poll_add:
             case o::poll_remove:
             case o::cancel:
+            case o::discard:
                 // The reactor does not generate these types of I/O requests yet, so
                 // this path is unreachable. As more features of io_uring are exploited,
                 // we'll utilize more of these opcodes.

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -508,3 +508,28 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_create_internal_discard_request) {
+    // Given discard request data.
+    const int fd{77};
+    const uint64_t offset{8192u};
+    const uint64_t length{4096u};
+
+    // When creating internal::io_request for it.
+    internal::io_request req = internal::io_request::make_discard(fd, offset, length);
+
+    // Then its opcode is set to discard.
+    BOOST_REQUIRE(req.opcode() == internal::io_request::operation::discard);
+
+    // And then its operation name is correct.
+    const std::string expected_name{"discard"};
+    BOOST_REQUIRE_EQUAL(req.opname(), expected_name);
+
+    // And then discard request can be accessed and has properly set fields.
+    auto& discard_req = req.as<internal::io_request::operation::discard>();
+    BOOST_REQUIRE_EQUAL(discard_req.fd, fd);
+    BOOST_REQUIRE_EQUAL(discard_req.offset, offset);
+    BOOST_REQUIRE_EQUAL(discard_req.length, length);
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
This set of changes is an another attempt to route discard requests
via the I/O queue to ensure, that they are issued to the drive in a
controlled way.

This PR:
- adds discard type to `internal::io_request`
- renames `io_desc_read_write` to `queued_io_request_completion` -- discards will use it too
- adds `discard_to_write_ratio` to `io-properties.yaml`
- adds `discard` direction to `io_direction_and_length`
- routes discard requests via the I/O queue
- introduces `remove_file_via_blocks_discarding()` function that can be used to remove files block by block