### PR TITLE
json2code_test: choose less popular port number

### DIFF
--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -32,11 +32,11 @@ import urllib.parse
 class TestJson2Code(unittest.TestCase):
     rest_api_httpd = None
     server = None
-    port = 10000
+    port = 15789
 
     @classmethod
     def setUpClass(cls):
-        args = [cls.rest_api_httpd, '--port', '10000', '--smp=2']
+        args = [cls.rest_api_httpd, '--port', f'{cls.port}', '--smp=2']
         cls.server = subprocess.Popen(args,
                                       stdin=subprocess.PIPE,
                                       stdout=subprocess.PIPE,


### PR DESCRIPTION
The json2code test uses hardcoded port 10000, which is a more popular port number than a randomly selected one, "because powers of 10" but also because it's used as the default port by Azurite.

I changed this to 15789 which was selected by asking an AI assistant to select a random port in the range 10,000-20,000 which would be a good port number.

The specific response was:

> Certainly! A good random port number in the range between 10,000 and 20,000 could be 15,789. This number is randomly chosen and not typically associated with well-known services, so it’s likely to be available for custom applications or services.