### PR TITLE
linux-aio: remove cpu reduction suggestions

### DIFF
--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -179,9 +179,9 @@ void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context) {
             auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
             throw std::runtime_error(
                 fmt::format("Could not setup Async I/O: {}. "
-                            "The required nr_event ({}) exceeds the limit of request capacity in /proc/sys/fs/aio-max-nr ({}). "
-                            "Try increasing that number or reducing the amount of logical CPUs available for your application",
-                            msg, nr, aio_max_nr));
+                            "The required nr_events {} exceeds the capacity in /proc/sys/fs/aio-max-nr {}. "
+                            "Set /proc/sys/fs/aio-max-nr to at least {}.",
+                            msg, nr, aio_max_nr, nr));
         } else {
             throw std::runtime_error(fmt::format("Could not setup Async I/O: {}", msg));
         }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4202,10 +4202,6 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
     seastar_logger.debug("Available AIO control blocks = aio-max-nr - aio-nr = {} - {} = {}", aio_max_nr, aio_nr, available_aio);
 
     if (available_aio < requested_aio) {
-        auto get_smp_count = [linear_over_cpus = available_aio - std::min(reserve_iocbs, available_aio)] (unsigned network) -> unsigned {
-            return linear_over_cpus / (storage_iocbs + preempt_iocbs + network);
-        };
-
         if (available_aio >= requested_aio_other + smp::count) { // at least one queue for each shard
             network_iocbs = (available_aio - requested_aio_other) / smp::count;
             seastar_logger.warn("Your system does not have enough AIO capacity for optimal network performance; reducing `max-networking-io-control-blocks'.");
@@ -4215,22 +4211,10 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
             seastar_logger.warn("");
             seastar_logger.warn("For optimal network performance, set /proc/sys/fs/aio-max-nr to at least {}.", aio_nr + requested_aio);
         } else {
-            std::string err = format("Your system does not satisfy minimum AIO requirements. "
-                                     "Set /proc/sys/fs/aio-max-nr to at least {} (minimum) or {} (recommended for networking performance)",
-                                     aio_nr + (requested_aio_other + smp::count), aio_nr + requested_aio);
-
-            unsigned smp_count_max = get_smp_count(1);
-            if (smp_count_max > 0) {
-                err.append(format(", or decrease the logical CPU count of the application to {} (maximum)", smp_count_max));
-
-                unsigned smp_count_recommended = get_smp_count(network_iocbs);
-                if (smp_count_recommended > 0) {
-                    err.append(format(" or {} (recommended for networking performance)", smp_count_recommended));
-                }
-            }
-
-            err.append(".");
-            throw std::runtime_error(err);
+            throw std::runtime_error(
+                format("Your system does not satisfy minimum AIO requirements. "
+                       "Set /proc/sys/fs/aio-max-nr to at least {} (minimum) or {} (recommended for networking performance).",
+                       aio_nr + (requested_aio_other + smp::count), aio_nr + requested_aio));
         }
     }
 


### PR DESCRIPTION
Follows https://github.com/scylladb/seastar/pull/2553.

Removes vCPU count reduction suggestions from linux-aio, following the discussion to keep Seastar advices focused on simple solutions to reduce limitations rather than complex adaptations.

Also, this change better alignes the advices in the 2 places.