### PR TITLE
build: include -fno-semantic-interposition in CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,7 @@ target_include_directories (seastar
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set (Seastar_PRIVATE_CXX_FLAGS
+  -fno-semantic-interposition
   -UNDEBUG
   -Wall
   -Werror


### PR DESCRIPTION
when building the shared libraries, `-fnosematntic-interposition` option can be used to improve the performance of the shared libraries, if interposition of exported symbol is not allowed.

by default, GCC respects the symbol interposition semantics defined by the ELF specification. but if we want to have a better performance for the shared libraries, and we don't want to override the exported symbols with, for instance, `LD_PRELOAD`, we can safely disable this behavior for better performance. as the interposition semantics prevents compiler from doing further optimizations like inlining. GCC only disables this when building with `-Ofast`, see https://github.com/gcc-mirror/gcc/commit/458d2c689963d8461d84670a3d8988cd6ecbfd81.

Clang just disables this behavior by default. see
https://github.com/llvm/llvm-project/commit/d1fd72343c6ff58a3b66bc0df56fed9ac21e4056.

so, in order to have better performance when building shared libraries, let's just disable the interposition semantics.

this change should have no impact on the Seastar static libraries, but it can improve the performance of the shared libraries.