### PR TITLE
scheduling: allow to check number of free scheduling group slots

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -124,8 +124,6 @@ class buffer_allocator;
 class priority_class;
 class poller;
 
-size_t scheduling_group_count();
-
 void increase_thrown_exceptions_counter() noexcept;
 
 }

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -126,6 +126,8 @@ future<> rename_scheduling_group(scheduling_group sg, sstring new_name) noexcept
 /// \return a future that is ready when the scheduling group has been renamed
 future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
 
+/// Returns number of active scheduling groups.
+size_t scheduling_group_count();
 
 /**
  * Represents a configuration for a specific scheduling group value,

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -129,6 +129,9 @@ future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring 
 /// Returns number of active scheduling groups.
 size_t scheduling_group_count();
 
+/// Returns number of free scheduling group slots.
+size_t scheduling_group_free_slots();
+
 /**
  * Represents a configuration for a specific scheduling group value,
  * it contains all that is needed to maintain a scheduling group specific

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5054,6 +5054,10 @@ rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_short
     });
 }
 
+size_t scheduling_group_count() {
+    auto b = s_used_scheduling_group_ids_bitmap.load(std::memory_order_relaxed);
+    return __builtin_popcountl(b);
+}
 namespace internal {
 
 void add_to_flush_poller(output_stream<char>& os) noexcept {
@@ -5136,11 +5140,6 @@ std::ostream& operator<<(std::ostream& os, const stall_report& sr) {
         return std::chrono::duration<float>(d) / 1ms;
     };
     return os << format("{} stalls, {} ms stall time, {} ms run time", sr.kernel_stalls, to_ms(sr.stall_time), to_ms(sr.run_wall_time));
-}
-
-size_t scheduling_group_count() {
-    auto b = s_used_scheduling_group_ids_bitmap.load(std::memory_order_relaxed);
-    return __builtin_popcountl(b);
 }
 
 void

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5058,6 +5058,11 @@ size_t scheduling_group_count() {
     auto b = s_used_scheduling_group_ids_bitmap.load(std::memory_order_relaxed);
     return __builtin_popcountl(b);
 }
+
+size_t scheduling_group_free_slots() {
+    return max_scheduling_groups() - scheduling_group_count();
+}
+
 namespace internal {
 
 void add_to_flush_poller(output_stream<char>& os) noexcept {

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -273,16 +273,19 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
         try {
             BOOST_REQUIRE_LE(scheduling_group_count(), max_scheduling_groups());
             scheduling_groups_deferred_cleanup.emplace_back(create_scheduling_group(format("sg_{}", i), 10).get());
+            BOOST_REQUIRE_EQUAL(scheduling_group_free_slots(), max_scheduling_groups() - scheduling_group_count());
         } catch (std::runtime_error& e) {
             // make sure it is the right exception.
             BOOST_REQUIRE_EQUAL(e.what(), fmt::format("Scheduling group limit exceeded while creating sg_{}", i));
             // make sure that the scheduling group count makes sense
             BOOST_REQUIRE_EQUAL(scheduling_group_count(), max_scheduling_groups());
+            BOOST_REQUIRE_EQUAL(scheduling_group_free_slots(), 0);
             // make sure that we expect this exception at this point
             BOOST_REQUIRE_GE(i, max_scheduling_groups());
         }
     }
     BOOST_REQUIRE_EQUAL(scheduling_group_count(), max_scheduling_groups());
+    BOOST_REQUIRE_EQUAL(scheduling_group_free_slots(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -36,6 +36,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/core/scheduling.hh>
 
 using namespace std::chrono_literals;
 
@@ -268,20 +269,20 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
     // The line below is necessary in order to skip support of copy and move construction of scheduling_group_destroyer.
     scheduling_groups_deferred_cleanup.reserve(max_scheduling_groups());
     // try to create 3 groups too many.
-    for (auto i = internal::scheduling_group_count(); i < max_scheduling_groups() + 3; i++) {
+    for (auto i = scheduling_group_count(); i < max_scheduling_groups() + 3; i++) {
         try {
-            BOOST_REQUIRE_LE(internal::scheduling_group_count(), max_scheduling_groups());
+            BOOST_REQUIRE_LE(scheduling_group_count(), max_scheduling_groups());
             scheduling_groups_deferred_cleanup.emplace_back(create_scheduling_group(format("sg_{}", i), 10).get());
         } catch (std::runtime_error& e) {
             // make sure it is the right exception.
             BOOST_REQUIRE_EQUAL(e.what(), fmt::format("Scheduling group limit exceeded while creating sg_{}", i));
             // make sure that the scheduling group count makes sense
-            BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
+            BOOST_REQUIRE_EQUAL(scheduling_group_count(), max_scheduling_groups());
             // make sure that we expect this exception at this point
             BOOST_REQUIRE_GE(i, max_scheduling_groups());
         }
     }
-    BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
+    BOOST_REQUIRE_EQUAL(scheduling_group_count(), max_scheduling_groups());
 }
 
 SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {


### PR DESCRIPTION
In ScyllaDB, we'd like to check how many scheduling groups were already created or how many free slots are there.

`scheduling_group_count()` was already present but it was in an internal namespace, making it impossible to use it in any app. This patch makes it exported to the user.
`scheduling_group_free_slots()` returns number of free scheduling group slots.

Refs https://github.com/scylladb/scylladb/issues/21051