### PR TITLE
gate: check: mark as const

### DIFF
--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -130,7 +130,7 @@ public:
     /// voluntarily stop itself after the gate is closed, by making calls to
     /// check() in appropriate places. check() with throw an exception and
     /// bail out of the long-running code if the gate is closed.
-    void check() {
+    void check() const {
         if (_stopped) {
             throw gate_closed_exception();
         }


### PR DESCRIPTION
`check()` doesn't modify the object so it can be marked as `const`.