### PR TITLE
README.md: note GitHub discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,16 @@ The documentation is available on the [web](http://docs.seastar.io/master/index.
 
 Resources
 ---------
-Ask questions and post patches on the development mailing list. Subscription
-information and archives are available [here](https://groups.google.com/forum/#!forum/seastar-dev),
-or just send an email to seastar-dev@googlegroups.com.
 
-Information can be found on the main [project website](http://seastar.io).
+* Seasatar Development Mailing List: Discuss challenges, propose improvements with
+  sending code contributions (patches), and get help from experienced developers.
+  Subscribe or browse archives: [here](https://groups.google.com/forum/#!forum/seastar-dev)
+  (or email seastar-dev@googlegroups.com).
+* GitHub Discussions: For more casual conversations and quick questions, consider
+  using the Seastar project's [discussions on Github](https://github.com/scylladb/seastar/discussions).
+* Issue Tracker: File bug reports on the project's [issue tracker](https://github.com/scylladb/seastar/issues).
 
-File bug reports on the project [issue tracker](https://github.com/scylladb/seastar/issues).
+Learn more about Seastar on the main [project website](http://seastar.io).
 
 The Native TCP/IP Stack
 -----------------------


### PR DESCRIPTION
since we enabled the GitHub discussion, we might want to encourage users to use it.

in this change

* reformat the "Resource" section so it is more structured. and categorize the different options for clarity
* add GitHub discussions to the bulletin list, so that users are aware of this new option for retrieving information and for contributing.