### PR TITLE
smp: disable mlock on overcommit

### DIFF
--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -131,6 +131,7 @@ struct reactor_options : public program_options::option_group {
     /// * \ref idle_poll_time_us = 0
     /// * \ref smp_options::thread_affinity = 0
     /// * \ref poll_aio = 0
+    /// * \ref smp_options::lock_memory = 0
     program_options::value<> overprovisioned;
     /// \brief Abort when seastar allocator cannot allocate memory.
     program_options::value<> abort_on_seastar_bad_alloc;

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -57,6 +57,8 @@ struct smp_options : public program_options::option_group {
     /// Path to accessible hugetlbfs mount (typically /dev/hugepages/something).
     program_options::value<std::string> hugepages;
     /// Lock all memory (prevents swapping).
+    ///
+    /// Disable for overprovisioned environments.
     program_options::value<bool> lock_memory;
     /// Pin threads to their cpus (disable for overprovisioning).
     ///


### PR DESCRIPTION
Memory locking keeps pages in physical memory, and decreases the amount of pages available for swapping on an overcommit setup. Thus, it can decrease fairness, increase memory pressure, and cause OOMs. So, it is less suitable for a cooperative overcommit setup.

This change disables memory locking on overcommit (overprovisioned - I hope I can rename that config). Also, it reuses the mlock variable. I assume that this change shouldn't break reasonable configs.