### PR TITLE
tests/unit: drop support of C++17

### DIFF
--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -32,25 +32,19 @@
 #include <chrono>
 #include <deque>
 #include <iterator>
-#if __has_include(<ranges>)
 #include <ranges>
-#endif
 #if __has_include(<version>)
 #include <version>
 #endif
 
 using namespace seastar;
 
-#ifdef __cpp_lib_concepts
 static_assert(std::weakly_incrementable<chunked_fifo<int>::iterator>);
 static_assert(std::weakly_incrementable<chunked_fifo<int>::const_iterator>);
 static_assert(std::sentinel_for<chunked_fifo<int>::iterator, chunked_fifo<int>::iterator>);
 static_assert(std::sentinel_for<chunked_fifo<int>::const_iterator, chunked_fifo<int>::const_iterator>);
-#endif
 
-#ifdef __cpp_lib_ranges
 static_assert(std::ranges::range<chunked_fifo<const int>>);
-#endif
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_small) {
     // Check all the methods of chunked_fifo but with a trivial type (int) and

--- a/tests/unit/circular_buffer_test.cc
+++ b/tests/unit/circular_buffer_test.cc
@@ -27,9 +27,7 @@
 #include <chrono>
 #include <deque>
 #include <random>
-#if __has_include(<ranges>)
 #include <ranges>
-#endif
 #if __has_include(<version>)
 #include <version>
 #endif
@@ -38,9 +36,7 @@
 
 using namespace seastar;
 
-#ifdef __cpp_lib_ranges
 static_assert(std::ranges::range<circular_buffer<int>>);
-#endif
 
 BOOST_AUTO_TEST_CASE(test_erasing) {
     circular_buffer<int> buf;


### PR DESCRIPTION
since we've dropped support for C++17, there is no need to check for the existance of C++20 headers or check for the macros which are defined for checking C++20 library support -- they should be available for a C++20 compiler and standard library.