### PR TITLE
file, scheduling: remove non-unified I/O and CPU scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,11 @@ set (Seastar_API_LEVEL
   "7"
   CACHE
   STRING
-  "Seastar compatibility API level (5=future<T>::get() returns T&&, 6=future is not variadic, 7=unified CPU/IO scheduling groups")
+  "Seastar compatibility API level (7=unified CPU/IO scheduling groups")
 
 set_property (CACHE Seastar_API_LEVEL
   PROPERTY
-  STRINGS 6)
+  STRINGS 7)
 
 set (Seastar_SCHEDULING_GROUPS_COUNT
   "16"

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -113,7 +113,7 @@ API Level History
 | 4   |  2020-06  | 2023-03 | Non-variadic futures in when_all_succeed()   |
 | 5   |  2020-08  | 2023-03 | future::get() returns std::monostate() instead of void |
 | 6   |  2020-09  | 2023-03 | future<T> instead of future<T...>            |
-| 7   |  2023-05  |         | unified CPU/IO scheduling groups             |
+| 7   |  2023-05  | 2024-09 | unified CPU/IO scheduling groups             |
 
 
 Note: The "mandatory" column indicates when backwards compatibility

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -137,35 +137,11 @@ protected:
 public:
     virtual ~file_impl() {}
 
-#if SEASTAR_API_LEVEL >= 7
     virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent*) = 0;
     virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, io_intent*) = 0;
     virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent*) = 0;
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent*) = 0;
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent*) = 0;
-#else
-    virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, const io_priority_class& pc) = 0;
-    virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc) = 0;
-    virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, const io_priority_class& pc) = 0;
-    virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc) = 0;
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc) = 0;
-
-    virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, const io_priority_class& pc, io_intent*) {
-        return write_dma(pos, buffer, len, pc);
-    }
-    virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc, io_intent*) {
-        return write_dma(pos, std::move(iov), pc);
-    }
-    virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, const io_priority_class& pc, io_intent*) {
-        return read_dma(pos, buffer, len, pc);
-    }
-    virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc, io_intent*) {
-        return read_dma(pos, std::move(iov), pc);
-    }
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc, io_intent*) {
-        return dma_read_bulk(offset, range_size, pc);
-    }
-#endif
 
     virtual future<> flush() = 0;
     virtual future<struct stat> stat() = 0;
@@ -289,32 +265,6 @@ public:
         return _file_impl->_write_max_length;
     }
 
-#if SEASTAR_API_LEVEL < 7
-    /**
-     * Perform a single DMA read operation.
-     *
-     * @param aligned_pos offset to begin reading at (should be aligned)
-     * @param aligned_buffer output buffer (should be aligned)
-     * @param aligned_len number of bytes to read (should be aligned)
-     * @param pc the IO priority class under which to queue this operation
-     * @param intent the IO intention confirmation (\ref seastar::io_intent)
-     *
-     * Alignment is HW dependent but use 4KB alignment to be on the safe side as
-     * explained above.
-     *
-     * ATTN: The method is going to be deprecated
-     *
-     * @return number of bytes actually read
-     *         or exceptional future in case of I/O error
-     */
-    template <typename CharType>
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<size_t>
-    dma_read(uint64_t aligned_pos, CharType* aligned_buffer, size_t aligned_len, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(aligned_pos, reinterpret_cast<uint8_t*>(aligned_buffer), aligned_len, internal::maybe_priority_class_ref(pc), intent);
-    }
-#endif
-
     /**
      * Perform a single DMA read operation.
      *
@@ -334,34 +284,6 @@ public:
     dma_read(uint64_t aligned_pos, CharType* aligned_buffer, size_t aligned_len, io_intent* intent = nullptr) noexcept {
         return dma_read_impl(aligned_pos, reinterpret_cast<uint8_t*>(aligned_buffer), aligned_len, internal::maybe_priority_class_ref(), intent);
     }
-
-#if SEASTAR_API_LEVEL < 7
-    /**
-     * Read the requested amount of bytes starting from the given offset.
-     *
-     * @param pos offset to begin reading from
-     * @param len number of bytes to read
-     * @param pc the IO priority class under which to queue this operation
-     * @param intent the IO intention confirmation (\ref seastar::io_intent)
-     *
-     * @return temporary buffer containing the requested data.
-     *         or exceptional future in case of I/O error
-     *
-     * This function doesn't require any alignment for both "pos" and "len"
-     *
-     * ATTN: The method is going to be deprecated
-     *
-     * @note size of the returned buffer may be smaller than "len" if EOF is
-     *       reached or in case of I/O error.
-     */
-    template <typename CharType>
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<temporary_buffer<CharType>> dma_read(uint64_t pos, size_t len, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(pos, len, internal::maybe_priority_class_ref(pc), intent).then([] (temporary_buffer<uint8_t> t) {
-            return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
-        });
-    }
-#endif
 
     /**
      * Read the requested amount of bytes starting from the given offset.
@@ -389,32 +311,6 @@ public:
     /// with \ref dma_read_exactly().
     class eof_error : public std::exception {};
 
-#if SEASTAR_API_LEVEL < 7
-    /**
-     * Read the exact amount of bytes.
-     *
-     * @param pos offset in a file to begin reading from
-     * @param len number of bytes to read
-     * @param pc the IO priority class under which to queue this operation
-     * @param intent the IO intention confirmation (\ref seastar::io_intent)
-     *
-     * ATTN: The method is going to be deprecated
-     *
-     * @return temporary buffer containing the read data
-     *        or exceptional future in case an error, holding:
-     *        end_of_file_error if EOF is reached, file_io_error or
-     *        std::system_error in case of I/O error.
-     */
-    template <typename CharType>
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<temporary_buffer<CharType>>
-    dma_read_exactly(uint64_t pos, size_t len, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_read_exactly_impl(pos, len, internal::maybe_priority_class_ref(pc), intent).then([] (temporary_buffer<uint8_t> t) {
-            return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
-        });
-    }
-#endif
-
     /**
      * Read the exact amount of bytes.
      *
@@ -435,25 +331,6 @@ public:
         });
     }
 
-#if SEASTAR_API_LEVEL < 7
-    /// Performs a DMA read into the specified iovec.
-    ///
-    /// \param pos offset to read from.  Must be aligned to \ref disk_read_dma_alignment.
-    /// \param iov vector of address/size pairs to read into.  Addresses must be
-    ///            aligned.
-    /// \param pc the IO priority class under which to queue this operation
-    /// \param intent the IO intention confirmation (\ref seastar::io_intent)
-    ///
-    /// ATTN: The method is going to be deprecated
-    ///
-    /// \return a future representing the number of bytes actually read.  A short
-    ///         read may happen due to end-of-file or an I/O error.
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<size_t> dma_read(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(pos, std::move(iov), internal::maybe_priority_class_ref(pc), intent);
-    }
-#endif
-
     /// Performs a DMA read into the specified iovec.
     ///
     /// \param pos offset to read from.  Must be aligned to \ref disk_read_dma_alignment.
@@ -466,27 +343,6 @@ public:
     future<size_t> dma_read(uint64_t pos, std::vector<iovec> iov, io_intent* intent = nullptr) noexcept {
         return dma_read_impl(pos, std::move(iov), internal::maybe_priority_class_ref(), intent);
     }
-
-#if SEASTAR_API_LEVEL < 7
-    /// Performs a DMA write from the specified buffer.
-    ///
-    /// \param pos offset to write into.  Must be aligned to \ref disk_write_dma_alignment.
-    /// \param buffer aligned address of buffer to read from.  Buffer must exists
-    ///               until the future is made ready.
-    /// \param len number of bytes to write.  Must be aligned.
-    /// \param pc the IO priority class under which to queue this operation
-    /// \param intent the IO intention confirmation (\ref seastar::io_intent)
-    ///
-    /// ATTN: The method is going to be deprecated
-    ///
-    /// \return a future representing the number of bytes actually written.  A short
-    ///         write may happen due to an I/O error.
-    template <typename CharType>
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<size_t> dma_write(uint64_t pos, const CharType* buffer, size_t len, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_write_impl(pos, reinterpret_cast<const uint8_t*>(buffer), len, internal::maybe_priority_class_ref(pc), intent);
-    }
-#endif
 
     /// Performs a DMA write from the specified buffer.
     ///
@@ -502,25 +358,6 @@ public:
     future<size_t> dma_write(uint64_t pos, const CharType* buffer, size_t len, io_intent* intent = nullptr) noexcept {
         return dma_write_impl(pos, reinterpret_cast<const uint8_t*>(buffer), len, internal::maybe_priority_class_ref(), intent);
     }
-
-#if SEASTAR_API_LEVEL < 7
-    /// Performs a DMA write to the specified iovec.
-    ///
-    /// \param pos offset to write into.  Must be aligned to \ref disk_write_dma_alignment.
-    /// \param iov vector of address/size pairs to write from.  Addresses must be
-    ///            aligned.
-    /// \param pc the IO priority class under which to queue this operation
-    /// \param intent the IO intention confirmation (\ref seastar::io_intent)
-    ///
-    /// ATTN: The method is going to be deprecated
-    ///
-    /// \return a future representing the number of bytes actually written.  A short
-    ///         write may happen due to an I/O error.
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<size_t> dma_write(uint64_t pos, std::vector<iovec> iov, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_write_impl(pos, std::move(iov), internal::maybe_priority_class_ref(pc), intent);
-    }
-#endif
 
     /// Performs a DMA write to the specified iovec.
     ///
@@ -701,34 +538,6 @@ public:
     // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
     // buffered generator yet.
     coroutine::experimental::generator<directory_entry> experimental_list_directory();
-
-#if SEASTAR_API_LEVEL < 7
-    /**
-     * Read a data bulk containing the provided addresses range that starts at
-     * the given offset and ends at either the address aligned to
-     * dma_alignment (4KB) or at the file end.
-     *
-     * @param offset starting address of the range the read bulk should contain
-     * @param range_size size of the addresses range
-     * @param pc the IO priority class under which to queue this operation
-     * @param intent the IO intention confirmation (\ref seastar::io_intent)
-     *
-     * ATTN: The method is going to be deprecated
-     *
-     * @return temporary buffer containing the read data bulk.
-     *        or exceptional future holding:
-     *        system_error exception in case of I/O error or eof_error when
-     *        "offset" is beyond EOF.
-     */
-    template <typename CharType>
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    future<temporary_buffer<CharType>>
-    dma_read_bulk(uint64_t offset, size_t range_size, const io_priority_class& pc, io_intent* intent = nullptr) noexcept {
-        return dma_read_bulk_impl(offset, range_size, internal::maybe_priority_class_ref(pc), intent).then([] (temporary_buffer<uint8_t> t) {
-            return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
-        });
-    }
-#endif
 
     /**
      * Read a data bulk containing the provided addresses range that starts at

--- a/include/seastar/core/fstream.hh
+++ b/include/seastar/core/fstream.hh
@@ -60,9 +60,6 @@ class file_input_stream_history {
 struct file_input_stream_options {
     size_t buffer_size = 8192;    ///< I/O buffer size
     unsigned read_ahead = 0;      ///< Maximum number of extra read-ahead operations
-#if SEASTAR_API_LEVEL < 7
-    ::seastar::io_priority_class io_priority_class = default_priority_class();
-#endif
     lw_shared_ptr<file_input_stream_history> dynamic_adjustments = { }; ///< Input stream history, if null dynamic adjustments are disabled
 };
 
@@ -107,9 +104,6 @@ struct file_output_stream_options {
     unsigned buffer_size = 65536;
     unsigned preallocation_size = 0; ///< Preallocate extents. For large files, set to a large number (a few megabytes) to reduce fragmentation
     unsigned write_behind = 1; ///< Number of buffers to write in parallel
-#if SEASTAR_API_LEVEL < 7
-    ::seastar::io_priority_class io_priority_class = default_priority_class();
-#endif
 };
 
 /// Create an output_stream for writing starting at the position zero of a

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -32,22 +32,10 @@
 #define SEASTAR_INCLUDE_API_V7
 #endif
 
-#if SEASTAR_API_LEVEL == 6
-#define SEASTAR_INCLUDE_API_V6 inline
-#else
-#define SEASTAR_INCLUDE_API_V6
-#endif
-
-
 // Declare them here so we don't have to use the macros everywhere
 namespace seastar {
-    SEASTAR_INCLUDE_API_V6 namespace api_v6 {
-        inline namespace and_newer {
-        }
-    }
     SEASTAR_INCLUDE_API_V7 namespace api_v7 {
         inline namespace and_newer {
-            using namespace api_v6::and_newer;
         }
     }
 }

--- a/include/seastar/core/io_priority_class.hh
+++ b/include/seastar/core/io_priority_class.hh
@@ -26,11 +26,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/modules.hh>
 
-#if SEASTAR_API_LEVEL < 7
-#include <array>
-#include <mutex>
-#endif
-
 #endif
 
 namespace seastar {
@@ -41,90 +36,11 @@ SEASTAR_MODULE_EXPORT_BEGIN
 
 using io_priority_class_id = unsigned;
 
-#if SEASTAR_API_LEVEL < 7
-// We could very well just add the name to the io_priority_class. However, because that
-// structure is passed along all the time - and sometimes we can't help but copy it, better keep
-// it lean. The name won't really be used for anything other than monitoring.
-class io_priority_class {
-    io_priority_class_id _id;
-
-    io_priority_class() = delete;
-    explicit io_priority_class(io_priority_class_id id) noexcept
-        : _id(id)
-    { }
-
-    bool rename_registered(sstring name);
-
-public:
-    io_priority_class_id id() const noexcept {
-        return _id;
-    }
-
-    [[deprecated("Use scheduling_groups and API level >= 7")]]
-    static io_priority_class register_one(sstring name, uint32_t shares);
-
-    /// \brief Updates the current amount of shares for a given priority class
-    ///
-    /// \param pc the priority class handle
-    /// \param shares the new shares value
-    /// \return a future that is ready when the share update is applied
-    future<> update_shares(uint32_t shares) const;
-
-    /// \brief Updates the current bandwidth for a given priority class
-    ///
-    /// The bandwidth applied is NOT shard-local, instead it is applied so that
-    /// all shards cannot consume more bytes-per-second altogether
-    ///
-    /// \param bandwidth the new bandwidth value in bytes/second
-    /// \return a future that is ready when the bandwidth update is applied
-    future<> update_bandwidth(uint64_t bandwidth) const;
-
-    /// Renames an io priority class
-    ///
-    /// Renames an `io_priority_class` previously created with register_one_priority_class().
-    ///
-    /// The operation is global and affects all shards.
-    /// The operation affects the exported statistics labels.
-    ///
-    /// \param pc The io priority class to be renamed
-    /// \param new_name The new name for the io priority class
-    /// \return a future that is ready when the io priority class have been renamed
-    future<> rename(sstring new_name) noexcept;
-
-    unsigned get_shares() const;
-    sstring get_name() const;
-
-private:
-    struct class_info {
-        unsigned shares = 0;
-        sstring name;
-        bool registered() const noexcept { return shares != 0; }
-    };
-
-    static constexpr unsigned _max_classes = 2048;
-    static std::mutex _register_lock;
-    static std::array<class_info, _max_classes> _infos;
-
-    friend std::tuple<unsigned, sstring> get_class_info(io_priority_class_id pc);
-};
-
-const io_priority_class& default_priority_class();
-
-#endif
-
 SEASTAR_MODULE_EXPORT_END
 
 namespace internal {
-#if SEASTAR_API_LEVEL >= 7
 struct maybe_priority_class_ref {
 };
-#else
-struct maybe_priority_class_ref {
-    const io_priority_class& pc;
-    explicit maybe_priority_class_ref(const io_priority_class& p) noexcept : pc(p) {}
-    maybe_priority_class_ref() noexcept : pc(default_priority_class()) {}
-};
-#endif
 }
 
 } // namespace seastar

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -46,15 +46,6 @@ namespace internal {
 const fair_group& get_fair_group(const io_queue& ioq, unsigned stream);
 }
 
-#if SEASTAR_API_LEVEL < 7
-SEASTAR_MODULE_EXPORT
-class io_priority_class;
-
-[[deprecated("Use io_priority_class.rename")]]
-future<>
-rename_priority_class(io_priority_class pc, sstring new_name);
-#endif
-
 SEASTAR_MODULE_EXPORT
 class io_intent;
 
@@ -77,9 +68,6 @@ struct maybe_priority_class_ref;
 class priority_class {
     unsigned _id;
 public:
-#if SEASTAR_API_LEVEL < 7
-    explicit priority_class(const io_priority_class& pc) noexcept;
-#endif
     explicit priority_class(const scheduling_group& sg) noexcept;
     explicit priority_class(internal::maybe_priority_class_ref pc) noexcept;
     unsigned id() const noexcept { return _id; }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -442,17 +442,6 @@ public:
         }
     }
 
-#if SEASTAR_API_LEVEL < 7
-    [[deprecated("Use io_priority_class::register_one")]]
-    io_priority_class register_one_priority_class(sstring name, uint32_t shares);
-
-    [[deprecated("Use io_priority_class.update_shares")]]
-    future<> update_shares_for_class(io_priority_class pc, uint32_t shares);
-
-    [[deprecated("Use io_priority_class.rename")]]
-    static future<> rename_priority_class(io_priority_class pc, sstring new_name) noexcept;
-#endif
-
     /// @private
     future<> update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth);
     /// @private

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -326,7 +326,6 @@ public:
     /// the calling shard
     float get_shares() const noexcept;
 
-#if SEASTAR_API_LEVEL >= 7
     /// \brief Updates the current IO bandwidth for a given scheduling group
     ///
     /// The bandwidth applied is NOT shard-local, instead it is applied so that
@@ -335,7 +334,6 @@ public:
     /// \param bandwidth the new bandwidth value in bytes/second
     /// \return a future that is ready when the bandwidth update is applied
     future<> update_io_bandwidth(uint64_t bandwidth) const;
-#endif
 
     friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
     friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -74,11 +74,6 @@ module seastar;
 
 namespace seastar {
 
-#if SEASTAR_API_LEVEL < 7
-static_assert(std::is_nothrow_copy_constructible_v<io_priority_class>);
-static_assert(std::is_nothrow_move_constructible_v<io_priority_class>);
-#endif
-
 namespace internal {
 
 struct fs_info {
@@ -1232,11 +1227,7 @@ future<uint64_t> file::get_inode_lifetime_hint() noexcept {
 future<temporary_buffer<uint8_t>>
 file::dma_read_bulk_impl(uint64_t offset, size_t range_size, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept {
   try {
-#if SEASTAR_API_LEVEL >= 7
     return _file_impl->dma_read_bulk(offset, range_size, intent);
-#else
-    return _file_impl->dma_read_bulk(offset, range_size, pc.pc, intent);
-#endif
   } catch (...) {
     return current_exception_as_future<temporary_buffer<uint8_t>>();
   }
@@ -1284,11 +1275,7 @@ future<> file::flush() noexcept {
 
 future<size_t> file::dma_write_impl(uint64_t pos, std::vector<iovec> iov, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept {
   try {
-#if SEASTAR_API_LEVEL >= 7
     return _file_impl->write_dma(pos, std::move(iov), intent);
-#else
-    return _file_impl->write_dma(pos, std::move(iov), pc.pc, intent);
-#endif
   } catch (...) {
     return current_exception_as_future<size_t>();
   }
@@ -1297,11 +1284,7 @@ future<size_t> file::dma_write_impl(uint64_t pos, std::vector<iovec> iov, intern
 future<size_t>
 file::dma_write_impl(uint64_t pos, const uint8_t* buffer, size_t len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept {
   try {
-#if SEASTAR_API_LEVEL >= 7
     return _file_impl->write_dma(pos, buffer, len, intent);
-#else
-    return _file_impl->write_dma(pos, buffer, len, pc.pc, intent);
-#endif
   } catch (...) {
     return current_exception_as_future<size_t>();
   }
@@ -1309,11 +1292,7 @@ file::dma_write_impl(uint64_t pos, const uint8_t* buffer, size_t len, internal::
 
 future<size_t> file::dma_read_impl(uint64_t pos, std::vector<iovec> iov, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept {
   try {
-#if SEASTAR_API_LEVEL >= 7
     return _file_impl->read_dma(pos, std::move(iov), intent);
-#else
-    return _file_impl->read_dma(pos, std::move(iov), pc.pc, intent);
-#endif
   } catch (...) {
     return current_exception_as_future<size_t>();
   }
@@ -1344,11 +1323,7 @@ file::dma_read_impl(uint64_t pos, size_t len, internal::maybe_priority_class_ref
 future<size_t>
 file::dma_read_impl(uint64_t aligned_pos, uint8_t* aligned_buffer, size_t aligned_len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept {
   try {
-#if SEASTAR_API_LEVEL >= 7
     return _file_impl->read_dma(aligned_pos, aligned_buffer, aligned_len, intent);
-#else
-    return _file_impl->read_dma(aligned_pos, aligned_buffer, aligned_len, pc.pc, intent);
-#endif
   } catch (...) {
     return current_exception_as_future<size_t>();
   }

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -72,17 +72,10 @@ static inline T select_buffer_size(T configured_value, T maximum_value) noexcept
     }
 }
 
-#if SEASTAR_API_LEVEL >= 7
 template <typename Options>
 inline internal::maybe_priority_class_ref get_io_priority(const Options& opts) {
     return internal::maybe_priority_class_ref{};
 }
-#else
-template <typename Options>
-inline internal::maybe_priority_class_ref get_io_priority(const Options& opts) {
-    return internal::maybe_priority_class_ref(opts.io_priority_class);
-}
-#endif
 
 class file_data_source_impl : public data_source_impl {
     struct issued_read {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -240,26 +240,6 @@ shard_id reactor::cpu_id() const {
     return _id;
 }
 
-#if SEASTAR_API_LEVEL < 7
-io_priority_class
-reactor::register_one_priority_class(sstring name, uint32_t shares) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    return io_priority_class::register_one(std::move(name), shares);
-#pragma GCC diagnostic pop
-}
-
-future<>
-reactor::update_shares_for_class(io_priority_class pc, uint32_t shares) {
-    return pc.update_shares(shares);
-}
-
-future<>
-reactor::rename_priority_class(io_priority_class pc, sstring new_name) noexcept {
-    return pc.rename(std::move(new_name));
-}
-#endif
-
 void reactor::update_shares_for_queues(internal::priority_class pc, uint32_t shares) {
     for (auto&& q : _io_queues) {
         q.second->update_shares_for_class(pc, shares);
@@ -1725,18 +1705,6 @@ bool
 reactor::reap_kernel_completions() {
     return _backend->reap_kernel_completions();
 }
-
-#if SEASTAR_API_LEVEL < 7
-const io_priority_class& default_priority_class() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    static thread_local auto shard_default_class = [] {
-        return io_priority_class::register_one("default", 1);
-    }();
-    return shard_default_class;
-#pragma GCC diagnostic pop
-}
-#endif
 
 namespace internal {
 
@@ -5014,16 +4982,12 @@ float scheduling_group::get_shares() const noexcept {
 void
 scheduling_group::set_shares(float shares) noexcept {
     engine()._task_queues[_id]->set_shares(shares);
-#if SEASTAR_API_LEVEL >= 7
     engine().update_shares_for_queues(internal::priority_class(*this), shares);
-#endif
 }
 
-#if SEASTAR_API_LEVEL >= 7
 future<> scheduling_group::update_io_bandwidth(uint64_t bandwidth) const {
     return engine().update_bandwidth_for_queues(internal::priority_class(*this), bandwidth);
 }
-#endif
 
 future<scheduling_group>
 create_scheduling_group(sstring name, sstring shortname, float shares) noexcept {
@@ -5056,13 +5020,6 @@ scheduling_group_key_create(scheduling_group_key_config cfg) noexcept {
     });
 }
 
-#if SEASTAR_API_LEVEL < 7
-future<>
-rename_priority_class(io_priority_class pc, sstring new_name) {
-    return pc.rename(std::move(new_name));
-}
-#endif
-
 future<>
 destroy_scheduling_group(scheduling_group sg) noexcept {
     if (sg == default_scheduling_group()) {
@@ -5090,9 +5047,7 @@ rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_short
     }
     return smp::invoke_on_all([sg, new_name, new_shortname] {
         engine()._task_queues[sg._id]->rename(new_name, new_shortname);
-#if SEASTAR_API_LEVEL >= 7
         engine().rename_queues(internal::priority_class(sg), new_name);
-#endif
         return engine().rename_scheduling_group_specific_data(sg);
     });
 }

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -120,59 +120,6 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
     BOOST_REQUIRE((name1_found && !name2_found) || (name2_found && !name1_found));
 }
 
-#if SEASTAR_API_LEVEL < 7
-SEASTAR_THREAD_TEST_CASE(test_renaming_io_priority_classes) {
-    // this seams a little bit out of place but the
-    // renaming functionality is primarily for statistics
-    // otherwise those classes could have just been reused
-    // without renaming them.
-    using namespace seastar;
-    static const char* name1 = "A";
-    static const char* name2 = "B";
-    seastar::io_priority_class pc = io_priority_class::register_one("hello",100);
-    smp::invoke_on_all([&pc] () {
-        // this is a trick to get all of the queues actually register their
-        // stats.
-        return pc.update_shares(101);
-    }).get();
-
-    boost::integer_range<int> rng(0, 1000);
-    // repeatedly change the group name back and forth in
-    // decresing time intervals to see if it generate double
-    //registration statistics errors.
-    for (auto&& i : rng) {
-        const char* name = i%2 ? name1 : name2;
-        const char* prev_name = i%2 ? name2 : name1;
-        sleep(std::chrono::microseconds(100000/(i+1))).get();
-        pc.rename(name).get();
-        std::set<sstring> label_vals = get_label_values(sstring("io_queue_shares"), sstring("class"));
-        // validate that the name that we *renamed to* is in the stats
-        BOOST_REQUIRE(label_vals.find(sstring(name)) != label_vals.end());
-        // validate that the name that we *renamed from* is *not* in the stats
-        BOOST_REQUIRE(label_vals.find(sstring(prev_name)) == label_vals.end());
-    }
-
-    smp::invoke_on_all([&pc] () {
-        return do_with(std::uniform_int_distribution<int>(), boost::irange<int>(0, 1000),
-                [&pc] (std::uniform_int_distribution<int>& dist, boost::integer_range<int>& rng) {
-            // flip a fair coin and rename to one of two options and rename to that
-            // scheduling group name, do it 1000 in parallel on all shards so there
-            // is a chance of collision.
-            return do_for_each(rng, [&pc, &dist] (auto i) {
-                bool odd = dist(seastar::testing::local_random_engine)%2;
-                return pc.rename(odd ? name1 : name2);
-            });
-        });
-    }).get();
-
-    std::set<sstring> label_vals = get_label_values(sstring("io_queue_shares"), sstring("class"));
-    // validate that only one of the names is eventually in the metrics
-    bool name1_found = label_vals.find(sstring(name1)) != label_vals.end();
-    bool name2_found = label_vals.find(sstring(name2)) != label_vals.end();
-    BOOST_REQUIRE((name1_found && !name2_found) || (name2_found && !name1_found));
-}
-#endif
-
 int count_by_label(const std::string& label) {
     seastar::foreign_ptr<seastar::metrics::impl::values_reference> values = seastar::metrics::impl::get_values();
     int count = 0;


### PR DESCRIPTION
In f94b1bb9cb8c04b5a ("Merge 'Unify CPU scheduling groups and IO priority classes' from Pavel Emelyanov"), we folded I/O scheduling control into scheduling groups. This was more than a year ago. As it was a breaking change, we introduced API_LEVEL 7 to avoid breaking users. We now make API_LEVEL 7 mandatory and remove non-unified scheduling support.