### PR TITLE
when_all: add Sentinel support to when_all_succeed() 

### DIFF
--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -297,7 +297,7 @@ do_when_all(FutureIterator begin, FutureIterator end) noexcept {
         return ret;
     };
     std::vector<typename itraits::value_type> ret =
-            make_values_vector(iterator_range_estimate_vector_capacity(begin, end, typename itraits::iterator_category()));
+            make_values_vector(iterator_range_estimate_vector_capacity(begin, end));
     // Important to invoke the *begin here, in case it's a function iterator,
     // so we launch all computation in parallel.
     std::move(begin, end, std::back_inserter(ret));

--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -128,9 +128,8 @@ public:
             } else {
                 memory::scoped_critical_alloc_section _;
                 if (_futures.empty()) {
-                    using itraits = std::iterator_traits<Iterator>;
                     if constexpr (seastar::internal::has_iterator_category<Iterator>::value) {
-                        auto n = seastar::internal::iterator_range_estimate_vector_capacity(it, end, typename itraits::iterator_category{});
+                        auto n = seastar::internal::iterator_range_estimate_vector_capacity(it, end);
                         _futures.reserve(n);
                     }
                 }


### PR DESCRIPTION
Extend `when_all_succeed()` and `iterator_range_estimate_vector_capacity()` to accept ranges with heterogeneous iterator
and sentinel types by adding a separate template parameter for the sentinel.
