### PR TITLE
file: add file_system_stat

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -180,6 +180,22 @@ struct stat_data {
     std::chrono::system_clock::time_point time_changed;   // Time of last status change (either content or attributes)
 };
 
+/// Filesystem-wide stat information
+/// See statvfs(3)
+struct file_system_stat_data {
+    size_t block_size;          // Filesystem block size
+    size_t fragment_size;       // Fragment size
+    uint64_t size_in_bytes;     // Size of filesystem in bytes
+    uint64_t free_bytes;        // Free space in bytes
+    uint64_t available_bytes;   // Available space in bytes for unprivileged users
+    uint64_t files_total;       // Number of inodes
+    uint64_t files_free;        // Number of free inodes
+    uint64_t files_available;   // Number of free inodes for unprivileged users
+    uint64_t fsid;              // Filesystem ID
+    uint64_t mount_flags;       // Mount flags
+    size_t max_filename_length; // Maximum filename length
+};
+
 /// @}
 
 SEASTAR_MODULE_EXPORT_END

--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -25,6 +25,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <type_traits>
+#include <cstdint>
+#include <chrono>
+
 #include <seastar/util/modules.hh>
 #endif
 
@@ -157,6 +160,25 @@ inline constexpr file_permissions operator|(file_permissions a, file_permissions
 inline constexpr file_permissions operator&(file_permissions a, file_permissions b) {
     return file_permissions(std::underlying_type_t<file_permissions>(a) & std::underlying_type_t<file_permissions>(b));
 }
+
+/// Filesystem object stat information
+struct stat_data {
+    uint64_t  device_id;      // ID of device containing file
+    uint64_t  inode_number;   // Inode number
+    uint64_t  mode;           // File type and mode
+    directory_entry_type type;
+    uint64_t  number_of_links;// Number of hard links
+    uint64_t  uid;            // User ID of owner
+    uint64_t  gid;            // Group ID of owner
+    uint64_t  rdev;           // Device ID (if special file)
+    uint64_t  size;           // Total size, in bytes
+    uint64_t  block_size;     // Block size for filesystem I/O
+    uint64_t  allocated_size; // Total size of allocated storage, in bytes
+
+    std::chrono::system_clock::time_point time_accessed;  // Time of last content access
+    std::chrono::system_clock::time_point time_modified;  // Time of last content modification
+    std::chrono::system_clock::time_point time_changed;   // Time of last status change (either content or attributes)
+};
 
 /// @}
 

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -69,25 +69,6 @@ struct group_details {
     std::vector<sstring> group_members;
 };
 
-/// Filesystem object stat information
-struct stat_data {
-    uint64_t  device_id;      // ID of device containing file
-    uint64_t  inode_number;   // Inode number
-    uint64_t  mode;           // File type and mode
-    directory_entry_type type;
-    uint64_t  number_of_links;// Number of hard links
-    uint64_t  uid;            // User ID of owner
-    uint64_t  gid;            // Group ID of owner
-    uint64_t  rdev;           // Device ID (if special file)
-    uint64_t  size;           // Total size, in bytes
-    uint64_t  block_size;     // Block size for filesystem I/O
-    uint64_t  allocated_size; // Total size of allocated storage, in bytes
-
-    std::chrono::system_clock::time_point time_accessed;  // Time of last content access
-    std::chrono::system_clock::time_point time_modified;  // Time of last content modification
-    std::chrono::system_clock::time_point time_changed;   // Time of last status change (either content or attributes)
-};
-
 /// File open options
 ///
 /// Options used to configure an open file.

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -445,6 +445,11 @@ future<uint64_t> fs_avail(std::string_view name) noexcept;
 future<uint64_t> fs_free(std::string_view name) noexcept;
 /// @}
 
+/// Return filesystem-wide stat where a file is located.
+///
+/// \param name name of the file to inspect
+future<file_system_stat_data> file_system_stat(std::string_view name) noexcept;
+
 namespace experimental {
 /// \defgroup interprocess-module Interprocess Communication
 ///

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -947,3 +947,13 @@ SEASTAR_TEST_CASE(test_oversized_io_works) {
         BOOST_REQUIRE((size_t)std::count_if(buf.get(), buf.get() + buf_size, [](auto x) { return x == 'a'; }) == buf_size);
     });
 }
+
+SEASTAR_TEST_CASE(test_file_system_stat) {
+    return tmp_dir::do_with_thread([] (tmp_dir& t) {
+        const auto& name = t.get_path().native();
+        auto fs_stat = file_system_stat(name).get();
+
+        BOOST_REQUIRE_GE(fs_stat.size_in_bytes, fs_stat.free_bytes);
+        BOOST_REQUIRE_GE(fs_stat.free_bytes, fs_stat.available_bytes);
+    });
+}


### PR DESCRIPTION
Return an abstract file_system_stat_data representing
the system statvfs for the filesystem identified
by the given file name.

The motivation is implementing a disk-space monitor
in scylladb.