### PR TITLE
build: do not print the default value of --c++-standard in help output

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -83,7 +83,7 @@ arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc'
 arg_parser.add_argument('--ccache', nargs='?', const='ccache', default='', metavar='CCACHE_BINARY_PATH',
                         help='Use ccache to cache compilation (and optionally provide a path to ccache binary)')
 arg_parser.add_argument('--c++-standard', action='store', dest='cpp_standard', default='',
-                        help='C++ standard to build with [default: %(default)s]')
+                        help='C++ standard to build with')
 arg_parser.add_argument('--cook', action='append', dest='cook', default=[],
                         help='Supply this dependency locally for development via `cmake-cooking` (can be repeated)')
 arg_parser.add_argument('--verbose', dest='verbose', action='store_true', help='Make configure output more verbose.')
@@ -159,7 +159,7 @@ def identify_best_standard(cpp_standards, compiler):
     raise Exception(f"{compiler} does not seem to support any of Seastar's preferred C++ standards - {cpp_standards}. Please upgrade your compiler.")
 
 
-if args.cpp_standard == '':
+if not args.cpp_standard:
     cpp_standards = ['23', '20']
     args.cpp_standard = identify_best_standard(cpp_standards, compiler=args.cxx)
 


### PR DESCRIPTION
before this change, the output of `./configure.py --help` looks like:
```
  --c++-standard CPP_STANDARD
                        C++ standard to build with [default: ]
```

because the default value of `--c++-standard` option is an empty string. printing out its value is not helpful, and could be confusing.

as the actual default value of this option varies depending on the used compiler, so even if we print out the deduced C++ standard, it is still confusing. not to mention that argparse does not differentiate the defaulted value in the returned namespace from `parse_args()` from the user specified one. so, a simpler approach is just do not specify the default value.

in this change, we

* do not specify the default value for `--c++-standard`, so its value would be `None` if not specified
* do not print its default value in the `--help` output