### PR TITLE
rpc: fix compilation error caused by fmt::runtime()

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <list>
@@ -218,7 +219,13 @@ class logger {
         // i.e. when the user still only defines a level-less logger.
         } else if (_logger && level <= log_level::info) {
             fmt::memory_buffer out;
-            fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<Args>(args)...);
+
+            if constexpr (std::is_same_v<const char*, decltype(fmt)>) {
+                fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<Args>(args)...);
+            } else {
+                fmt::format_to(fmt::appender(out), fmt, std::forward<Args>(args)...);
+            }
+
             _logger(sstring{out.data(), out.size()});
         }
     }


### PR DESCRIPTION
Depending on the 'SEASTAR_LOGGER_COMPILE_TIME_FMT' the declaration of 'logger::log()'
function may use either 'fmt::format_string' or 'const char*' format parameter.

In the case of the usage of 'const char*', there is a need to call 'fmt::runtime()' function to
obtain format_string.

When the project was built on Ubuntu 22.04 using the steps described in the tutorial,
there was a compilation error related to passing argument with type 'fmt::format_string<>'
to 'fmt::runtime()' that handles characters strings.

This change introduces contexpr if statement to remove the compilation error and use
'fmt::runtime()' only when the function takes 'const char*'.