### PR TITLE
build: do not support c-ares >= 1.33

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -51,6 +51,7 @@ find_package_handle_standard_args (c-ares
 if (c-ares_FOUND)
   set (c-ares_LIBRARIES ${c-ares_LIBRARY})
   set (c-ares_INCLUDE_DIRS ${c-ares_INCLUDE_DIR})
+  set (c-ares_VERSION ${PC_c-ares_VERSION})
   if (NOT (TARGET c-ares::cares))
     add_library (c-ares::cares UNKNOWN IMPORTED)
 

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -166,4 +166,11 @@ macro (seastar_find_dependencies)
   else ()
     find_package(Protobuf 2.5.0 REQUIRED)
   endif ()
+
+  if (c-ares_VERSION VERSION_GREATER_EQUAL 1.33)
+    # https://github.com/scylladb/seastar/issues/2472
+    message (FATAL_ERROR
+      "c-ares ${c-ares_VERSION} is not supported. "
+      "Seastar requires c-ares version lower than 1.33")
+  endif ()
 endmacro ()


### PR DESCRIPTION
we don't support c-ares 1.33 yet. so error out when c-ares >= 1.33 is detected.

Refs #2472