### PR TITLE
Misc compile include/warn fixes

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2906,7 +2906,8 @@ reactor::wakeup() {
     _sleeping.store(false, std::memory_order_relaxed);
 
     uint64_t one = 1;
-    ::write(_notify_eventfd.get(), &one, sizeof(one));
+    auto res = ::write(_notify_eventfd.get(), &one, sizeof(one));
+    assert(res == sizeof(one) && "write(2) failed on _reactor._notify_eventfd");
 }
 
 void reactor::start_aio_eventfd_loop() {
@@ -2916,7 +2917,7 @@ void reactor::start_aio_eventfd_loop() {
     future<> loop_done = repeat([this] {
         return _aio_eventfd->readable().then([this] {
             char garbage[8];
-            ::read(_aio_eventfd->get_fd(), garbage, 8); // totally uninteresting
+            std::ignore = ::read(_aio_eventfd->get_fd(), garbage, 8); // totally uninteresting
             return _stopping ? stop_iteration::yes : stop_iteration::no;
         });
     });
@@ -2931,7 +2932,8 @@ void reactor::stop_aio_eventfd_loop() {
         return;
     }
     uint64_t one = 1;
-    ::write(_aio_eventfd->get_fd(), &one, 8);
+    auto res = ::write(_aio_eventfd->get_fd(), &one, 8);
+    assert(res == 8 && "write(2) failed on _reactor._aio_eventfd");
 }
 
 inline

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -22,12 +22,16 @@
 
 #ifdef SEASTAR_MODULE
 module;
+#endif
+
 #include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <array>
 #include <pthread.h>
 #include <signal.h>
+
+#ifdef SEASTAR_MODULE
 module seastar;
 #else
 #include <seastar/core/reactor.hh>

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -70,7 +70,8 @@ void thread_pool::work(sstring name) {
             std::atomic_thread_fence(std::memory_order_seq_cst);
             if (_main_thread_idle.load(std::memory_order_relaxed)) {
                 uint64_t one = 1;
-                ::write(_reactor._notify_eventfd.get(), &one, 8);
+                auto res = ::write(_reactor._notify_eventfd.get(), &one, 8);
+                assert(res == 8 && "write(2) failed on _reactor._notify_eventfd");
             }
         }
     }

--- a/tests/perf/linux_perf_event.cc
+++ b/tests/perf/linux_perf_event.cc
@@ -24,6 +24,8 @@
  * This file was copied from Scylla (https://github.com/scylladb/scylla)
  */
 
+#include <cassert>
+
 #include <seastar/testing/linux_perf_event.hh>
 
 #include <linux/perf_event.h>
@@ -61,7 +63,8 @@ linux_perf_event::read() {
         return 0;
     }
     uint64_t ret;
-    ::read(_fd, &ret, sizeof(ret));
+    auto res = ::read(_fd, &ret, sizeof(ret));
+    assert(res == sizeof(ret) && "read(2) failed on perf_event fd");
     return ret;
 }
 

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -17,7 +17,7 @@
  */
 /*
  * Copyright (C) 2019 Red Hat, Inc.
- */ 
+ */
 
 #include <filesystem>
 
@@ -88,7 +88,7 @@ future<> ud_server_client::init_server() {
                     }
                 }
                 client_round();
-            } 
+            }
         });
 
         return do_until([this](){return rounds_left<=0;}, [&lstn,this]() {
@@ -131,7 +131,7 @@ future<> ud_server_client::init_server() {
 /// If 'client_path' is set, the client binds to the named path.
 // Runs in a seastar::thread.
 void ud_server_client::client_round() {
-    auto cc = client_path ? 
+    auto cc = client_path ?
         engine().net().connect(server_addr, socket_address{unix_domain_addr{*client_path}}).get() :
         engine().net().connect(server_addr).get();
 
@@ -154,11 +154,16 @@ future<> ud_server_client::run() {
 
 }
 
+void rm(std::string_view what) {
+    auto res = system(fmt::format("rm -f {}", what).c_str());
+    BOOST_REQUIRE_EQUAL(res, 0);
+}
+
 //  testing the various address types, both on the server and on the
 //  client side
 
 SEASTAR_TEST_CASE(unixdomain_server) {
-    system("rm -f /tmp/ry");
+    rm("/tmp/ry");
     ud_server_client uds("/tmp/ry", std::nullopt, 3);
     return do_with(std::move(uds), [](auto& uds){
         return uds.run();
@@ -205,7 +210,7 @@ SEASTAR_TEST_CASE(unixdomain_text) {
 }
 
 SEASTAR_TEST_CASE(unixdomain_bind) {
-    system("rm -f 111 112");
+    rm("111 112");
     ud_server_client uds("111"s, "112"s, 1);
     return do_with(std::move(uds), [](auto& uds){
         return uds.run();
@@ -213,7 +218,7 @@ SEASTAR_TEST_CASE(unixdomain_bind) {
 }
 
 SEASTAR_TEST_CASE(unixdomain_short) {
-    system("rm -f 3");
+    rm("3");
     ud_server_client uds("3"s, std::nullopt, 10);
     return do_with(std::move(uds), [](auto& uds){
         return uds.run();


### PR DESCRIPTION
Fix wrong includes related to SEASTAR_MODULE
Fix "unused result" warnings in gcc

Tests all pass, see changes for details.