### PR TITLE
reactor, linux-aio: clean up `smp::adjust_max_networking_aio_io_control_blocks`

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -479,7 +479,7 @@ private:
     void allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_config cfg);
     void create_thread(std::function<void ()> thread_loop);
     unsigned adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs, unsigned reserve_iocbs);
-    static void log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network);
+    static void log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network, unsigned reserve);
 public:
     static unsigned count;
 };


### PR DESCRIPTION
`smp::adjust_max_networking_aio_io_control_blocks` has become a bit incohesive in the process of adding IOCB reservation; clean up the function.

Triggered by #2538.

See also #2396 (commit ec5da7a606dd) and #2533 (commit c5f9e3a23449).