### PR TITLE
loopback: add pending capacity param and fix deadlock in httpd_test

### DIFF
--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1641,7 +1641,7 @@ SEASTAR_TEST_CASE(case_insensitive_header_reply) {
 }
 
 SEASTAR_THREAD_TEST_CASE(multiple_connections) {
-    loopback_connection_factory lcf(1);
+    loopback_connection_factory lcf = loopback_connection_factory::with_pending_capacity(smp::count + 1, 1);
     http_server server("test");
     httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
     socket_address addr{ipv4_addr()};


### PR DESCRIPTION
The class `loopback_connection_factory` used a magic number valued `10` as the capacity of the connection queue per shard. As a result, test units can badly program the device. For example, `httpd_test` would deadlock on a machine with 10 vCPUs or more, because `connect()` waits for queue space to be released, and queue space is only released after the `connect()` call. This commit adds a `pending_capacity` param to provide the needed control for test units, via factory method to disambiguate constructors. Also, it fixes the deadlock in `httpd_test.cc` using the new interface.