### PR TITLE
build: do not include -DBoost_TEST_DYN_LINK in seastar_testing_cflags

### DIFF
--- a/pkgconfig/seastar-testing.pc.in
+++ b/pkgconfig/seastar-testing.pc.in
@@ -12,7 +12,7 @@ boost_cflags=-I$<JOIN:@Boost_INCLUDE_DIRS@, -I>
 boost_unit_test_libs=@Boost_UNIT_TEST_FRAMEWORK_LIBRARY@
 
 # Us.
-seastar_testing_cflags=-DBoost_TEST_DYN_LINK
+seastar_testing_cflags=
 seastar_testing_libs=${libdir}/$<TARGET_FILE_NAME:seastar_testing>
 
 Requires: seastar >= 1.0


### PR DESCRIPTION
before this change, we include `-DBoost_TEST_DYN_LINK` in seastar_testing_cflags. but this macro is not documented by Boost document, what we should use is `BOOST_TEST_DYN_LINK` if we want to link against Boost.Test's shared library. see https://www.boost.org/doc/libs/1_86_0/libs/test/doc/html/boost_test/utf_reference/link_references/link_boost_test_dyn_link.html

the reason why the tests build, is that they pass

- either link against `Boost::dynamic_linking` via Seastar's CMake
  building system
- or pass `-DBOOST_ALL_DYN_LINK` by themselves
- or pass `-DSEASTAR_TESTING_MAIN` to use Seastar's `main()`

but either way, seasetar_testing is not supposed to expose this definition or ``BOOST_TEST_DYN_LINK` in its compile options.

in this change, we just drop this definition from cflags. as it is never checked by Boost.Test. And tests are supposed to define `SEASTAR_TESTING_MAIN` by themselves.