### PR TITLE
build: Add options to select sanitizers in configure.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,13 @@ set (Seastar_SANITIZE
   "DEFAULT"
   CACHE
   STRING
-  "Enable ASAN and UBSAN. Can be ON, OFF or DEFAULT (which enables it for Debug and Sanitize)")
+  "Enable sanitizers. Can be ON, OFF or DEFAULT (which enables it for Debug and Sanitize)")
+
+set (Seastar_SANITIZERS
+  "address;undefined_behavior"
+  CACHE
+  STRING
+  "Sanitizers enabled when building Seastar")
 
 set (Seastar_DEBUG_SHARED_PTR
   "DEFAULT"
@@ -391,11 +397,27 @@ set (Seastar_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set (Seastar_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set (Seastar_GEN_BINARY_DIR ${Seastar_BINARY_DIR}/gen)
 
+include (TriStateOption)
+tri_state_option (${Seastar_SANITIZE}
+  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
+  CONDITION sanitizers_enabled)
+
+if (NOT sanitizers_enabled)
+  set (Seastar_SANITIZERS "")
+endif ()
+
 #
 # Dependencies.
 #
 
-include (SeastarDependencies)
+set (Seastar_SANITIZERS_DEPENDENCY_STRING ${Seastar_SANITIZERS})
+
+configure_file (
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/SeastarDependencies.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SeastarDependencies-build.cmake
+  @ONLY)
+
+include (SeastarDependencies-build)
 seastar_find_dependencies ()
 
 # Private build dependencies not visible to consumers
@@ -880,19 +902,16 @@ if (Seastar_DPDK)
       DPDK::dpdk)
 endif ()
 
-include (TriStateOption)
-tri_state_option (${Seastar_SANITIZE}
-  DEFAULT_BUILD_TYPES "Debug" "Sanitize"
-  CONDITION condition)
-if (condition)
+if (sanitizers_enabled)
   if (NOT Sanitizers_FOUND)
     message (FATAL_ERROR "Sanitizers not found!")
   endif ()
-  set (Seastar_Sanitizers_OPTIONS $<${condition}:${Sanitizers_COMPILE_OPTIONS}>)
-  target_link_libraries (seastar
-    PUBLIC
-      $<${condition}:Sanitizers::address>
-      $<${condition}:Sanitizers::undefined_behavior>)
+  set (Seastar_Sanitizers_OPTIONS $<${sanitizers_enabled}:${Sanitizers_COMPILE_OPTIONS}>)
+  foreach (component ${Seastar_SANITIZERS})
+    target_link_libraries (seastar
+      PUBLIC
+        $<${sanitizers_enabled}:Sanitizers::${component}>)
+  endforeach ()
 endif ()
 
 # We only need valgrind to find uninitialized memory uses, so disable
@@ -1349,6 +1368,23 @@ if (Seastar_INSTALL)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/seastar-testing-install.pc
     INPUT ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/seastar-testing-install.pc.in)
 
+  if (_is_Multi_Config)
+    set (Seastar_CMAKE "_$<CONFIG>.cmake")
+  else ()
+    set (Seastar_CMAKE ".cmake")
+  endif ()
+
+  set (Seastar_SANITIZERS_DEPENDENCY_STRING "$<${sanitizers_enabled}:${Seastar_SANITIZERS}>")
+
+  configure_file (
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/SeastarDependencies.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/SeastarDependencies.cmake.in
+    @ONLY)
+
+  file (GENERATE
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SeastarDependencies${Seastar_CMAKE}
+    INPUT ${CMAKE_CURRENT_BINARY_DIR}/SeastarDependencies.cmake.in)
+
   include (CMakePackageConfigHelpers)
   set (install_cmakedir ${CMAKE_INSTALL_LIBDIR}/cmake/Seastar)
 
@@ -1396,6 +1432,11 @@ if (Seastar_INSTALL)
     DESTINATION ${install_cmakedir})
 
   install (
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/SeastarDependencies${Seastar_CMAKE}
+    DESTINATION ${install_cmakedir}
+    RENAME SeastarDependencies.cmake)
+
+  install (
     FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindGnuTLS.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLinuxMembarrier.cmake
@@ -1412,7 +1453,6 @@ if (Seastar_INSTALL)
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findrt.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Finducontext.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findyaml-cpp.cmake
-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SeastarDependencies.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibUring.cmake
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSystemTap-SDT.cmake
     DESTINATION ${install_cmakedir})

--- a/cmake/SeastarDependencies.cmake.in
+++ b/cmake/SeastarDependencies.cmake.in
@@ -137,6 +137,9 @@ macro (seastar_find_dependencies)
   seastar_set_dep_args (rt REQUIRED)
   seastar_set_dep_args (numactl
     OPTION ${Seastar_NUMA})
+  seastar_set_dep_args (Sanitizers
+    COMPONENTS
+      @Seastar_SANITIZERS_DEPENDENCY_STRING@)
   seastar_set_dep_args (ucontext REQUIRED)
   seastar_set_dep_args (yaml-cpp REQUIRED
     VERSION 0.5.1)

--- a/configure.py
+++ b/configure.py
@@ -142,6 +142,7 @@ arg_parser.add_argument('--heap-profiling', dest='heap_profiling', action='store
 arg_parser.add_argument('--dpdk-machine', default='native', help='Specify the target architecture')
 add_tristate(arg_parser, name='deferred-action-require-noexcept', dest='deferred_action_require_noexcept', help='noexcept requirement for deferred actions', default=True)
 arg_parser.add_argument('--prefix', dest='install_prefix', default='/usr/local', help='Root installation path of Seastar files')
+arg_parser.add_argument('--sanitizers', action='store', dest='sanitizers', default='address;undefined_behavior', help='Use specified sanitizers')
 args = arg_parser.parse_args()
 
 
@@ -209,6 +210,7 @@ def configure_mode(mode):
         tr(args.deferred_action_require_noexcept, 'DEFERRED_ACTION_REQUIRE_NOEXCEPT'),
         tr(args.unused_result_error, 'UNUSED_RESULT_ERROR'),
         tr(args.debug_shared_ptr, 'DEBUG_SHARED_PTR', value_when_none='default'),
+        tr(args.sanitizers, 'SANITIZERS'),
     ]
 
     ingredients_to_cook = set(args.cook)


### PR DESCRIPTION
We are going to add ThreadSanitizer that can't be used together with
AddressSanitizer. We want to choose which sanitizers to use.

Sanitizers can be specified as semicolon separated list:
```
./configure.py --sanitizers address;undefined_behavior
```

Specified sanitizers are passed to Seastar_SANITIZERS list.

Enabling sanitizers is consistently with Seastar_SANITIZE option.