### PR TITLE
build: set CMAKE_POSITION_INDEPENDENT_CODE when building shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,17 +317,26 @@ set (Seastar_TEST_TIMEOUT
   STRING
   "Maximum allowed time for a test to run, in seconds.")
 
-option (BUILD_SHARED_LIBS
-  "Build seastar library as shared libraries instead of static"
-  OFF)
 cmake_dependent_option (Seastar_BUILD_SHARED_LIBS
   "Build Seastar as shared libraries" OFF
-  "NOT DEFINED BUILD_SHARED_LIB" OFF)
+  "NOT DEFINED BUILD_SHARED_LIBS" OFF)
 cmake_dependent_option (Seastar_BUILD_STATIC_LIBS
   "Build Seastar as static libraries" ON
-  "NOT DEFINED BUILD_SHARED_LIB" OFF)
+  "NOT DEFINED BUILD_SHARED_LIBS" OFF)
+if (DEFINED BUILD_SHARED_LIBS)
+  if (BUILD_SHARED_LIBS)
+    set (Seastar_BUILD_SHARED_LIBS ON)
+    set (Seastar_BUILD_STATIC_LIBS OFF)
+  else ()
+    set (Seastar_BUILD_SHARED_LIBS OFF)
+    set (Seastar_BUILD_STATIC_LIBS ON)
+  endif ()
+endif ()
 if (NOT (Seastar_BUILD_SHARED_LIBS OR Seastar_BUILD_STATIC_LIBS))
   message (FATAL_ERROR "Seastar_BUILD_STATIC_LIBS and Seastar_BUILD_STATIC_LIBS cannot both be disabled")
+endif ()
+if (Seastar_BUILD_SHARED_LIBS)
+  set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
 function (seastar_add_library name objects)
@@ -405,7 +414,7 @@ if ((NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")) OR
     (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.2))
   string (APPEND Seastar_ASAN_OPTIONS ":detect_stack_use_after_return=1")
 endif ()
-if (BUILD_SHARED_LIBS)
+if (Seastar_BUILD_SHARED_LIBS)
   string (APPEND Seastar_ASAN_OPTIONS ":verify_asan_link_order=0")
 endif ()
 
@@ -883,7 +892,7 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 23)
   endif ()
 endif ()
 
-if (BUILD_SHARED_LIBS OR Seastar_BUILD_SHARED_LIBS)
+if (Seastar_BUILD_SHARED_LIBS)
   # use initial-exec TLS, as it puts the TLS variables in the static TLS space
   # instead of allocating them using malloc. otherwise intercepting mallocs and
   # friends could lead to recursive call of malloc functions when a dlopen'ed
@@ -970,7 +979,7 @@ include (CTest)
 target_compile_definitions(seastar-objects
   PUBLIC
   SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
-  $<$<BOOL:${BUILD_SHARED_LIBS}>:SEASTAR_BUILD_SHARED_LIBS>)
+  $<$<BOOL:${Seastar_BUILD_SHARED_LIBS}>:SEASTAR_BUILD_SHARED_LIBS>)
 
 target_compile_features(seastar-objects
   PUBLIC


### PR DESCRIPTION
in 54e25a9d, we enabled Seastar to build shared and static libraries in a single pass. but we failed to set `POSITION_INDEPENDENT_CODE` property for the targets if `BUILD_SHARED_LIBS` is not set. this breaks the build if user does't pass `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` to `cmake` when generating the building system of seastar.

in this change:

- we set the global `CMAKE_POSITION_INDEPENDENT_CODE` as long as `Seastar_BUILD_STATIC_LIBS` is set. please note, this does not incur the runtime performance degration of the static libraries. because, even the object files included by a static library are compiled with `-fPIC`, the linker treats these files as if they were directly compiled *into* the program when it links the seastar application.
- set the correct `Seastar_ASAN_OPTION` if `Seastar_BUILD_SHARED_LIBS` is set. this should fix the test failure when `Seastar_BUILD_SHARED_LIBS` is set, while `BUILD_SHARED_LIBS` is not.
- fix the typo of `BUILD_SHARED_LIB`. it should have been `BUILD_SHARED_LIBS`. this breaks the support of `BUILD_SHARED_LIBS`.
- deduce the values of `Seastar_BUILD_STATIC_LIBS` and `Seastar_BUILD_SHARED_LIBS` from the value of `BUILD_SHARED_LIBS` if it is set. if user wants to use `BUILD_SHARED_LIBS`, we should respect the decision, and in the meanwhile, we don't want to check all of these three variables everywhere. instead we just check `Seastar_BUILD_SHARED_LIBS` and `Seastar_BUILD_STATIC_LIBS`.
- remove `BUILD_SHARED_LIBS` as an option. because, if we have it as an option, we would have to provide a default value for it. either it is TRUE of FALSE, we would have to respect it. this defeats the purpose of 54e25a9d, and prevents us from having both shared *and* static libraries in a single pass. but we still respect this CMake variable.