### PR TITLE
docker: bump up to clang {18,19} and gcc {13,14}

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,34 +1,34 @@
 # syntax=docker/dockerfile:1
 
-FROM ubuntu:mantic
+FROM ubuntu:oracular
 
 RUN --mount=type=bind,source=./install-dependencies.sh,target=/install-dependencies.sh \
     apt-get update && apt-get install -y \
     curl \
     gnupg \
-    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-17 main" \
+    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-oracular-18 main" \
     >> /etc/apt/sources.list.d/llvm.list \
-    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main" \
+    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-oracular-19 main" \
     >> /etc/apt/sources.list.d/llvm.list \
     && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && apt-get update && apt-get install -y \
     build-essential \
-    clang-17 \
     clang-18 \
-    clang-tools-18 \
-    gcc-12 \
-    g++-12 \
+    clang-19 \
+    clang-tools-19 \
     gcc-13 \
     g++-13 \
+    gcc-14 \
+    g++-14 \
     pandoc \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 17 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 17 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 14 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 14 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 18 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 18 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 19 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 19 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 19 \
     && bash ./install-dependencies.sh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
since we only support the latest two major releases of compilers. at the moment of writing, Clang just released v19, and the latest major release of GCC is v14.

so we should install them respectively.

because ubuntu mantis is already EOF. see
https://wiki.ubuntu.com/Releases. and it does not include the latest GCC and Clang packages. we need to bump up the base image from ubuntu:mantis to ubuntu:orcular despite that orcular is not an LTS release. we should use new ubuntu LTS release once it's out.