### PR TITLE
build: support c-ares >= 1.34.1

### DIFF
--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -167,10 +167,10 @@ macro (seastar_find_dependencies)
     find_package(Protobuf 2.5.0 REQUIRED)
   endif ()
 
-  if (c-ares_VERSION VERSION_GREATER_EQUAL 1.33)
+  if (c-ares_VERSION VERSION_GREATER_EQUAL 1.33.0 AND c-ares_VERSION VERSION_LESS 1.34.1)
     # https://github.com/scylladb/seastar/issues/2472
     message (FATAL_ERROR
       "c-ares ${c-ares_VERSION} is not supported. "
-      "Seastar requires c-ares version lower than 1.33")
+      "Seastar requires c-ares version <1.33 or >=1.34.1 ")
   endif ()
 endmacro ()


### PR DESCRIPTION
in c-ares 1.34.0, it addressed a regression with custom socket callbacks due to DNS cookie support. because 1.34.0's release tarball failed to include some header file. so let's claim the support to c-ares < 1.33 or >= 1.34.1.

Refs #2472
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>