### PR TITLE
Add ThreadSanitizer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,11 +182,45 @@ mark_as_advanced (
     CMAKE_EXE_LINKER_FLAGS_SANITIZE
     CMAKE_SHARED_LINKER_FLAGS_SANITIZE)
 
+set (CMAKE_CXX_FLAGS_SANITIZETHREAD
+  "-Os -g"
+  CACHE
+  STRING
+  "Flags used by the C++ compiler during sanitize-thread builds."
+  FORCE)
+
+set (CMAKE_C_FLAGS_SANITIZETHREAD
+  "-Os -g"
+  CACHE
+  STRING
+  "Flags used by the C compiler during sanitize-thread builds."
+  FORCE)
+
+set (CMAKE_EXE_LINKER_FLAGS_SANITIZETHREAD
+  ""
+  CACHE
+  STRING
+  "Flags used for linking binaries during sanitize-thread builds."
+  FORCE)
+
+set (CMAKE_SHARED_LINKER_FLAGS_SANITIZETHREAD
+  ""
+  CACHE
+  STRING
+  "Flags used by the shared libraries linker during sanitize-thread builds."
+  FORCE)
+
+mark_as_advanced (
+    CMAKE_CXX_FLAGS_SANITIZETHREAD
+    CMAKE_C_FLAGS_SANITIZETHREAD
+    CMAKE_EXE_LINKER_FLAGS_SANITIZETHREAD
+    CMAKE_SHARED_LINKER_FLAGS_SANITIZETHREAD)
+
 set (CMAKE_BUILD_TYPE
   "${CMAKE_BUILD_TYPE}"
   CACHE
   STRING
-  "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel Dev Sanitize."
+  "Choose the type of build, options are: None Debug Release RelWithDebInfo Dev Sanitize SanitizeThread."
   FORCE)
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -356,7 +390,7 @@ endif ()
 
 
 set (Seastar_TEST_ENVIRONMENT
-  "ASAN_OPTIONS=${Seastar_ASAN_OPTIONS};UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1;BOOST_TEST_CATCH_SYSTEM_ERRORS=no"
+  "ASAN_OPTIONS=${Seastar_ASAN_OPTIONS};UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1;TSAN_OPTIONS=halt_on_error=1;BOOST_TEST_CATCH_SYSTEM_ERRORS=no"
   CACHE
   STRING
   "Environment variables for running tests")
@@ -376,6 +410,12 @@ set (Seastar_SANITIZE
   CACHE
   STRING
   "Enable ASAN and UBSAN. Can be ON, OFF or DEFAULT (which enables it for Debug and Sanitize)")
+
+set (Seastar_SANITIZE_THREAD
+  "DEFAULT"
+  CACHE
+  STRING
+  "Enable TSAN. Can be ON, OFF or DEFAULT (which enables it for SanitizeThread)")
 
 set (Seastar_DEBUG_SHARED_PTR
   "DEFAULT"
@@ -888,6 +928,26 @@ if (condition)
       $<${condition}:Sanitizers::undefined_behavior>)
 endif ()
 
+tri_state_option (${Seastar_SANITIZE_THREAD}
+  DEFAULT_BUILD_TYPES "SanitizeThread"
+  CONDITION condition)
+if (condition)
+  if (NOT ThreadSanitizer_FOUND)
+    message (FATAL_ERROR "Thread sanitizer not found!")
+  endif ()
+  set (Seastar_Sanitizers_OPTIONS ${ThreadSanitizer_COMPILER_OPTIONS})
+  target_link_libraries (seastar
+    PUBLIC
+      $<${condition}:Sanitizers::thread>)
+  target_compile_definitions(seastar
+    PUBLIC
+      SEASTAR_NO_EXCEPTION_HACK)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Disabled because tsan doesn't support std::atomic_thread_fence
+    list (APPEND Seastar_PRIVATE_CXX_FLAGS -Wno-error=tsan)
+  endif ()
+endif ()
+
 # We only need valgrind to find uninitialized memory uses, so disable
 # the leak sanitizer.
 # To test with valgrind run "ctest -T memcheck"
@@ -961,6 +1021,10 @@ endif ()
 
 if (Sanitizers_FIBER_SUPPORT)
   list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_ASAN_FIBER_SUPPORT)
+endif ()
+
+if (ThreadSanitizer_FIBER_SUPPORT)
+  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_TSAN_FIBER_SUPPORT)
 endif ()
 
 if (Seastar_ALLOC_PAGE_SIZE)
@@ -1079,11 +1143,11 @@ foreach (definition
     SEASTAR_SHUFFLE_TASK_QUEUE)
   target_compile_definitions (seastar
     PUBLIC
-      $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:${definition}>)
+      $<$<IN_LIST:$<CONFIG>,Debug;Sanitize;SanitizeThread>:${definition}>)
 endforeach ()
 
 tri_state_option (${Seastar_DEBUG_SHARED_PTR}
-  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize" "SanitizeThread"
   CONDITION condition)
 if (condition)
   target_compile_definitions (seastar
@@ -1092,7 +1156,7 @@ if (condition)
 endif ()
 
 tri_state_option (${Seastar_DEBUG_SHARED_PTR}
-  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize" "SanitizeThread"
   CONDITION condition)
 if (condition)
   target_compile_definitions (seastar
@@ -1103,7 +1167,7 @@ endif ()
 include (CheckLibc)
 
 tri_state_option (${Seastar_STACK_GUARDS}
-  DEFAULT_BUILD_TYPES "Debug" "Sanitize" "Dev"
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize" "SanitizeThread" "Dev"
   CONDITION condition)
 if (condition)
   # check for -fstack-clash-protection together with -Werror, because

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ Build modes
 The configure.py script is a wrapper around cmake. The --mode argument
 maps to CMAKE_BUILD_TYPE, and supports the following modes
 
-|          | CMake mode          | Debug info | Optimi&shy;zations | Sanitizers   | Allocator | Checks   | Use for                                |
-| -------- | ------------------- | ---------- | ------------------ |------------- | --------- | -------- | -------------------------------------- |
-| debug    | `Debug`             | Yes        | `-O0`              | ASAN, UBSAN  | System    | All      | gdb                                    |
-| release  | `RelWithDebInfo`    | Yes        | `-O3`              | None         | Seastar   | Asserts  | production                             |
-| dev      | `Dev` (Custom)      | No         | `-O1`              | None         | Seastar   | Asserts  | build and test cycle                   |
-| sanitize | `Sanitize` (Custom) | Yes        | `-Os`              | ASAN, UBSAN  | System    | All      | second level of tests, track down bugs |
+|                 | CMake mode                | Debug info | Optimi&shy;zations | Sanitizers  | Allocator | Checks  | Use for                                |
+| --------------- | ------------------------- | ---------- | ------------------ | ----------- | --------- | ------- | -------------------------------------- |
+| debug           | `Debug`                   | Yes        | `-O0`              | ASAN, UBSAN | System    | All     | gdb                                    |
+| release         | `RelWithDebInfo`          | Yes        | `-O3`              | None        | Seastar   | Asserts | production                             |
+| dev             | `Dev` (Custom)            | No         | `-O1`              | None        | Seastar   | Asserts | build and test cycle                   |
+| sanitize        | `Sanitize` (Custom)       | Yes        | `-Os`              | ASAN, UBSAN | System    | All     | second level of tests, track down bugs |
+| sanitize-thread | `SanitizeThread` (Custom) | Yes        | `-Os`              | TSAN        | System    | All     | race detection                         |
 
 Note that seastar is more sensitive to allocators and optimizations than
 usual. A quick rule of the thumb of the relative performances is that

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -37,6 +37,13 @@ if (Sanitizers_UNDEFINED_BEHAVIOR_FOUND)
   set (Sanitizers_UNDEFINED_BEHAVIOR_COMPILER_OPTIONS "-fsanitize=undefined;-fno-sanitize=vptr")
 endif ()
 
+set (CMAKE_REQUIRED_FLAGS -fsanitize=thread)
+check_cxx_source_compiles ("int main() {}" Sanitizers_THREAD_FOUND)
+
+if (Sanitizers_THREAD_FOUND)
+  set (ThreadSanitizer_COMPILER_OPTIONS -fsanitize=thread)
+endif ()
+
 set (Sanitizers_COMPILER_OPTIONS
   ${Sanitizers_ADDRESS_COMPILER_OPTIONS}
   ${Sanitizers_UNDEFINED_BEHAVIOR_COMPILER_OPTIONS})
@@ -45,12 +52,20 @@ file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/Sanitizers_fiber_test.cc _saniti
 set (CMAKE_REQUIRED_FLAGS ${Sanitizers_COMPILER_OPTIONS})
 check_cxx_source_compiles ("${_sanitizers_fiber_test_code}" Sanitizers_FIBER_SUPPORT)
 
+file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/ThreadSanitizer_fiber_test.cc _thread_sanitizer_fiber_test_code)
+set (CMAKE_REQUIRED_FLAGS ${ThreadSanitizer_COMPILER_OPTIONS})
+check_cxx_source_compiles ("${_thread_sanitizer_fiber_test_code}" ThreadSanitizer_FIBER_SUPPORT)
+
 include (FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args (Sanitizers
   REQUIRED_VARS
     Sanitizers_ADDRESS_COMPILER_OPTIONS
     Sanitizers_UNDEFINED_BEHAVIOR_COMPILER_OPTIONS)
+
+find_package_handle_standard_args (ThreadSanitizer
+  REQUIRED_VARS
+    ThreadSanitizer_COMPILER_OPTIONS)
 
 if (Sanitizers_FOUND)
   if (NOT (TARGET Sanitizers::address))
@@ -69,5 +84,16 @@ if (Sanitizers_FOUND)
       PROPERTIES
         INTERFACE_COMPILE_OPTIONS "${Sanitizers_UNDEFINED_BEHAVIOR_COMPILER_OPTIONS}"
         INTERFACE_LINK_LIBRARIES "${Sanitizers_UNDEFINED_BEHAVIOR_COMPILER_OPTIONS}")
+  endif ()
+endif ()
+
+if (ThreadSanitizer_FOUND)
+  if (NOT (TARGET Sanitizers::thread))
+    add_library (Sanitizers::thread INTERFACE IMPORTED)
+
+    set_target_properties (Sanitizers::thread
+      PROPERTIES
+        INTERFACE_COMPILE_OPTIONS ${ThreadSanitizer_COMPILER_OPTIONS}
+        INTERFACE_LINK_LIBRARIES ${ThreadSanitizer_COMPILER_OPTIONS})
   endif ()
 endif ()

--- a/cmake/code_tests/ThreadSanitizer_fiber_test.cc
+++ b/cmake/code_tests/ThreadSanitizer_fiber_test.cc
@@ -1,0 +1,14 @@
+extern "C" {
+    void* __tsan_get_current_fiber();
+    void* __tsan_create_fiber(unsigned flags);
+    void __tsan_destroy_fiber(void* fiber);
+    void __tsan_switch_to_fiber(void* fiber, unsigned flags);
+}
+
+int main() {
+    void* new_fiber = __tsan_create_fiber(0);
+    void* main_fiber = __tsan_get_current_fiber();
+    __tsan_switch_to_fiber(new_fiber, 0);
+    __tsan_switch_to_fiber(main_fiber, 0);
+    __tsan_destroy_fiber(new_fiber);
+}

--- a/configure.py
+++ b/configure.py
@@ -169,7 +169,7 @@ MODES = seastar_cmake.SUPPORTED_MODES if args.mode == 'all' else [args.mode]
 # For convenience.
 tr = seastar_cmake.translate_arg
 
-MODE_TO_CMAKE_BUILD_TYPE = {'release': 'RelWithDebInfo', 'debug': 'Debug', 'dev': 'Dev', 'sanitize': 'Sanitize' }
+MODE_TO_CMAKE_BUILD_TYPE = {'release': 'RelWithDebInfo', 'debug': 'Debug', 'dev': 'Dev', 'sanitize': 'Sanitize', 'sanitize-thread' : 'SanitizeThread'}
 
 
 def configure_mode(mode):

--- a/include/seastar/core/thread_impl.hh
+++ b/include/seastar/core/thread_impl.hh
@@ -36,11 +36,17 @@ class thread_context;
 class scheduling_group;
 
 struct jmp_buf_link {
-#ifdef SEASTAR_ASAN_ENABLED
+#if defined(SEASTAR_ASAN_ENABLED) || defined(SEASTAR_TSAN_ENABLED)
     ucontext_t context;
+#ifdef SEASTAR_ASAN_ENABLED
     void* fake_stack = nullptr;
     const void* stack_bottom;
     size_t stack_size;
+#endif
+#ifdef SEASTAR_TSAN_ENABLED
+    void* fiber = nullptr;
+    bool destroy_tsan_fiber = false;
+#endif
 #else
     jmp_buf jmpbuf;
 #endif
@@ -52,6 +58,9 @@ public:
     void switch_out();
     void initial_switch_in_completed();
     void final_switch_out();
+#ifdef SEASTAR_TSAN_ENABLED
+    ~jmp_buf_link();
+#endif
 };
 
 extern thread_local jmp_buf_link* g_current_context;

--- a/include/seastar/util/std-compat.hh
+++ b/include/seastar/util/std-compat.hh
@@ -47,6 +47,10 @@ namespace std::pmr {
 #define SEASTAR_ASAN_ENABLED
 #endif
 
+#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
+#define SEASTAR_TSAN_ENABLED
+#endif
+
 #if __has_include(<source_location>)
 #include <source_location>
 #endif

--- a/seastar_cmake.py
+++ b/seastar_cmake.py
@@ -17,7 +17,7 @@
 
 import os
 
-SUPPORTED_MODES = ['release', 'debug', 'dev', 'sanitize']
+SUPPORTED_MODES = ['release', 'debug', 'dev', 'sanitize', 'sanitize-thread']
 
 ROOT_PATH = os.path.realpath(os.path.dirname(__file__))
 

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -103,7 +103,7 @@ posix_thread::posix_thread(attr a, std::function<void ()> func)
         throw std::system_error(r, std::system_category());
     }
 
-#ifndef SEASTAR_ASAN_ENABLED
+#if !defined(SEASTAR_ASAN_ENABLED) && !defined(SEASTAR_TSAN_ENABLED)
     auto stack_size = a._stack_size.size;
     if (!stack_size) {
         stack_size = 2 << 20;

--- a/src/testing/entry_point.cc
+++ b/src/testing/entry_point.cc
@@ -45,13 +45,13 @@ static void install_dummy_handler(int sig) {
 }
 
 int entry_point(int argc, char** argv) {
-#ifndef SEASTAR_ASAN_ENABLED
+#if !defined(SEASTAR_ASAN_ENABLED) && !defined(SEASTAR_TSAN_ENABLED)
     // Before we call into boost, install some dummy signal
     // handlers. This seems to be the only way to stop boost from
     // installing its own handlers, which disables our backtrace
     // printer. The real handler will be installed when the reactor is
     // constructed.
-    // If we are using ASAN, it has already installed a signal handler
+    // If we are using asan/tsan, it has already installed a signal handler
     // that does its own stack printing.
     for (int sig : {SIGSEGV, SIGABRT}) {
         install_dummy_handler(sig);

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -142,7 +142,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
         }
         auto operator()(const X& x) {
             return yield().then([this, &x] {
-                BOOST_REQUIRE(!destroyed);
+                assert(!destroyed);
                 return x.cpu_id_squared();
             });
         }
@@ -158,7 +158,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
         }
         auto operator()(int x) {
             return yield().then([this, x] {
-                BOOST_REQUIRE(!destroyed);
+                assert(!destroyed);
                 res += x;
             });
         }
@@ -169,7 +169,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
                 return x.map_reduce(reduce{result}, map{}).then([&result] {
                     long n = smp::count - 1;
                     long expected = (n * (n + 1) * (2*n + 1)) / 6;
-                    BOOST_REQUIRE_EQUAL(result, expected);
+                    assert(result == expected);
                 });
             });
         });
@@ -186,7 +186,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
         }
         auto operator()(const X& x) const {
             return yield().then([this, &x] {
-                BOOST_REQUIRE(!destroyed);
+                assert(!destroyed);
                 return x.cpu_id_squared();
             });
         }
@@ -199,7 +199,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
             destroyed = true;
         }
         auto operator()(long res, int x) {
-            BOOST_REQUIRE(!destroyed);
+            assert(!destroyed);
             return res + x;
         }
     };
@@ -208,7 +208,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
             return x.map_reduce0(map{}, 0L, reduce{}).then([] (long result) {
                 long n = smp::count - 1;
                 long expected = (n * (n + 1) * (2*n + 1)) / 6;
-                BOOST_REQUIRE_EQUAL(result, expected);
+                assert(result == expected);
             });
         });
     });
@@ -224,7 +224,7 @@ SEASTAR_TEST_CASE(test_map_lifetime) {
         }
         auto operator()(const X& x) const {
             return yield().then([this, &x] {
-                BOOST_REQUIRE(!destroyed);
+                assert(!destroyed);
                 return x.cpu_id_squared();
             });
         }
@@ -232,9 +232,9 @@ SEASTAR_TEST_CASE(test_map_lifetime) {
     return do_with_distributed<X>([] (distributed<X>& x) {
         return x.start().then([&x] {
             return x.map(map{}).then([] (std::vector<int> result) {
-                BOOST_REQUIRE_EQUAL(result.size(), smp::count);
+                assert(result.size() == smp::count);
                 for (size_t i = 0; i < (size_t)smp::count; i++) {
-                    BOOST_REQUIRE_EQUAL(result[i], i * i);
+                    assert(std::cmp_equal(result[i], i * i));
                 }
             });
         });

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -71,8 +71,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            assert(sgs[i].get_specific<int>(key1) == (i + 1) * factor);
+            assert(sgs[i].get_specific<ivec>(key2)[0] == (i + 1) * factor);
         }
 
     }).get();
@@ -81,7 +81,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            assert(expected_sum == sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -90,7 +90,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                assert(expected_sum == sum);
             });
 
         });
@@ -129,8 +129,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            assert(sgs[i].get_specific<int>(key1) == (i + 1) * factor);
+            assert(sgs[i].get_specific<ivec>(key2)[0] == (i + 1) * factor);
         }
 
     }).get();
@@ -139,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            assert(expected_sum == sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -148,7 +148,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                assert(expected_sum == sum);
             });
 
         });
@@ -191,8 +191,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            assert(sgs[i].get_specific<int>(key1) == (i + 1) * factor);
+            assert(sgs[i].get_specific<ivec>(key2)[0] == (i + 1) * factor);
         }
 
     }).get();
@@ -201,7 +201,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            assert(expected_sum == sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -210,7 +210,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                assert(expected_sum == sum);
             });
 
         });
@@ -234,7 +234,7 @@ SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) 
                                 internal::scheduling_group_index(*(attr.sched_group)));
 
             smp::invoke_on_all([sched_group_idx = internal::scheduling_group_index(*(attr.sched_group))] () {
-                BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()), sched_group_idx);
+                assert(internal::scheduling_group_index(current_scheduling_group()) == sched_group_idx);
             }).get();
         }).get();
     }).get();
@@ -326,7 +326,7 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     smp::invoke_on_all([&sgs, &keys] () {
         for (size_t s = 0; s < std::size(sgs); ++s) {
             for (size_t k = 0; k < std::size(keys); ++k) {
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-old-{}", s));
+                assert(sgs[s].get_specific<value>(keys[k])._sg_name == fmt::format("sg-old-{}", s));
                 sgs[s].get_specific<value>(keys[k])._id = 1;
             }
         }
@@ -339,9 +339,9 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     smp::invoke_on_all([&sgs, &keys] () {
         for (size_t s = 0; s < std::size(sgs); ++s) {
             for (size_t k = 0; k < std::size(keys); ++k) {
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-new-{}", s));
+                assert(sgs[s].get_specific<value>(keys[k])._sg_name == fmt::format("sg-new-{}", s));
                 // Checks that the value only saw a rename(), not a reconstruction.
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._id, 1);
+                assert(sgs[s].get_specific<value>(keys[k])._id == 1);
             }
         }
     }).get();
@@ -364,7 +364,7 @@ SEASTAR_THREAD_TEST_CASE(sg_create_check_unique_constructor_invocation) {
         check() {
             auto sg = current_scheduling_group();
             auto id = internal::scheduling_group_index(sg);
-            BOOST_REQUIRE(groups.count(id) == 0);
+            assert(groups.count(id) == 0);
             groups.emplace(id);
         }
     };


### PR DESCRIPTION
ThreadSanitizer helps to detect data races. The PR adds TSan support to seastar and a build mode where it is enabled. It allows to run seastar applications with ThreadSanitizer.

During testing, the sanitizer reported data races in the following places:
- already fixed 48c6888
- [exception_hacks.cc](https://github.com/scylladb/seastar/compare/master...devDDen:add-tsan-support?expand=1#diff-d2b16640353e324e5def6b7a674bb6f511f26cb1000521b35c6a211c68cb9a15) in `_Unwind_RaiseException` (fixed here)
- in `tests/unit/*` in `BOOST_REQUIRE` (fixed here) due to Boost.Test macros are not thread safe. To get an accurate stack trace, the Boost.Test library must be built with ThreadSanitizer