### PR TITLE
seastar/testing: only include used headers

### DIFF
--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -26,7 +26,6 @@
 
 #include <fmt/format.h>
 
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/testing/linux_perf_event.hh>

--- a/include/seastar/testing/seastar_test.hh
+++ b/include/seastar/testing/seastar_test.hh
@@ -22,21 +22,13 @@
 
 #pragma once
 
-#include <vector>
-
-#include <boost/test/unit_test.hpp>
-
+#include <exception>
+#include <string_view>
+#include <boost/test/unit_test.hpp> // IWYU pragma: export
 #include <seastar/core/future.hh>
-#include <seastar/util/std-compat.hh>
-#include <seastar/testing/entry_point.hh>
+#include <seastar/testing/entry_point.hh> // IWYU pragma: keep
 
 #define SEASTAR_TEST_INVOKE(func, ...) func(__VA_ARGS__)
-
-namespace boost::unit_test::decorator {
-
-class collector_t;
-
-}
 
 namespace seastar {
 

--- a/include/seastar/testing/test_case.hh
+++ b/include/seastar/testing/test_case.hh
@@ -26,7 +26,7 @@
 #include <boost/preprocessor/comparison/equal.hpp>
 #include <boost/preprocessor/variadic/size.hpp>
 
-#include <seastar/core/future.hh>
+#include <seastar/core/future.hh> // IWYU pragma: keep
 
 #include <seastar/testing/seastar_test.hh>
 

--- a/include/seastar/testing/test_runner.hh
+++ b/include/seastar/testing/test_runner.hh
@@ -24,11 +24,9 @@
 #include <memory>
 #include <functional>
 #include <atomic>
-#include <random>
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/testing/exchanger.hh>
-#include <seastar/testing/random.hh>
 
 namespace seastar {
 

--- a/include/seastar/testing/thread_test_case.hh
+++ b/include/seastar/testing/thread_test_case.hh
@@ -22,9 +22,11 @@
 
 #pragma once
 
+// IWYU pragma: begin_keep
 #include <seastar/core/future.hh>
 #include <seastar/core/thread.hh>
-
+// IWYU pragma: end_keep
+//
 #include <boost/preprocessor/control/iif.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 #include <boost/preprocessor/variadic/size.hpp>

--- a/src/testing/entry_point.cc
+++ b/src/testing/entry_point.cc
@@ -20,6 +20,7 @@
  * Copyright (C) 2018 ScyllaDB Ltd.
  */
 
+#include <boost/test/unit_test.hpp>
 #include <seastar/testing/entry_point.hh>
 #include <seastar/testing/seastar_test.hh>
 #include <seastar/testing/test_runner.hh>

--- a/src/testing/random.cc
+++ b/src/testing/random.cc
@@ -19,6 +19,7 @@
  * Copyright (C) 2020 Cloudius Systems, Ltd.
  */
 
+#include <random>
 #include <seastar/testing/test_runner.hh>
 
 namespace seastar {

--- a/src/testing/test_runner.cc
+++ b/src/testing/test_runner.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_runner.hh>
 
 namespace seastar {

--- a/tests/unit/allocator_test.cc
+++ b/tests/unit/allocator_test.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_runner.hh>
 #include <cmath>
 #include <iostream>

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -1,4 +1,5 @@
 #include <seastar/core/reactor.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/net/ip.hh>

--- a/tests/unit/execution_stage_test.cc
+++ b/tests/unit/execution_stage_test.cc
@@ -24,6 +24,7 @@
 #include <chrono>
 
 #include <seastar/core/thread.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -21,6 +21,7 @@
  */
 
 #include <seastar/core/thread.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -19,6 +19,7 @@
  * Copyright (C) 2014-2015 Cloudius Systems, Ltd.
  */
 
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/file_utils_test.cc
+++ b/tests/unit/file_utils_test.cc
@@ -21,7 +21,9 @@
  */
 
 #include <stdlib.h>
+#include <random>
 
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -29,6 +29,7 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/core/thread.hh>

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -22,6 +22,7 @@
 
 #include <seastar/core/thread.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -31,6 +31,7 @@
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/internal/estimated_histogram.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -27,6 +27,7 @@
 #include <seastar/rpc/lz4_compressor.hh>
 #include <seastar/rpc/lz4_fragmented_compressor.hh>
 #include <seastar/rpc/multi_algo_compressor_factory.hh>
+#include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>


### PR DESCRIPTION
including unused header hurts the readability of source code. and could potentially slow down the compiling.

these unused headers were identified with clang-include-cleaner with following process:

1. ./configure.py --disable-dpdk --compiler clang++ \ --compile-commands-json --mode debug
2. find include/seastar/testing -name *.hh \ -exec echo {} \; \ -exec clang-include-cleaner --print=changes -p build/debug {} \;
3. audit all the reported unused headers, check if they are used or not by inspecting the header files in the report, and remove the includes which are not used. add the marks to the one which are actually used.

the "IWYU" marks are documented at
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md, since clang's include-cleaner supports IWYU pragma. they are used to prevent the false alarms in future.