### PR TITLE
build: Clean up `compile_option` after FindSanitizers module

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -40,6 +40,7 @@ foreach (component ${Sanitizers_FIND_COMPONENTS})
     message (FATAL_ERROR "Unsupported sanitizer: ${component}")
   endif ()
   list(APPEND Sanitizers_COMPILE_OPTIONS "${${compile_options}}")
+  unset (compile_options)
 endforeach ()
 
 include(CheckCXXSourceCompiles)


### PR DESCRIPTION
Unset the `compile_option` variable after it's used in the FindSanitizers module to prevent potential conflicts with other CMake build configurations. Previously, this variable persisted after `find_package(Sanitizers)`, which could lead to unexpected build behavior if the same variable name was used elsewhere.

This change follows CMake best practices where Find modules clean up temporary variables after use.