### PR TITLE
program-options: add missing include <memory>

### DIFF
--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -37,6 +37,7 @@
 #include <vector>
 #include <optional>
 #include <set>
+#include <memory>
 #endif
 
 /// \defgroup program-options Program Options


### PR DESCRIPTION
Needed for std::unique_ptr.