### PR TITLE
rwlock: add try_hold_{read,write}_lock methods

### DIFF
--- a/include/seastar/core/rwlock.hh
+++ b/include/seastar/core/rwlock.hh
@@ -167,6 +167,12 @@ public:
         return get_units(_sem, 1, as);
     }
 
+    /// try_hold_read_lock() synchronously tries to get a read lock and, if successful, returns an
+    /// optional object which, when destroyed, releases the lock.
+    std::optional<holder> try_hold_read_lock() noexcept {
+        return try_get_units(_sem, 1);
+    }
+
     /// hold_write_lock() waits for a write lock and returns an object which,
     /// when destroyed, releases the lock. This makes it easy to ensure that
     /// the lock is eventually undone, at any circumstance (even including
@@ -184,6 +190,12 @@ public:
 
     future<holder> hold_write_lock(abort_source& as) {
         return get_units(_sem, max_ops, as);
+    }
+
+    /// try_hold_write_lock() synchronously tries to get a write lock and, if successful, returns an
+    /// optional object which, when destroyed, releases the lock.
+    std::optional<holder> try_hold_write_lock() noexcept {
+        return try_get_units(_sem, max_ops);
     }
 
     /// Checks if any read or write locks are currently held.

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -175,6 +175,26 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_hold_abort) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(test_rwlock_hold) {
+    rwlock l;
+
+    auto rl = l.hold_read_lock().get();
+
+    auto opt_rl = l.try_hold_read_lock();
+    BOOST_REQUIRE(opt_rl.has_value());
+    BOOST_REQUIRE(!l.try_hold_write_lock());
+
+    rl.return_all();
+    BOOST_REQUIRE(!l.try_hold_write_lock());
+
+    opt_rl->return_all();
+    auto opt_wl = l.try_hold_write_lock();
+    BOOST_REQUIRE(opt_wl.has_value());
+
+    BOOST_REQUIRE(!l.try_hold_read_lock());
+    BOOST_REQUIRE(!l.try_hold_write_lock());
+}
+
 SEASTAR_THREAD_TEST_CASE(test_failed_with_lock) {
     struct test_lock {
         future<> lock() noexcept {


### PR DESCRIPTION
Add synchronous try_hold_* methods so that users
can optimize contention-free paths by avoiding
extra-allocations that might be needed for waiting on the lock, if it's taken.