### PR TITLE
treewide: Trim trailing spaces

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -147,7 +147,7 @@ find_package (Seastar ${VERSION} REQUIRED)
 
 add_executable (my_program
   my_program.cc)
-  
+
 target_link_libraries (my_program
   PRIVATE Seastar::seastar)
 ```

--- a/README-DPDK.md
+++ b/README-DPDK.md
@@ -19,8 +19,8 @@ $ ./configure.py --mode debug --enable-dpdk --cflags='-march=armv8-a+crc+crypto'
 To use your own self-compiled DPDK package, follow this procedure:
 
 1. Setup host to compile DPDK:
-   - Ubuntu 
-     `sudo apt-get install -y build-essential linux-image-extra-$(uname -r)` 
+   - Ubuntu
+     `sudo apt-get install -y build-essential linux-image-extra-$(uname -r)`
 2. Prepare a DPDK SDK:
    - Download the latest DPDK release: `wget https://fast.dpdk.org/rel/dpdk-23.07.tar.xz`
    - Untar it.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ then compile:
 $ ninja -C build/release
 ```
 
-In case there are compilation issues, especially like ```g++: internal compiler error: Killed (program cc1plus)``` 
+In case there are compilation issues, especially like ```g++: internal compiler error: Killed (program cc1plus)```
 try giving more memory to gcc, either by limiting the amount of threads ( -j1 ) and/or allowing at least 4g ram to your
 machine.
 
@@ -94,7 +94,7 @@ find_package (Seastar REQUIRED)
 
 add_executable (my_app
   my_app.cc)
-  
+
 target_link_libraries (my_app
   Seastar::seastar)
 ```

--- a/coding-style.md
+++ b/coding-style.md
@@ -90,7 +90,7 @@ Avoid output parameters; use return values instead.  In/out parameters are trick
 
 If a function accepts a lambda or an `std::function`, make it the last argument, so that it can be easily provided inline:
 
-```c++ 
+```c++
 template <typename Func>
 void function_accepting_a_lambda(int a, int b, Func func);
 

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -11,7 +11,7 @@
     </tab>
     <tab type="classes" visible="yes" title="">
       <tab type="classlist" visible="yes" title="" intro=""/>
-      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
     </tab>
@@ -19,7 +19,7 @@
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="examples" visible="yes" title="" intro=""/>  
+    <tab type="examples" visible="yes" title="" intro=""/>
   </navindex>
 
   <!-- Layout definition for a class page -->

--- a/doc/building-dpdk.md
+++ b/doc/building-dpdk.md
@@ -1,8 +1,8 @@
 ## Building with a DPDK network backend
 
  1. Setup host to compile DPDK:
-    - Ubuntu 
-         `sudo apt-get install -y build-essential linux-image-extra-$(uname -r)` 
+    - Ubuntu
+         `sudo apt-get install -y build-essential linux-image-extra-$(uname -r)`
  2. Configure the project with DPDK enabled: `./configure.py --mode=release --enable-dpdk`
  3. Run `ninja-build build/release`.
 

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -30,7 +30,7 @@ better for newer kernels.
 
 Filesystem implementation quality can have significant effect on
 file I/O performance. XFS is known to be working, ext4 may work well
-too. Test your filesystem and kernel versions to be sure. 
+too. Test your filesystem and kernel versions to be sure.
 
 Patches for new platforms (e.g, Windows) are welcome.
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -8,18 +8,18 @@ Example:
 
 1. When you commit, use "-s " in your git commit command, which adds a DCO signed off message. DCO is a "Developer's Certificate of Origin" http://elinux.org/Developer_Certificate_Of_Origin
 
-For the commit message, you can prefix a tag for an area of the codebase the patch is addressing 
+For the commit message, you can prefix a tag for an area of the codebase the patch is addressing
 
-        git commit -s -m "core: some descriptive commit message" 
+        git commit -s -m "core: some descriptive commit message"
 
-2. then send an email to the google group 
+2. then send an email to the google group
 
         git send-email <revision>..<final_revision> --to seastar-dev@googlegroups.com
 
-NOTE: for sending replies to patches, use --in-reply-to with the message ID of the original message. Also, if you are sending out a new version of the change, use git rebase and then a `git send-email` with a `-v2`, for instance, to denote that it is a second version. 
+NOTE: for sending replies to patches, use --in-reply-to with the message ID of the original message. Also, if you are sending out a new version of the change, use git rebase and then a `git send-email` with a `-v2`, for instance, to denote that it is a second version.
 
 # Testing and Approval
-Run test.py and ensure tests are passing (at least) as well as before the patch. 
+Run test.py and ensure tests are passing (at least) as well as before the patch.
 
 
 

--- a/doc/io-scheduler.md
+++ b/doc/io-scheduler.md
@@ -27,7 +27,7 @@ The "normalization" operation is defined as
 
 $$ N(ticket) = \frac {ticket_0}{iops_{r_{max}}} + \frac {ticket_1}{bandwidth_{r_{max}}} $$
 
-With that the main equation turns into 
+With that the main equation turns into
 
 $$ \frac {d}{dt} \sum_{ticket} N(ticket) \le 1.0 $$
 
@@ -65,11 +65,11 @@ _c<sub>i</sub>_ -- the amount of requests completed by reactor loop at tick _i_
 
 We can observe _d<sub>i</sub>_ and _c<sub>i</sub>_ in the dispatcher, but _not_ the _p<sub>i</sub>_, because we don't have direct access to disks' queues
 
-After _n_ ticks we have 
+After _n_ ticks we have
 
-_D<sub>n</sub>_ -- total amount of requests dispatched, 
-_P<sub>n</sub>_ -- total amount of requests processed, 
-_C<sub>n</sub>_ -- total amount of requests completed, 
+_D<sub>n</sub>_ -- total amount of requests dispatched,
+_P<sub>n</sub>_ -- total amount of requests processed,
+_C<sub>n</sub>_ -- total amount of requests completed,
 
 $$ D_n = \sum_{i=0}^n d_i $$
 
@@ -114,4 +114,4 @@ $$ \lim_{n\to\infty} Rc_n = 1 $$
 
 $$ \lim_{n\to\infty} \frac {D_n} {C_n} = \lim_{n\to\infty} \( Rd_n \times Rc_n \) =  \lim_{n\to\infty} Rd_n  $$
 
-IOW -- we can say if the disk is accumulating the queue or not by observing the dispatched-to-completed (to _completed_, not _processed_) over a long enough time 
+IOW -- we can say if the disk is accumulating the queue or not by observing the dispatched-to-completed (to _completed_, not _processed_) over a long enough time

--- a/doc/mini-tutorial.md
+++ b/doc/mini-tutorial.md
@@ -83,7 +83,7 @@ future<> loop_to(int end) {
     });
 }
 ```
- 
+
 The *make_ready_future()* function returns a future that is already
 available --- corresponding to the loop termination condition, where
 no further I/O needs to take place.
@@ -194,9 +194,9 @@ void f() {
 ```
 ### Setup notes
 
-SeaStar is a high performance framework and tuned to get the best 
+SeaStar is a high performance framework and tuned to get the best
 performance by default. As such, we're tuned towards polling vs interrupt
 driven. Our assumption is that applications written for SeaStar will be
 busy handling 100,000 IOPS and beyond. Polling means that each of our
-cores will consume 100% cpu even when no work is given to it. 
+cores will consume 100% cpu even when no work is given to it.
 

--- a/doc/native-stack.md
+++ b/doc/native-stack.md
@@ -9,7 +9,7 @@ To test the native stack without dpdk, install and start the `libvirt` daemon.  
 
 Seastar's vhost driver will need a tap device to connect to.  The scripts `scripts/tap.sh` will set up a tap device and bind it to `virbr0`:
 
-	$ sh ./scripts/tap.sh 
+	$ sh ./scripts/tap.sh
 	Set 'tap0' nonpersistent
 	bridge name	bridge id		STP enabled	interfaces
 	virbr0		8000.5254008be729	no		tap0
@@ -50,5 +50,5 @@ You can now ping the IP address shown (`192.168.122.18`) or connect to it:
 	rtt min/avg/max/mdev = 0.093/0.116/0.160/0.023 ms
 	
 	$ curl http://192.168.122.18:10000/
-	"hello" 
+	"hello"
 

--- a/doc/network-configuration.md
+++ b/doc/network-configuration.md
@@ -8,19 +8,19 @@ The new configuration can be provided either by command line with --net-config o
 ### DPDK access
 Network device (called port in DPDK) can be accessed by either port index ( zero based index of device shown by dpdk-setup.sh ) or its PCI address (shown by lspci, lshw tools)
 
-Example config line with pci address given: 
+Example config line with pci address given:
 
 ```
 eth0: {pci_address: 0000:06:00.0, ip: 192.168.100.10, gateway: 192.168.100.1, netmask: 255.255.255.0 }
-``` 
+```
 
-Example config line with port index given: 
+Example config line with port index given:
 
 ```
 eth0: {port_index: 0, ip: 192.168.100.10, gateway: 192.168.100.1, netmask: 255.255.255.0 }
 ```
 
-Please note that device name - eth0 above, is not used by DPDK itself, it remains only for configuration consistency. 
+Please note that device name - eth0 above, is not used by DPDK itself, it remains only for configuration consistency.
 The hardware configuration has to be specied in the same way accross all network devices, so for example if pci_address is specified for one network device, port_index cannot be specified for any other.
 
 

--- a/doc/prometheus.md
+++ b/doc/prometheus.md
@@ -78,5 +78,5 @@ For example, the following scrap config, will query for all the http metrics:
       metrics_path: /metrics
       params:
         __name__: ['http*']
-``` 
+```
 

--- a/doc/rpc-compression.md
+++ b/doc/rpc-compression.md
@@ -6,10 +6,10 @@ RPC protocol only defines `COMPRESS` feature bit but does not define format of i
 If application supports multiple compression algorithms it may use the data for algorithm
 negotiation. RPC provides convenience class `multi_algo_compressor_factory` to do it
 so that each application will not have to re-implement the same logic. The class gets list
-of supported compression algorithms and send them as comma separated list in the client `COMPRESS` 
-feature payload. On receiving of the list it matches common algorithm between client and server. 
-In case there is more than one the order of algorithms in client's list is considered to be a tie 
-breaker (first algorithm wins). Once a compressor is chosen by the server, it puts the identifier of 
+of supported compression algorithms and send them as comma separated list in the client `COMPRESS`
+feature payload. On receiving of the list it matches common algorithm between client and server.
+In case there is more than one the order of algorithms in client's list is considered to be a tie
+breaker (first algorithm wins). Once a compressor is chosen by the server, it puts the identifier of
 this in the returned `COMPRESS` feature payload, informing the client of which algorithm should be used
 for the connection.
 

--- a/doc/rpc-streaming.md
+++ b/doc/rpc-streaming.md
@@ -121,4 +121,4 @@ protocol negotiation this connection will have `Stream parent` feature with `rc`
 
 When `rpc::sink` is sent over RPC call it is serialized as its connection ID. Server's RPC handler
 then lookups the connection and creates an `rpc::source` from it. When RPC handler returns `rpc::sink`
-the same happens in other direction.    
+the same happens in other direction.

--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -7,7 +7,7 @@ All integral data is encoded in little endian format.
 ## Protocol negotiation
 
 The negotiation works by exchanging negotiation frame immediately after connection establishment. The negotiation frame format is:
-    
+
     uint8_t magic[8] = SSTARRPC
     uint32_t len
     uint8_t data[len]
@@ -22,9 +22,9 @@ The negotiation frame data is itself composed of multiple records, one for each 
      }
 
 A `negotiation_frame_feature_record` signals that an optional feature is present in the client, and can contain additional feature-specific data.  The feature number will be omitted in a server response if an optional feature is declined by the server.
-    
+
 Actual negotiation looks like this:
-    
+
          Client                                  Server
     --------------------------------------------------------------------------------------------------
     send negotiation frame
@@ -55,7 +55,7 @@ Actual negotiation looks like this:
 
 #### Connection ID
     feature_number: 2
-    uint64_t conenction_id  : RPC connection ID 
+    uint64_t conenction_id  : RPC connection ID
 
     Server assigns unique connection ID for each connection and sends it to a client using
     this feature.
@@ -65,13 +65,13 @@ Actual negotiation looks like this:
     uint64_t connection_id : RPC connection ID representing a parent of the stream
 
     If this feature is present it means that the connection is not regular RPC connection
-    but stream connection. If parent connection is closed or aborted all streams belonging 
+    but stream connection. If parent connection is closed or aborted all streams belonging
     to it will be closed as well.
-   
+
     Stream connection is a connection that allows bidirectional flow of bytes which may carry one or
     more messages in each direction. Stream connection should be explicitly closed by both client and
     server. Closing is done by sending special EOS frame (described below).
-    
+
 
 #### Isolation
     feature number: 4
@@ -114,16 +114,16 @@ Actual negotiation looks like this:
     uint8_t data[len]
 
 msg_id has to be positive and may never be reused.
-data is transparent for the protocol and serialized/deserialized by a user 
+data is transparent for the protocol and serialized/deserialized by a user
 
 ## Response frame format
     int64_t msg_id
     uint32_t len
     uint32_t handler_duration - present if handler duration is negotiated
     uint8_t data[len]
-    
+
 if msg_id < 0 enclosed response contains an exception that came as a response to msg id abs(msg_id)
-data is transparent for the protocol and serialized/deserialized by a user 
+data is transparent for the protocol and serialized/deserialized by a user
 
 the handler_duration is in microseconds, the value of 0xffffffff means that it wasn't measured
 and should be disregarded by client
@@ -133,7 +133,7 @@ and should be disregarded by client
    uint8_t data[len]
 
 len == 0xffffffff signals end of stream
-data is transparent for the protocol and serialized/deserialized by a user 
+data is transparent for the protocol and serialized/deserialized by a user
 
 ## Exception encoding
     uint32_t type
@@ -143,7 +143,7 @@ data is transparent for the protocol and serialized/deserialized by a user
 ### Known exception types
     USER = 0
     UNKNOWN_VERB = 1
-    
+
 #### USER exception encoding
 
     uint32_t len
@@ -155,7 +155,7 @@ It is delivered to a caller as rpc::remote_verb_error(char[len])
 #### UNKNOWN_VERB exception encoding
 
     uint64_t verb_id
-    
+
 This exception is sent as a response to a request with unknown verb_id, the verb id is passed back as part of the exception payload.
 
 ## More formal protocol description
@@ -182,7 +182,7 @@ This exception is sent as a response to a request with unknown verb_id, the verb
 	negotiation_frame = 'SSTARRPC' len32(negotiation_frame_data) negotiation_frame_data
 	negotiation_frame_data = negotiation_frame_feature_record*
 	negotiation_frame_feature_record = feature_number len {byte}*len
-	feature_number = uint32_t 
+	feature_number = uint32_t
 
 Note that replies can come in order different from requests, and some requests may not have a reply at all.
 

--- a/doc/template.css
+++ b/doc/template.css
@@ -10,7 +10,7 @@ body {
 	background: #FFFFFF;
 	font-size: 13pt;
 	line-height: 1.10;
-	font-family: arial, sans-serif; 
+	font-family: arial, sans-serif;
 	margin-left: 15pt;
 	margin-right: 15pt;
 	text-align: justify;

--- a/include/seastar/core/fsnotify.hh
+++ b/include/seastar/core/fsnotify.hh
@@ -72,7 +72,7 @@ public:
         attrib = IN_ATTRIB,             // Metadata changed—for example, permissions, timestamps, extended attributes
         close_write = IN_CLOSE_WRITE,   // File opened for writing was closed.
         close_nowrite = IN_CLOSE_NOWRITE,// File or directory not opened for writing was closed.
-        create_child = IN_CREATE,       // File/directory created in watched directory 
+        create_child = IN_CREATE,       // File/directory created in watched directory
         delete_child = IN_DELETE,       // File/directory deleted from watched directory.
         delete_self = IN_DELETE_SELF,   // Watched file/directory was itself deleted.  (This event
                                         // also occurs if an object is moved to another filesystem)
@@ -85,9 +85,9 @@ public:
         open = IN_OPEN,                 // File was opened
         close = IN_CLOSE,               // close_write|close_nowrite
         move = IN_MOVE,                 // move_from|move_to
-        oneshot = IN_ONESHOT,           // listen for only a single notification, after which the 
+        oneshot = IN_ONESHOT,           // listen for only a single notification, after which the
                                         // token will be invalid
-        ignored = IN_IGNORED,           // generated when a token or the file being watched is deleted 
+        ignored = IN_IGNORED,           // generated when a token or the file being watched is deleted
         onlydir = IN_ONLYDIR,           // Watch pathname only if it is a directory; the error ENOT‐
                                         // DIR results if pathname is not a directory.  Using this
                                         // flag provides an application with a race-free way of

--- a/include/seastar/core/function_traits.hh
+++ b/include/seastar/core/function_traits.hh
@@ -27,16 +27,16 @@ namespace seastar {
 
 template<typename T>
 struct function_traits;
- 
+
 template<typename Ret, typename... Args>
 struct function_traits<Ret(Args...)>
 {
     using return_type = Ret;
     using args_as_tuple = std::tuple<Args...>;
     using signature = Ret (Args...);
- 
+
     static constexpr std::size_t arity = sizeof...(Args);
- 
+
     template <std::size_t N>
     struct arg
     {

--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -215,7 +215,7 @@ public:
     static io_request make_writev(int fd, uint64_t pos, std::vector<iovec>& iov, bool nowait_works) {
         io_request req;
         req._writev = {
-          .op = operation::writev,  
+          .op = operation::writev,
           .nowait_works = nowait_works,
           .fd = fd,
           .pos = pos,

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -361,7 +361,7 @@ future<stat_data> file_stat(std::string_view name, follow_symlink fs = follow_sy
 
 /// Wrapper around getgrnam_r.
 /// If the provided group name does not exist in the group database, this call will return an empty optional.
-/// If the provided group name exists in the group database, the optional returned will contain the struct group_details information. 
+/// If the provided group name exists in the group database, the optional returned will contain the struct group_details information.
 /// When an unexpected error is thrown by the getgrnam_r libc call, this function throws std::system_error with std::error_code.
 /// \param groupname name of the group
 ///

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -882,7 +882,7 @@ template <typename R, typename Func, typename... Args>
 requires std::invocable<Func, Service&, Args...>
     && std::is_same_v<futurize_t<std::invoke_result_t<Func, Service&, internal::sharded_unwrap_t<Args>...>>, future<>>
     && internal::unsigned_range<R>
-future<> 
+future<>
 sharded<Service>::invoke_on(R range, Func func, Args... args) noexcept {
     try {
         return invoke_on(std::forward<R>(range), smp_submit_to_options{}, std::move(func), std::move(args)...);

--- a/include/seastar/core/when_any.hh
+++ b/include/seastar/core/when_any.hh
@@ -20,7 +20,7 @@
  * author: Niek J Bouman
  * reviewers: Avi Kivity, Benny Halevy
  * November 2021
- */ 
+ */
 
 #pragma once
 
@@ -65,7 +65,7 @@ public:
 ///
 /// Given a range of futures as input, wait for the first of them
 /// to resolve (either successfully or with an exception), and return
-/// all of them in a \c when_any_result (following the concurrency TS from 
+/// all of them in a \c when_any_result (following the concurrency TS from
 /// the standard library), containing a std::vector to all futures
 /// and the index (into the vector) of the future that resolved.
 ///

--- a/include/seastar/coroutine/all.hh
+++ b/include/seastar/coroutine/all.hh
@@ -169,7 +169,7 @@ private:
             std::apply([] (Futures&... futures) {
                 std::exception_ptr e;
                 // Call get_exception for every failed future, to avoid exceptional future
-                // ignored warnings. 
+                // ignored warnings.
                 (void)(..., (futures.failed() ? (e = futures.get_exception(), 0) : 0));
                 if (e) {
                     std::rethrow_exception(std::move(e));

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -84,7 +84,7 @@ class connection : public boost::intrusive::list_base_hook<> {
     const bool _tls;
 public:
     [[deprecated("use connection(http_server&, connected_socket&&, bool tls)")]]
-    connection(http_server& server, connected_socket&& fd, socket_address, bool tls) 
+    connection(http_server& server, connected_socket&& fd, socket_address, bool tls)
             : connection(server, std::move(fd), tls) {}
     connection(http_server& server, connected_socket&& fd, bool tls)
             : _server(server)
@@ -103,7 +103,7 @@ public:
             , _read_buf(_fd.input())
             , _write_buf(_fd.output())
             , _client_addr(std::move(client_addr))
-            , _server_addr(std::move(server_addr)) 
+            , _server_addr(std::move(server_addr))
             , _tls(tls) {
         on_new_connection();
     }

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -78,13 +78,13 @@ struct reply {
         see_other = 303, //!< see_other
         not_modified = 304, //!< not_modified
         use_proxy = 305, //!< use_proxy
-        temporary_redirect = 307, //!< temporary_redirect 
+        temporary_redirect = 307, //!< temporary_redirect
         bad_request = 400, //!< bad_request
         unauthorized = 401, //!< unauthorized
         payment_required = 402, //!< payment_required
         forbidden = 403, //!< forbidden
         not_found = 404, //!< not_found
-        method_not_allowed = 405, //!< method_not_allowed 
+        method_not_allowed = 405, //!< method_not_allowed
         not_acceptable = 406, //!< not_acceptable
         request_timeout = 408, //!< request_timeout
         conflict = 409, //!< conflict
@@ -104,7 +104,7 @@ struct reply {
         bad_gateway = 502, //!< bad_gateway
         service_unavailable = 503,  //!< service_unavailable
         gateway_timeout = 504, //!< gateway_timeout
-        http_version_not_supported = 505, //!< http_version_not_supported 
+        http_version_not_supported = 505, //!< http_version_not_supported
         insufficient_storage = 507, //!< insufficient_storage
         bandwidth_limit_exceeded = 509, //!< bandwidth_limit_exceeded
         network_read_timeout = 598, //!< network_read_timeout

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -69,7 +69,7 @@ public:
     /** creates an uninitialized socket_address. this can be written into, or used as
      *  "unspecified" for such addresses as bind(addr) or local address in socket::connect
      *  (i.e. system picks)
-     */ 
+     */
     socket_address() noexcept;
 
     ::sockaddr& as_posix_sockaddr() noexcept { return u.sa; }

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -243,7 +243,7 @@ namespace tls {
     };
 
     /**
-     * Session resumption support. 
+     * Session resumption support.
      * We only support TLS1.3 session tickets.
     */
     enum class session_resume_mode {
@@ -270,7 +270,7 @@ namespace tls {
 
         /**
          * Sets session resume mode.
-         * If session resumption is set to TLS13 session tickets, 
+         * If session resumption is set to TLS13 session tickets,
          * calling this also functions as key rotation, i.e. creates
          * a new window of TLS session keys.
         */
@@ -337,7 +337,7 @@ namespace tls {
         /// \brief server name to be used for the SNI TLS extension
         sstring server_name = {};
 
-        /// \brief Optional session resume data. Must be retrieved via 
+        /// \brief Optional session resume data. Must be retrieved via
         /// get_session_resume_data below.
         session_data session_resume_data;
     };
@@ -446,15 +446,15 @@ namespace tls {
     future<std::optional<session_dn>> get_dn_information(connected_socket& socket);
 
     /**
-     * Subject alt name types. 
+     * Subject alt name types.
     */
     enum class subject_alt_name_type {
         dnsname = 1, // string value representing a 'DNS' entry
-        rfc822name, // string value representing an 'email' entry 
+        rfc822name, // string value representing an 'email' entry
         uri, // string value representing an 'uri' entry
         ipaddress, // inet_address value representing an 'IP' entry
-        othername, // string value 
-        dn, // string value 
+        othername, // string value
+        dn, // string value
     };
 
     // Subject alt name entry
@@ -471,7 +471,7 @@ namespace tls {
      * Returns the alt name entries of matching types, or all entries if 'types' is empty
      * The values are extracted from the client authentication certificate, if available.
      * If no certificate authentication is used in the connection, en empty list is returned.
-     * 
+     *
      * If the socket is not connected a system_error exception will be thrown.
      * If the socket is not a TLS socket an exception will be thrown.
     */
@@ -479,8 +479,8 @@ namespace tls {
 
     /**
      * Checks if the socket was connected using session resume.
-     * Will force handshake if not already done. 
-     * 
+     * Will force handshake if not already done.
+     *
      * If the socket is not connected a system_error exception will be thrown.
      * If the socket is not a TLS socket an exception will be thrown.
     */
@@ -488,13 +488,13 @@ namespace tls {
 
     /**
      * Get session resume data from a connected client socket. Will force handshake if not already done.
-     * 
+     *
      * If the socket is not connected a system_error exception will be thrown.
      * If the socket is not a TLS socket an exception will be thrown.
      * If no session resumption data is available, returns empty buffer.
-     * 
+     *
      * Note: TLS13 session tickets most of the time require data to have been transferred
-     * between client/server. To ensure getting the session data, it is advisable to 
+     * between client/server. To ensure getting the session data, it is advisable to
      * delay this call to sometime before shutting down/closing the socket.
     */
     future<session_data> get_session_resume_data(connected_socket&);
@@ -503,12 +503,12 @@ namespace tls {
     std::ostream& operator<<(std::ostream&, const subject_alt_name&);
 
     /**
-     * Alt name to string. 
+     * Alt name to string.
      * Note: because naming of alternative names is inconsistent between tools,
      * and because openssl is probably more popular when creating certs anyway,
      * this routine will be inconsistent with both gnutls and openssl (though more
      * in line with the latter) and name the constants as follows:
-     * 
+     *
      * dnsname: "DNS"
      * rfc822name: "EMAIL"
      * uri: "URI"
@@ -521,7 +521,7 @@ namespace tls {
 
     /**
      * Error handling.
-     * 
+     *
      * The error_category instance used by exceptions thrown by TLS
      */
     const std::error_category& error_category();

--- a/include/seastar/net/unix_address.hh
+++ b/include/seastar/net/unix_address.hh
@@ -17,7 +17,7 @@
  */
 /*
  * Copyright (C) 2019 Red Hat, Inc.
- */ 
+ */
 #pragma once
 
 #ifndef SEASTAR_MODULE

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -154,9 +154,9 @@ struct server_options {
     bool tcp_nodelay = true;
     std::optional<streaming_domain_type> streaming_domain;
     server_socket::load_balancing_algorithm load_balancing_algorithm = server_socket::load_balancing_algorithm::default_;
-    // optional filter function. If set, will be called with remote 
-    // (connecting) address.    
-    // Returning false will refuse the incoming connection. 
+    // optional filter function. If set, will be called with remote
+    // (connecting) address.
+    // Returning false will refuse the incoming connection.
     // Returning true will allow the mechanism to proceed.
     std::function<bool(const socket_address&)> filter_connection = {};
 };

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -285,7 +285,7 @@ public:
     virtual rcv_buf decompress(rcv_buf data) = 0;
     virtual sstring name() const = 0;
     virtual future<> close() noexcept { return make_ready_future<>(); };
-    
+
     // factory to create compressor for a connection
     class factory {
     public:
@@ -293,7 +293,7 @@ public:
         // return feature string that will be sent as part of protocol negotiation
         virtual const sstring& supported() const = 0;
         // negotiate compress algorithm
-        // send_empty_frame() requests an empty frame to be sent to the peer compressor on the other side of the connection. 
+        // send_empty_frame() requests an empty frame to be sent to the peer compressor on the other side of the connection.
         // By attaching a header to this empty frame, the compressor can communicate somthing to the peer,
         // send_empty_frame() mustn't be called from inside compress() or decompress().
         virtual std::unique_ptr<compressor> negotiate(sstring feature, bool is_server, std::function<future<>()> send_empty_frame) const {

--- a/include/seastar/util/later.hh
+++ b/include/seastar/util/later.hh
@@ -41,7 +41,7 @@ future<> now() {
 /// Schedules a future to run "soon". yield() can be used to break long-but-finite
 /// loops into pieces. Note that if nothing else is runnable,
 /// It will not check for I/O, and so an infinite loop with yield() will just
-/// burn CPU. 
+/// burn CPU.
 future<> yield() noexcept;
 
 /// Yield the cpu if the task quota is exhausted.
@@ -49,7 +49,7 @@ future<> yield() noexcept;
 /// Check if the current continuation is preempted and yield if so. Otherwise
 /// return a ready future.
 ///
-/// \note Threads and coroutines (see seastar::thread::maybe_yield() and 
+/// \note Threads and coroutines (see seastar::thread::maybe_yield() and
 ///       seastar::coroutine::maybe_yield() have their own custom variants,
 ///       and the various continuation-based loops (do_for_each() and similar)
 ///       do this automatically.

--- a/include/seastar/util/sampler.hh
+++ b/include/seastar/util/sampler.hh
@@ -69,8 +69,8 @@ public:
     }
 
     /// This method should be called if maybe_sample returned true for particular
-    /// allocation. It returns true if a sample should be taken and handles 
-    /// resetting the sample interval countdown.    
+    /// allocation. It returns true if a sample should be taken and handles
+    /// resetting the sample interval countdown.
     bool definitely_sample(size_t alloc_size) {
         // this will hold if maybe_sample returned false for this allocation
         if (interval_to_next_sample_ >= 0) {

--- a/scripts/perftune.py
+++ b/scripts/perftune.py
@@ -1615,7 +1615,7 @@ Modes description:
 
  If there isn't any mode given script will use a default mode:
     - If number of CPU cores is greater than 16, allocate a single IRQ CPU core for each 16 CPU cores in 'cpu_mask'.
-      IRQ cores are going to be allocated evenly on available NUMA nodes according to 'cpu_mask' value.  
+      IRQ cores are going to be allocated evenly on available NUMA nodes according to 'cpu_mask' value.
     - If number of physical CPU cores per Rx HW queue is greater than 4 and less than 16 - use the 'sq-split' mode.
     - Otherwise, if number of hyper-threads per Rx HW queue is greater than 4 - use the 'sq' mode.
     - Otherwise use the 'mq' mode.

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -49,7 +49,7 @@ module;
  * (see: https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=df9c7d8d8f3ed0785ed83e7fd0c7ddc92cbfbe15)
  * There is a confliction with c++ keyword `fallthrough`, so undefine fallthrough here.
  */
-#undef fallthrough   
+#undef fallthrough
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min
@@ -408,7 +408,7 @@ coroutine::experimental::generator<directory_entry> posix_file_impl::experimenta
     // due to https://github.com/scylladb/seastar/issues/1913, we cannot use
     // buffered generator yet.
     // TODO:
-    // Keep 8 entries. The sizeof(directory_entry) is 24 bytes, the name itself 
+    // Keep 8 entries. The sizeof(directory_entry) is 24 bytes, the name itself
     // is allocated out of this buffer, so the buffer would grow up to ~200 bytes
     return make_list_directory_generator(_fd);
 }

--- a/src/core/fsnotify.cc
+++ b/src/core/fsnotify.cc
@@ -93,7 +93,7 @@ future<std::vector<fsnotifier::event>> fsnotifier::impl::wait() {
         while (p < e) {
             auto ev = reinterpret_cast<const ::inotify_event*>(p);
             if (ev->wd == me->_close_dummy && me->_close_dummy != -1) {
-                me->_fd.close();                
+                me->_fd.close();
             } else {
                 events.emplace_back(event {
                     ev->wd, flags(ev->mask), ev->cookie,
@@ -108,12 +108,12 @@ future<std::vector<fsnotifier::event>> fsnotifier::impl::wait() {
 }
 
 void fsnotifier::impl::shutdown() {
-    // reactor does not yet have 
+    // reactor does not yet have
     // any means of "shutting down" a non-socket read,
     // so we work around this by creating a watch for something ubiquitous,
     // then removing the watch while adding a mark.
     // This will cause any event waiter to wake up, but ignore the event for our
-    // dummy. 
+    // dummy.
     (void)create_watch("/", flags::delete_self).then([me = shared_from_this()](watch_token t) {
         me->_close_dummy = t;
         me->remove_watch(t);

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1092,7 +1092,7 @@ void cpu_pages::free(void* ptr, size_t size) {
 #endif
 }
 
-// Is the passed pointer a local pointer, i.e., allocated on the current shard from the 
+// Is the passed pointer a local pointer, i.e., allocated on the current shard from the
 // per-shard allocator.
 [[gnu::always_inline]]
 inline bool
@@ -1643,12 +1643,12 @@ void *allocate_slowpath(size_t size) {
 
         // original_malloc_func might be null for allocations before main
         // in constructors before original_malloc_func ctor is called
-        // Note on #2137: Moved to here, because there is lots of code 
+        // Note on #2137: Moved to here, because there is lots of code
         // that implicitly relies on the static init fiasco below to have occurred, and thus
         // cpu_mem_ptr being available and inited. This is not great.
         init_cpu_mem();
 
-        // #2137 - static init fiasco for fallback functions. 
+        // #2137 - static init fiasco for fallback functions.
         // If dependent libraries do malloc _before_ the above declaration inits are run,
         // we end up here with nowhere to go. Add a second check and attempt the full init
         // already. If we find the functions, all is good. Otherwise, trudge along and probably
@@ -2637,7 +2637,7 @@ configure(std::vector<resource::memory> m, bool mbind,
     return {};
 }
 
-void configure_minimal() 
+void configure_minimal()
 {}
 
 statistics stats() {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4825,7 +4825,7 @@ std::chrono::nanoseconds reactor::total_steal_time() {
     // Because we calculate sleep time with timestamps around polling methods that may sleep, like
     // io_getevents, we systematically over-count sleep time, since there is CPU usage within the
     // period timed as sleep, before and after an actual sleep occurs (and no sleep may occur at all,
-    // e.g., if there are events immediately available). Over-counting sleep means we under-count the 
+    // e.g., if there are events immediately available). Over-counting sleep means we under-count the
     // wall-clock awake time, and so if there is no "true" steal, we will generally have a small
     // *negative* steal time, because we under-count awake wall clock time while thread CPU time does
     // not have a corresponding error.
@@ -4836,7 +4836,7 @@ std::chrono::nanoseconds reactor::total_steal_time() {
     //
     // Finally, we don't just clamp difference of awake and CPU time since proces start at 0, but
     // take the last value we returned from this function and then calculate the incremental steal
-    // time since that measurement, clamped to 0. This means that as soon as steal time becomes 
+    // time since that measurement, clamped to 0. This means that as soon as steal time becomes
     // positive, it will be reflected in the measurement, rather than needing to "consume" all the
     // accumulated negative steal time before positive steal times start showing up.
 

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -146,8 +146,8 @@ future<> destroy_smp_service_group(smp_service_group ssg) noexcept {
 
 void init_default_smp_service_group(shard_id cpu) {
     // default_smp_service_group == smp_service_group(0) -> we assume service groups are empty
-    // at this point. If they are not, it is quite possibly because we are running repeated 
-    // reactors in the program. Probably a test (see #2148). 
+    // at this point. If they are not, it is quite possibly because we are running repeated
+    // reactors in the program. Probably a test (see #2148).
     // This would be fine, we just create extra junk here, _but_ it is quite possible
     // that we actually run with different cpu count (see smp_options::smp), in which case
     // the `get_smp_service_groups_semaphore` below can cause us to return uninitialized memory.

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -389,7 +389,7 @@ void http_server::set_content_streaming(bool b) {
     _content_streaming = b;
 }
 
-future<> http_server::listen(socket_address addr, listen_options lo, 
+future<> http_server::listen(socket_address addr, listen_options lo,
             server_credentials_ptr listener_credentials) {
     if (listener_credentials) {
         _listeners.push_back(seastar::tls::listen(listener_credentials, addr, lo));

--- a/src/json/formatter.cc
+++ b/src/json/formatter.cc
@@ -159,13 +159,13 @@ sstring formatter::to_json(bool b) {
     return (b) ? "true" : "false";
 }
 
-sstring formatter::to_json(const date_time& d) {    
+sstring formatter::to_json(const date_time& d) {
     // use RFC3339/RFC8601 "internet format"
     // which is stipulated as mandatory for swagger
     // dates
     // Note that this assumes dates are in UTC timezone
     static constexpr const char* TIME_FORMAT = "%FT%TZ";
-    
+
     char buff[50];
     sstring res = "\"";
     strftime(buff, 50, TIME_FORMAT, &d);

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -128,8 +128,8 @@ namespace dpdk {
 /******************* Net device related constatns *****************************/
 static constexpr uint16_t default_ring_size      = 512;
 
-// 
-// We need 2 times the ring size of buffers because of the way PMDs 
+//
+// We need 2 times the ring size of buffers because of the way PMDs
 // refill the ring.
 //
 static constexpr uint16_t mbufs_per_queue_rx     = 2 * default_ring_size;
@@ -555,7 +555,7 @@ class dpdk_qp : public net::qp {
             // For a TSO case each MSS window should not include more than 8
             // fragments including headers.
             //
-            
+
             // Calculate the number of frags containing headers.
             //
             // Note: we support neither VLAN nor tunneling thus headers size

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -70,7 +70,7 @@ seastar::net::inet_address::inet_address(::in6_addr i, uint32_t scope) noexcept
                 : _in_family(family::INET6), _in6(i), _scope(scope) {
 }
 
-std::optional<seastar::net::inet_address> 
+std::optional<seastar::net::inet_address>
 seastar::net::inet_address::parse_numerical(const sstring& addr) {
     inet_address in;
     if (::inet_pton(AF_INET, addr.c_str(), &in._in)) {
@@ -107,7 +107,7 @@ seastar::net::inet_address::parse_numerical(const sstring& addr) {
 
 seastar::net::inet_address::inet_address(const sstring& addr)
                 : inet_address([&addr] {
-    auto res = parse_numerical(addr);                        
+    auto res = parse_numerical(addr);
     if (res) {
         return std::move(*res);
     }

--- a/src/net/socket_address.cc
+++ b/src/net/socket_address.cc
@@ -17,7 +17,7 @@
  */
 /*
  * Copyright (C) 2016 ScyllaDB.
- */ 
+ */
 /*! \file
     \brief Some non-INET-specific socket address code
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -233,7 +233,7 @@ network_interface::network_interface(shared_ptr<net::network_interface_impl> imp
 
 network_interface::network_interface(network_interface&&) noexcept = default;
 network_interface& network_interface::operator=(network_interface&&) noexcept = default;
-    
+
 uint32_t network_interface::index() const {
     return _impl->index();
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -129,7 +129,7 @@ static future<file_result> read_fully(const sstring& name, const sstring& what) 
         return do_with(std::move(f), [name = std::move(name)](file& f) mutable {
             return f.stat().then([&f, name = std::move(name)](struct stat s) mutable {
                 return f.dma_read_bulk<char>(0, s.st_size).then([s, name = std::move(name)](temporary_buffer<char> buf) mutable {
-                    return file_result{ std::move(buf), file_info{ 
+                    return file_result{ std::move(buf), file_info{
                         std::move(name), std::chrono::system_clock::from_time_t(s.st_mtim.tv_sec) +
                             std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::nanoseconds(s.st_mtim.tv_nsec))
                     } };
@@ -223,14 +223,14 @@ class tls::dh_params::impl : gnutlsobj {
         return dh_ptr(params, &gnutls_dh_params_deinit);
     }
 public:
-    impl(dh_ptr p) 
-        : _params(std::move(p)) 
+    impl(dh_ptr p)
+        : _params(std::move(p))
     {}
     impl(level lvl)
 #if GNUTLS_VERSION_NUMBER >= 0x030506
         : _params(nullptr, &gnutls_dh_params_deinit)
         , _sec_param(to_gnutls_level(lvl))
-#else        
+#else
         : impl([&] {
             auto bits = gnutls_sec_param_to_pk_bits(GNUTLS_PK_DH, to_gnutls_level(lvl));
             auto ptr = new_dh_params();
@@ -245,14 +245,14 @@ public:
             blob_wrapper w(pkcs3);
             gtls_chk(gnutls_dh_params_import_pkcs3(ptr.get(), &w, gnutls_x509_crt_fmt_t(fmt)));
             return ptr;
-        }()) 
+        }())
     {}
     impl(const impl& v)
         : impl([&v] {
             auto ptr = new_dh_params();
             gtls_chk(gnutls_dh_params_cpy(ptr.get(), v));
             return ptr;
-        }()) 
+        }())
     {}
     ~impl() = default;
 
@@ -854,9 +854,9 @@ public:
                 auto i = _watches.find(e.id);
                 if (i != _watches.end()) {
                     auto& filename = i->second.second;
-                    // only add actual file watches to 
+                    // only add actual file watches to
                     // query set. If this was a directory
-                    // watch, the file should already be 
+                    // watch, the file should already be
                     // in there.
                     if (_all_files.count(filename)) {
                         _files[filename] = e.mask;
@@ -918,7 +918,7 @@ public:
             } catch (...) {
                 if (std::any_of(_files.begin(), _files.end(), [](auto& p) { return p.second == fsnotifier::flags::ignored; })) {
                     // if any file in the reload set was deleted - i.e. we have not seen a "closed" yet - assume
-                    // this is a spurious reload and we'd better wait for next event - hopefully a "closed" - 
+                    // this is a spurious reload and we'd better wait for next event - hopefully a "closed" -
                     // and try again
                     return;
                 }
@@ -931,7 +931,7 @@ public:
         }
         void on_success() {
             _files.clear();
-            // remove all directory watches, since we've successfully 
+            // remove all directory watches, since we've successfully
             // reloaded -> the file watches themselves should suffice now
             auto i = _watches.begin();
             auto e = _watches.end();
@@ -967,7 +967,7 @@ public:
         future<fsnotifier::watch_token> add_watch(const sstring& filename, fsnotifier::flags flags = fsnotifier::flags::close_write|fsnotifier::flags::delete_self) {
             return _fsn.create_watch(filename, flags).then([this, filename = filename](fsnotifier::watch w) {
                 auto t = w.token();
-                // we might create multiple watches for same token in case of dirs, avoid deleting previously 
+                // we might create multiple watches for same token in case of dirs, avoid deleting previously
                 // created one
                 if (_watches.count(t)) {
                     w.release();
@@ -1086,7 +1086,7 @@ public:
             }
             // Maybe set up server session ticket support
             switch (_creds->get_session_resume_mode()) {
-                case session_resume_mode::NONE: 
+                case session_resume_mode::NONE:
                 default:
                     break;
                 case session_resume_mode::TLS13_SESSION_TICKET:
@@ -1094,7 +1094,7 @@ public:
                     break;
             }
         }
- 
+
         auto prio = _creds->get_priority();
         if (prio) {
             gtls_chk(gnutls_priority_set(*this, prio));
@@ -1307,7 +1307,7 @@ public:
                 ss << stat_str;
                 if (stat_str.back() != ' ') {
                     ss << ' ';
-                } 
+                }
                 ss << "(Issuer=[" << dn->issuer << "], Subject=[" << dn->subject << "])";
                 stat_str = ss.str();
             }
@@ -1584,8 +1584,8 @@ public:
                         std::bind(&session::do_shutdown, this)).then(
                         std::bind(&session::wait_for_eof, this)).finally([me = shared_from_this()] {});
         // note moved finally clause above. It is theorethically possible
-        // that we could complete do_shutdown just before the close calls 
-        // below, get pre-empted, have "close()" finish, get freed, and 
+        // that we could complete do_shutdown just before the close calls
+        // below, get pre-empted, have "close()" finish, get freed, and
         // then call wait_for_eof on stale pointer.
     }
     void close() noexcept {
@@ -1654,13 +1654,13 @@ public:
     future<session_data> get_session_resume_data() {
         return state_checked_access([this] {
             /**
-             * Session ticket data is not available just because handshake 
+             * Session ticket data is not available just because handshake
              * was done. First off, of course other part must support it,
              * but we also (mostly?) need to actually transfer data before
              * the ticket is received.
-             * 
+             *
              * Check session flags so we can return no data in the case
-             * none is avail. Gnutls returns a 4-byte "empty marker" 
+             * none is avail. Gnutls returns a 4-byte "empty marker"
              * on none avail.
             */
             auto flags = gnutls_session_get_flags(*this);
@@ -1676,7 +1676,7 @@ public:
         return state_checked_access([this] {
             return extract_dn_information();
         });
-    }    
+    }
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) {
         return state_checked_access([this](std::unordered_set<subject_alt_name_type> types) {
             std::vector<subject_alt_name> res;

--- a/src/rpc/lz4_fragmented_compressor.cc
+++ b/src/rpc/lz4_fragmented_compressor.cc
@@ -128,9 +128,9 @@ snd_buf lz4_fragmented_compressor::compress(size_t head_space, snd_buf data) {
 
     // Input chunks do not have to be multiplies of chunk_size.
     // We handle such cases by reassembling a chunk in this temporary buffer.
-    // Note that this is similar to the ring buffer compression case in docs, 
-    // we need to ensure that a suitable amount of (maybe) previous data is 
-    // stable in this or input buffer, thus make the temp buffer 
+    // Note that this is similar to the ring buffer compression case in docs,
+    // we need to ensure that a suitable amount of (maybe) previous data is
+    // stable in this or input buffer, thus make the temp buffer
     // LZ4_DECODER_RING_BUFFER_SIZE(chunk_size) large, and treat it as a ring.
     static constexpr auto lin_buf_size = LZ4_DECODER_RING_BUFFER_SIZE(chunk_size);
     static thread_local char temporary_chunk_data[lin_buf_size];
@@ -296,7 +296,7 @@ rcv_buf lz4_fragmented_compressor::decompress(rcv_buf data) {
     // compressed. If not, decompression will fail, typically
     // on text-like constructs. Making our dest buffers 64K
     // ensures we retain a suitable dictionary region for all
-    // passes. 
+    // passes.
     constexpr auto buf_size = 64 * 1024;
     size_t dst_offset = 0;
 

--- a/src/testing/test_runner.cc
+++ b/src/testing/test_runner.cc
@@ -48,7 +48,7 @@ test_runner::start(int ac, char** av) {
 
     // Don't interfere with seastar signal handling
     sigset_t mask;
-    sigfillset(&mask);            
+    sigfillset(&mask);
     for (auto sig : { SIGSEGV }) {
         sigdelset(&mask, sig);
     }

--- a/tests/perf/allocator_perf.cc
+++ b/tests/perf/allocator_perf.cc
@@ -29,7 +29,7 @@ struct alloc_bench {
     static constexpr size_t small_alloc_size = 8;
     static constexpr size_t large_alloc_size = 32000;
     static constexpr size_t MAX_POINTERS = 1000;
-    
+
     enum alloc_test_flags : uint8_t {
         MEASURE_ALLOC = 1,
         MEASURE_FREE  = 2
@@ -115,7 +115,7 @@ PERF_TEST_F(alloc_bench, single_alloc_and_free_small_many)
     }
 }
 
-// Allocate from more than one page. Should also not suffer a perf penalty 
+// Allocate from more than one page. Should also not suffer a perf penalty
 // As we should have at least min free of 50 objects (hard coded internally)
 PERF_TEST_F(alloc_bench, single_alloc_and_free_small_many_cross_page)
 {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -568,7 +568,7 @@ function(seastar_add_certgen name)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-  
+
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT}"
     COMMAND ${OPENSSL} x509 -req -in ${CERT_REQ} -CA ${CERT_CAROOT} -CAkey ${CERT_CAPRIVKEY} -CAcreateserial -out ${CERT_CERT} -days ${CERT_DAYS} -extensions req_ext -extfile ${CERT_NAME}.cfg
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"  "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -163,10 +163,10 @@ SEASTAR_THREAD_TEST_CASE(test_cross_thread_realloc) {
     // shard.
     // Needs at least 2 shards to usefully test the cross-shard aspect but
     // still passes when only 1 shard is used.
-    auto do_xshard_realloc = [](bool cross_shard, size_t initial_size, size_t realloc_size) { 
+    auto do_xshard_realloc = [](bool cross_shard, size_t initial_size, size_t realloc_size) {
         BOOST_TEST_CONTEXT("cross_shard=" << cross_shard << ", initial="
                 << initial_size << ", realloc_size=" << realloc_size) {
-                    
+
             auto other_shard = (this_shard_id() + cross_shard) % smp::count;
 
             char *p = static_cast<char *>(malloc(initial_size));
@@ -389,7 +389,7 @@ SEASTAR_TEST_CASE(test_diagnostics_allocation) {
     check_function_allocation("empty", 0, []{});
 
     check_function_allocation("operator new", 1, []{
-        // note that many pairs of malloc/free-alikes can just be optimized 
+        // note that many pairs of malloc/free-alikes can just be optimized
         // away, but not operator new(size_t), per the standard
         void * volatile p = operator new(1);
         operator delete(p);

--- a/tests/unit/cert.cfg.in
+++ b/tests/unit/cert.cfg.in
@@ -4,20 +4,20 @@ default_keyfile = @CERT_PRIVKEY@
 default_md = sha256
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
-prompt = no            
-[ req_distinguished_name ] 
+prompt = no
+[ req_distinguished_name ]
 C = @CERT_COUNTRY@
 ST = @CERT_STATE@
-L = @CERT_LOCALITY@  
+L = @CERT_LOCALITY@
 O = @CERT_ORG@
 OU = @CERT_UNIT@
 CN= @CERT_COMMON@
-emailAddress = @CERT_EMAIL@    
-[v3_ca]    
-subjectKeyIdentifier=hash  
+emailAddress = @CERT_EMAIL@
+[v3_ca]
+subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
-basicConstraints = CA:true 
-[v3_req]   
+basicConstraints = CA:true
+[v3_req]
 # Extensions to add to a certificate request
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment

--- a/tests/unit/condition_variable_test.cc
+++ b/tests/unit/condition_variable_test.cc
@@ -89,7 +89,7 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_pred) {
     }
     // should not affect outcome.
     cv.signal();
-    
+
     try {
         cv.wait(100ms, [&] { return ready; }).get();
         BOOST_FAIL("should not reach");

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -271,7 +271,7 @@ SEASTAR_TEST_CASE(test_preemption) {
     // task queue shaffling in debug mode which may cause co-routine
     // continuation to run first.
     while(preempted < 1000 && !x) {
-        preempted += need_preempt(); 
+        preempted += need_preempt();
         co_await make_ready_future<>();
     }
     auto save_x = x;
@@ -349,11 +349,11 @@ SEASTAR_TEST_CASE(test_all_ready_exceptions) {
 SEASTAR_TEST_CASE(test_all_nonready_exceptions) {
     try {
         co_await coroutine::all(
-            [] () -> future<> { 
+            [] () -> future<> {
                 co_await sleep(1ms);
                 throw 1;
             },
-            [] () -> future<> { 
+            [] () -> future<> {
                 co_await sleep(1ms);
                 throw 2;
             }
@@ -365,14 +365,14 @@ SEASTAR_TEST_CASE(test_all_nonready_exceptions) {
 
 SEASTAR_TEST_CASE(test_all_heterogeneous_types) {
     auto [a, b] = co_await coroutine::all(
-        [] () -> future<int> { 
+        [] () -> future<int> {
             co_await sleep(1ms);
             co_return 1;
         },
-        [] () -> future<> { 
+        [] () -> future<> {
             co_await sleep(1ms);
         },
-        [] () -> future<long> { 
+        [] () -> future<long> {
             co_await sleep(1ms);
             co_return 2L;
         }

--- a/tests/unit/dns_test.cc
+++ b/tests/unit/dns_test.cc
@@ -90,14 +90,14 @@ SEASTAR_TEST_CASE(test_timeout_udp) {
     });
 }
 
-// NOTE: cannot really test timeout in TCP mode, because seastar sockets do not support 
+// NOTE: cannot really test timeout in TCP mode, because seastar sockets do not support
 // connect with timeout -> cannot complete connect future in dns::do_connect in reasonable
 // time.
 
 // But we can test for connection refused working as expected.
 SEASTAR_TEST_CASE(test_connection_refused_tcp) {
     dns_resolver::options opts;
-    opts.servers = std::vector<inet_address>({ inet_address("127.0.0.1") }); 
+    opts.servers = std::vector<inet_address>({ inet_address("127.0.0.1") });
     opts.use_tcp_query = true;
     opts.tcp_port = 29953; // not a dns port
 

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -260,7 +260,7 @@ public:
     {
         _pending.resize(shards_count);
     }
-    
+
     static loopback_connection_factory with_pending_capacity(unsigned pending_capacity, unsigned shards_count = smp::count) {
         auto lcf = loopback_connection_factory(shards_count);
         lcf._pending_capacity = pending_capacity;

--- a/tests/unit/mkcert.gmk
+++ b/tests/unit/mkcert.gmk
@@ -35,7 +35,7 @@ all     	: $(crt)
 clean		:
 		@rm -f $(crt) $(csr) $(pubkey) $(prvkey)
 
-%.key		: 
+%.key		:
 		@echo generating $@
 		openssl genpkey -out $@ -algorithm $(alg) $(alg_opt)
 
@@ -78,7 +78,7 @@ $(config) 	: $(MAKEFILE_LIST)
 
 %.csr		: %.key $(config)
 	        @echo generating $@
-	        openssl req -new -key $< -out $@ -config $(config) 
+	        openssl req -new -key $< -out $@ -config $(config)
 
 %.crt  		: %.csr $(root) $(rootkey)
 		@echo generating $@

--- a/tests/unit/network_interface_test.cc
+++ b/tests/unit/network_interface_test.cc
@@ -42,7 +42,7 @@ SEASTAR_TEST_CASE(list_interfaces) {
     BOOST_REQUIRE_GT(interfaces.size(), 0);
 
     for (auto& nif : interfaces) {
-        niflog.info("Iface: {}, index = {}, mtu = {}, loopback = {}, virtual = {}, up = {}", 
+        niflog.info("Iface: {}, index = {}, mtu = {}, loopback = {}, virtual = {}, up = {}",
             nif.name(), nif.index(), nif.mtu(), nif.is_loopback(), nif.is_virtual(), nif.is_up()
         );
         if (nif.hardware_address().size() >= 6) {
@@ -50,7 +50,7 @@ SEASTAR_TEST_CASE(list_interfaces) {
         }
         for (auto& addr : nif.addresses()) {
             niflog.info("   Addr: {}", addr);
-        }        
+        }
     }
 
     return make_ready_future();
@@ -75,7 +75,7 @@ SEASTAR_TEST_CASE(match_ipv6_scope) {
         net::inet_address na(text);
 
         BOOST_REQUIRE_EQUAL(na.as_ipv6_address(), i->as_ipv6_address());
-        // also verify that the inet_address itself matches        
+        // also verify that the inet_address itself matches
         BOOST_REQUIRE_EQUAL(na, *i);
         // and that inet_address _without_ scope matches.
         BOOST_REQUIRE_EQUAL(net::inet_address(na.as_ipv6_address()), *i);

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1820,7 +1820,7 @@ SEASTAR_THREAD_TEST_CASE(test_compressor_empty_frames) {
     cfg.server_options = so;
 
     rpc_test_env<>::do_with_thread(cfg, co, [&] (rpc_test_env<>& env, test_rpc_proto::client& c) {
-        // Perform an RPC once to initialize the connection and compressors. 
+        // Perform an RPC once to initialize the connection and compressors.
         env.register_handler(1, []() { return 42; }).get();
         auto proto_client = env.proto().make_client<int()>(1);
         BOOST_REQUIRE_EQUAL(proto_client(c).get(), 42);

--- a/tests/unit/sharded_test.cc
+++ b/tests/unit/sharded_test.cc
@@ -232,7 +232,7 @@ class coordinator_synced_shard_map : public peering_sharded_service<coordinator_
 
 public:
     coordinator_synced_shard_map(unsigned coordinator_id) : unsigned_per_shard(smp::count), coordinator_id(coordinator_id) {}
-    
+
     future<> sync(unsigned value) {
         return container().invoke_on(coordinator_id, [shard_id = this_shard_id(), value] (coordinator_synced_shard_map& s) {
             s.unsigned_per_shard[shard_id] = value;
@@ -261,7 +261,7 @@ SEASTAR_THREAD_TEST_CASE(invoke_on_range_contiguous) {
     f1.get();
     f2.get();
 
-    auto f3 = s.invoke_on(coordinator_id, [mid, half1_id, half2_id] (coordinator_synced_shard_map& s) { 
+    auto f3 = s.invoke_on(coordinator_id, [mid, half1_id, half2_id] (coordinator_synced_shard_map& s) {
         for (unsigned i = 0; i < mid; ++i) {
             BOOST_REQUIRE_EQUAL(half1_id, s.get_synced(i));
         }
@@ -290,7 +290,7 @@ SEASTAR_THREAD_TEST_CASE(invoke_on_range_fragmented) {
     f1.get();
     f2.get();
 
-    auto f3 = s.invoke_on(coordinator_id, [even_id, odd_id] (coordinator_synced_shard_map& s) { 
+    auto f3 = s.invoke_on(coordinator_id, [even_id, odd_id] (coordinator_synced_shard_map& s) {
         for (unsigned i = 0; i < smp::count; i += 2) {
             BOOST_REQUIRE_EQUAL(even_id, s.get_synced(i));
         }

--- a/tests/unit/signal_test.cc
+++ b/tests/unit/signal_test.cc
@@ -45,4 +45,4 @@ SEASTAR_TEST_CASE(test_sighup) {
             BOOST_REQUIRE_EQUAL(signaled, true);
         });
     });
-} 
+}

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE core
 // formatting of std::optional was introduced in fmt 10
-#define FMT_VERSION_OPTIONAL_FORMAT 100000 
+#define FMT_VERSION_OPTIONAL_FORMAT 100000
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/sstring.hh>

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -487,7 +487,7 @@ class echoserver {
 public:
     echoserver(size_t message_size, bool use_dh_params = true)
             : _certs(
-                    use_dh_params 
+                    use_dh_params
                         ? ::make_shared<tls::server_credentials>(::make_shared<tls::dh_params>())
                         : ::make_shared<tls::server_credentials>()
                     )
@@ -828,7 +828,7 @@ SEASTAR_THREAD_TEST_CASE(test_close_timout) {
     };
 
     auto constexpr iterations = 500;
-        
+
     for (int i = 0; i < iterations; ++i) {
         auto b1 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::SERVER_TX);
         auto b2 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::CLIENT_TX);
@@ -848,7 +848,7 @@ SEASTAR_THREAD_TEST_CASE(test_close_timout) {
         auto f2 = is.read();
         f1.get();
         f2.get();
-        
+
         // block further writes
         ssir._close = true;
         csir._close = true;
@@ -863,7 +863,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
     namespace fs = std::filesystem;
 
     // copy the wrong certs. We don't trust these
-    // blocking calls, but this is a test and seastar does not have a copy 
+    // blocking calls, but this is a test and seastar does not have a copy
     // util and I am lazy...
     fs::copy_file(certfile("other.crt"), tmp.path() / "test.crt");
     fs::copy_file(certfile("other.key"), tmp.path() / "test.key");
@@ -1018,8 +1018,8 @@ SEASTAR_THREAD_TEST_CASE(test_reload_broken_certificates) {
 
 using namespace std::chrono_literals;
 
-// the same as previous test, but we set a big tolerance for 
-// reload errors, and verify that either our scheduling/fs is 
+// the same as previous test, but we set a big tolerance for
+// reload errors, and verify that either our scheduling/fs is
 // super slow, or we got through the changes without failures.
 SEASTAR_THREAD_TEST_CASE(test_reload_tolerance) {
     tmpdir tmp;
@@ -1154,7 +1154,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_by_move) {
     // it should reload here as well.
     p.get_future().get();
 
-    // could get two notifications. but not more. 
+    // could get two notifications. but not more.
     for (int i = 0;; ++i) {
         p = promise();
         try {
@@ -1491,7 +1491,7 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
 }
 
 /**
- * Test TLS13 session ticket support. 
+ * Test TLS13 session ticket support.
 */
 SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
     tls::credentials_builder b;
@@ -1523,8 +1523,8 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         output_stream<char> out(c.output().detach(), 1024);
         output_stream<char> sout(s.connection.output().detach(), 1024);
 
-        // write data in both directions. Required for session data to 
-        // become available. 
+        // write data in both directions. Required for session data to
+        // become available.
         out.write("nils").get();
         auto fin = in.read();
         auto fout = out.flush();
@@ -1569,7 +1569,7 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         // This is ok. Will force a handshake.
         auto f = tls::check_session_is_resumed(c);
 
-        // But we need to force some IO to make the 
+        // But we need to force some IO to make the
         // handshake actually happen.
         auto in = s.connection.input();
         output_stream<char> out(c.output().detach(), 1024);

--- a/tests/unit/tmpdir.hh
+++ b/tests/unit/tmpdir.hh
@@ -26,17 +26,17 @@
 
 namespace seastar {
 
-/** 
+/**
  * Temp dir helper for RAII usage when doing tests
- * in seastar threads. Will not work in "normal" mode. 
- * Just use tmp_dir::do_with for that. 
+ * in seastar threads. Will not work in "normal" mode.
+ * Just use tmp_dir::do_with for that.
  */
 class tmpdir {
     seastar::tmp_dir _tmp;
 public:
     tmpdir(tmpdir&&) = default;
     tmpdir(const tmpdir&) = delete;
-    
+
     tmpdir(const sstring& name = sstring(seastar::default_tmpdir()) + "/testXXXX") {
         _tmp.create(std::filesystem::path(name)).get();
     }


### PR DESCRIPTION
Trimming trailing spaces is an accepted best practice.

The practical benefit is that contributors with editors configured to always trim trailing spaces will not need to add an exception for seastar.

If maintainers want I could look into adding a CI action to prevent future inclusion of trailing spaces.