### PR TITLE
build,github: add a step to check include style 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,6 +99,10 @@ jobs:
         if: ${{ inputs.mode == 'dev' && inputs.compiler == 'clang++' }}
         run: cmake --build build/${{ inputs.mode }} --target checkheaders
 
+      - name: Check Include Style
+        if: ${{ inputs.mode == 'dev' && inputs.compiler == 'clang++' }}
+        run: cmake --build build/${{ inputs.mode }} --target check-include-style
+
       - name: Build with C++20 modules
         if: ${{ contains(inputs.enables, 'cxx-modules') }}
         run: cmake --build build/${{ inputs.mode }} --target hello_cxx_module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1262,7 +1262,9 @@ endif ()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Dev")
   include (CheckHeaders)
+  include (CheckIncludeStyle)
   add_custom_target (checkheaders)
+  add_custom_target (check-include-style)
   foreach (lib seastar seastar_testing seastar_perf_testing)
     if (TARGET ${lib})
       seastar_check_self_contained (checkheaders ${lib}
@@ -1270,6 +1272,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Dev")
         # impl.hh headers are internal implementations of .hh, so they are not
         # compilable. let's exclude them from the files to be checked.
         EXCLUDE "_impl.hh$|-impl.hh$")
+      seastar_check_include_style (check-include-style ${lib})
     endif ()
   endforeach ()
 endif ()

--- a/cmake/CheckIncludeStyle.cmake
+++ b/cmake/CheckIncludeStyle.cmake
@@ -1,0 +1,17 @@
+# seastar_check_include_style() enforces that all source and header files under
+# specified directories include the headers with predefined list of prefixes
+# with angle brackets instead of quotes.
+
+find_package (Python3 COMPONENTS Interpreter)
+
+function (seastar_check_include_style target library)
+  get_target_property (sources ${library} SOURCES)
+  set (check-target "${target}-${library}")
+  message("${sources}")
+  add_custom_target("${check-target}"
+    COMMAND Python3::Interpreter ${CMAKE_CURRENT_LIST_DIR}/cmake/check-seastar-include-style.py ${sources}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMENT "Checking include directive styles for ${library} source files"
+    USES_TERMINAL)
+  add_dependencies (${target} ${check-target})
+endfunction ()

--- a/cmake/check-seastar-include-style.py
+++ b/cmake/check-seastar-include-style.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import fileinput
+import os.path
+import re
+import sys
+
+
+def check_includes(files, dirname):
+    # Check for include directives with quotes for specified dirname
+    incorrect_include = re.compile(rf'#include\s+"({dirname}/[^\"]+)"')
+    num_errors = 0
+    for line in fileinput.input(files=files, encoding="utf-8"):
+        # Look for #include \"seastar/...\" pattern
+        if matched := incorrect_include.match(line):
+            location = f"{fileinput.filename()}:{fileinput.lineno()}"
+            header = matched.group(1)
+            print(f"{location}: warning: please include seastar headers using: #include <{header}>")
+            num_errors += 1
+    return num_errors
+
+
+def main():
+    # If any incorrect includes are found, fail the check
+    files = [fn for fn in sys.argv[1:] if os.path.exists(fn)]
+    if check_includes(files, "seastar") > 0:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Previously, we do not enforce the policy of including Seastar headers using angle brackets instead of double quotes in our github workflow. In this change, a new step is added to check include style when building the Dev mode. This allows our CI to fail if a change violates this policy.