### PR TITLE
dns: Support c-ares before 1.22

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -55,6 +55,11 @@ std::ostream& operator<<(std::ostream& os, const opt_family& f) {
 
 }
 
+#if (ARES_VERSION < 0x011600)
+// ares_channel_t is only present since c-ares 1.22.0 (November 2023)
+typedef struct ares_channeldata ares_channel_t;
+#endif
+
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::net::opt_family> : fmt::ostream_formatter {};
 #endif


### PR DESCRIPTION
ares_channel_t has been introduced in c-ares 1.22 (November 2023). This version is not yet in most Linux distributions with long version cycles, e.g. Debian.

A simple and easy to maintain solution is to provide a compatibility typedef.

This fixes build failure on older c-ares, which was introduced in 7139445c5af424fb27ae7809409f4e10a29d0b9a

Fixes https://github.com/scylladb/seastar/issues/2492