### PR TITLE
rpc: conditionally use fmt::runtime() based on SEASTAR_LOGGER_COMPILE_TIME_FMT

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <list>
@@ -219,13 +218,11 @@ class logger {
         // i.e. when the user still only defines a level-less logger.
         } else if (_logger && level <= log_level::info) {
             fmt::memory_buffer out;
-
-            if constexpr (std::is_same_v<const char*, decltype(fmt)>) {
-                fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<Args>(args)...);
-            } else {
-                fmt::format_to(fmt::appender(out), fmt, std::forward<Args>(args)...);
-            }
-
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
+            fmt::format_to(fmt::appender(out), fmt, std::forward<Args>(args)...);
+#else
+            fmt::format_to(fmt::appender(out), fmt::runtime(fmt), std::forward<Args>(args)...);
+#endif
             _logger(sstring{out.data(), out.size()});
         }
     }


### PR DESCRIPTION
in 8c58a723, we fixed the build failure when passing `fmt::format_string<>` to `fmt::runtime()`. but we were checking the fmt string's type to see if it is a `const char*`. this works fine. as there are only two cases,

1. `SEASTAR_LOGGER_COMPILE_TIME_FMT` is defined, and a templated parameter of `fmt::format_string<...>` is passed in.
2. `SEASTAR_LOGGER_COMPILE_TIME_FMT` is not defined, and a `const char*` pointer is passed in.

it would be better if we can check the same macro and dispatch based on it to pass `fmt` or `fmt::runtime(fmt)` to `fmt::format_to()`, for

- better readability. as we are more consistent this way.
- probably faster compilation. the preprocessor pass could be faster than the compiler which actually evaluate the `std::is_same_v` type trait.

so, in this change, let's switch to the plain macro based dispatch.