### PR TITLE
util/backtrace: Optimize formatter to reduce memory allocation overhead

### DIFF
--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -84,18 +84,20 @@ public:
     using vector_type = boost::container::static_vector<frame, 64>;
 private:
     vector_type _frames;
-    size_t _hash;
-    char _delimeter;
+    size_t _hash = 0;
+    char _delimeter = ' ';
 private:
     size_t calculate_hash() const noexcept;
 public:
-    simple_backtrace(vector_type f, char delimeter = ' ') noexcept : _frames(std::move(f)), _hash(calculate_hash()), _delimeter(delimeter) {}
-    simple_backtrace(char delimeter = ' ') noexcept : simple_backtrace({}, delimeter) {}
+    simple_backtrace(vector_type f) noexcept : _frames(std::move(f)), _hash(calculate_hash()) {}
+    simple_backtrace() noexcept = default;
+    [[deprecated]] simple_backtrace(vector_type f, char delimeter) : _frames(std::move(f)), _hash(calculate_hash()), _delimeter(delimeter) {}
+    [[deprecated]] simple_backtrace(char delimeter) : _delimeter(delimeter) {}
 
     size_t hash() const noexcept { return _hash; }
     char delimeter() const noexcept { return _delimeter; }
 
-    friend std::ostream& operator<<(std::ostream& out, const simple_backtrace&);
+    friend fmt::formatter<simple_backtrace>;
 
     bool operator==(const simple_backtrace& o) const noexcept {
         return _hash == o._hash && _frames == o._frames;
@@ -116,7 +118,7 @@ public:
         : _task_type(&ti)
     { }
 
-    friend std::ostream& operator<<(std::ostream& out, const task_entry&);
+    friend fmt::formatter<task_entry>;
 
     bool operator==(const task_entry& o) const noexcept {
         return *_task_type == *o._task_type;
@@ -151,7 +153,7 @@ public:
     size_t hash() const noexcept { return _hash; }
     char delimeter() const noexcept { return _main.delimeter(); }
 
-    friend std::ostream& operator<<(std::ostream& out, const tasktrace&);
+    friend fmt::formatter<tasktrace>;
 
     bool operator==(const tasktrace& o) const noexcept;
 
@@ -182,10 +184,22 @@ struct hash<seastar::tasktrace> {
 
 }
 
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<seastar::tasktrace> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<seastar::simple_backtrace> : fmt::ostream_formatter {};
-#endif
+template <> struct fmt::formatter<seastar::frame> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::frame&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<seastar::simple_backtrace> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::simple_backtrace&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<seastar::tasktrace> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::tasktrace&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<seastar::task_entry> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::task_entry&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 namespace seastar {
 


### PR DESCRIPTION
This commit addresses a critical memory allocation issue in backtrace formatting by directly specializing fmt::formatter for backtrace types, eliminating dependency on iostream-based formatting.

Problem:
---

When Seastar applications experience high memory pressure, logging backtrace information could fail due to additional memory allocation required by iostream formatting. This resulted in errors like:

```
ERROR 2024-12-10 01:59:16,905 [shard 0:main] seastar_memory - seastar/src/core/memory.cc:2126 @void seastar::memory::maybe_dump_memory_diagnostics(size_t, bool): failed to log message: fmt='Failed to allocate {} bytes at {}': std::__ios_failure (error iostream:1, basic_ios::clear: iostream error)"
```

Solution:
---

- Implement direct fmt::formatter specialization for backtrace
- Remove reliance on operator<< for string representation
- Reduce memory allocation pressure during out-of-memory scenarios
- Improve reliability of backtrace logging under extreme memory constraints

Additional Compatibility Note:
---

Due to changes in fmt library versioning, this implementation ensures fmt::formatter is always defined for backtrace types, even when using fmt versions earlier than 9.0. Previously, these formatters were conditionally defined based on the fmt version. Now, the formatters are consistently available, with operator<< implemented using the new fmt::formatter specialization.

This change ensures that backtrace logging can proceed even when the system is under significant memory pressure, providing more reliable post-mortem debugging information.