### PR TITLE
treewide: replace boost::irange with std::views::iota where possible

### DIFF
--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -25,11 +25,11 @@
 #include <chrono>
 #include <random>
 #include <memory>
+#include <ranges>
 #include <vector>
 #include <cmath>
 #include <sys/vfs.h>
 #include <sys/sysmacros.h>
-#include <boost/range/irange.hpp>
 #include <boost/program_options.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <fstream>
@@ -468,7 +468,7 @@ public:
         }
 
         auto worker = worker_ptr.get();
-        auto concurrency = boost::irange<unsigned, unsigned>(0, max_os_concurrency, 1);
+        auto concurrency = std::views::iota(0u, max_os_concurrency);
         return parallel_for_each(std::move(concurrency), [worker] (unsigned idx) {
             auto bufptr = worker->get_buffer();
             auto buf = bufptr.get();

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -22,9 +22,9 @@
 #include <vector>
 #include <chrono>
 #include <random>
+#include <ranges>
 #include <yaml-cpp/yaml.h>
 #include <fmt/core.h>
-#include <boost/range/irange.hpp>
 #pragma GCC diagnostic push
 // see https://github.com/boostorg/accumulators/pull/54
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -429,7 +429,7 @@ public:
         co.tcp_nodelay = _ccfg.nodelay;
         co.isolation_cookie = _cfg.sg_name;
         _client = std::make_unique<rpc_protocol::client>(_rpc, co, _caddr);
-        return parallel_for_each(boost::irange(0u, _cfg.parallelism), [this] (auto dummy) {
+        return parallel_for_each(std::views::iota(0u, _cfg.parallelism), [this] (auto dummy) {
           auto f = make_ready_future<>();
           if (_cfg.sleep_time) {
               // Do initial small delay to de-synchronize fibers
@@ -513,7 +513,7 @@ public:
     virtual future<> run() override {
         _stop = std::chrono::steady_clock::now() + _cfg.duration;
         return with_scheduling_group(_cfg.sg, [this] {
-          return parallel_for_each(boost::irange(0u, _cfg.parallelism), [this] (auto dummy) {
+          return parallel_for_each(std::views::iota(0u, _cfg.parallelism), [this] (auto dummy) {
             return do_until([this] {
                 return std::chrono::steady_clock::now() > _stop;
             }, [this] {

--- a/demos/rpc_demo.cc
+++ b/demos/rpc_demo.cc
@@ -19,6 +19,7 @@
  * Copyright 2015 Cloudius Systems
  */
 #include <cmath>
+#include <ranges>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/rpc/rpc.hh>
@@ -26,8 +27,6 @@
 #include <seastar/rpc/lz4_compressor.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/loop.hh>
-
-#include <boost/range/irange.hpp>
 
 using namespace seastar;
 
@@ -229,7 +228,7 @@ int main(int ac, char** av) {
             (void)sleep(400ms).then([test12] () mutable {
                 // server is configured for 10MB max, throw 25MB worth of requests at it.
                 auto now = rpc::rpc_clock_type::now();
-                return parallel_for_each(boost::irange(0, 25), [test12, now] (int idx) mutable {
+                return parallel_for_each(std::views::iota(0, 25), [test12, now] (int idx) mutable {
                     return test12(*client, 100, uninitialized_string(1'000'000)).then([idx, now] {
                         auto later = rpc::rpc_clock_type::now();
                         auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(later - now);

--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -19,6 +19,7 @@
  * Copyright 2015 Cloudius Systems
  */
 #include <cmath>
+#include <ranges>
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/reactor.hh>
@@ -27,8 +28,6 @@
 #include <seastar/core/loop.hh>
 #include <seastar/net/dns.hh>
 #include "tls_echo_server.hh"
-
-#include <boost/range/irange.hpp>
 
 using namespace seastar;
 namespace bpo = boost::program_options;
@@ -97,7 +96,7 @@ int main(int ac, char** av) {
                 }
                 return tls::connect(certs, ia, options).then([=](::connected_socket s) {
                     auto strms = ::make_lw_shared<streams>(std::move(s));
-                    auto range = boost::irange(size_t(0), i);
+                    auto range = std::views::iota(size_t(0), i);
                     return do_for_each(range, [=](auto) {
                         auto f = strms->out.write(*msg);
                         if (!do_read) {

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1619,7 +1619,7 @@ In the examples we saw earlier, `main()` ran our function `f()` only once, on th
 seastar::future<> service_loop();
 
 seastar::future<> f() {
-    return seastar::parallel_for_each(boost::irange<unsigned>(0, seastar::smp::count),
+    return seastar::parallel_for_each(std::views::iota(0u, seastar::smp::count),
             [] (unsigned c) {
         return seastar::smp::submit_to(c, service_loop);
     });
@@ -2320,7 +2320,7 @@ Consider the following asynchronous function `loop()`, which loops until some sh
 ```cpp
 seastar::future<long> loop(int parallelism, bool& stop) {
     return seastar::do_with(0L, [parallelism, &stop] (long& counter) {
-        return seastar::parallel_for_each(boost::irange<unsigned>(0, parallelism),
+        return seastar::parallel_for_each(std::views::iota(0u, parallelism),
             [&stop, &counter]  (unsigned c) {
                 return seastar::do_until([&stop] { return stop; }, [&counter] {
                     ++counter;

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -33,9 +33,9 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/combine.hpp>
-#include <boost/range/irange.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/core/loop.hh>
+#include <ranges>
 #include <regex>
 #include <string_view>
 
@@ -400,7 +400,7 @@ public:
 
 static future<> get_map_value(metrics_families_per_shard& vec) {
     vec.resize(smp::count);
-    return parallel_for_each(boost::irange(0u, smp::count), [&vec] (auto cpu) {
+    return parallel_for_each(std::views::iota(0u, smp::count), [&vec] (auto cpu) {
         return smp::submit_to(cpu, [] {
             return mi::get_values();
         }).then([&vec, cpu] (auto res) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -31,6 +31,7 @@ module;
 #include <exception>
 #include <filesystem>
 #include <fstream>
+#include <ranges>
 #include <regex>
 #include <thread>
 
@@ -62,7 +63,6 @@ module;
 #include <boost/intrusive/list.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/irange.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
@@ -1078,7 +1078,7 @@ reactor::~reactor() {
             // The following line will preserve the convention that constructor and destructor functions
             // for the per sg values are called in the context of the containing scheduling group.
             *internal::current_scheduling_group_ptr() = scheduling_group(tq->_id);
-            for (size_t key : boost::irange<size_t>(0, sg_data.scheduling_group_key_configs.size())) {
+            for (size_t key : std::views::iota(0u, sg_data.scheduling_group_key_configs.size())) {
                 void* val = this_sg.specific_vals[key];
                 if (val) {
                     if (sg_data.scheduling_group_key_configs[key].destructor) {

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -28,7 +28,7 @@ module;
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
-#include <boost/range/irange.hpp>
+#include <ranges>
 #include <regex>
 #include <stdlib.h>
 #include <unistd.h>
@@ -401,7 +401,7 @@ allocate_io_queues(hwloc_topology_t topology, std::vector<cpu> cpus, std::unorde
     // above, hwloc won't do us any good here. Later on, we will use this information to assign
     // shards to coordinators that are node-local to themselves.
     std::unordered_map<unsigned, std::set<unsigned>> numa_nodes;
-    for (auto shard: boost::irange(0, int(cpus.size()))) {
+    for (auto shard: std::views::iota(0, int(cpus.size()))) {
         auto node_id = node_of_shard(shard);
 
         if (numa_nodes.count(node_id) == 0) {

--- a/src/core/sharded.cc
+++ b/src/core/sharded.cc
@@ -23,7 +23,7 @@
 module;
 #endif
 
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -39,7 +39,7 @@ namespace internal {
 
 future<>
 sharded_parallel_for_each(unsigned nr_shards, on_each_shard_func on_each_shard) noexcept(std::is_nothrow_move_constructible_v<on_each_shard_func>) {
-    return parallel_for_each(boost::irange<unsigned>(0, nr_shards), std::move(on_each_shard));
+    return parallel_for_each(std::views::iota(0u, nr_shards), std::move(on_each_shard));
 }
 
 }

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -27,7 +27,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/when_all.hh>
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 static constexpr fair_queue::class_id cid = 0;
 
@@ -98,7 +98,7 @@ struct perf_fair_queue {
 future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
-        return parallel_for_each(boost::irange(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
+        return parallel_for_each(std::views::iota(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
             auto cap = local.queue(loc).tokens_capacity(double(1) / std::numeric_limits<int>::max() + double(1) / std::numeric_limits<int>::max());
             auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;

--- a/tests/perf/smp_submit_to_perf.cc
+++ b/tests/perf/smp_submit_to_perf.cc
@@ -20,7 +20,7 @@
  */
 
 #include <random>
-#include <boost/range/irange.hpp>
+#include <ranges>
 #include <fmt/core.h>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
@@ -55,7 +55,7 @@ class thinker {
     future<> _done;
 
     future<> start_thinking(unsigned concurrency) {
-        return parallel_for_each(boost::irange(0u, concurrency), [this] (unsigned f) {
+        return parallel_for_each(std::views::iota(0u, concurrency), [this] (unsigned f) {
             return do_until([this] { return _stop; }, [this] {
                 auto until = steady_clock::now() + _pause.get();
                 while (steady_clock::now() < until) {
@@ -116,7 +116,7 @@ class worker {
     }
 
     future<> start_working(unsigned concurrency, respond_type resp, microseconds tmo) {
-        return parallel_for_each(boost::irange(0u, concurrency), [this, resp, tmo] (unsigned f) {
+        return parallel_for_each(std::views::iota(0u, concurrency), [this, resp, tmo] (unsigned f) {
             return do_until([this] { return _stop; }, [this, resp, tmo] {
                 return smp::submit_to(_to, [resp, tmo] {
                     switch (resp) {

--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -30,9 +30,9 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/later.hh>
 #include <stdexcept>
+#include <ranges>
 #include <tuple>
 
-#include <boost/range/irange.hpp>
 
 using namespace seastar;
 
@@ -70,7 +70,7 @@ int main(int argc, char** argv)
         });
         // test for alien::submit_to(), which returns a std::future<int>
         std::vector<std::future<int>> counts;
-        for (auto i : boost::irange(0u, smp::count)) {
+        for (auto i : std::views::iota(0u, smp::count)) {
             // send messages from alien.
             counts.push_back(alien::submit_to(app.alien(), i, [i] {
                 return seastar::make_ready_future<int>(i);
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
         std::cerr << "Bad everything: " << everything << " != " << expected << std::endl;
         return 1;
     }
-    const auto shards = boost::irange(0u, smp::count);
+    const auto shards = std::views::iota(0u, smp::count);
     auto expected = std::accumulate(std::begin(shards), std::end(shards), 0);
     if (total != expected) {
         std::cerr << "Bad total: " << total << " != " << expected << std::endl;

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -22,7 +22,6 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <boost/range/irange.hpp>
 #include <boost/test/tools/context.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -142,8 +141,8 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_pop_n) {
         }
     };
 
-    for (size_t size : boost::irange((size_t)0, 2 * N) ) {
-        for (size_t pop_count : boost::irange((size_t)0, size + 1) ) {
+    for (size_t size : std::views::iota((size_t)0, 2 * N) ) {
+        for (size_t pop_count : std::views::iota((size_t)0, size + 1) ) {
             BOOST_TEST_CONTEXT("size: " << size << ", pop_count: " << pop_count) {
                 fill_and_reset(size);
 

--- a/tests/unit/closeable_test.cc
+++ b/tests/unit/closeable_test.cc
@@ -21,7 +21,7 @@
 
 #include <exception>
 
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -363,7 +363,7 @@ SEASTAR_TEST_CASE(gate_holder_parallel_copy_test) {
             auto gh = g.hold();
             // Copying the gate::holder in the lambda below should keep it open
             // until all instances complete
-            (void)parallel_for_each(boost::irange(0, expected), [&count, gh = gh] (int) {
+            (void)parallel_for_each(std::views::iota(0, expected), [&count, gh = gh] (int) {
                 count++;
                 return make_ready_future<>();
             });

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -32,8 +32,7 @@
 #include <seastar/util/closeable.hh>
 #include <seastar/util/later.hh>
 #include <mutex>
-
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -347,8 +346,8 @@ SEASTAR_TEST_CASE(test_smp_service_groups) {
         shard_id other_shard = smp::count - 1;
         remote_worker rm1(1);
         remote_worker rm2(1000);
-        auto bunch1 = parallel_for_each(boost::irange(0, 20), [&] (int ignore) { return rm1.do_remote_work(other_shard, ssg1); });
-        auto bunch2 = parallel_for_each(boost::irange(0, 2000), [&] (int ignore) { return rm2.do_remote_work(other_shard, ssg2); });
+        auto bunch1 = parallel_for_each(std::views::iota(0, 20), [&] (int ignore) { return rm1.do_remote_work(other_shard, ssg1); });
+        auto bunch2 = parallel_for_each(std::views::iota(0, 2000), [&] (int ignore) { return rm2.do_remote_work(other_shard, ssg2); });
         bunch1.get();
         bunch2.get();
         if (smp::count > 1) {

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <system_error>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -31,7 +32,6 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/core/sharded.hh>
-#include <boost/range/irange.hpp>
 
 namespace seastar {
 
@@ -284,7 +284,7 @@ public:
         _pending[shard] = nullptr;
     }
     future<> destroy_all_shards() {
-        return parallel_for_each(boost::irange(0u, _shards_count), [this](shard_id shard) {
+        return parallel_for_each(std::views::iota(0u, _shards_count), [this](shard_id shard) {
             return smp::submit_to(shard, [this] {
                 destroy_shard(this_shard_id());
             });

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -36,6 +36,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_runner.hh>
 #include <boost/range/irange.hpp>
+#include <ranges>
 
 SEASTAR_TEST_CASE(test_add_group) {
     using namespace seastar::metrics;
@@ -84,7 +85,7 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
     static const char* name1 = "A";
     static const char* name2 = "B";
     scheduling_group sg =  create_scheduling_group("hello", 111).get();
-    boost::integer_range<int> rng(0, 1000);
+    auto rng = std::views::iota(0, 1000);
     // repeatedly change the group name back and forth in
     // decresing time intervals to see if it generate double
     //registration statistics errors.

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -31,7 +31,7 @@
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/shared_mutex.hh>
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -175,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(test_non_default_broken_semaphore) {
 
 SEASTAR_TEST_CASE(test_shared_mutex_exclusive) {
     return do_with(shared_mutex(), unsigned(0), [] (shared_mutex& sm, unsigned& counter) {
-        return parallel_for_each(boost::irange(0, 10), [&sm, &counter] (int idx) {
+        return parallel_for_each(std::views::iota(0, 10), [&sm, &counter] (int idx) {
             return with_lock(sm, [&counter] {
                 BOOST_REQUIRE_EQUAL(counter, 0u);
                 ++counter;
@@ -200,7 +200,7 @@ SEASTAR_TEST_CASE(test_shared_mutex_shared) {
                 });
             });
         };
-        return map_reduce(boost::irange(0, 100), running_in_parallel, false, std::bit_or<bool>()).then([&counter] (bool result) {
+        return map_reduce(std::views::iota(0, 100), running_in_parallel, false, std::bit_or<bool>()).then([&counter] (bool result) {
             BOOST_REQUIRE_EQUAL(result, true);
             BOOST_REQUIRE_EQUAL(counter, 0u);
         });
@@ -237,7 +237,7 @@ SEASTAR_TEST_CASE(test_shared_mutex_mixed) {
                 return running_in_parallel(instance);
             }
         };
-        return map_reduce(boost::irange(0, 100), run, false, std::bit_or<bool>()).then([&counter] (bool result) {
+        return map_reduce(std::views::iota(0, 100), run, false, std::bit_or<bool>()).then([&counter] (bool result) {
             BOOST_REQUIRE_EQUAL(result, true);
             BOOST_REQUIRE_EQUAL(counter, 0u);
         });

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -30,9 +30,9 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <atomic>
 #include <chrono>
-#include <sys/mman.h>
+#include <ranges>
 
-#include <boost/range/irange.hpp>
+#include <sys/mman.h>
 
 #ifndef SEASTAR_DEBUG
 
@@ -118,7 +118,7 @@ SEASTAR_THREAD_TEST_CASE(no_poll_no_stall) {
     static constexpr unsigned tasks = 2000;
     promise<> p;
     auto f = p.get_future();
-    parallel_for_each(boost::irange(0u, tasks), [&p] (unsigned int i) {
+    parallel_for_each(std::views::iota(0u, tasks), [&p] (unsigned int i) {
         (void)yield().then([i, &p] {
             spin(500us);
             if (i == tasks - 1) {


### PR DESCRIPTION
this change is created in the same spirit of f322e764.

in this change, we partially modernizes our range usage while maintaining existing functionality.