### PR TITLE
file: Convert file operations to use coroutines

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -199,35 +199,31 @@ posix_file_impl::flush() noexcept {
 
 future<struct stat>
 posix_file_impl::stat() noexcept {
-    return engine()._thread_pool->submit<syscall_result_extra<struct stat>>([fd = _fd] {
+    auto ret = co_await engine()._thread_pool->submit<syscall_result_extra<struct stat>>([fd = _fd] {
         struct stat st;
         auto ret = ::fstat(fd, &st);
         return wrap_syscall(ret, st);
-    }).then([] (syscall_result_extra<struct stat> ret) {
-        ret.throw_if_error();
-        return make_ready_future<struct stat>(ret.extra);
     });
+    ret.throw_if_error();
+    co_return ret.extra;
 }
 
 future<>
 posix_file_impl::truncate(uint64_t length) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, length] {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>([this, length] {
         return wrap_syscall<int>(::ftruncate(_fd, length));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        return make_ready_future<>();
     });
+    sr.throw_if_error();
 }
 
 future<int>
 posix_file_impl::ioctl(uint64_t cmd, void* argp) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, cmd, argp] () mutable {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>([this, cmd, argp] () mutable {
         return wrap_syscall<int>(::ioctl(_fd, cmd, argp));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        // Some ioctls require to return a positive integer back.
-        return make_ready_future<int>(sr.result);
     });
+    sr.throw_if_error();
+    // Some ioctls require to return a positive integer back.
+    co_return sr.result;
 }
 
 future<int>
@@ -242,13 +238,12 @@ posix_file_impl::ioctl_short(uint64_t cmd, void* argp) noexcept {
 
 future<int>
 posix_file_impl::fcntl(int op, uintptr_t arg) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, op, arg] () mutable {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>([this, op, arg] () mutable {
         return wrap_syscall<int>(::fcntl(_fd, op, arg));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        // Some fcntls require to return a positive integer back.
-        return make_ready_future<int>(sr.result);
     });
+    sr.throw_if_error();
+    // Some fcntls require to return a positive integer back.
+    co_return sr.result;
 }
 
 future<int>
@@ -263,13 +258,12 @@ posix_file_impl::fcntl_short(int op, uintptr_t arg) noexcept {
 
 future<>
 posix_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, offset, length] () mutable {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
+            [this, offset, length] () mutable {
         return wrap_syscall<int>(::fallocate(_fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE,
             offset, length));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        return make_ready_future<>();
     });
+    sr.throw_if_error();
 }
 
 future<>
@@ -278,19 +272,18 @@ posix_file_impl::allocate(uint64_t position, uint64_t length) noexcept {
     // FALLOC_FL_ZERO_RANGE is fairly new, so don't fail if it's not supported.
     static bool supported = true;
     if (!supported) {
-        return make_ready_future<>();
+        co_return;
     }
-    return engine()._thread_pool->submit<syscall_result<int>>([this, position, length] () mutable {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
+            [this, position, length] () mutable {
         auto ret = ::fallocate(_fd, FALLOC_FL_ZERO_RANGE|FALLOC_FL_KEEP_SIZE, position, length);
         if (ret == -1 && errno == EOPNOTSUPP) {
             ret = 0;
             supported = false; // Racy, but harmless.  At most we issue an extra call or two.
         }
         return wrap_syscall<int>(ret);
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        return make_ready_future<>();
     });
+    sr.throw_if_error();
 #else
     return make_ready_future<>();
 #endif
@@ -347,14 +340,13 @@ posix_file_impl::close() noexcept {
 
 future<uint64_t>
 blockdev_file_impl::size() noexcept {
-    return engine()._thread_pool->submit<syscall_result_extra<size_t>>([this] {
+    auto ret = co_await engine()._thread_pool->submit<syscall_result_extra<size_t>>([this] {
         uint64_t size;
         int ret = ::ioctl(_fd, BLKGETSIZE64, &size);
         return wrap_syscall(ret, size);
-    }).then([] (syscall_result_extra<uint64_t> ret) {
-        ret.throw_if_error();
-        return make_ready_future<uint64_t>(ret.extra);
     });
+    ret.throw_if_error();
+    co_return ret.extra;
 }
 
 static std::optional<directory_entry_type> dirent_type(const linux_dirent64& de) {
@@ -646,13 +638,12 @@ blockdev_file_impl::truncate(uint64_t length) noexcept {
 
 future<>
 blockdev_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
-    return engine()._thread_pool->submit<syscall_result<int>>([this, offset, length] () mutable {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
+            [this, offset, length] () mutable {
         uint64_t range[2] { offset, length };
         return wrap_syscall<int>(::ioctl(_fd, BLKDISCARD, &range));
-    }).then([] (syscall_result<int> sr) {
-        sr.throw_if_error();
-        return make_ready_future<>();
     });
+    sr.throw_if_error();
 }
 
 future<>
@@ -964,10 +955,9 @@ append_challenged_posix_file_impl::allocate(uint64_t position, uint64_t length) 
 future<struct stat>
 append_challenged_posix_file_impl::stat() noexcept {
     // FIXME: can this conflict with anything?
-    return posix_file_impl::stat().then([this] (struct stat stat) {
-        stat.st_size = _logical_size;
-        return stat;
-    });
+    auto stat = co_await posix_file_impl::stat();
+    stat.st_size = _logical_size;
+    co_return stat;
 }
 
 future<>


### PR DESCRIPTION
A number of small cleanups utilizing coroutines to make code clearer.
