### PR TITLE
build: do not check for CMAKE_CXX_STANDARD < 20

### DIFF
--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -36,12 +36,8 @@ include(CMakeParseArguments)
 # - Boost::foo
 set (Boost_NO_BOOST_CMAKE ON)
 
-if (CMAKE_CXX_STANDARD LESS 20)
-  set (_seastar_boost_version 1.64.0)
-else ()
-  # for including the fix of https://github.com/boostorg/test/pull/252
-  set (_seastar_boost_version 1.73.0)
-endif ()
+# for including the fix of https://github.com/boostorg/test/pull/252
+set (_seastar_boost_version 1.73.0)
 
 # This is the minimum version of Boost we need the CMake-bundled `FindBoost.cmake` to know about.
 find_package (Boost ${_seastar_boost_version} MODULE)


### PR DESCRIPTION
in 5d3ee98073, we dropped the support of C++17. so no need to check if the C++ standard is less than 20 -- it should be always greater or equal to 20.