### PR TITLE
cmake: Depend on libbsd if DPDK depends on it

### DIFF
--- a/cmake/Finddpdk.cmake
+++ b/cmake/Finddpdk.cmake
@@ -129,6 +129,13 @@ find_package_handle_standard_args (dpdk
   REQUIRED_VARS
     ${dpdk_REQUIRED})
 
+# Depending on whether libbsd-dev exists at build time, DPDK may be built with a dependency on
+# libbsd. Note that other libraries in dpdk_PC_LIBRARIES are handled using separate logic
+# (see rte_libs above), thus the additional dependencies must be handled on a case by case basis.
+if ("bsd" IN_LIST dpdk_PC_LIBRARIES)
+  list (APPEND dpdk_dependencies "bsd")
+endif ()
+
 if (dpdk_FOUND AND NOT (TARGET dpdk))
   get_filename_component (library_suffix "${dpdk_EAL_LIBRARY}" LAST_EXT)
   # strictly speaking, we should have being using check_c_compiler_flag()
@@ -163,6 +170,7 @@ if (dpdk_FOUND AND NOT (TARGET dpdk))
     set_target_properties (dpdk
       PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${dpdk_INCLUDE_DIR}
+        INTERFACE_LINK_LIBRARIES "${dpdk_dependencies}"
         IMPORTED_OBJECTS ${dpdk_object_path}
         ${compile_options})
     # we include dpdk in seastar already, so no need to expose it with
@@ -175,7 +183,7 @@ if (dpdk_FOUND AND NOT (TARGET dpdk))
     set_target_properties (DPDK::dpdk
       PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${dpdk_PC_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${_dpdk_libraries}"
+        INTERFACE_LINK_LIBRARIES "${_dpdk_libraries};${dpdk_dependencies}"
         ${compile_options})
   endif()
 endif ()


### PR DESCRIPTION
Fixes #2411.

If libbsd-dev is installed during build time, DPDK will depend on it without a way to turn this off.

config/meson.build has the following:

```
libbsd = dependency('libbsd', required: false, method: 'pkg-config') if libbsd.found()
    dpdk_conf.set('RTE_USE_LIBBSD', 1)
endif
```

And lib/eal/include/rte_string_fns.h contains:

```
#ifdef RTE_USE_LIBBSD
#include <bsd/string.h>

#else /* no BSD header files, create own */
#define strlcpy(dst, src, size) rte_strlcpy(dst, src, size)
#define strlcat(dst, src, size) rte_strlcat(dst, src, size)

#endif /* RTE_USE_LIBBSD */
#endif /* FREEBSD */
```

Accordingly the only way to address this inflexibility is to ensure that dpdk dependencies are appropriately transferred to INTERFACE_LINK_LIBRARIES of the dpdk library.