### PR TITLE
scheduling_group: fix race between scheduling group and key creation

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -47,6 +47,7 @@
 #include <seastar/core/scheduling_specific.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_mutex.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread_cputime_clock.hh>
@@ -282,6 +283,7 @@ private:
 
     boost::container::static_vector<std::unique_ptr<task_queue>, max_scheduling_groups()> _task_queues;
     internal::scheduling_group_specific_thread_local_data _scheduling_group_specific_data;
+    shared_mutex _scheduling_group_keys_mutex;
     int64_t _last_vruntime = 0;
     task_queue_list _active_task_queues;
     task_queue_list _activating_task_queues;

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/map_reduce.hh>
 #include <seastar/util/modules.hh>
 #include <array>
+#include <map>
 #include <typeindex>
 #include <vector>
 #include <ranges>
@@ -46,7 +47,7 @@ struct scheduling_group_specific_thread_local_data {
         std::vector<void*> specific_vals;
     };
     std::array<per_scheduling_group, max_scheduling_groups()> per_scheduling_group_data;
-    std::vector<scheduling_group_key_config> scheduling_group_key_configs;
+    std::map<unsigned long, scheduling_group_key_config> scheduling_group_key_configs;
 };
 
 #ifdef SEASTAR_BUILD_SHARED_LIBS

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1073,14 +1073,14 @@ reactor::~reactor() {
             // The following line will preserve the convention that constructor and destructor functions
             // for the per sg values are called in the context of the containing scheduling group.
             *internal::current_scheduling_group_ptr() = scheduling_group(tq->_id);
-            for (size_t key : std::views::iota(0u, sg_data.scheduling_group_key_configs.size())) {
-                void* val = this_sg.specific_vals[key];
+            for (const auto& [key_id, cfg] : sg_data.scheduling_group_key_configs) {
+                void* val = this_sg.specific_vals[key_id];
                 if (val) {
-                    if (sg_data.scheduling_group_key_configs[key].destructor) {
-                        sg_data.scheduling_group_key_configs[key].destructor(val);
+                    if (cfg.destructor) {
+                        cfg.destructor(val);
                     }
                     free(val);
-                    this_sg.specific_vals[key] = nullptr;
+                    this_sg.specific_vals[key_id] = nullptr;
                 }
             }
         }
@@ -4904,15 +4904,14 @@ void
 reactor::allocate_scheduling_group_specific_data(scheduling_group sg, unsigned long key_id) {
     auto& sg_data = _scheduling_group_specific_data;
     auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
+    const auto& cfg = sg_data.scheduling_group_key_configs[key_id];
     this_sg.specific_vals.resize(std::max<size_t>(this_sg.specific_vals.size(), key_id+1));
-    this_sg.specific_vals[key_id] =
-        aligned_alloc(sg_data.scheduling_group_key_configs[key_id].alignment,
-                sg_data.scheduling_group_key_configs[key_id].allocation_size);
+    this_sg.specific_vals[key_id] = aligned_alloc(cfg.alignment, cfg.allocation_size);
     if (!this_sg.specific_vals[key_id]) {
         std::abort();
     }
-    if (sg_data.scheduling_group_key_configs[key_id].constructor) {
-        sg_data.scheduling_group_key_configs[key_id].constructor(this_sg.specific_vals[key_id]);
+    if (cfg.constructor) {
+        cfg.constructor(this_sg.specific_vals[key_id]);
     }
 }
 
@@ -4922,10 +4921,9 @@ reactor::rename_scheduling_group_specific_data(scheduling_group sg) {
         return with_scheduling_group(sg, [this, sg] {
             auto& sg_data = _scheduling_group_specific_data;
             auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
-            for (size_t i = 0; i < sg_data.scheduling_group_key_configs.size(); ++i) {
-                auto &c = sg_data.scheduling_group_key_configs[i];
-                if (c.rename) {
-                    (c.rename)(this_sg.specific_vals[i]);
+            for (const auto& [key_id, cfg] : sg_data.scheduling_group_key_configs) {
+                if (cfg.rename) {
+                    (cfg.rename)(this_sg.specific_vals[key_id]);
                 }
             }
         });
@@ -4942,7 +4940,7 @@ reactor::init_scheduling_group(seastar::scheduling_group sg, sstring name, sstri
         _task_queues[sg._id] = std::make_unique<task_queue>(sg._id, name, shortname, shares);
 
         return with_scheduling_group(sg, [this, sg, &sg_data] () {
-            for (unsigned long key_id = 0; key_id < sg_data.scheduling_group_key_configs.size(); key_id++) {
+            for (const auto& [key_id, cfg] : sg_data.scheduling_group_key_configs) {
                 allocate_scheduling_group_specific_data(sg, key_id);
             }
         });
@@ -4954,7 +4952,6 @@ reactor::init_new_scheduling_group_key(scheduling_group_key key, scheduling_grou
     return with_lock(_scheduling_group_keys_mutex, [this, key, cfg] {
         auto& sg_data = _scheduling_group_specific_data;
         auto key_id = internal::scheduling_group_key_id(key);
-        sg_data.scheduling_group_key_configs.resize(std::max<size_t>(sg_data.scheduling_group_key_configs.size(), key_id + 1));
         sg_data.scheduling_group_key_configs[key_id] = cfg;
         return parallel_for_each(_task_queues, [this, cfg, key_id] (std::unique_ptr<task_queue>& tq) {
             if (tq) {
@@ -4984,11 +4981,11 @@ reactor::destroy_scheduling_group(scheduling_group sg) noexcept {
     return with_scheduling_group(sg, [this, sg] () {
         auto& sg_data = _scheduling_group_specific_data;
         auto& this_sg = sg_data.per_scheduling_group_data[sg._id];
-        for (unsigned long key_id = 0; key_id < sg_data.scheduling_group_key_configs.size(); key_id++) {
+        for (const auto& [key_id, cfg] : sg_data.scheduling_group_key_configs) {
             void* val = this_sg.specific_vals[key_id];
             if (val) {
-                if (sg_data.scheduling_group_key_configs[key_id].destructor) {
-                    sg_data.scheduling_group_key_configs[key_id].destructor(val);
+                if (cfg.destructor) {
+                    cfg.destructor(val);
                 }
                 free(val);
                 this_sg.specific_vals[key_id] = nullptr;


### PR DESCRIPTION
The functions create_scheduling_group and scheduling_group_key_create
may have unexpected results when run concurrently.

when creating a SG key, we:
1. allocate a key
2. insert the key config
3. for all SGs, initialize data for the SG and key

with preemptions possible in between each step.

Another process could see an intermediate state where a key was created
but not fully initialized yet. This may lead to the data being
initialized twice for the new key, or functions operating on
uninitialized key data.

To solve this we introduce a shared_mutex which is locked exclusively
when creating a new key, and is held with shared access when creating a
scheduling group and when a consistent read access of all keys is required.

Fixes https://github.com/scylladb/seastar/issues/2231