### PR TITLE
README.md: specify CMAKE_CXX_STANDARD in the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ and with CMake using the `Seastar` package:
 `CMakeLists.txt` for `my_app`:
 
 ```
+set (CMAKE_CXX_STANDARD 23)
+
 find_package (Seastar REQUIRED)
 
 add_executable (my_app


### PR DESCRIPTION
the C++ standard used by a CMake project is specified by `CMAKE_CXX_STANDARD`, but if this variable is not specified, the default standard used by the compiler is used. at the moment of writing, GCC-14.2 uses C++17 as its default C++ standard. but Seastar by default uses the highest C++ standard supported by the configured compiler. and it is C++23 for GCC-14.2.

in 52dab12a, we added the compatibility checks to avoid the build failure caused by the discrepancies between different compilers and the different C++ standards. and let CMake warn at seeing different compilers or different C++ standands used when building Seastar and its parent project.

in the sample, we didn't specify the C++ standard. so user is very likely to run into the build failure reported by #2181, where the Seastar library was compiled using C++23, while the Seastar application is compiled using C++17.

in this change, we specify `CMAKE_CXX_STANDARD` explicitly to avoid this confusion.