### PR TITLE
README.md: use the github homepage of Ceph for Crimson

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ Projects using Seastar
 * [redpanda](https://vectorized.io/): A Kafka replacement for mission critical systems
 * [Scylla](https://github.com/scylladb/scylla): A fast and reliable NoSQL data store compatible with Cassandra and DynamoDB
 * [smf](https://github.com/smfrpc/smf): The fastest RPC in the West
-* [Ceph - Crimson](https://docs.ceph.com/en/reef/dev/crimson/crimson/): Next-generation OSD (Object Storage Daemon) implementation based on the Seastar framework
+* [Ceph - Crimson](https://github.com/ceph/ceph): Next-generation OSD (Object Storage Daemon) implementation based on the Seastar framework


### PR DESCRIPTION
Reef is a major version of Ceph, and the URL of "Ceph - Crimson" is a page targeting Crimson developers. We should instead reference the project's homepage or its github project address like other projects.

so, in this change, let's reference Ceph's project page on GitHub.