### PR TITLE
print: remove dead code

### DIFF
--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -32,17 +32,6 @@
 #include <sstream>
 #endif
 
-#if 0
-inline
-std::ostream&
-operator<<(std::ostream& os, const void* ptr) {
-    auto flags = os.flags();
-    os << "0x" << std::hex << reinterpret_cast<uintptr_t>(ptr);
-    os.flags(flags);
-    return os;
-}
-#endif
-
 SEASTAR_MODULE_EXPORT
 inline
 std::ostream&


### PR DESCRIPTION
operator<< overload for `const void*` was commented out in ceb0c942. this code has been around for more than 8 years at the time of writing. there is not point to keep it anymore.