### PR TITLE
build: drop the workaround for a GCC bug

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -33,8 +33,6 @@ foreach (component ${Sanitizers_FIND_COMPONENTS})
     list (APPEND ${compile_options} -fsanitize=address)
   elseif (component STREQUAL "undefined_behavior")
     list (APPEND ${compile_options} -fsanitize=undefined)
-    # Disable vptr because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88684
-    list (APPEND ${compile_options} -fno-sanitize=vptr)
   else ()
     message (FATAL_ERROR "Unsupported sanitizer: ${component}")
   endif ()


### PR DESCRIPTION
this change partially reverts 87a6540906, which workarounded a bug in GCC-10 and LLVM-3.8, see
https://gcc.gnu.org/git/?p=gcc.git&a=commit;h=1842a04ce06a470b731bc9a29bfec17e6e147c3f and
https://github.com/llvm/llvm-project/commit/894d5821e7af9128398ec8153f3cb4025ae9ad50 respectively.

since scylla builds with GCC-13 and GCC-14, LLVM-17 and LLVM-18. so we don't need to keep this workaround anymore.