### PR TITLE
file: add file_system_space

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -487,6 +487,7 @@ public:
         return file_accessible(pathname, access_flags::exists);
     }
     future<fs_type> file_system_at(std::string_view pathname) noexcept;
+    future<std::filesystem::space_info> file_system_space(std::string_view pathname) noexcept;
     future<struct statvfs> statvfs(std::string_view pathname) noexcept;
     future<> remove_file(std::string_view pathname) noexcept;
     future<> rename_file(std::string_view old_pathname, std::string_view new_pathname) noexcept;

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -445,6 +445,11 @@ future<uint64_t> fs_avail(std::string_view name) noexcept;
 future<uint64_t> fs_free(std::string_view name) noexcept;
 /// @}
 
+/// Return filesystem-wide space_info where a file is located.
+///
+/// \param name name of the file in the filesystem to inspect
+future<std::filesystem::space_info> file_system_space(std::string_view name) noexcept;
+
 namespace experimental {
 /// \defgroup interprocess-module Interprocess Communication
 ///

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -128,6 +128,10 @@ future<uint64_t> fs_free(std::string_view name) noexcept {
     });
 }
 
+future<std::filesystem::space_info> file_system_space(std::string_view name) noexcept {
+    return engine().file_system_space(name);
+}
+
 future<stat_data> file_stat(std::string_view name, follow_symlink follow) noexcept {
     return engine().file_stat(name, follow);
 }


### PR DESCRIPTION
Return space_info for the filesystem identified
by the given file name.

space_info provides simpler and standard space information about the filesystem, in contrast to the posix statvfs which requires knowledge about the how to convert
f_block to bytes by multiplying by f_frsize.