### PR TITLE
treewide: reduce the usage of iostream in headers

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -18,6 +18,7 @@
 /*
  * Copyright (C) 2021 ScyllaDB
  */
+#include <iostream>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -19,6 +19,7 @@
  * Copyright (C) 2022 ScyllaDB
  */
 
+#include <iostream>
 #include <vector>
 #include <chrono>
 #include <random>

--- a/demos/rpc_demo.cc
+++ b/demos/rpc_demo.cc
@@ -19,6 +19,7 @@
  * Copyright 2015 Cloudius Systems
  */
 #include <cmath>
+#include <iostream>
 #include <ranges>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>

--- a/include/seastar/core/format.hh
+++ b/include/seastar/core/format.hh
@@ -1,0 +1,48 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#ifndef SEASTAR_MODULE
+#include <fmt/format.h>
+#endif
+
+namespace seastar {
+
+/**
+ * Evaluate the formatted string in a native fmt library format
+ *
+ * @param fmt format string with the native fmt library syntax
+ * @param a positional parameters
+ *
+ * @return sstring object with the result of applying the given positional
+ *         parameters on a given format string.
+ */
+template <typename... A>
+sstring
+format(fmt::format_string<A...> fmt, A&&... a) {
+    fmt::memory_buffer out;
+    fmt::format_to(fmt::appender(out), fmt, std::forward<A>(a)...);
+    return sstring{out.data(), out.size()};
+}
+
+}

--- a/include/seastar/core/internal/estimated_histogram.hh
+++ b/include/seastar/core/internal/estimated_histogram.hh
@@ -25,8 +25,8 @@
 #include <algorithm>
 #include <vector>
 #include <chrono>
+#include <string>
 #include <seastar/core/metrics_types.hh>
-#include <seastar/core/print.hh>
 #include <seastar/core/bitops.hh>
 #include <limits>
 #include <array>

--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -25,7 +25,6 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
-#include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <iostream>
 #include <iomanip>

--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
@@ -118,22 +119,6 @@ log(A&&... a) {
     print(std::forward<A>(a)...);
 }
 
-/**
- * Evaluate the formatted string in a native fmt library format
- *
- * @param fmt format string with the native fmt library syntax
- * @param a positional parameters
- *
- * @return sstring object with the result of applying the given positional
- *         parameters on a given format string.
- */
-template <typename... A>
-sstring
-format(fmt::format_string<A...> fmt, A&&... a) {
-    fmt::memory_buffer out;
-    fmt::format_to(fmt::appender(out), fmt, std::forward<A>(a)...);
-    return sstring{out.data(), out.size()};
-}
 
 // temporary, use fmt::print() instead
 template <typename... A>

--- a/include/seastar/net/packet-util.hh
+++ b/include/seastar/net/packet-util.hh
@@ -23,7 +23,6 @@
 
 #include <seastar/net/packet.hh>
 #include <map>
-#include <iostream>
 
 namespace seastar {
 
@@ -145,8 +144,7 @@ public:
                 continue;
             } else {
                 // If we reach here, we have a bug with merge.
-                std::cerr << "packet_merger: merge error\n";
-                abort();
+                std::abort();
                 break;
             }
         }

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <seastar/core/format.hh>
 #include <seastar/core/function_traits.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -27,7 +28,6 @@
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/core/simple-stream.hh>
 #include <seastar/net/packet-data-source.hh>
-#include <seastar/core/print.hh>
 
 #include <boost/type.hpp> // for compatibility
 

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/modules.hh>

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -36,6 +36,7 @@
 #include <memory>
 #include <variant>
 #include <boost/container/static_vector.hpp>
+#include <fmt/ostream.h>
 #endif
 
 namespace seastar {

--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
 #include <seastar/util/modules.hh>
 
 #ifndef SEASTAR_MODULE

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -26,6 +26,7 @@ module;
 
 #include <cinttypes>
 #include <atomic>
+#include <iostream>
 #include <vector>
 #include <queue>
 #include <getopt.h>

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -21,14 +21,13 @@
 
 #pragma once
 
-#ifndef SEASTAR_MODULE
-#include <iostream>
-#endif
-
 #include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
+#include <seastar/util/log.hh>
 
 namespace seastar {
+
+extern logger seastar_logger;
 
 namespace net {
 
@@ -135,7 +134,7 @@ public:
 
     virtual void set_reuseaddr(bool reuseaddr) override {
         // FIXME: implement
-        std::cerr << "Reuseaddr is not supported by native stack" << std::endl;
+        seastar_logger.error("Reuseaddr is not supported by native stack");
     }
 
     virtual bool get_reuseaddr() const override {
@@ -244,7 +243,7 @@ native_connected_socket_impl<Protocol>::get_nodelay() const {
 template <typename Protocol>
 void native_connected_socket_impl<Protocol>::set_keepalive(bool keepalive) {
     // FIXME: implement
-    std::cerr << "Keepalive is not supported by native stack" << std::endl;
+    seastar_logger.error("Keepalive is not supported by native stack");
 }
 template <typename Protocol>
 bool native_connected_socket_impl<Protocol>::get_keepalive() const {
@@ -255,7 +254,7 @@ bool native_connected_socket_impl<Protocol>::get_keepalive() const {
 template <typename Protocol>
 void native_connected_socket_impl<Protocol>::set_keepalive_parameters(const keepalive_params&) {
     // FIXME: implement
-    std::cerr << "Keepalive parameters are not supported by native stack" << std::endl;
+    seastar_logger.error("Keepalive parameters are not supported by native stack");
 }
 
 template <typename Protocol>


### PR DESCRIPTION
for better compilation speed, as `<iostream>` is the one of the heaviest C++ headers.

in this series:

- stop using iostream in `seastar/net/packet-util.hh`
- extract `seastar::format()` into `format.hh`
- use `format.hh` directly

tested on my laptop with 32 G memory, 8c16t. 

- ccache and distcc are not enabled
- all interaction with the computer are stopped
- most of the active foreground tasks showed by `top` are stopped

before this change:
---


```console
$ git clean -dfx
$ ./configure.py --mode debug --disable-dpdk --compiler clang++      
$ time cmake --build build/debug
...
real    2m43.926s
user    35m58.795s
sys     1m50.180s
```

after this change:
---

```console
$ git clean -dfx
$ ./configure.py --mode debug --disable-dpdk --compiler clang++      
$ time cmake --build build/debug
...
real    2m42.688s
user    35m55.328s
sys     1m50.926s
```

i repeated the test for 3 times. the change shortened the build time 3 out of 3 times.