### PR TITLE
build: check for P2582R1 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -821,6 +821,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     -Wno-error=deprecated-declarations)
 endif ()
 
+if (CMAKE_CXX_STANDARD GREATER_EQUAL 23)
+  include (CheckP2582R1)
+  if (Cxx_Compiler_IMPLEMENTS_P2581R1)
+    target_compile_definitions (seastar
+      PUBLIC SEASTAR_P2581R1)
+  endif ()
+endif ()
+
 if (BUILD_SHARED_LIBS)
   # use initial-exec TLS, as it puts the TLS variables in the static TLS space
   # instead of allocating them using malloc. otherwise intercepting mallocs and

--- a/cmake/CheckP2582R1.cmake
+++ b/cmake/CheckP2582R1.cmake
@@ -1,0 +1,26 @@
+include (CheckCXXSourceCompiles)
+include (CMakePushCheckState)
+
+cmake_push_check_state (RESET)
+
+set (CMAKE_REQUIRED_FLAGS "-std=c++23")
+
+# check if the compiler implements the inherited vs non-inherited guide
+# tiebreaker specified by P2582R1, see https://wg21.link/P2582R1
+check_cxx_source_compiles ("
+template <typename T> struct B {
+    B(T) {}
+};
+
+template <typename T> struct C : public B<T> {
+    using B<T>::B;
+};
+
+B(int) -> B<char>;
+C c2(42);
+
+int main() {}
+"
+  Cxx_Compiler_IMPLEMENTS_P2581R1)
+
+cmake_pop_check_state ()

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -403,8 +403,10 @@ public:
 
 /// @}
 
+#ifndef SEASTAR_P2581R1
 template <typename... T>
 tuple(T&&...) ->  tuple<T...>;
+#endif
 
 } // namespace rpc
 


### PR DESCRIPTION
in a recent GCC packaging update in fedora, the maintainer backported a patch [PR116276](https://gcc.gnu.org/pipermail/gcc-patches/2024-August/659909.html) from GCC-14. the patch implements
[P2582R1 - Wording for class template argument deduction from inherited constructors](https://wg21.link/P2582R1) which was accepted by C++23. since it's included by C++23, Clang is also working in this direction, see
https://github.com/llvm/llvm-project/issues/92606.

this is the reason why gcc-14.2.1-3 fails to build the tree, which relies on the behavior without P2582R1.

in this change, we check for the support of P2581R1 with CMake, and define `SEASTAR_P2581R1` macro if the proposed behavior is implemented. we define the argument deduction guide for `rpc::tuple` only if this macro is not defined. this should address the build failure. and it is future-proof as once Clang supports P2581R1, we can detect it, and disable the dedution guide as well.

Fixes #2445
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>