### PR TITLE
log: drop specialization of boost::lexical_cast for log_level

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -35,7 +35,6 @@
 #include <atomic>
 #include <mutex>
 #include <type_traits>
-#include <boost/lexical_cast.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #endif
@@ -71,14 +70,6 @@ struct fmt::formatter<seastar::log_level> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(seastar::log_level level, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
-
-// Boost doesn't auto-deduce the existence of the streaming operators for some reason
-
-namespace boost {
-template<>
-seastar::log_level lexical_cast(const std::string& source);
-
-}
 
 namespace seastar {
 SEASTAR_MODULE_EXPORT_BEGIN

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -631,18 +631,6 @@ logging_settings extract_settings(const options& opts) {
 }
 
 }
-namespace boost {
-template<>
-seastar::log_level lexical_cast(const std::string& source) {
-    std::istringstream in(source);
-    seastar::log_level level;
-    if (!(in >> level)) {
-        throw boost::bad_lexical_cast();
-    }
-    return level;
-}
-
-}
 
 namespace std {
 std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {


### PR DESCRIPTION
log.hh contains a declaration of a specializtion of lexical_cast for log_level, noting boost doesn't pick up operator<< for log_level, but everything seems to work without the specialization. Dropping it means we can drop yet another boost dependency in a commonly used header file, one that pulls in much of the boost.ranges core.