### PR TITLE
build: suppress CMake warning about CMP0057

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -20,6 +20,9 @@
 # Copyright (C) 2018 Scylladb, Ltd.
 #
 
+cmake_policy (PUSH)
+cmake_policy (SET CMP0057 NEW)
+
 if(NOT Sanitizers_FIND_COMPONENTS)
   set(Sanitizers_FIND_COMPONENTS
     address
@@ -78,3 +81,5 @@ if (Sanitizers_FOUND)
     endif ()
   endforeach ()
 endif ()
+
+cmake_policy (POP)


### PR DESCRIPTION
when building a project by consuming Seastar's CMake config files, if the parent project does not set the policy CMP0057, CMake warns:

```
CMake Warning (dev) at /tmp/seastar/lib64/cmake/Seastar/FindSanitizers.cmake:53 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /tmp/seastar/lib64/cmake/Seastar/SeastarDependencies.cmake:55 (find_dependency)
  /tmp/seastar/lib64/cmake/Seastar/SeastarDependencies.cmake:98 (seastar_find_dep)
  /tmp/seastar/lib64/cmake/Seastar/SeastarConfig.cmake:56 (seastar_find_dependencies)
  CMakeLists.txt:5 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /tmp/seastar/lib64/cmake/Seastar/FindSanitizers.cmake:53 (if):
  if given arguments:

    "address" "IN_LIST" "Sanitizers_FIND_COMPONENTS"

  Unknown arguments specified
Call Stack (most recent call first):
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /tmp/seastar/lib64/cmake/Seastar/SeastarDependencies.cmake:55 (find_dependency)
  /tmp/seastar/lib64/cmake/Seastar/SeastarDependencies.cmake:98 (seastar_find_dep)
  /tmp/seastar/lib64/cmake/Seastar/SeastarConfig.cmake:56 (seastar_find_dependencies)
  CMakeLists.txt:5 (find_package)
```

it is the library's responsibility to provide a warning-free CMake module, so let's silence this warning. as we are indeed using `IN_LIST` as an operator in `if` clause.