### PR TITLE
json: add moving push to json_list

### DIFF
--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -162,11 +162,20 @@ public:
 
     /**
      * Add an element to the list.
-     * @param element a new element that will be added to the list
+     * @param element a new element that will be added to the end of the list
      */
     void push(const T& element) {
         _set = true;
         _elements.push_back(element);
+    }
+
+    /**
+     * Move an element into the list.
+     * @param element a new element that will be added to the list using move-construction
+     */
+    void push(T&& element) {
+        _set = true;
+        _elements.push_back(std::move(element));
     }
 
     virtual std::string to_string() override


### PR DESCRIPTION
When building up json lists in memory we have only the `push` method which takes const T&, but one taking an rvalue reference and moves into the list would be useful for heavy elements.