### PR TITLE
Fix ipv6 socket_address comparision

### DIFF
--- a/src/net/socket_address.cc
+++ b/src/net/socket_address.cc
@@ -151,7 +151,7 @@ bool socket_address::operator==(const socket_address& a) const noexcept {
     auto& in1 = as_posix_sockaddr_in6();
     auto& in2 = a.as_posix_sockaddr_in6();
 
-    return IN6_ARE_ADDR_EQUAL(&in1, &in2);
+    return IN6_ARE_ADDR_EQUAL(&in1.sin6_addr, &in2.sin6_addr);
 }
 
 std::string unix_domain_addr_text(const socket_address& sa) {

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -103,3 +103,26 @@ SEASTAR_TEST_CASE(tcp_packet_test) {
     });
 }
 
+SEASTAR_TEST_CASE(ipv6_equal_test) {
+    const uint16_t port{8080};
+    const uint16_t port2{8088};
+
+    const std::string str_addr1{"abcd:fedc:ba98:7654:3210:0123:4567:89ab"};
+    const std::string str_addr2{"0123:4567:89ab:cdef:3210:0123:4567:89ab"};
+    const std::string str_addr3{"abcd:fedc:ba98:7654:3210:0123:4567:8900"};
+
+    socket_address sock_addr1(ipv6_addr(str_addr1, port));
+    socket_address sock_addr2(ipv6_addr(str_addr2, port));
+    socket_address sock_addr3(ipv6_addr(str_addr1, port));
+
+    socket_address sock_addr4(ipv6_addr(str_addr3, port));
+    socket_address sock_addr5(ipv6_addr(str_addr1, port2));
+
+    BOOST_CHECK_NE(sock_addr1, sock_addr2);
+    BOOST_CHECK_EQUAL(sock_addr1, sock_addr3);
+    BOOST_CHECK_NE(sock_addr1, sock_addr4);
+    BOOST_CHECK_NE(sock_addr1, sock_addr5);
+
+    return make_ready_future();
+}
+


### PR DESCRIPTION
Fix #2566 

Pass correct types to IN6_ARE_ADDR_EQUAL macro
Add unit test 