### PR TITLE
iostream/http: Fix output_stream::write(temporary_buffer) overload

### DIFF
--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -119,7 +119,9 @@ class http_chunked_data_sink_impl : public data_sink_impl {
 public:
     http_chunked_data_sink_impl(output_stream<char>& out) : _out(out) {
     }
-    virtual future<> put(net::packet data)  override { abort(); }
+    virtual future<> put(net::packet data) override {
+        return data_sink_impl::fallback_put(std::move(data));
+    }
     using data_sink_impl::put;
     virtual future<> put(temporary_buffer<char> buf) override {
         if (buf.size() == 0) {
@@ -166,7 +168,9 @@ public:
         // at the very beginning, 0 bytes were written
         _bytes_written = 0;
     }
-    virtual future<> put(net::packet data)  override { abort(); }
+    virtual future<> put(net::packet data) override {
+        return data_sink_impl::fallback_put(std::move(data));
+    }
     using data_sink_impl::put;
     virtual future<> put(temporary_buffer<char> buf) override {
         if (buf.size() == 0 || _bytes_written == _limit) {


### PR DESCRIPTION
Previously, calling the `write(temporary_buffer<char>)` overload on an `output_stream<char>` obtained from `http::reply::write_body` would cause an abort.

This commit fixes this by providing a helper function (in the `data_sink_impl` base class) named `fallback_put`, which classes that inherit from this base class can use to implement the `put(net::packet)` overload. Also, this commit lets `http_chunked_data_sink_impl` and `http_content_length_data_sink_impl` make use of this helper.

`fallback_put(net::packet)` works simply by extracting the temporary_buffers contained in the packet, and calling the `put(temporary_buffer<char>)` overload for each `temporary_buffer`.

Note that we create this `fallback_put` function instead of defining the virtual member `put(net::packet)` function in the `data_sink_impl` class, to avoid `put(net::packet)` and `put(temporary_buffer<char>)` calling each other leading to infinite recursion.

This commit also adds unit tests to `tests/unit/httpd_test.cc` for testing the `write` overload with `http_chunked_data_sink_impl` and `http_content_length_data_sink_impl`.

Thanks to Pavel (xemul) for his help.

Fixes #1701