### PR TITLE
prometheus: sanitize label value for text protocol

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -19,6 +19,7 @@
  * Copyright (C) 2016 ScyllaDB
  */
 
+#include <fmt/core.h>
 #include <seastar/core/prometheus.hh>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
@@ -198,33 +199,35 @@ static void fill_metric(pm::MetricFamily& mf, const metrics::impl::metric_value&
     }
 }
 
-static std::string to_str(seastar::metrics::impl::data_type dt) {
+static std::ostream& operator<<(std::ostream& os, seastar::metrics::impl::data_type dt) {
     switch (dt) {
     case seastar::metrics::impl::data_type::GAUGE:
-        return "gauge";
+        return os << "gauge";
     case seastar::metrics::impl::data_type::COUNTER:
     case seastar::metrics::impl::data_type::REAL_COUNTER:
-        return "counter";
+        return os << "counter";
     case seastar::metrics::impl::data_type::HISTOGRAM:
-        return "histogram";
+        return os << "histogram";
     case seastar::metrics::impl::data_type::SUMMARY:
-        return "summary";
+        return os << "summary";
     }
-    return "untyped";
+    return os << "untyped";
 }
 
-static std::string to_str(const seastar::metrics::impl::metric_value& v) {
+static std::ostream& operator<<(std::ostream& os, const seastar::metrics::impl::metric_value& v) {
     switch (v.type()) {
     case seastar::metrics::impl::data_type::GAUGE:
     case seastar::metrics::impl::data_type::REAL_COUNTER:
-        return std::to_string(v.d());
+        fmt::print(os, "{:.6f}", v.d());
+        break;
     case seastar::metrics::impl::data_type::COUNTER:
-        return std::to_string(v.i());
+        fmt::print(os, "{}", v.i());
+        break;
     case seastar::metrics::impl::data_type::HISTOGRAM:
     case seastar::metrics::impl::data_type::SUMMARY:
         break;
     }
-    return ""; // we should never get here but it makes the compiler happy
+    return os;
 }
 
 /*
@@ -740,20 +743,19 @@ public:
     }
 };
 
-std::string get_value_as_string(std::stringstream& s, const mi::metric_value& value) noexcept {
+void write_value_as_string(std::stringstream& s, const mi::metric_value& value) noexcept {
     std::string value_str;
     try {
-        value_str = to_str(value);
+        s << value;
     } catch (const std::range_error& e) {
-        seastar_logger.debug("prometheus: get_value_as_string: {}: {}", s.str(), e.what());
-        value_str = "NaN";
+        seastar_logger.debug("prometheus: write_value_as_string: {}: {}", s.str(), e.what());
+        s << "NaN";
     } catch (...) {
         auto ex = std::current_exception();
         // print this error as it's ignored later on by `connection::start_response`
-        seastar_logger.error("prometheus: get_value_as_string: {}: {}", s.str(), ex);
+        seastar_logger.error("prometheus: write_value_as_string: {}: {}", s.str(), ex);
         std::rethrow_exception(std::move(ex));
     }
-    return value_str;
 }
 
 future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m, bool show_help, bool enable_aggregation, std::function<bool(const mi::labels_type&)> filter) {
@@ -775,7 +777,7 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
                     if (show_help && metric_family.metadata().d.str() != "") {
                         s << "# HELP " << name << " " <<  metric_family.metadata().d.str() << '\n';
                     }
-                    s << "# TYPE " << name << " " << to_str(metric_family.metadata().type) << '\n';
+                    s << "# TYPE " << name << " " << metric_family.metadata().type << '\n';
                     found = true;
                 }
                 if (should_aggregate) {
@@ -786,7 +788,8 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
                     write_histogram(s, ctx, name, value.get_histogram(), value_info.id.labels());
                 } else {
                     add_name(s, name, value_info.id.labels(), ctx);
-                    s << get_value_as_string(s, value) << '\n';
+                    write_value_as_string(s, value);
+                    s << '\n';
                 }
                 out.write(s.str()).get();
                 thread::maybe_yield();
@@ -799,7 +802,8 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
                         write_histogram(s, ctx, name, h.second.get_histogram(), h.first);
                     } else {
                         add_name(s, name, h.first, ctx);
-                        s << get_value_as_string(s, h.second) << '\n';
+                        write_value_as_string(s, h.second);
+                        s << '\n';
                     }
                     out.write(s.str()).get();
                     thread::maybe_yield();

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/loop.hh>
 #include <regex>
+#include <string_view>
 
 namespace seastar {
 
@@ -226,11 +227,29 @@ static std::string to_str(const seastar::metrics::impl::metric_value& v) {
     return ""; // we should never get here but it makes the compiler happy
 }
 
+/*
+ * Sanitizes the prometheus label value as per the line format rules and writes it out to the ostream:
+ * > label_value can be any sequence of UTF-8 characters, but the backslash (\), double-quote ("), and
+ * > line feed (\n) characters have to be escaped as \\, \", and \n, respectively.
+ */
+static void escape_and_write_label_value(std::ostream& s, std::string_view label_value) {
+    for (char c : label_value) {
+        switch (c) {
+            case '\\': s << R"(\\)"; break;
+            case '\"': s << R"(\")"; break;
+            case '\n': s << R"(\n)"; break;
+            default:   s << c;
+        }
+    }
+}
+
 static void add_name(std::ostream& s, const sstring& name, const std::map<sstring, sstring>& labels, const config& ctx) {
     s << name << "{";
     const char* delimiter = "";
     if (ctx.label) {
-        s << ctx.label->key()  << "=\"" << ctx.label->value() << '"';
+        s << ctx.label->key()  << "=\"";
+        escape_and_write_label_value(s, ctx.label->value());
+        s << '"';
         delimiter = ",";
     }
 
@@ -238,7 +257,9 @@ static void add_name(std::ostream& s, const sstring& name, const std::map<sstrin
         for (auto l : labels) {
             if (!boost::algorithm::starts_with(l.first, "__")) {
                 s << delimiter;
-                s << l.first  << "=\"" << l.second << '"';
+                s << l.first  << "=\"";
+                escape_and_write_label_value(s, l.second);
+                s << '"';
                 delimiter = ",";
             }
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -458,6 +458,10 @@ seastar_add_test (source_location
 seastar_add_test (shared_token_bucket
   SOURCES shared_token_bucket_test.cc)
 
+seastar_add_test (prometheus_http
+  SOURCES
+    prometheus_http_test.cc)
+
 function(seastar_add_certgen name)
   cmake_parse_arguments(CERT
     ""

--- a/tests/unit/prometheus_http_test.cc
+++ b/tests/unit/prometheus_http_test.cc
@@ -1,0 +1,93 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2024 ScyllaDB
+ */
+
+#include "loopback_socket.hh"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/prometheus.hh>
+#include <seastar/http/common.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/closeable.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+using namespace seastar;
+using namespace httpd;
+using namespace std::literals;
+
+namespace {
+
+struct test_metrics {
+    metrics::metric_groups _metrics;
+
+    void setup_metrics() {
+        _metrics.add_group("aaaa", {
+            metrics::make_gauge("int_test", [] { return 10; }, metrics::description{"simple minimal test"}),
+            metrics::make_gauge("double_test", [] { return 1234567654321.0; }, metrics::description{"test that a long double is printed fully and not in scientific notation"}),
+            metrics::make_counter("counter_test", [] () -> int64_t { return 1234567654321; }, metrics::description{"test with a long counter value"}),
+        });
+    }
+};
+
+future<> test_prometheus_metrics_body() {
+    test_metrics metrics;
+    metrics.setup_metrics();
+
+    co_await seastar::async([] {
+        loopback_connection_factory lcf(1);
+        http_server server("test");
+        loopback_socket_impl lsi(lcf);
+        httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
+
+        prometheus::config ctx;
+        add_prometheus_routes(server, ctx).get();
+
+        future<> client = seastar::async([&lsi] {
+            connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
+            input_stream<char> input(c_socket.input());
+            auto close_input = deferred_close(input);
+            output_stream<char> output(c_socket.output());
+            auto close_output = deferred_close(output);
+
+            output.write(sstring("GET /metrics HTTP/1.1\r\nHost: test\r\n\r\n")).get();
+            output.flush().get();
+            auto resp = input.read().get();
+            auto resp_str = std::string(resp.get(), resp.size());
+            BOOST_REQUIRE(std::ranges::search(resp_str, "200 OK"sv));
+
+            BOOST_REQUIRE_MESSAGE(std::ranges::search(resp_str, R"(seastar_aaaa_int_test{shard="0"} 10.000000)"sv), "Response: " + resp_str);
+            BOOST_REQUIRE_MESSAGE(std::ranges::search(resp_str, R"(seastar_aaaa_double_test{shard="0"} 1234567654321.000000)"sv), "Response: " + resp_str);
+            BOOST_REQUIRE_MESSAGE(std::ranges::search(resp_str, R"(seastar_aaaa_counter_test{shard="0"} 1234567654321)"sv), "Response: " + resp_str);
+        });
+
+        server.do_accepts(0).get();
+
+        client.get();
+        server.stop().get();
+    });
+}
+
+}
+
+SEASTAR_TEST_CASE(test_prometheus_metrics) {
+    return test_prometheus_metrics_body();
+}


### PR DESCRIPTION
This PR fixes a bug in the prometheus text-based endpoint where a label value with a special character (backslash (\), double-quote (") or line feed (\n)) makes the whole metrics output unparseable by prometheus.

The prometheus text protocol requires that the label value to be escaped. Note that this is only needed for the text protocol and not for the protobuf-based prometheus protocol.

> label_value can be any sequence of UTF-8 characters, but the backslash (\), double-quote ("), and line feed (\n) characters have to be escaped as \\, \", and \n, respectively.

From https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md


This also adds a new test (`prometheus_http_test.cc`) to validate the output of the text-based prometheus response. I've introduced this because it was simpler to make explicit checks on the text output than modifying `prometheus_test.py` and `metrics_tester.cc` to do that. I am open to give a go at working this into `prometheus_test.py` if you prefer that.

Finally, we switch to using `fmt::print` to format the metric value and the metric type instead of the originally used `std::to_string`. `std::to_string` is going to change its formatting behaviour in C++26 and so we prefer a more deterministic formatter here. The formatting matters because if the floating point numbers are converted to scientific notation, they can lose precision.

As an added benefit, using `fmt::print` writes these values to the output stream directly which means that we avoid a string copy when writing these values to the prometheus text-based response.
