### PR TITLE
core: reactor_config: add reserve_io_control_blocks

### DIFF
--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -170,6 +170,16 @@ struct reactor_options : public program_options::option_group {
     ///
     /// Default: 10000.
     program_options::value<unsigned> max_networking_io_control_blocks;
+    /// \brief Leave this many I/O control blocks (IOCBs) as reserve.
+    ///
+    /// This is to allows leaving a (small) reserve aside so other applications
+    /// also using IOCBs can run alongside the seastar application.
+    /// The reserve takes precedence over \ref max_networking_io_control_blocks.
+    ///
+    /// Default: 0
+    ///
+    /// \see max_networking_io_control_blocks
+    program_options::value<unsigned> reserve_io_control_blocks;
     /// \brief Enable seastar heap profiling.
     ///
     /// Allocations will be sampled every N bytes on average. Zero means off.

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -478,7 +478,7 @@ private:
     void pin(unsigned cpu_id);
     void allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_config cfg);
     void create_thread(std::function<void ()> thread_loop);
-    unsigned adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs);
+    unsigned adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs, unsigned reserve_iocbs);
     static void log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network);
 public:
     static unsigned count;


### PR DESCRIPTION
This new option allows reserving the configured amount of IOCBs, so they are available to a side application running in parallell to the seastar application.
The use case is ScyllaDB and its tool applications, both ScyllaDB and its tool applications need IOCBs to run, so ScyllaDB has to be able to tell seastar to reserve some IOCBs for the tools as well.