### PR TITLE
build: add compiler and C++ standard compatibility checks

### DIFF
--- a/cmake/SeastarConfig.cmake.in
+++ b/cmake/SeastarConfig.cmake.in
@@ -25,6 +25,32 @@
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
+if (CMAKE_CXX_STANDARD)
+  set (current_cxx_standard ${CMAKE_CXX_STANDARD})
+else ()
+  set (current_cxx_standard ${CMAKE_CXX_STANDARD_DEFAULT})
+endif ()
+
+if (NOT (current_cxx_standard STREQUAL @CMAKE_CXX_STANDARD@))
+  message(WARNING
+    "C++ Standard mismatch detected:
+- Seastar was compiled with: C++@CMAKE_CXX_STANDARD@
+- This project is configured to use: C++${current_cxx_standard}
+This mismatch may lead to build failures due to differences in the supported \
+features of these two standards. Please adjust your project's C++ standard to \
+match Seastar.")
+endif ()
+
+if (NOT ((CMAKE_CXX_COMPILER_ID STREQUAL @CMAKE_CXX_COMPILER_ID@) AND
+         (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL @CMAKE_CXX_COMPILER_VERSION@)))
+  message (WARNING
+    "Compiler mismatch detected:
+- Seastar was compiled with: @CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@ \
+- This project is configured to use: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}
+This mismatch may lead to build failures due to differences in supported features and ABI compatibility. \
+Please configure your project to use the same C++ compiler to match Seastar.")
+endif ()
+
 #
 # Dependencies.
 #


### PR DESCRIPTION
we install `SeastarConfig.cmake` so that a Seastar project can consume the Seastar libraries using `find_package(Seastar)`. this CMake config file checks for the dependencies used by CMake, and defines the Seastar libraries to be consumed by the parent project. one of the dependence is detected using FindSourceLocation.cmake, which is also shipped along with Seastar, this find module is provided so that we can detect the C++ compiler support of `std::source_location` related features. But the result of the detection depends on the C++ standard used, which is default to the one configured by the used C++ compiler if not specified. if the parent project consumes precompiled Seastar libraries, and use a differnt C++ standard, the parent project could fail to build, because Seastar and parent project are using different compiling options.

mismatches in C++ standards or compilers between Seastar and the parent project can lead to build failures or runtime issues. while not always problematic, these mismatches can cause unexpected behavior.

in this change, we detect

- the C++ standards used by the parent project and Seastar
- the C++ compiler used by the parent project and Seastar

warnings are non-fatal as compatibility is possible in some cases, but developers should be aware of potential issues and test thoroughly.

Fixes #2181
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>