### PR TITLE
http/client: make `abort_source` passed to connection_factory::make() optional

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -152,7 +152,7 @@ public:
      * The implementations of this method should return ready-to-use socket that will
      * be used by \ref client as transport for its http connections
      */
-    virtual future<connected_socket> make(abort_source*) = 0;
+    virtual future<connected_socket> make(abort_source* = nullptr) = 0;
     virtual ~connection_factory() {}
 };
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -210,7 +210,7 @@ public:
             : _addr(std::move(addr))
     {
     }
-    virtual future<connected_socket> make(abort_source* as) override {
+    virtual future<connected_socket> make(abort_source* as = nullptr) override {
         return seastar::connect(_addr, {}, transport::TCP);
     }
 };

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -46,7 +46,7 @@ class loopback_http_factory : public http::experimental::connection_factory {
     loopback_socket_impl lsi;
 public:
     explicit loopback_http_factory(loopback_connection_factory& f) : lsi(f) {}
-    virtual future<connected_socket> make(abort_source* as) override {
+    virtual future<connected_socket> make(abort_source* as = nullptr) override {
         return lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr()));
     }
 };
@@ -957,7 +957,7 @@ SEASTAR_TEST_CASE(test_client_response_parse_error) {
 SEASTAR_TEST_CASE(test_client_abort_new_conn) {
     class delayed_factory : public http::experimental::connection_factory {
     public:
-        virtual future<connected_socket> make(abort_source* as) override {
+        virtual future<connected_socket> make(abort_source* as = nullptr) override {
             assert(as != nullptr);
             return sleep_abortable(std::chrono::seconds(1), *as).then([] {
                 return make_exception_future<connected_socket>(std::runtime_error("Shouldn't happen"));


### PR DESCRIPTION
in 35badf56f1, we added abortable `make_request()` API. and added an `abort_source` pointer to `connection_factory::make()`, but this broke the build of existing classes which inherit from `connection_factory`. as they don't implement a `make()` with this parameter:
```
In file included from /home/kefu/dev/scylladb/tools/scylla-nodetool.cc:52:
/home/kefu/dev/scylladb/utils/http.hh:67:38: error: 'make' marked 'override' but does not override any member functions
   67 |     virtual future<connected_socket> make() override {
      |                                      ^
In file included from /home/kefu/dev/scylladb/tools/scylla-nodetool.cc:11:
In file included from /usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/chrono:49:
In file included from /usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/bits/shared_ptr.h:53:
In file included from /usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/bits/shared_ptr_base.h:59:
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/bits/unique_ptr.h:1076:34: error: allocating an object of abstract class type 'utils::http::dns_connection_factory'
 1076 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
      |                                  ^
/home/kefu/dev/scylladb/tools/scylla-nodetool.cc:185:28: note: in instantiation of function template specialization 'std::make_unique<utils::http::dns_connection_factory, seastar::basic_sstring<char, unsigned int, 15> &, unsigned short &, bool, seastar::logger &>' requested here
  185 |         , _api_client(std::make_unique<utils::http::dns_connection_factory>(_host, _port, false, nlog), 1)
      |                            ^
/home/kefu/dev/scylladb/seastar/include/seastar/http/client.hh:155:38: note: unimplemented pure virtual method 'make' in 'dns_connection_factory'
  155 |     virtual future<connected_socket> make(abort_source*) = 0;
      |                                      ^
```

in this change, in order to fix the build, let's make this parameter optional.

Refs 35badf56f1
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>