### PR TITLE
rpc: switch rpc::type from boost to std

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -32,7 +32,6 @@
 #include <stdexcept>
 #include <string>
 #include <any>
-#include <boost/type.hpp>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/variant_utils.hh>
 #include <seastar/core/timer.hh>
@@ -50,7 +49,7 @@ using rpc_clock_type = lowres_clock;
 
 // used to tag a type for serializers
 template<typename T>
-using type = boost::type<T>;
+using type = std::type_identity<T>;
 
 struct stats {
     using counter_type = uint64_t;


### PR DESCRIPTION
rpc has a marker type rpc::type which it uses to communicate with the user-provided deserializer. It is currently based on boost::type.

In an ideal universe, switching to the similar std::type_identity would involve only changing the typedef. However, some users pass boost::type directly, so we can't do that without breaking them.

To preserve compatiblity, have all read() calls pass through a helper function that checks which variant is available and calls it. The older one is marked deprecated. With that done, we switch the rpc::type alias to std::type_identity.