### PR TITLE
doc: compatibility: update the notes on supported GCC versions

### DIFF
--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -38,11 +38,11 @@ Patches for new platforms (e.g, Windows) are welcome.
 Compilers
 =========
 
-Seastar supports gcc and clang. Ports to other compilers are
+Seastar supports GCC and Clang. Ports to other compilers are
 welcome.
 
 The last two major releases of a compiler are supported (e.g.
-gcc 11 and gcc 12). Patches to support older versions are welcome,
+GCC 13 and GCC 14). Patches to support older versions are welcome,
 as long as they don't require onerous compromises.
 
 Deprecation


### PR DESCRIPTION
- replace gcc and clang with GCC and Clang. as GCC and Clang are their names. while "gcc" and "clang" are command line names we are using.
- replace gcc 11 and gcc 12 with GCC 13 and GCC 14. as the latest GCC version is GCC 14.