### PR TITLE
fair_queue: Export the number of times class was activated

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -651,6 +651,7 @@ private:
         emit_one_metrics(out, "io_queue_starvation_time_sec");
         emit_one_metrics(out, "io_queue_consumption");
         emit_one_metrics(out, "io_queue_adjusted_consumption");
+        emit_one_metrics(out, "io_queue_activations");
     }
 
 public:


### PR DESCRIPTION
Activation of a class happens when it receives a request into its empty queue. When activated, class also updates its "accumulator" that's responsible for fair-selection of classes according to its shares. Each activation a class may lose some accumulator point, thus losing some portion of the disk capacity.

Knowing the activation rate is very useful, right now we only have some side ways to get an idea of this counter.