### PR TITLE
tls: clear session ticket before releasing

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -345,6 +345,7 @@ struct gnutls_datum : public gnutls_datum_t {
             return *this;
         }
         if (data != nullptr) {
+            ::gnutls_memset(data, 0, size);
             ::gnutls_free(data);
         }
         data = std::exchange(other.data, nullptr);
@@ -353,6 +354,7 @@ struct gnutls_datum : public gnutls_datum_t {
     }
     ~gnutls_datum() {
         if (data != nullptr) {
+            ::gnutls_memset(data, 0, size);
             ::gnutls_free(data);
         }
     }


### PR DESCRIPTION
This avoids leaking TLS1.3 session tickets to the free list by clearing the session ticket before releasing it with free. The session tickets contain sensitive data that should not be leaked to the free list.

This is documented in the man page of [gnutls_session_ticket_enable_server](https://man7.org/linux/man-pages/man3/gnutls_session_ticket_enable_server.3.html):
```
Request that the server should attempt session resumption using
session tickets, i.e., by delegating storage to the client.
 key must be initialized using
gnutls_session_ticket_key_generate().  To avoid leaking that key,
use gnutls_memset() prior to releasing it.
```

The TLS 1.3 session ticket implementation for reference is here: https://github.com/scylladb/seastar/pull/2155