### PR TITLE
build: improve c-ares version extraction method

### DIFF
--- a/cmake/Findc-ares.cmake
+++ b/cmake/Findc-ares.cmake
@@ -37,15 +37,15 @@ find_path (c-ares_INCLUDE_DIR
     ${PC_c-ares_INCLUDE_DIRS})
 
 if (c-ares_INCLUDE_DIR)
-  file(STRINGS "${c-ares_INCLUDE_DIR}/ares_version.h" ares_VERSION_LINE
-    REGEX "^#define[ \t]+ARES_VERSION_STR \"[^\"]*\"$")
-  if (ares_VERSION_LINE MATCHES "ARES_VERSION_STR \"(([0-9]+)\\.([0-9]+)\\.([0-9]+))")
-    set (c-ares_VERSION "${CMAKE_MATCH_1}")
-    set (c-ares_VERSION_MAJOR "${CMAKE_MATCH_2}")
-    set (c-ares_VERSION_MINOR "${CMAKE_MATCH_3}")
-    set (c-ares_VERSION_PATCH "${CMAKE_MATCH_4}")
-  endif ()
-  unset (ares_VERSION_LINE)
+  foreach (v MAJOR MINOR PATCH)
+    file(STRINGS "${c-ares_INCLUDE_DIR}/ares_version.h" ares_VERSION_LINE
+      REGEX "^#define[ \t]+ARES_VERSION_${v}[ \t]+[0-9]+$")
+    if (ares_VERSION_LINE MATCHES "ARES_VERSION_${v} ([0-9]+)")
+      set (c-ares_VERSION_${v} "${CMAKE_MATCH_1}")
+    endif ()
+    unset (ares_VERSION_LINE)
+  endforeach ()
+  set (c-ares_VERSION ${c-ares_VERSION_MAJOR}.${c-ares_VERSION_MINOR}.${c-ares_VERSION_PATCH})
 endif ()
 
 mark_as_advanced (


### PR DESCRIPTION
this change enhances the version extraction process to handle both literal and macro-based version definitions in c-ares.

in 5d53fb6d, we extract the c-ares version by looking for `ARES_VERSION_STR` and matching the version numbers in it. as, in c-ares 1.32, the line looks like:
```c
  #define ARES_VERSION_STR "1.33.0"
```
but this method fails for c-ares 1.33+ due to non-literal `ARES_VERSION_STR` definitionin. as in c-ares 1.33+, it looks like
```c
  #define ARES_VERSION_STR             \
    ARES_STRINGIFY(ARES_VERSION_MAJOR) \
    "." ARES_STRINGIFY(ARES_VERSION_MINOR) "." ARES_STRINGIFY(ARES_VERSION_PATCH)
```

this fails the parser. and the version number is always empty.

in this change, we match the MAJOR, MINOR and PATCH version components separately. this approach increases resilience. after this change, Seastar is able to detect the versions of both c-ares 1.32 and 1.33.

Refs 5d53fb6d
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>