### PR TITLE
build: s/Sanitizers_COMPILER_OPTIONS/Sanitizers_COMPILE_OPTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,7 +883,7 @@ if (condition)
   if (NOT Sanitizers_FOUND)
     message (FATAL_ERROR "Sanitizers not found!")
   endif ()
-  set (Seastar_Sanitizers_OPTIONS ${Sanitizers_COMPILER_OPTIONS})
+  set (Seastar_Sanitizers_OPTIONS ${Sanitizers_COMPILE_OPTIONS})
   target_link_libraries (seastar
     PUBLIC
       $<${condition}:Sanitizers::address>


### PR DESCRIPTION
this change addresses a regression introduced by ed889199, which renamed the exported CMake variable of `Sanitizers_COMPILER_OPTIONS` to `Sanitizers_COMPILE_OPTIONS`, to be more consistent with the names used by CMake. but it failed to update the top-level `CMakeLists.txt`, which was still using the old name to populate this setting down to .pc. that's why some parent project fails to link with the latest seastar with sanitizers enabled.

in this change, we correct the variable name.