### PR TITLE
treewide: include fmt/ostream.h for using fmt::print()

### DIFF
--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -26,6 +26,7 @@
 #include <seastar/util/modules.hh>
 #ifndef SEASTAR_MODULE
 #include <fmt/printf.h>
+#include <fmt/ostream.h>
 #include <iostream>
 #include <iomanip>
 #include <chrono>

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -20,6 +20,7 @@
  */
 
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 #include <seastar/core/prometheus.hh>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>

--- a/src/net/ethernet.cc
+++ b/src/net/ethernet.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/core/print.hh>
 #include <seastar/net/ethernet.hh>
+#include <fmt/ostream.h>
 #include <boost/algorithm/string.hpp>
 #include <string>
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -9,6 +9,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/numeric.hpp>
+#include <fmt/ostream.h>
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::rpc::streaming_domain_type> : fmt::ostream_formatter {};


### PR DESCRIPTION
explicitly include fmt/ostream.h for fmt::print()

The `fmt::print(std::ostream&, ...)` API is provided through `fmt/ostream.h`. Previously, we relied on indirect inclusion of this header through other fmt headers, which was fragile and broke with fmt 8.x.

Fix this by explicitly including `fmt/ostream.h` in all source files that use the ostream API. This addresses build failures with fmt 8.x while making the header dependencies more explicit.

See https://fmt.dev/11.0/api/#ostream-api
Fixes #2584