### PR TITLE
sharded.hh: add invoke_on variant for a shard range

### DIFF
--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -75,6 +75,7 @@ module;
 #include <optional>
 #include <queue>
 #include <random>
+#include <ranges>
 #include <regex>
 #include <source_location>
 #include <sstream>


### PR DESCRIPTION
Add a convenient method to invoke a function on a range of shards, to have better support for the cold control path on more complex compute models like shard groups for different tasks. A workload can benefit from such a model if inter-task cooperation is better when grouping from perf and QoS perspectives, for example. Or a computation requires a only a subset of shards due to internal concurrency limits.

