### PR TITLE
Extract websocket functionality that is common to both server and future client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,7 @@ add_library (seastar
   src/util/read_first_line.cc
   src/util/tmp_file.cc
   src/util/short_streams.cc
+  src/websocket/parser.cc
   src/websocket/server.cc
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,7 @@ add_library (seastar
   include/seastar/util/closeable.hh
   include/seastar/util/source_location-compat.hh
   include/seastar/util/short_streams.hh
+  include/seastar/websocket/common.hh
   include/seastar/websocket/server.hh
   src/core/alien.cc
   src/core/file.cc
@@ -778,6 +779,7 @@ add_library (seastar
   src/util/tmp_file.cc
   src/util/short_streams.cc
   src/websocket/parser.cc
+  src/websocket/common.cc
   src/websocket/server.cc
   )
 

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -165,6 +165,7 @@ protected:
 };
 
 std::string sha1_base64(std::string_view source);
+std::string encode_base64(std::string_view source);
 
 extern logger websocket_logger;
 

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -166,7 +166,7 @@ protected:
 
 std::string sha1_base64(std::string_view source);
 
-extern logger wlogger;
+extern logger websocket_logger;
 
 /// @}
 }

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -1,0 +1,172 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2024 ScyllaDB
+ */
+
+#pragma once
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/net/api.hh>
+#include <seastar/util/log.hh>
+#include <seastar/websocket/parser.hh>
+
+namespace seastar::experimental::websocket {
+
+extern sstring magic_key_suffix;
+
+using handler_t = std::function<future<>(input_stream<char>&, output_stream<char>&)>;
+
+class server;
+
+/// \defgroup websocket WebSocket
+/// \addtogroup websocket
+/// @{
+
+/*!
+ * \brief an error in handling a WebSocket connection
+ */
+class exception : public std::exception {
+    std::string _msg;
+public:
+    exception(std::string_view msg) : _msg(msg) {}
+    virtual const char* what() const noexcept {
+        return _msg.c_str();
+    }
+};
+
+/*!
+ * \brief a server WebSocket connection
+ */
+class connection : public boost::intrusive::list_base_hook<> {
+protected:
+    using buff_t = temporary_buffer<char>;
+
+    /*!
+     * \brief Implementation of connection's data source.
+     */
+    class connection_source_impl final : public data_source_impl {
+        queue<buff_t>* data;
+
+    public:
+        connection_source_impl(queue<buff_t>* data) : data(data) {}
+
+        virtual future<buff_t> get() override {
+            return data->pop_eventually().then_wrapped([](future<buff_t> f){
+                try {
+                    return make_ready_future<buff_t>(std::move(f.get()));
+                } catch(...) {
+                    return current_exception_as_future<buff_t>();
+                }
+            });
+        }
+
+        virtual future<> close() override {
+            data->push(buff_t(0));
+            return make_ready_future<>();
+        }
+    };
+
+    /*!
+     * \brief Implementation of connection's data sink.
+     */
+    class connection_sink_impl final : public data_sink_impl {
+        queue<buff_t>* data;
+    public:
+        connection_sink_impl(queue<buff_t>* data) : data(data) {}
+
+        virtual future<> put(net::packet d) override {
+            net::fragment f = d.frag(0);
+            return data->push_eventually(temporary_buffer<char>{std::move(f.base), f.size});
+        }
+
+        size_t buffer_size() const noexcept override {
+            return data->max_size();
+        }
+
+        virtual future<> close() override {
+            data->push(buff_t(0));
+            return make_ready_future<>();
+        }
+    };
+
+    /*!
+     * \brief This function processess received PING frame.
+     * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
+     */
+    future<> handle_ping();
+    /*!
+     * \brief This function processess received PONG frame.
+     * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3
+     */
+    future<> handle_pong();
+
+    static const size_t PIPE_SIZE = 512;
+    connected_socket _fd;
+    input_stream<char> _read_buf;
+    output_stream<char> _write_buf;
+    bool _done = false;
+
+    websocket_parser _websocket_parser;
+    queue <temporary_buffer<char>> _input_buffer;
+    input_stream<char> _input;
+    queue <temporary_buffer<char>> _output_buffer;
+    output_stream<char> _output;
+
+    sstring _subprotocol;
+    handler_t _handler;
+public:
+    /*!
+     * \param fd established socket used for communication
+     */
+    connection(connected_socket&& fd)
+        : _fd(std::move(fd))
+        , _read_buf(_fd.input())
+        , _write_buf(_fd.output())
+        , _input_buffer{PIPE_SIZE}
+        , _output_buffer{PIPE_SIZE}
+    {
+        _input = input_stream<char>{data_source{
+                std::make_unique<connection_source_impl>(&_input_buffer)}};
+        _output = output_stream<char>{data_sink{
+                std::make_unique<connection_sink_impl>(&_output_buffer)}};
+    }
+
+    /*!
+     * \brief close the socket
+     */
+    void shutdown_input();
+    future<> close(bool send_close = true);
+
+protected:
+    future<> read_one();
+    future<> response_loop();
+    /*!
+     * \brief Packs buff in websocket frame and sends it to the client.
+     */
+    future<> send_data(opcodes opcode, temporary_buffer<char>&& buff);
+};
+
+std::string sha1_base64(std::string_view source);
+
+extern logger wlogger;
+
+/// @}
+}

--- a/include/seastar/websocket/parser.hh
+++ b/include/seastar/websocket/parser.hh
@@ -1,0 +1,143 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/iostream.hh>
+
+namespace seastar::experimental::websocket {
+
+/// \addtogroup websocket
+/// @{
+
+/*!
+ * \brief Possible type of a websocket frame.
+ */
+enum opcodes {
+    CONTINUATION = 0x0,
+    TEXT = 0x1,
+    BINARY = 0x2,
+    CLOSE = 0x8,
+    PING = 0x9,
+    PONG = 0xA,
+    INVALID = 0xFF,
+};
+
+struct frame_header {
+    static constexpr uint8_t FIN = 7;
+    static constexpr uint8_t RSV1 = 6;
+    static constexpr uint8_t RSV2 = 5;
+    static constexpr uint8_t RSV3 = 4;
+    static constexpr uint8_t MASKED = 7;
+
+    uint8_t fin : 1;
+    uint8_t rsv1 : 1;
+    uint8_t rsv2 : 1;
+    uint8_t rsv3 : 1;
+    uint8_t opcode : 4;
+    uint8_t masked : 1;
+    uint8_t length : 7;
+    frame_header(const char* input) {
+        this->fin = (input[0] >> FIN) & 1;
+        this->rsv1 = (input[0] >> RSV1) & 1;
+        this->rsv2 = (input[0] >> RSV2) & 1;
+        this->rsv3 = (input[0] >> RSV3) & 1;
+        this->opcode = input[0] & 0b1111;
+        this->masked = (input[1] >> MASKED) & 1;
+        this->length = (input[1] & 0b1111111);
+    }
+    // Returns length of the rest of the header.
+    uint64_t get_rest_of_header_length() {
+        size_t next_read_length = sizeof(uint32_t); // Masking key
+        if (length == 126) {
+            next_read_length += sizeof(uint16_t);
+        } else if (length == 127) {
+            next_read_length += sizeof(uint64_t);
+        }
+        return next_read_length;
+    }
+    uint8_t get_fin() {return fin;}
+    uint8_t get_rsv1() {return rsv1;}
+    uint8_t get_rsv2() {return rsv2;}
+    uint8_t get_rsv3() {return rsv3;}
+    uint8_t get_opcode() {return opcode;}
+    uint8_t get_masked() {return masked;}
+    uint8_t get_length() {return length;}
+
+    bool is_opcode_known() {
+        //https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
+        return opcode < 0xA && !(opcode < 0x8 && opcode > 0x2);
+    }
+};
+
+class websocket_parser {
+    enum class parsing_state : uint8_t {
+        flags_and_payload_data,
+        payload_length_and_mask,
+        payload
+    };
+    enum class connection_state : uint8_t {
+        valid,
+        closed,
+        error
+    };
+    using consumption_result_t = consumption_result<char>;
+    using buff_t = temporary_buffer<char>;
+    // What parser is currently doing.
+    parsing_state _state;
+    // State of connection - can be valid, closed or should be closed
+    // due to error.
+    connection_state _cstate;
+    sstring _buffer;
+    std::unique_ptr<frame_header> _header;
+    uint64_t _payload_length = 0;
+    uint64_t _consumed_payload_length = 0;
+    uint32_t _masking_key;
+    buff_t _result;
+
+    static future<consumption_result_t> dont_stop() {
+        return make_ready_future<consumption_result_t>(continue_consuming{});
+    }
+    static future<consumption_result_t> stop(buff_t data) {
+        return make_ready_future<consumption_result_t>(stop_consuming(std::move(data)));
+    }
+    uint64_t remaining_payload_length() const {
+        return _payload_length - _consumed_payload_length;
+    }
+
+    // Removes mask from payload given in p.
+    void remove_mask(buff_t& p, size_t n) {
+        char *payload = p.get_write();
+        for (uint64_t i = 0, j = 0; i < n; ++i, j = (j + 1) % 4) {
+            payload[i] ^= static_cast<char>(((_masking_key << (j * 8)) >> 24));
+        }
+    }
+public:
+    websocket_parser() : _state(parsing_state::flags_and_payload_data),
+                         _cstate(connection_state::valid),
+                         _masking_key(0) {}
+    future<consumption_result_t> operator()(temporary_buffer<char> data);
+    bool is_valid() { return _cstate == connection_state::valid; }
+    bool eof() { return _cstate == connection_state::closed; }
+    opcodes opcode() const;
+    buff_t result();
+};
+
+/// @}
+}

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -31,6 +31,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/websocket/parser.hh>
 
 namespace seastar::experimental::websocket {
 
@@ -52,120 +53,6 @@ public:
     virtual const char* what() const noexcept {
         return _msg.c_str();
     }
-};
-
-/*!
- * \brief Possible type of a websocket frame.
- */
-enum opcodes {
-    CONTINUATION = 0x0,
-    TEXT = 0x1,
-    BINARY = 0x2,
-    CLOSE = 0x8,
-    PING = 0x9,
-    PONG = 0xA,
-    INVALID = 0xFF,
-};
-
-struct frame_header {
-    static constexpr uint8_t FIN = 7;
-    static constexpr uint8_t RSV1 = 6;
-    static constexpr uint8_t RSV2 = 5;
-    static constexpr uint8_t RSV3 = 4;
-    static constexpr uint8_t MASKED = 7;
-
-    uint8_t fin : 1;
-    uint8_t rsv1 : 1;
-    uint8_t rsv2 : 1;
-    uint8_t rsv3 : 1;
-    uint8_t opcode : 4;
-    uint8_t masked : 1;
-    uint8_t length : 7;
-    frame_header(const char* input) {
-        this->fin = (input[0] >> FIN) & 1;
-        this->rsv1 = (input[0] >> RSV1) & 1;
-        this->rsv2 = (input[0] >> RSV2) & 1;
-        this->rsv3 = (input[0] >> RSV3) & 1;
-        this->opcode = input[0] & 0b1111;
-        this->masked = (input[1] >> MASKED) & 1;
-        this->length = (input[1] & 0b1111111);
-    }
-    // Returns length of the rest of the header.
-    uint64_t get_rest_of_header_length() {
-        size_t next_read_length = sizeof(uint32_t); // Masking key
-        if (length == 126) {
-            next_read_length += sizeof(uint16_t);
-        } else if (length == 127) {
-            next_read_length += sizeof(uint64_t);
-        }
-        return next_read_length;
-    }
-    uint8_t get_fin() {return fin;}
-    uint8_t get_rsv1() {return rsv1;}
-    uint8_t get_rsv2() {return rsv2;}
-    uint8_t get_rsv3() {return rsv3;}
-    uint8_t get_opcode() {return opcode;}
-    uint8_t get_masked() {return masked;}
-    uint8_t get_length() {return length;}
-
-    bool is_opcode_known() {
-        //https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
-        return opcode < 0xA && !(opcode < 0x8 && opcode > 0x2);
-    }
-};
-
-class websocket_parser {
-    enum class parsing_state : uint8_t {
-        flags_and_payload_data,
-        payload_length_and_mask,
-        payload
-    };
-    enum class connection_state : uint8_t {
-        valid,
-        closed,
-        error
-    };
-    using consumption_result_t = consumption_result<char>;
-    using buff_t = temporary_buffer<char>;
-    // What parser is currently doing.
-    parsing_state _state;
-    // State of connection - can be valid, closed or should be closed
-    // due to error.
-    connection_state _cstate;
-    sstring _buffer;
-    std::unique_ptr<frame_header> _header;
-    uint64_t _payload_length;
-    uint64_t _consumed_payload_length = 0;
-    uint32_t _masking_key;
-    buff_t _result;
-
-    static future<consumption_result_t> dont_stop() {
-        return make_ready_future<consumption_result_t>(continue_consuming{});
-    }
-    static future<consumption_result_t> stop(buff_t data) {
-        return make_ready_future<consumption_result_t>(stop_consuming(std::move(data)));
-    }
-    uint64_t remaining_payload_length() const {
-        return _payload_length - _consumed_payload_length;
-    }
-
-    // Removes mask from payload given in p.
-    void remove_mask(buff_t& p, size_t n) {
-        char *payload = p.get_write();
-        for (uint64_t i = 0, j = 0; i < n; ++i, j = (j + 1) % 4) {
-            payload[i] ^= static_cast<char>(((_masking_key << (j * 8)) >> 24));
-        }
-    }
-public:
-    websocket_parser() : _state(parsing_state::flags_and_payload_data),
-                         _cstate(connection_state::valid),
-                         _payload_length(0),
-                         _masking_key(0) {}
-    future<consumption_result_t> operator()(temporary_buffer<char> data);
-    bool is_valid() { return _cstate == connection_state::valid; }
-    bool eof() { return _cstate == connection_state::closed; }
-    opcodes opcode() const;
-    buff_t result();
 };
 
 /*!

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -22,137 +22,36 @@
 #pragma once
 
 #include <map>
-#include <functional>
 
 #include <seastar/http/request_parser.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/net/api.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/when_all.hh>
-#include <seastar/websocket/parser.hh>
+#include <seastar/websocket/common.hh>
 
 namespace seastar::experimental::websocket {
 
-using handler_t = std::function<future<>(input_stream<char>&, output_stream<char>&)>;
-
-class server;
-
-/// \defgroup websocket WebSocket
 /// \addtogroup websocket
 /// @{
 
 /*!
- * \brief an error in handling a WebSocket connection
- */
-class exception : public std::exception {
-    std::string _msg;
-public:
-    exception(std::string_view msg) : _msg(msg) {}
-    virtual const char* what() const noexcept {
-        return _msg.c_str();
-    }
-};
-
-/*!
  * \brief a server WebSocket connection
  */
-class server_connection : public boost::intrusive::list_base_hook<> {
-    using buff_t = temporary_buffer<char>;
+class server_connection : public connection {
 
-    /*!
-     * \brief Implementation of connection's data source.
-     */
-    class connection_source_impl final : public data_source_impl {
-        queue<buff_t>* data;
-
-    public:
-        connection_source_impl(queue<buff_t>* data) : data(data) {}
-
-        virtual future<buff_t> get() override {
-            return data->pop_eventually().then_wrapped([](future<buff_t> f){
-                try {
-                    return make_ready_future<buff_t>(std::move(f.get()));
-                } catch(...) {
-                    return current_exception_as_future<buff_t>();
-                }
-            });
-        }
-
-        virtual future<> close() override {
-            data->push(buff_t(0));
-            return make_ready_future<>();
-        }
-    };
-
-    /*!
-     * \brief Implementation of connection's data sink.
-     */
-    class connection_sink_impl final : public data_sink_impl {
-        queue<buff_t>* data;
-    public:
-        connection_sink_impl(queue<buff_t>* data) : data(data) {}
-
-        virtual future<> put(net::packet d) override {
-            net::fragment f = d.frag(0);
-            return data->push_eventually(temporary_buffer<char>{std::move(f.base), f.size});
-        }
-
-        size_t buffer_size() const noexcept override {
-            return data->max_size();
-        }
-
-        virtual future<> close() override {
-            data->push(buff_t(0));
-            return make_ready_future<>();
-        }
-    };
-
-    /*!
-     * \brief This function processess received PING frame.
-     * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
-     */
-    future<> handle_ping();
-    /*!
-     * \brief This function processess received PONG frame.
-     * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3
-     */
-    future<> handle_pong();
-
-    static const size_t PIPE_SIZE = 512;
     server& _server;
-    connected_socket _fd;
-    input_stream<char> _read_buf;
-    output_stream<char> _write_buf;
     http_request_parser _http_parser;
-    bool _done = false;
 
-    websocket_parser _websocket_parser;
-    queue <temporary_buffer<char>> _input_buffer;
-    input_stream<char> _input;
-    queue <temporary_buffer<char>> _output_buffer;
-    output_stream<char> _output;
-
-    sstring _subprotocol;
-    handler_t _handler;
 public:
     /*!
      * \param server owning \ref server
      * \param fd established socket used for communication
      */
     server_connection(server& server, connected_socket&& fd)
-        : _server(server)
-        , _fd(std::move(fd))
-        , _read_buf(_fd.input())
-        , _write_buf(_fd.output())
-        , _input_buffer{PIPE_SIZE}
-        , _output_buffer{PIPE_SIZE}
-    {
-        _input = input_stream<char>{data_source{
-                std::make_unique<connection_source_impl>(&_input_buffer)}};
-        _output = output_stream<char>{data_sink{
-                std::make_unique<connection_sink_impl>(&_output_buffer)}};
+        : connection(std::move(fd))
+        , _server(server) {
         on_new_connection();
     }
     ~server_connection();
@@ -161,23 +60,11 @@ public:
      * \brief serve WebSocket protocol on a server_connection
      */
     future<> process();
-    /*!
-     * \brief close the socket
-     */
-    void shutdown_input();
-    future<> close(bool send_close = true);
 
 protected:
     future<> read_loop();
-    future<> read_one();
     future<> read_http_upgrade_request();
-    future<> response_loop();
     void on_new_connection();
-    /*!
-     * \brief Packs buff in websocket frame and sends it to the client.
-     */
-    future<> send_data(opcodes opcode, temporary_buffer<char>&& buff);
-
 };
 
 /*!

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -56,9 +56,9 @@ public:
 };
 
 /*!
- * \brief a WebSocket connection
+ * \brief a server WebSocket connection
  */
-class connection : public boost::intrusive::list_base_hook<> {
+class server_connection : public boost::intrusive::list_base_hook<> {
     using buff_t = temporary_buffer<char>;
 
     /*!
@@ -141,7 +141,7 @@ public:
      * \param server owning \ref server
      * \param fd established socket used for communication
      */
-    connection(server& server, connected_socket&& fd)
+    server_connection(server& server, connected_socket&& fd)
         : _server(server)
         , _fd(std::move(fd))
         , _read_buf(_fd.input())
@@ -155,10 +155,10 @@ public:
                 std::make_unique<connection_sink_impl>(&_output_buffer)}};
         on_new_connection();
     }
-    ~connection();
+    ~server_connection();
 
     /*!
-     * \brief serve WebSocket protocol on a connection
+     * \brief serve WebSocket protocol on a server_connection
      */
     future<> process();
     /*!
@@ -188,7 +188,7 @@ protected:
  */
 class server {
     std::vector<server_socket> _listeners;
-    boost::intrusive::list<connection> _connections;
+    boost::intrusive::list<server_connection> _connections;
     std::map<std::string, handler_t> _handlers;
     gate _task_gate;
 public:
@@ -219,7 +219,7 @@ public:
      */
     void register_handler(const std::string& name, handler_t handler);
 
-    friend class connection;
+    friend class server_connection;
 protected:
     void accept(server_socket &listener);
     future<stop_iteration> accept_one(server_socket &listener);

--- a/src/websocket/common.cc
+++ b/src/websocket/common.cc
@@ -29,7 +29,7 @@
 namespace seastar::experimental::websocket {
 
 sstring magic_key_suffix = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-logger wlogger("websocket");
+logger websocket_logger("websocket");
 
 future<> connection::handle_ping() {
     // TODO
@@ -109,14 +109,14 @@ future<> connection::read_one() {
             case opcodes::BINARY:
                 return _input_buffer.push_eventually(_websocket_parser.result());
             case opcodes::CLOSE:
-                wlogger.debug("Received close frame.");
+                websocket_logger.debug("Received close frame.");
                 // datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
                 return close(true);
             case opcodes::PING:
-                wlogger.debug("Received ping frame.");
+                websocket_logger.debug("Received ping frame.");
                 return handle_ping();
             case opcodes::PONG:
-                wlogger.debug("Received pong frame.");
+                websocket_logger.debug("Received pong frame.");
                 return handle_pong();
             default:
                 // Invalid - do nothing.
@@ -125,7 +125,7 @@ future<> connection::read_one() {
         } else if (_websocket_parser.eof()) {
             return close(false);
         }
-        wlogger.debug("Reading from socket has failed.");
+        websocket_logger.debug("Reading from socket has failed.");
         return close(true);
     });
 }

--- a/src/websocket/common.cc
+++ b/src/websocket/common.cc
@@ -1,0 +1,154 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2024 ScyllaDB
+ */
+
+#include <seastar/websocket/common.hh>
+#include <seastar/core/byteorder.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/defer.hh>
+#include <gnutls/crypto.h>
+#include <gnutls/gnutls.h>
+
+namespace seastar::experimental::websocket {
+
+sstring magic_key_suffix = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+logger wlogger("websocket");
+
+future<> connection::handle_ping() {
+    // TODO
+    return make_ready_future<>();
+}
+
+future<> connection::handle_pong() {
+    // TODO
+    return make_ready_future<>();
+}
+
+future<> connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
+    char header[10] = {'\x80', 0};
+    size_t header_size = 2;
+
+    header[0] += opcode;
+
+    if ((126 <= buff.size()) && (buff.size() <= std::numeric_limits<uint16_t>::max())) {
+        header[1] = 0x7E;
+        write_be<uint16_t>(header + 2, buff.size());
+        header_size += sizeof(uint16_t);
+    } else if (std::numeric_limits<uint16_t>::max() < buff.size()) {
+        header[1] = 0x7F;
+        write_be<uint64_t>(header + 2, buff.size());
+        header_size += sizeof(uint64_t);
+    } else {
+        header[1] = uint8_t(buff.size());
+    }
+
+    scattered_message<char> msg;
+    msg.append(sstring(header, header_size));
+    msg.append(std::move(buff));
+    return _write_buf.write(std::move(msg)).then([this] {
+        return _write_buf.flush();
+    });
+}
+
+future<> connection::response_loop() {
+    return do_until([this] {return _done;}, [this] {
+        // FIXME: implement error handling
+        return _output_buffer.pop_eventually().then([this] (
+                temporary_buffer<char> buf) {
+            return send_data(opcodes::BINARY, std::move(buf));
+        });
+    }).finally([this]() {
+        return _write_buf.close();
+    });
+}
+
+void connection::shutdown_input() {
+    _fd.shutdown_input();
+}
+
+future<> connection::close(bool send_close) {
+    return [this, send_close]() {
+        if (send_close) {
+            return send_data(opcodes::CLOSE, temporary_buffer<char>(0));
+        } else {
+            return make_ready_future<>();
+        }
+    }().finally([this] {
+        _done = true;
+        return when_all_succeed(_input.close(), _output.close()).discard_result().finally([this] {
+            _fd.shutdown_output();
+        });
+    });
+}
+
+future<> connection::read_one() {
+    return _read_buf.consume(_websocket_parser).then([this] () mutable {
+        if (_websocket_parser.is_valid()) {
+            // FIXME: implement error handling
+            switch(_websocket_parser.opcode()) {
+            // We do not distinguish between these 3 types.
+            case opcodes::CONTINUATION:
+            case opcodes::TEXT:
+            case opcodes::BINARY:
+                return _input_buffer.push_eventually(_websocket_parser.result());
+            case opcodes::CLOSE:
+                wlogger.debug("Received close frame.");
+                // datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
+                return close(true);
+            case opcodes::PING:
+                wlogger.debug("Received ping frame.");
+                return handle_ping();
+            case opcodes::PONG:
+                wlogger.debug("Received pong frame.");
+                return handle_pong();
+            default:
+                // Invalid - do nothing.
+                ;
+            }
+        } else if (_websocket_parser.eof()) {
+            return close(false);
+        }
+        wlogger.debug("Reading from socket has failed.");
+        return close(true);
+    });
+}
+
+std::string sha1_base64(std::string_view source) {
+    unsigned char hash[20];
+    assert(sizeof(hash) == gnutls_hash_get_len(GNUTLS_DIG_SHA1));
+    if (int ret = gnutls_hash_fast(GNUTLS_DIG_SHA1, source.data(), source.size(), hash);
+        ret != GNUTLS_E_SUCCESS) {
+        throw websocket::exception(fmt::format("gnutls_hash_fast: {}", gnutls_strerror(ret)));
+    }
+    gnutls_datum_t hash_data{
+        .data = hash,
+        .size = sizeof(hash),
+    };
+    gnutls_datum_t base64_encoded;
+    if (int ret = gnutls_base64_encode2(&hash_data, &base64_encoded);
+        ret != GNUTLS_E_SUCCESS) {
+        throw websocket::exception(fmt::format("gnutls_base64_encode2: {}", gnutls_strerror(ret)));
+    }
+    auto free_base64_encoded = defer([&] () noexcept { gnutls_free(base64_encoded.data); });
+    // base64_encoded.data is "unsigned char *"
+    return std::string(reinterpret_cast<const char*>(base64_encoded.data), base64_encoded.size);
+}
+
+}

--- a/src/websocket/parser.cc
+++ b/src/websocket/parser.cc
@@ -1,0 +1,136 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <seastar/websocket/parser.hh>
+#include <seastar/core/byteorder.hh>
+
+namespace seastar::experimental::websocket {
+
+opcodes websocket_parser::opcode() const {
+    if (_header) {
+        return opcodes(_header->opcode);
+    } else {
+        return opcodes::INVALID;
+    }
+}
+
+websocket_parser::buff_t websocket_parser::result() {
+    return std::move(_result);
+}
+
+future<websocket_parser::consumption_result_t> websocket_parser::operator()(
+        temporary_buffer<char> data) {
+    if (data.size() == 0) {
+        // EOF
+        _cstate = connection_state::closed;
+        return websocket_parser::stop(std::move(data));
+    }
+    if (_state == parsing_state::flags_and_payload_data) {
+        if (_buffer.length() + data.size() >= 2) {
+            // _buffer.length() is less than 2 when entering this if body due to how
+            // the rest of code is structured. The else branch will never increase
+            // _buffer.length() to >=2 and other paths to this condition will always
+            // have buffer cleared.
+            assert(_buffer.length() < 2);
+
+            size_t hlen = _buffer.length();
+            _buffer.append(data.get(), 2 - hlen);
+            data.trim_front(2 - hlen);
+            _header = std::make_unique<frame_header>(_buffer.data());
+            _buffer = {};
+
+            // https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
+            // We must close the connection if data isn't masked.
+            if ((!_header->masked) ||
+                // RSVX must be 0
+                (_header->rsv1 | _header->rsv2 | _header->rsv3) ||
+                // Opcode must be known.
+                (!_header->is_opcode_known())) {
+                _cstate = connection_state::error;
+                return websocket_parser::stop(std::move(data));
+            }
+            _state = parsing_state::payload_length_and_mask;
+        } else {
+            _buffer.append(data.get(), data.size());
+            return websocket_parser::dont_stop();
+        }
+    }
+    if (_state == parsing_state::payload_length_and_mask) {
+        size_t const required_bytes = _header->get_rest_of_header_length();
+        if (_buffer.length() + data.size() >= required_bytes) {
+            if (_buffer.length() < required_bytes) {
+                size_t hlen = _buffer.length();
+                _buffer.append(data.get(), required_bytes - hlen);
+                data.trim_front(required_bytes - hlen);
+            }
+            _payload_length = _header->length;
+            char const *input = _buffer.data();
+            if (_header->length == 126) {
+                _payload_length = consume_be<uint16_t>(input);
+            } else if (_header->length == 127) {
+                _payload_length = consume_be<uint64_t>(input);
+            }
+
+            _masking_key = consume_be<uint32_t>(input);
+            _buffer = {};
+            _state = parsing_state::payload;
+        } else {
+            _buffer.append(data.get(), data.size());
+            return websocket_parser::dont_stop();
+        }
+    }
+    if (_state == parsing_state::payload) {
+        if (data.size() < remaining_payload_length()) {
+            // data has insufficient data to complete the frame - consume data.size() bytes
+            if (_result.empty()) {
+                _result = temporary_buffer<char>(remaining_payload_length());
+                _consumed_payload_length = 0;
+            }
+            std::copy(data.begin(), data.end(), _result.get_write() + _consumed_payload_length);
+            _consumed_payload_length += data.size();
+            return websocket_parser::dont_stop();
+        } else {
+            // data has sufficient data to complete the frame - consume remaining_payload_length()
+            auto consumed_bytes = remaining_payload_length();
+            if (_result.empty()) {
+                // Try to avoid memory copies in case when network packets contain one or more full
+                // websocket frames.
+                if (consumed_bytes == data.size()) {
+                    _result = std::move(data);
+                    data = temporary_buffer<char>(0);
+                } else {
+                    _result = data.share();
+                    _result.trim(consumed_bytes);
+                    data.trim_front(consumed_bytes);
+                }
+            } else {
+                std::copy(data.begin(), data.begin() + consumed_bytes,
+                          _result.get_write() + _consumed_payload_length);
+                data.trim_front(consumed_bytes);
+            }
+            remove_mask(_result, _payload_length);
+            _consumed_payload_length = 0;
+            _state = parsing_state::flags_and_payload_data;
+            return websocket_parser::stop(std::move(data));
+        }
+    }
+    _cstate = connection_state::error;
+    return websocket_parser::stop(std::move(data));
+}
+
+}

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -59,7 +59,7 @@ future<stop_iteration> server::accept_one(server_socket &listener) {
         auto conn = std::make_unique<server_connection>(*this, std::move(ar.connection));
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().finally([conn = std::move(conn)] {
-                wlogger.debug("Connection is finished");
+                websocket_logger.debug("Connection is finished");
             });
         }).handle_exception_type([](const gate_closed_exception &e) {});
         return make_ready_future<stop_iteration>(stop_iteration::no);
@@ -67,11 +67,11 @@ future<stop_iteration> server::accept_one(server_socket &listener) {
         // We expect a ECONNABORTED when server::stop is called,
         // no point in warning about that.
         if (e.code().value() != ECONNABORTED) {
-            wlogger.error("accept failed: {}", e);
+            websocket_logger.error("accept failed: {}", e);
         }
         return make_ready_future<stop_iteration>(stop_iteration::yes);
     }).handle_exception([](std::exception_ptr ex) {
-        wlogger.info("accept failed: {}", ex);
+        websocket_logger.info("accept failed: {}", ex);
         return make_ready_future<stop_iteration>(stop_iteration::yes);
     });
 }
@@ -102,7 +102,7 @@ void server_connection::on_new_connection() {
 
 future<> server_connection::process() {
     return when_all_succeed(read_loop(), response_loop()).discard_result().handle_exception([] (const std::exception_ptr& e) {
-        wlogger.debug("Processing failed: {}", e);
+        websocket_logger.debug("Processing failed: {}", e);
     });
 }
 
@@ -131,17 +131,17 @@ future<> server_connection::read_http_upgrade_request() {
     }
     this->_handler = this->_server._handlers[subprotocol];
     this->_subprotocol = subprotocol;
-    wlogger.debug("Sec-WebSocket-Protocol: {}", subprotocol);
+    websocket_logger.debug("Sec-WebSocket-Protocol: {}", subprotocol);
 
     sstring sec_key = req->get_header("Sec-Websocket-Key");
     sstring sec_version = req->get_header("Sec-Websocket-Version");
 
     sstring sha1_input = sec_key + magic_key_suffix;
 
-    wlogger.debug("Sec-Websocket-Key: {}, Sec-Websocket-Version: {}", sec_key, sec_version);
+    websocket_logger.debug("Sec-Websocket-Key: {}, Sec-Websocket-Version: {}", sec_key, sec_version);
 
     std::string sha1_output = sha1_base64(sha1_input);
-    wlogger.debug("SHA1 output: {} of size {}", sha1_output, sha1_output.size());
+    websocket_logger.debug("SHA1 output: {} of size {}", sha1_output, sha1_output.size());
 
     co_await _write_buf.write(http_upgrade_reply_template);
     co_await _write_buf.write(sha1_output);

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -62,7 +62,7 @@ void server::accept(server_socket &listener) {
 
 future<stop_iteration> server::accept_one(server_socket &listener) {
     return listener.accept().then([this](accept_result ar) {
-        auto conn = std::make_unique<connection>(*this, std::move(ar.connection));
+        auto conn = std::make_unique<server_connection>(*this, std::move(ar.connection));
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().finally([conn = std::move(conn)] {
                 wlogger.debug("Connection is finished");
@@ -92,21 +92,21 @@ future<> server::stop() {
     }
 
     return _task_gate.close().finally([this] {
-        return parallel_for_each(_connections, [] (connection& conn) {
+        return parallel_for_each(_connections, [] (server_connection& conn) {
             return conn.close(true).handle_exception([] (auto ignored) {});
         });
     });
 }
 
-connection::~connection() {
+server_connection::~server_connection() {
     _server._connections.erase(_server._connections.iterator_to(*this));
 }
 
-void connection::on_new_connection() {
+void server_connection::on_new_connection() {
     _server._connections.push_back(*this);
 }
 
-future<> connection::process() {
+future<> server_connection::process() {
     return when_all_succeed(read_loop(), response_loop()).discard_result().handle_exception([] (const std::exception_ptr& e) {
         wlogger.debug("Processing failed: {}", e);
     });
@@ -133,7 +133,7 @@ static std::string sha1_base64(std::string_view source) {
     return std::string(reinterpret_cast<const char*>(base64_encoded.data), base64_encoded.size);
 }
 
-future<> connection::read_http_upgrade_request() {
+future<> server_connection::read_http_upgrade_request() {
     _http_parser.init();
     co_await _read_buf.consume(_http_parser);
 
@@ -180,18 +180,18 @@ future<> connection::read_http_upgrade_request() {
     co_await _write_buf.flush();
 }
 
-future<> connection::handle_ping() {
+future<> server_connection::handle_ping() {
     // TODO
     return make_ready_future<>();
 }
 
-future<> connection::handle_pong() {
+future<> server_connection::handle_pong() {
     // TODO
     return make_ready_future<>();
 }
 
 
-future<> connection::read_one() {
+future<> server_connection::read_one() {
     return _read_buf.consume(_websocket_parser).then([this] () mutable {
         if (_websocket_parser.is_valid()) {
             // FIXME: implement error handling
@@ -225,7 +225,7 @@ future<> connection::read_one() {
     });
 }
 
-future<> connection::read_loop() {
+future<> server_connection::read_loop() {
     return read_http_upgrade_request().then([this] {
         return when_all_succeed(
             _handler(_input, _output).handle_exception([this] (std::exception_ptr e) mutable {
@@ -240,11 +240,11 @@ future<> connection::read_loop() {
     });
 }
 
-void connection::shutdown_input() {
+void server_connection::shutdown_input() {
     _fd.shutdown_input();
 }
 
-future<> connection::close(bool send_close) {
+future<> server_connection::close(bool send_close) {
     return [this, send_close]() {
         if (send_close) {
             return send_data(opcodes::CLOSE, temporary_buffer<char>(0));
@@ -259,7 +259,7 @@ future<> connection::close(bool send_close) {
     });
 }
 
-future<> connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
+future<> server_connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
     char header[10] = {'\x80', 0};
     size_t header_size = 2;
 
@@ -285,7 +285,7 @@ future<> connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
     });
 }
 
-future<> connection::response_loop() {
+future<> server_connection::response_loop() {
     return do_until([this] {return _done;}, [this] {
         // FIXME: implement error handling
         return _output_buffer.pop_eventually().then([this] (

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -42,18 +42,6 @@ static sstring http_upgrade_reply_template =
 
 static logger wlogger("websocket");
 
-opcodes websocket_parser::opcode() const {
-    if (_header) {
-        return opcodes(_header->opcode);
-    } else {
-        return opcodes::INVALID;
-    }
-}
-
-websocket_parser::buff_t websocket_parser::result() {
-    return std::move(_result);
-}
-
 void server::listen(socket_address addr, listen_options lo) {
     _listeners.push_back(seastar::listen(addr, lo));
     accept(_listeners.back());
@@ -190,106 +178,6 @@ future<> connection::read_http_upgrade_request() {
     }
     co_await _write_buf.write("\r\n\r\n", 4);
     co_await _write_buf.flush();
-}
-
-future<websocket_parser::consumption_result_t> websocket_parser::operator()(
-        temporary_buffer<char> data) {
-    if (data.size() == 0) {
-        // EOF
-        _cstate = connection_state::closed;
-        return websocket_parser::stop(std::move(data));
-    }
-    if (_state == parsing_state::flags_and_payload_data) {
-        if (_buffer.length() + data.size() >= 2) {
-            // _buffer.length() is less than 2 when entering this if body due to how
-            // the rest of code is structured. The else branch will never increase
-            // _buffer.length() to >=2 and other paths to this condition will always
-            // have buffer cleared.
-            assert(_buffer.length() < 2);
-
-            size_t hlen = _buffer.length();
-            _buffer.append(data.get(), 2 - hlen);
-            data.trim_front(2 - hlen);
-            _header = std::make_unique<frame_header>(_buffer.data());
-            _buffer = {};
-
-            // https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
-            // We must close the connection if data isn't masked.
-            if ((!_header->masked) ||
-                    // RSVX must be 0
-                    (_header->rsv1 | _header->rsv2 | _header->rsv3) ||
-                    // Opcode must be known.
-                    (!_header->is_opcode_known())) {
-                _cstate = connection_state::error;
-                return websocket_parser::stop(std::move(data));
-            }
-            _state = parsing_state::payload_length_and_mask;
-        } else {
-            _buffer.append(data.get(), data.size());
-            return websocket_parser::dont_stop();
-        }
-    }
-    if (_state == parsing_state::payload_length_and_mask) {
-        size_t const required_bytes = _header->get_rest_of_header_length();
-        if (_buffer.length() + data.size() >= required_bytes) {
-            if (_buffer.length() < required_bytes) {
-                size_t hlen = _buffer.length();
-                _buffer.append(data.get(), required_bytes - hlen);
-                data.trim_front(required_bytes - hlen);
-            }
-            _payload_length = _header->length;
-            char const *input = _buffer.data();
-            if (_header->length == 126) {
-                _payload_length = consume_be<uint16_t>(input);
-            } else if (_header->length == 127) {
-                _payload_length = consume_be<uint64_t>(input);
-            }
-
-            _masking_key = consume_be<uint32_t>(input);
-            _buffer = {};
-            _state = parsing_state::payload;
-        } else {
-            _buffer.append(data.get(), data.size());
-            return websocket_parser::dont_stop();
-        }
-    }
-    if (_state == parsing_state::payload) {
-        if (data.size() < remaining_payload_length()) {
-            // data has insufficient data to complete the frame - consume data.size() bytes
-            if (_result.empty()) {
-                _result = temporary_buffer<char>(remaining_payload_length());
-                _consumed_payload_length = 0;
-            }
-            std::copy(data.begin(), data.end(), _result.get_write() + _consumed_payload_length);
-            _consumed_payload_length += data.size();
-            return websocket_parser::dont_stop();
-        } else {
-            // data has sufficient data to complete the frame - consume remaining_payload_length()
-            auto consumed_bytes = remaining_payload_length();
-            if (_result.empty()) {
-                // Try to avoid memory copies in case when network packets contain one or more full
-                // websocket frames.
-                if (consumed_bytes == data.size()) {
-                    _result = std::move(data);
-                    data = temporary_buffer<char>(0);
-                } else {
-                    _result = data.share();
-                    _result.trim(consumed_bytes);
-                    data.trim_front(consumed_bytes);
-                }
-            } else {
-                std::copy(data.begin(), data.begin() + consumed_bytes,
-                          _result.get_write() + _consumed_payload_length);
-                data.trim_front(consumed_bytes);
-            }
-            remove_mask(_result, _payload_length);
-            _consumed_payload_length = 0;
-            _state = parsing_state::flags_and_payload_data;
-            return websocket_parser::stop(std::move(data));
-        }
-    }
-    _cstate = connection_state::error;
-    return websocket_parser::stop(std::move(data));
 }
 
 future<> connection::handle_ping() {

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -25,22 +25,16 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/scattered_message.hh>
-#include <seastar/core/byteorder.hh>
 #include <seastar/http/request.hh>
-#include <gnutls/crypto.h>
-#include <gnutls/gnutls.h>
 
 namespace seastar::experimental::websocket {
 
-static sstring magic_key_suffix = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 static sstring http_upgrade_reply_template =
     "HTTP/1.1 101 Switching Protocols\r\n"
     "Upgrade: websocket\r\n"
     "Connection: Upgrade\r\n"
     "Sec-WebSocket-Version: 13\r\n"
     "Sec-WebSocket-Accept: ";
-
-static logger wlogger("websocket");
 
 void server::listen(socket_address addr, listen_options lo) {
     _listeners.push_back(seastar::listen(addr, lo));
@@ -112,27 +106,6 @@ future<> server_connection::process() {
     });
 }
 
-static std::string sha1_base64(std::string_view source) {
-    unsigned char hash[20];
-    assert(sizeof(hash) == gnutls_hash_get_len(GNUTLS_DIG_SHA1));
-    if (int ret = gnutls_hash_fast(GNUTLS_DIG_SHA1, source.data(), source.size(), hash);
-        ret != GNUTLS_E_SUCCESS) {
-        throw websocket::exception(fmt::format("gnutls_hash_fast: {}", gnutls_strerror(ret)));
-    }
-    gnutls_datum_t hash_data{
-        .data = hash,
-        .size = sizeof(hash),
-    };
-    gnutls_datum_t base64_encoded;
-    if (int ret = gnutls_base64_encode2(&hash_data, &base64_encoded);
-        ret != GNUTLS_E_SUCCESS) {
-        throw websocket::exception(fmt::format("gnutls_base64_encode2: {}", gnutls_strerror(ret)));
-    }
-    auto free_base64_encoded = defer([&] () noexcept { gnutls_free(base64_encoded.data); });
-    // base64_encoded.data is "unsigned char *"
-    return std::string(reinterpret_cast<const char*>(base64_encoded.data), base64_encoded.size);
-}
-
 future<> server_connection::read_http_upgrade_request() {
     _http_parser.init();
     co_await _read_buf.consume(_http_parser);
@@ -180,51 +153,6 @@ future<> server_connection::read_http_upgrade_request() {
     co_await _write_buf.flush();
 }
 
-future<> server_connection::handle_ping() {
-    // TODO
-    return make_ready_future<>();
-}
-
-future<> server_connection::handle_pong() {
-    // TODO
-    return make_ready_future<>();
-}
-
-
-future<> server_connection::read_one() {
-    return _read_buf.consume(_websocket_parser).then([this] () mutable {
-        if (_websocket_parser.is_valid()) {
-            // FIXME: implement error handling
-            switch(_websocket_parser.opcode()) {
-                // We do not distinguish between these 3 types.
-                case opcodes::CONTINUATION:
-                case opcodes::TEXT:
-                case opcodes::BINARY:
-                    return _input_buffer.push_eventually(_websocket_parser.result());
-                case opcodes::CLOSE:
-                    wlogger.debug("Received close frame.");
-                    /*
-                     * datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
-                     */
-                    return close(true);
-                case opcodes::PING:
-                    wlogger.debug("Received ping frame.");
-                    return handle_ping();
-                case opcodes::PONG:
-                    wlogger.debug("Received pong frame.");
-                    return handle_pong();
-                default:
-                    // Invalid - do nothing.
-                    ;
-            }
-        } else if (_websocket_parser.eof()) {
-            return close(false);
-        }
-        wlogger.debug("Reading from socket has failed.");
-        return close(true);
-    });
-}
-
 future<> server_connection::read_loop() {
     return read_http_upgrade_request().then([this] {
         return when_all_succeed(
@@ -237,63 +165,6 @@ future<> server_connection::read_loop() {
         ).discard_result();
     }).finally([this] {
         return _read_buf.close();
-    });
-}
-
-void server_connection::shutdown_input() {
-    _fd.shutdown_input();
-}
-
-future<> server_connection::close(bool send_close) {
-    return [this, send_close]() {
-        if (send_close) {
-            return send_data(opcodes::CLOSE, temporary_buffer<char>(0));
-        } else {
-            return make_ready_future<>();
-        }
-    }().finally([this] {
-        _done = true;
-        return when_all_succeed(_input.close(), _output.close()).discard_result().finally([this] {
-            _fd.shutdown_output();
-        });
-    });
-}
-
-future<> server_connection::send_data(opcodes opcode, temporary_buffer<char>&& buff) {
-    char header[10] = {'\x80', 0};
-    size_t header_size = 2;
-
-    header[0] += opcode;
-
-    if ((126 <= buff.size()) && (buff.size() <= std::numeric_limits<uint16_t>::max())) {
-        header[1] = 0x7E;
-        write_be<uint16_t>(header + 2, buff.size());
-        header_size += sizeof(uint16_t);
-    } else if (std::numeric_limits<uint16_t>::max() < buff.size()) {
-        header[1] = 0x7F;
-        write_be<uint64_t>(header + 2, buff.size());
-        header_size += sizeof(uint64_t);
-    } else {
-        header[1] = uint8_t(buff.size());
-    }
-
-    scattered_message<char> msg;
-    msg.append(sstring(header, header_size));
-    msg.append(std::move(buff));
-    return _write_buf.write(std::move(msg)).then([this] {
-        return _write_buf.flush();
-    });
-}
-
-future<> server_connection::response_loop() {
-    return do_until([this] {return _done;}, [this] {
-        // FIXME: implement error handling
-        return _output_buffer.pop_eventually().then([this] (
-                temporary_buffer<char> buf) {
-            return send_data(opcodes::BINARY, std::move(buf));
-        });
-    }).finally([this]() {
-        return _write_buf.close();
     });
 }
 

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -62,7 +62,7 @@ future<> test_websocket_handshake_common(std::string subprotocol) {
                     });
                 });
             });
-        websocket::connection conn(dummy, acceptor.get().connection);
+        websocket::server_connection conn(dummy, acceptor.get().connection);
         future<> serve = conn.process();
         auto close = defer([&conn, &input, &output, &serve] () noexcept {
             conn.close().get();
@@ -132,7 +132,7 @@ future<> test_websocket_handler_registration_common(std::string subprotocol) {
                 });
             });
         });
-        websocket::connection conn(ws, acceptor.get().connection);
+        websocket::server_connection conn(ws, acceptor.get().connection);
         future<> serve = conn.process();
 
         auto close = defer([&conn, &input, &output, &serve] () noexcept {


### PR DESCRIPTION
Currently websocket server embeds a lot of functionality that would be useful for websocket client. This PR extracts it into a form that is easier to reuse. The websocket client itself has been implemented in https://github.com/scylladb/seastar/pull/2552.

This PR extracts parts of https://github.com/scylladb/seastar/pull/2552 to make it easier to land.