### PR TITLE
build: allow CMake to find Boost using package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ list (APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_BINARY_DIR})
 
 cmake_policy (SET CMP0090 NEW)
-foreach (policy CMP0127 CMP0135)
+foreach (policy CMP0127 CMP0135 CMP0167)
   if (POLICY ${policy})
     cmake_policy (SET ${policy} NEW)
   endif ()

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -22,25 +22,18 @@
 
 include(CMakeParseArguments)
 
-#
-# CMake bundles `FindBoost.cmake`, which is coupled to the Boost version. If
-# we're on a system without a recent enough version of `FindBoost.cmake`, then
-# we need to use the one bundled with Seastar.
-#
-# The "real" FIND_PACKAGE invocation for Boost is inside SEASTAR_FIND_DEPENDENCIES.
-#
-
-# Be consistent in results from FindBoost.cmake.
 # This is required because cmake-boost may return to Boost_{component}_LIBRARY:
 # - /usr/lib64/libboost_foo.so
 # - Boost::foo
+# While pkgconf's .pc file consumers expect argument which can be passed as
+# part of the command line arguments
 set (Boost_NO_BOOST_CMAKE ON)
 
 # for including the fix of https://github.com/boostorg/test/pull/252
 set (_seastar_boost_version 1.73.0)
 
 # This is the minimum version of Boost we need the CMake-bundled `FindBoost.cmake` to know about.
-find_package (Boost ${_seastar_boost_version} MODULE)
+find_package (Boost ${_seastar_boost_version})
 if (Boost_VERSION_STRING VERSION_LESS 1.81.0)
   set_target_properties (Boost::boost PROPERTIES
     INTERFACE_COMPILE_DEFINITIONS "BOOST_NO_CXX98_FUNCTION_BASE")


### PR DESCRIPTION
Remove the "MODULE" parameter from `find_package(Boost)` call to allow using Boost's provided BoostConfig.cmake instead of CMake's FindBoost module. This aligns with CMake 3.30's policy CMP0167 which deprecates FindBoost.cmake.

Background:
- We previously dropped our vendored FindBoost.cmake in bf684aca
- CMake is deprecating its FindBoost module as Boost now provides its own package config files
- Using Boost's config files is the recommended approach going forward

This change:
- Silences [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html) policy warnings like ``` CMake Warning (dev) at CMakeLists.txt:133 (find_package): Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake --help-policy CMP0167" for policy details.  Use the cmake_policy command to set the policy and suppress this warning. ```
- Removes outdated comments about bundled FindBoost.cmake, which was removed in bf684aca02.
- Enables using Boost's native package configuration

Refs bf684aca02