### PR TITLE
shared_ptr: remove deprecated lw_shared_ptr assignment operator

### DIFF
--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -342,12 +342,6 @@ public:
     lw_shared_ptr& operator=(std::nullptr_t) noexcept {
         return *this = lw_shared_ptr();
     }
-    [[deprecated("call make_lw_shared<> and assign the result instead")]]
-    lw_shared_ptr& operator=(T&& x) noexcept {
-        this->~lw_shared_ptr();
-        new (this) lw_shared_ptr(make_lw_shared<T>(std::move(x)));
-        return *this;
-    }
 
     T& operator*() const noexcept { return *accessors<T>::to_value(_p); }
     T* operator->() const noexcept { return accessors<T>::to_value(_p); }


### PR DESCRIPTION
The assignment operator was deprecated in 8038c131b7c ("shared_ptr: deprecate lw_shared_ptr operator=(T&&)"), more than a year ago. It is safe to remove it now.