### PR TITLE
build: extract c-ares version from header file

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -36,6 +36,18 @@ find_path (c-ares_INCLUDE_DIR
     ${PC_c-ares_INCLUDEDIR}
     ${PC_c-ares_INCLUDE_DIRS})
 
+if (c-ares_INCLUDE_DIR)
+  file(STRINGS "${c-ares_INCLUDE_DIR}/ares_version.h" ares_VERSION_LINE
+    REGEX "^#define[ \t]+ARES_VERSION_STR \"[^\"]*\"$")
+  if (ares_VERSION_LINE MATCHES "ARES_VERSION_STR \"(([0-9]+)\\.([0-9]+)\\.([0-9]+))")
+    set (c-ares_VERSION "${CMAKE_MATCH_1}")
+    set (c-ares_VERSION_MAJOR "${CMAKE_MATCH_2}")
+    set (c-ares_VERSION_MINOR "${CMAKE_MATCH_3}")
+    set (c-ares_VERSION_PATCH "${CMAKE_MATCH_4}")
+  endif ()
+  unset (ares_VERSION_LINE)
+endif ()
+
 mark_as_advanced (
   c-ares_LIBRARY
   c-ares_INCLUDE_DIR)
@@ -46,12 +58,11 @@ find_package_handle_standard_args (c-ares
   REQUIRED_VARS
     c-ares_LIBRARY
     c-ares_INCLUDE_DIR
-  VERSION_VAR PC_c-ares_VERSION)
+  VERSION_VAR c-ares_VERSION)
 
 if (c-ares_FOUND)
   set (c-ares_LIBRARIES ${c-ares_LIBRARY})
   set (c-ares_INCLUDE_DIRS ${c-ares_INCLUDE_DIR})
-  set (c-ares_VERSION ${PC_c-ares_VERSION})
   if (NOT (TARGET c-ares::cares))
     add_library (c-ares::cares UNKNOWN IMPORTED)
 


### PR DESCRIPTION
before this change, we get c-ares's version with pkg-config, but this could be wrong if we have multiple c-ares version installed into the system, and the one to be used is specified using CMake variable of `c-ares_ROOT` via the command line like:

```console
cmake -Dc-ares_ROOT=install-path/of/c-ares
```

as `pkg_check_modules()` does not respect the `c-ares_ROOT` variable, it always find the .pc file in the default paths.

in order to get the version of the c-ares library specified by the `c-ares_ROOT` variable, let's extract the version number in the header file. this should fix the build of seastar on fedora 41 with both c-ares 1.33 shipped by the fedora 41, and c-ares 1.32 installed manually.