### PR TITLE
Add missing `assert.h` header to `chunked_fifo`

### DIFF
--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -23,6 +23,7 @@
 
 #ifndef SEASTAR_MODULE
 #include <algorithm>
+#include <cassert>
 #include <type_traits>
 #include <seastar/util/modules.hh>
 #endif


### PR DESCRIPTION
`assert(...)` is being used in the `pop_front_n` method and none of the other headers in the file include assert transitively.