### PR TITLE
stall-detector: Remove unused _stall_detector_reports_per_minute

### DIFF
--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -55,7 +55,6 @@ struct cpu_stall_detector_config {
 class cpu_stall_detector {
 protected:
     std::atomic<uint64_t> _last_tasks_processed_seen{};
-    unsigned _stall_detector_reports_per_minute;
     std::atomic<uint64_t> _stall_detector_missed_ticks = { 0 };
     unsigned _reported = 0;
     unsigned _total_reported = 0;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1178,7 +1178,6 @@ void cpu_stall_detector::update_config(cpu_stall_detector_config cfg) {
     _config = cfg;
     _threshold = std::chrono::duration_cast<sched_clock::duration>(cfg.threshold);
     _slack = std::chrono::duration_cast<sched_clock::duration>(cfg.threshold * cfg.slack);
-    _stall_detector_reports_per_minute = cfg.stall_detector_reports_per_minute;
     _max_reports_per_minute = cfg.stall_detector_reports_per_minute;
     _rearm_timer_at = reactor::now();
 }


### PR DESCRIPTION
The _max_reports_per_minute is used instead.