### PR TITLE
core/units: remove space before literal identifier

### DIFF
--- a/include/seastar/core/units.hh
+++ b/include/seastar/core/units.hh
@@ -34,10 +34,10 @@ constexpr size_t KB = 1 << 10;
 constexpr size_t MB = 1 << 20;
 constexpr size_t GB = 1 << 30;
 
-constexpr size_t operator"" _KiB(unsigned long long n) { return n << 10; }
-constexpr size_t operator"" _MiB(unsigned long long n) { return n << 20; }
-constexpr size_t operator"" _GiB(unsigned long long n) { return n << 30; }
-constexpr size_t operator"" _TiB(unsigned long long n) { return n << 40; }
+constexpr size_t operator""_KiB(unsigned long long n) { return n << 10; }
+constexpr size_t operator""_MiB(unsigned long long n) { return n << 20; }
+constexpr size_t operator""_GiB(unsigned long long n) { return n << 30; }
+constexpr size_t operator""_TiB(unsigned long long n) { return n << 40; }
 
 SEASTAR_MODULE_EXPORT_END
 }


### PR DESCRIPTION
clang 20 complains:
```
/home/kefu/dev/seastar/include/seastar/core/units.hh:37:29: warning: identifier '_KiB' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   37 | constexpr size_t operator"" _KiB(unsigned long long n) { return n << 10; }
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_KiB
/home/kefu/dev/seastar/include/seastar/core/units.hh:38:29: warning: identifier '_MiB' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   38 | constexpr size_t operator"" _MiB(unsigned long long n) { return n << 20; }
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_MiB
/home/kefu/dev/seastar/include/seastar/core/units.hh:39:29: warning: identifier '_GiB' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   39 | constexpr size_t operator"" _GiB(unsigned long long n) { return n << 30; }
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_GiB
/home/kefu/dev/seastar/include/seastar/core/units.hh:40:29: warning: identifier '_TiB' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   40 | constexpr size_t operator"" _TiB(unsigned long long n) { return n << 40; }
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_TiB
```

because, in
[CWG2521](https://wg21.link/CWG2521), it proposes that compiler should consider
```c++
  string operator "" _i18n(const char*, std::size_t); // OK, deprecated
```
as "OK, deprecated".

and Clang implemented this proposal, as it was accepted by [C++23](https://eel.is/c++draft/over.literal).
Since Seastar supports both C++20 and C++23 standards. let's remove the space between `"` and `_` to be more compliant to the C++23 standard and to silence the warning.