### PR TITLE
seastar-addr2line: adjust llvm termination regex

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -36,10 +36,15 @@ class Addr2Line:
     # address, which we force by adding a dummy 0x0 address. The
     # pattern varies between binutils addr2line and llvm-addr2line
     # so we match both.
+    # The LLVM output is usually literally:
+    #  0x0: ?? at ??
+    # but not always, e.g., when ASAN is linked it may be (for example):
+    #  0x0: ?? at /v/llvm/llvm/src/compiler-rt/lib/asan/asan_fake_stack.h:133
+    # so that's why we liberally accept .* as the part after "at" below
     dummy_pattern = re.compile(
         r"(.*0x0000000000000000: \?\? \?\?:0\n)" # addr2line pattern
         r"|"
-        r"(.*0x0: \?\? at \?\?:0\n)"  # llvm-addr2line pattern
+        r"(.*0x0: \?\? at .*\n)"  # llvm-addr2line pattern
         )
 
     def __init__(self, binary, concise=False, cmd_path="addr2line"):


### PR DESCRIPTION
We feed addresses into the underlying addr2line binary one at a time, passing:

```
<address>
0x0
```

each time. The 0x0 "dummy" is there so we can tell when the decoding is finished, as it will emit a characteristic line. We need this sentinel because the address itself can emit several frames (due to inlining).

If the dummy output (associated with the 0x0 frame) is not correctly detected the symptom is that seastar-addr2line simply hangs while decoding a backtrace.

This change adjusts the regex used to detect the dummy output, since in the case where ASAN is linked in it can be different than we expected (the file will be an ASAN internal thing rather than ??).