### PR TITLE
Enable `smp_message_queue metrics` by default

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -423,8 +423,6 @@ metric_function make_function(T& val, data_type dt) {
 }
 }
 
-extern const bool metric_disabled;
-
 extern label shard_label;
 
 /*

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -544,8 +544,6 @@ void impl::set_metric_family_configs(const std::vector<metric_family_config>& fa
 }
 }
 
-const bool metric_disabled = false;
-
 relabel_config::relabel_action relabel_config_action(const std::string& action) {
     if (action == "skip_when_empty") {
         return relabel_config::relabel_action::skip_when_empty;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3646,16 +3646,16 @@ void smp_message_queue::start(unsigned cpuid) {
     _metrics.add_group("smp", {
             // queue_length     value:GAUGE:0:U
             // Absolute value of num packets in last tx batch.
-            sm::make_queue_length("send_batch_queue_length", _last_snt_batch, sm::description("Current send batch queue length"), {sm::shard_label(instance)})(sm::metric_disabled),
-            sm::make_queue_length("receive_batch_queue_length", _last_rcv_batch, sm::description("Current receive batch queue length"), {sm::shard_label(instance)})(sm::metric_disabled),
-            sm::make_queue_length("complete_batch_queue_length", _last_cmpl_batch, sm::description("Current complete batch queue length"), {sm::shard_label(instance)})(sm::metric_disabled),
-            sm::make_queue_length("send_queue_length", _current_queue_length, sm::description("Current send queue length"), {sm::shard_label(instance)})(sm::metric_disabled),
+            sm::make_queue_length("send_batch_queue_length", _last_snt_batch, sm::description("Current send batch queue length"), {sm::shard_label(instance)}),
+            sm::make_queue_length("receive_batch_queue_length", _last_rcv_batch, sm::description("Current receive batch queue length"), {sm::shard_label(instance)}),
+            sm::make_queue_length("complete_batch_queue_length", _last_cmpl_batch, sm::description("Current complete batch queue length"), {sm::shard_label(instance)}),
+            sm::make_queue_length("send_queue_length", _current_queue_length, sm::description("Current send queue length"), {sm::shard_label(instance)}),
             // total_operations value:DERIVE:0:U
-            sm::make_counter("total_received_messages", _received, sm::description("Total number of received messages"), {sm::shard_label(instance)})(sm::metric_disabled),
+            sm::make_counter("total_received_messages", _received, sm::description("Total number of received messages"), {sm::shard_label(instance)}),
             // total_operations value:DERIVE:0:U
-            sm::make_counter("total_sent_messages", _sent, sm::description("Total number of sent messages"), {sm::shard_label(instance)})(sm::metric_disabled),
+            sm::make_counter("total_sent_messages", _sent, sm::description("Total number of sent messages"), {sm::shard_label(instance)}),
             // total_operations value:DERIVE:0:U
-            sm::make_counter("total_completed_messages", _compl, sm::description("Total number of messages completed"), {sm::shard_label(instance)})(sm::metric_disabled)
+            sm::make_counter("total_completed_messages", _compl, sm::description("Total number of messages completed"), {sm::shard_label(instance)})
     });
 }
 


### PR DESCRIPTION
These metrics were originally disabled for overloading the collectd servers many years back. However, these days they seem like a drop in the bucket relative to number of metrics seastar generates. Beyond this they would be useful to have when debugging issues related to cross-shard traffic.