### PR TITLE
file: remove deprecated file lifetime hint APIs

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -462,20 +462,6 @@ public:
     ///         if the operation has failed
     future<int> fcntl_short(int op, uintptr_t arg = 0UL) noexcept;
 
-    /// Set a lifetime hint for the open file descriptor corresponding to seastar::file
-    ///
-    /// Write lifetime  hints  can be used to inform the kernel about the relative
-    /// expected lifetime of writes on a given inode or via open file descriptor.
-    /// An application may use the different hint values to separate writes into different
-    /// write classes, so that multiple users or applications running on a single storage back-end
-    /// can aggregate their I/O  patterns in a consistent manner.
-    /// Refer fcntl(2) man page for more details on write lifetime hints.
-    ///
-    /// \param hint the hint value of the stream
-    /// \return future indicating success or failure
-    [[deprecated("This API was removed from the kernel")]]
-    future<> set_file_lifetime_hint(uint64_t hint) noexcept;
-
     /// Set a lifetime hint for the inode corresponding to seastar::file
     ///
     /// Write lifetime  hints  can be used to inform the kernel about the relative
@@ -488,20 +474,6 @@ public:
     /// \param hint the hint value of the stream
     /// \return future indicating success or failure
     future<> set_inode_lifetime_hint(uint64_t hint) noexcept;
-
-    /// Get the lifetime hint of the open file descriptor of seastar::file which was set by
-    /// \ref set_file_lifetime_hint()
-    ///
-    /// Write lifetime  hints  can be used to inform the kernel about the relative
-    /// expected lifetime of writes on a given inode or via open file descriptor.
-    /// An application may use the different hint values to separate writes into different
-    /// write classes, so that multiple users or applications running on a single storage back-end
-    /// can aggregate their I/O  patterns in a consistent manner.
-    /// Refer fcntl(2) man page for more details on write lifetime hints.
-    ///
-    /// \return the hint value of the open file descriptor
-    [[deprecated("This API was removed from the kernel")]]
-    future<uint64_t> get_file_lifetime_hint() noexcept;
 
     /// Get the lifetime hint of the inode of seastar::file which was set by
     /// \ref set_inode_lifetime_hint()

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1186,10 +1186,6 @@ future<> file::set_lifetime_hint_impl(int op, uint64_t hint) noexcept {
     });
 }
 
-future<> file::set_file_lifetime_hint(uint64_t hint) noexcept {
-    return set_lifetime_hint_impl(F_SET_FILE_RW_HINT, hint);
-}
-
 future<> file::set_inode_lifetime_hint(uint64_t hint) noexcept {
     return set_lifetime_hint_impl(F_SET_RW_HINT, hint);
 }
@@ -1208,10 +1204,6 @@ future<uint64_t> file::get_lifetime_hint_impl(int op) noexcept {
             return current_exception_as_future<uint64_t>();
         }
     });
-}
-
-future<uint64_t> file::get_file_lifetime_hint() noexcept {
-    return get_lifetime_hint_impl(F_GET_FILE_RW_HINT);
 }
 
 future<uint64_t> file::get_inode_lifetime_hint() noexcept {


### PR DESCRIPTION
These were deprecated in 2022 (1dc616a5220) in response for removal for the kernel. We can safely remove the deprecated APIs now.