### PR TITLE
build: persist Seastar options in SeastarConfig.cmake

### DIFF
--- a/cmake/SeastarConfig.cmake.in
+++ b/cmake/SeastarConfig.cmake.in
@@ -56,6 +56,10 @@ endif ()
 #
 
 include (SeastarDependencies)
+set (Seastar_DPDK @Seastar_DPDK@)
+set (Seastar_IO_URING @Seastar_IO_URING@)
+set (Seastar_HWLOC @Seastar_HWLOC@)
+set (Seastar_NUMA @Seastar_NUMA@)
 seastar_find_dependencies ()
 
 if (NOT TARGET Seastar::seastar)


### PR DESCRIPTION
SeastarConfig.cmake is installed/redistributed by Seastar. this file is consumed by `find_package(Seastar)`. but the options configuring the build dependencies should be consistent when build Seastar and when consuming the built Seastar libraries. for instance, when building Seastar, a feature relying on a certain package is enabled. the Seastar application consuming the prebuild Seastar should check for the existence of this package. on the other hand, if a package is not used at all, the Seastar application is not obliged to check it.

in this change, we make all the options impacting the package detection subvars in `SeastarConfig.cmake.in`, so that Seastar application can detect the used package properly.