### PR TITLE
stall-analyser: pass args.tmin instead of tmin

### DIFF
--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -442,7 +442,7 @@ def main():
             sys.exit()
         if args.format == 'graph':
             print_command_line_options(args)
-            print_stats(tally, tmin)
+            print_stats(tally, args.tmin)
         render.print_graph(args.direction, args.width, args.branch_threshold)
     except BrokenPipeError:
         pass


### PR DESCRIPTION
8e583411 introduced a regression, which passes an undefined variable of `tmin` to `print_stats()`.

in this change, we pass `args.tmin` instead of `tmin` to this function.