### PR TITLE
Introduce output_stream writing shugar

### DIFF
--- a/include/seastar/util/iostream.hh
+++ b/include/seastar/util/iostream.hh
@@ -1,0 +1,60 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2024 ScyllaDB
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/util/modules.hh>
+
+namespace seastar {
+namespace util {
+SEASTAR_MODULE_EXPORT_BEGIN
+
+/// Writes data to stream and properly flushes and closes one
+///
+/// \param out \ref output_stream to write to
+/// \param writer callable invoked to write data itself
+///
+/// The helper takes ownership of the output_stream, flushes and closes it
+/// after the writer is done. The stream is not useable after it resolves.
+template <typename W>
+requires std::is_invocable_r_v<future<>, W, output_stream<char>&>
+future<> write_to_stream_and_close(output_stream<char>&& out_, W writer) {
+    output_stream<char> out = std::move(out_);
+    std::exception_ptr ex;
+    try {
+        co_await writer(out);
+        co_await out.flush();
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await out.close();
+    if (ex) {
+        co_await coroutine::return_exception_ptr(std::move(ex));
+    }
+}
+
+SEASTAR_MODULE_EXPORT_END
+} // util namespace
+} // seastar namespace
+


### PR DESCRIPTION
When putting data into output_stream() a common pattern exists. Data is written into stream, then flushed and the end and the stream is closed. Any exception that may pop up in the middle shouldn't leave stream not closed, so in the code it looks smth like

```
    try {
        for (...) {
           co_await out.write()
        }
        co_await out.flush()
    } catch () {
        ex = current_exception()
    }
    co_await out.close()
    if (ex) {
        throw ex
    }
```

This is very typical to http client and handlers code that use request::write_bod() and response::write_body() overloads that call user-provided lambda giving it chunked or content-length output_stream. The caller then implements the paterns described above on its own.

This PR suggest a pair of helpers -- one is the util::write_to_stream() function that looks literally like above; the other one is request and response .write_body() overloads that accept a callback doing only the out.write() (for the loop) part of the above, flushing and closing the stream on its own.