### PR TITLE
tcp: Convert tcp::poll_tcb() to coroutine

### DIFF
--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -815,9 +815,8 @@ tcp<InetTraits>::tcp(inet_type& inet)
 
 template <typename InetTraits>
 future<> tcp<InetTraits>::poll_tcb(ipaddr to, lw_shared_ptr<tcb> tcb) {
-    return  _inet.get_l2_dst_address(to).then([this, tcb = std::move(tcb)] (ethernet_address dst) {
-            _poll_tcbs.emplace_back(std::move(tcb), dst);
-    });
+    auto dst = co_await _inet.get_l2_dst_address(to);
+    _poll_tcbs.emplace_back(std::move(tcb), dst);
 }
 
 template <typename InetTraits>


### PR DESCRIPTION
Small cleanup utilizing coroutines to make code clearer. If such PRs are welcome, I will submit a few similar trivial cleanups.