### PR TITLE
reactor: fix crash in pending registration task after poller dtor

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3426,7 +3426,6 @@ poller::~poller() {
         if (_registration_task) {
             // not added yet, so don't do it at all.
             _registration_task->cancel();
-            delete _registration_task;
         } else if (!engine()._finished_running_tasks) {
             // If _finished_running_tasks, the call to add_task() below will just
             // leak it, since no one will call task::run_and_dispose(). Just leave


### PR DESCRIPTION
A poller destructor that finds the poller still has a registration task cancels it (sets _p = nullptr), however the task remains on the task queue.
The original commit (below) introduced deleting such registration task object right in ~poller().
Which means the reactor will pick this task from the task queue while the contents is stale: use after free.
If we're lucky, _p will still read as nullptr, but otherwise run_and_dispose() will likely segfault.

Fix:
Removed deleting _registration_task: run_and_dispose() will do it.

Fixes: bcb5cf3a8dca19be0e577ee4e3bcd246f949dce6