### PR TITLE
Make http::client::make_request() abortable

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -132,6 +132,8 @@ private:
     future<reply_ptr> maybe_wait_for_continue(const request& req);
     future<> write_body(const request& rq);
     future<reply_ptr> recv_reply();
+
+    void shutdown() noexcept;
 };
 
 /**

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -185,19 +185,20 @@ private:
 
     using connection_ptr = seastar::shared_ptr<connection>;
 
-    future<connection_ptr> get_connection();
-    future<connection_ptr> make_connection();
+    future<connection_ptr> get_connection(abort_source* as);
+    future<connection_ptr> make_connection(abort_source* as);
     future<> put_connection(connection_ptr con);
     future<> shrink_connections();
 
     template <std::invocable<connection&> Fn>
-    auto with_connection(Fn&& fn);
+    auto with_connection(Fn&& fn, abort_source*);
 
     template <typename Fn>
     requires std::invocable<Fn, connection&>
-    auto with_new_connection(Fn&& fn);
+    auto with_new_connection(Fn&& fn, abort_source*);
 
-    future<> do_make_request(connection& con, request& req, reply_handler& handle, std::optional<reply::status_type> expected);
+    future<> do_make_request(request req, reply_handler handle, abort_source*, std::optional<reply::status_type> expected);
+    future<> do_make_request(connection& con, request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
 
 public:
     /**

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -286,6 +286,18 @@ public:
     future<> make_request(request req, reply_handler handle, std::optional<reply::status_type> expected = std::nullopt);
 
     /**
+     * \brief Send the request and handle the response (abortable)
+     *
+     * Same as previous method, but aborts the request upon as.request_abort() call
+     *
+     * \param req -- request to be sent
+     * \param handle -- the response handler
+     * \param as -- abort source that aborts the request
+     * \param expected -- the optional expected reply status code, default is std::nullopt
+     */
+    future<> make_request(request req, reply_handler handle, abort_source& as, std::optional<reply::status_type> expected = std::nullopt);
+
+    /**
      * \brief Updates the maximum number of connections a client may have
      *
      * If the new limit is less than the amount of connections a client has, they will be

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -150,7 +150,7 @@ public:
      * The implementations of this method should return ready-to-use socket that will
      * be used by \ref client as transport for its http connections
      */
-    virtual future<connected_socket> make() = 0;
+    virtual future<connected_socket> make(abort_source*) = 0;
     virtual ~connection_factory() {}
 };
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -342,6 +342,10 @@ future<> client::make_request(request req, reply_handler handle, std::optional<r
     return do_make_request(std::move(req), std::move(handle), nullptr, std::move(expected));
 }
 
+future<> client::make_request(request req, reply_handler handle, abort_source& as, std::optional<reply::status_type> expected) {
+    return do_make_request(std::move(req), std::move(handle), &as, std::move(expected));
+}
+
 future<> client::do_make_request(request req, reply_handler handle, abort_source* as, std::optional<reply::status_type> expected) {
     return do_with(std::move(req), std::move(handle), [this, as, expected] (request& req, reply_handler& handle) mutable {
         return with_connection([this, &req, &handle, as, expected] (connection& con) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -45,7 +45,7 @@ class loopback_http_factory : public http::experimental::connection_factory {
     loopback_socket_impl lsi;
 public:
     explicit loopback_http_factory(loopback_connection_factory& f) : lsi(f) {}
-    virtual future<connected_socket> make() override {
+    virtual future<connected_socket> make(abort_source* as) override {
         return lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr()));
     }
 };


### PR DESCRIPTION
This PR adds abort_source& argument to client::make_request() method. With it, calling abort_source::request_abort() will break the request making process wherever it is and resolve the make_request() with abort_requested_exception exception.

One of the use-cases is to let client impose a timeout on the make_request(). For that, a timer should be armed that would request abort on the abort source passed to the method. In #2304 there was an attempt to put a timeout on connect() only, but this approach is more generic and allows aborting request at any stage, not only connecting.

Another scenario is stopping long operations on user request. There can be several examples of what "long" operation can be. One of them is simple connect() to the server -- TCP times out after 1 minute by default, and breaking this earlier can be useful. Another example of long operation is S3 file uploading. It may happen in "parts" and part can be of any size, so simple writing of the request body into the socket may take time.

fixes: #2409 
closes: #2304 