### PR TITLE
scheduler: Report long queue stall

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -620,6 +620,7 @@ private:
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
     friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
+    friend seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const task_queue& tq);
 
     future<struct statfs> fstatfs(int fd) noexcept;
     friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags, struct stat st) noexcept;


### PR DESCRIPTION
There can be at least two kinds of CPU stalls in seastar: task stall and queue stalls. The former is when a single task non-preemptively occupies a CPU for a too long period of time (configured by the option named blocked-reactor-notify-ms). The latter happens when the list of tasks to run happens to go above a certain threshold (configured by the option named max-task-backlog which is 1000 by default). In that case scheduler bites the buller and doesn't stop running tasks until the queue shrinks ignoring the need_preempt() value.

The stall of the second kind can be detected by checking the "stalls" historgram in the "reactor" group and is also implicitly reported via time-spent-in-task-quota-voilation counter. However, it's good to have more information about this stall other than knowing that "bad things" had just happenned.

The suggestion is to print which tasks are currently there in the queues by iterating the queue, collecting the typeif(*task).name()-s into a histogram and dumping it into logs.