### PR TITLE
Tunnel requested abort exception to semaphore wait caller

### DIFF
--- a/include/seastar/core/abort_on_expiry.hh
+++ b/include/seastar/core/abort_on_expiry.hh
@@ -33,7 +33,7 @@ namespace seastar {
 /// @{
 
 /// Facility to tie a timeout with an abort source
-/// Can be used to make abortanle fibers also support timeouts
+/// Can be used to make abortable fibers also support timeouts
 SEASTAR_MODULE_EXPORT
 template<typename Clock = lowres_clock>
 class abort_on_expiry {
@@ -44,7 +44,7 @@ public:
     using time_point = typename Clock::time_point;
     /// Creates a timer and an abort source associated with it
     /// When the timer reaches timeout point it triggers an
-    /// abort autimatically
+    /// abort automatically
     abort_on_expiry(time_point timeout) : _tr([this] {
         _as.request_abort_ex(timed_out_error{});
     }) {

--- a/include/seastar/core/abort_on_expiry.hh
+++ b/include/seastar/core/abort_on_expiry.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/util/modules.hh>
 
 namespace seastar {
@@ -45,7 +46,7 @@ public:
     /// When the timer reaches timeout point it triggers an
     /// abort autimatically
     abort_on_expiry(time_point timeout) : _tr([this] {
-        _as.request_abort();
+        _as.request_abort_ex(timed_out_error{});
     }) {
         _tr.arm(timeout);
     }

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -327,6 +327,9 @@ public:
         if (_ex) {
             return make_exception_future(_ex);
         }
+        if (Clock::now() >= timeout) [[unlikely]] {
+            return make_exception_future(get_timeout_exception());
+        }
         try {
             entry& e = _wait_list.emplace_back(promise<>(), nr);
             auto f = e.pr.get_future();
@@ -362,6 +365,9 @@ public:
         }
         if (_ex) {
             return make_exception_future(_ex);
+        }
+        if (as.abort_requested()) [[unlikely]] {
+            return make_exception_future(get_aborted_exception());
         }
         try {
             entry& e = _wait_list.emplace_back(promise<>(), nr);

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -186,9 +186,11 @@ private:
     }
     struct expiry_handler {
         basic_semaphore& sem;
-        void operator()(entry& e) noexcept {
+        void operator()(entry& e, const std::optional<std::exception_ptr>& ex) noexcept {
             if (e.timer) {
                 e.pr.set_exception(sem.get_timeout_exception());
+            } else if (ex) {
+                e.pr.set_exception(*ex);
             } else if (sem._ex) {
                 e.pr.set_exception(sem._ex);
             } else {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -318,7 +318,9 @@ seastar_add_test (file_io
   SOURCES file_io_test.cc)
 
 seastar_add_test (file_utils
-  SOURCES file_utils_test.cc)
+  SOURCES
+    file_utils_test.cc
+    expected_exception.hh)
 
 seastar_add_test (foreign_ptr
   SOURCES foreign_ptr_test.cc)
@@ -332,7 +334,9 @@ seastar_add_test (fstream
     mock_file.hh)
 
 seastar_add_test (futures
-  SOURCES futures_test.cc)
+  SOURCES
+    futures_test.cc
+    expected_exception.hh)
 
 seastar_add_test (sharded
   SOURCES sharded_test.cc)
@@ -397,7 +401,9 @@ seastar_add_test (rpc
     rpc_test.cc)
 
 seastar_add_test (semaphore
-  SOURCES semaphore_test.cc)
+  SOURCES
+    semaphore_test.cc
+    expected_exception.hh)
 
 seastar_add_test (shared_ptr
   KIND BOOST
@@ -732,7 +738,9 @@ seastar_add_test (exception_logging
   SOURCES exception_logging_test.cc)
 
 seastar_add_test (closeable
-  SOURCES closeable_test.cc)
+  SOURCES
+    closeable_test.cc
+    expected_exception.hh)
 
 seastar_add_test (pipe
   SOURCES pipe_test.cc)

--- a/tests/unit/closeable_test.cc
+++ b/tests/unit/closeable_test.cc
@@ -19,8 +19,6 @@
  * Copyright 2021 ScyllaDB
  */
 
-#include <exception>
-
 #include <ranges>
 
 #include <seastar/testing/test_case.hh>
@@ -30,12 +28,9 @@
 #include <seastar/util/closeable.hh>
 #include <seastar/core/loop.hh>
 
-using namespace seastar;
+#include "expected_exception.hh"
 
-class expected_exception : public std::runtime_error {
-public:
-    expected_exception() : runtime_error("expected") {}
-};
+using namespace seastar;
 
 SEASTAR_TEST_CASE(deferred_close_test) {
   return do_with(gate(), 0, 42, [] (gate& g, int& count, int& expected) {

--- a/tests/unit/expected_exception.hh
+++ b/tests/unit/expected_exception.hh
@@ -1,0 +1,33 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2025-present ScyllaDB
+ */
+
+#pragma once
+
+#include <exception>
+
+namespace seastar {
+
+class expected_exception : public std::runtime_error {
+public:
+    expected_exception() : std::runtime_error("expected") {}
+};
+
+} // namespace seastar

--- a/tests/unit/file_utils_test.cc
+++ b/tests/unit/file_utils_test.cc
@@ -35,13 +35,10 @@
 #include <seastar/util/tmp_file.hh>
 #include <seastar/util/file.hh>
 
+#include "expected_exception.hh"
+
 using namespace seastar;
 namespace fs = std::filesystem;
-
-class expected_exception : std::runtime_error {
-public:
-    expected_exception() : runtime_error("expected") {}
-};
 
 SEASTAR_TEST_CASE(test_make_tmp_file) {
     return make_tmp_file().then([] (tmp_file tf) {

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -21,7 +21,6 @@
 
 #include <boost/test/tools/old/interface.hpp>
 #include <cstddef>
-#include <exception>
 #include <forward_list>
 #include <iterator>
 #include <ranges>
@@ -57,6 +56,8 @@
 #include <seastar/core/internal/api-level.hh>
 #include <unistd.h>
 
+#include "expected_exception.hh"
+
 using namespace seastar;
 using namespace std::chrono_literals;
 
@@ -70,11 +71,6 @@ static_assert(std::is_nothrow_copy_constructible_v<shared_future<>>);
 static_assert(std::is_nothrow_move_constructible_v<shared_future<>>);
 
 static_assert(std::is_nothrow_move_constructible_v<shared_promise<>>);
-
-class expected_exception : public std::runtime_error {
-public:
-    expected_exception() : runtime_error("expected") {}
-};
 
 #if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 13)
 #pragma GCC diagnostic push

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -33,6 +33,8 @@
 #include <seastar/core/shared_mutex.hh>
 #include <ranges>
 
+#include "expected_exception.hh"
+
 using namespace seastar;
 using namespace std::chrono_literals;
 
@@ -168,9 +170,9 @@ SEASTAR_THREAD_TEST_CASE(test_non_default_broken_semaphore) {
     auto sem = basic_semaphore<test_semaphore_exception_factory>(0);
     auto fut = sem.wait();
     BOOST_REQUIRE(!fut.available());
-    sem.broken(std::runtime_error("test"));
-    BOOST_REQUIRE_THROW(fut.get(), std::runtime_error);
-    BOOST_REQUIRE_THROW(sem.wait().get(), std::runtime_error);
+    sem.broken(expected_exception());
+    BOOST_REQUIRE_THROW(fut.get(), expected_exception);
+    BOOST_REQUIRE_THROW(sem.wait().get(), expected_exception);
 }
 
 SEASTAR_TEST_CASE(test_shared_mutex_exclusive) {


### PR DESCRIPTION
Today, when calling `wait(abort_source&)` the caller always gets `semaphore_aborted` error when abort is requested.
However, with `abort_on_expiry`, the actual reason could be timeout expiry, which should be distinguishable from the abort error.

This series modifies `abort_on_expiry` first to request abort with a `timed_out_error` exception, and then `internal::abortable_fifo` and `semaphore` are changed to tunnel that exception to the caller.

Respective unit tests were added to test those cases.

The motivation for this change is https://github.com/scylladb/scylladb/pull/22017
which will use scylladb utils::composite_abort_source to compose an `abort_on_expiry` abort_source, used for point request timeout and a global abort_source used on shutdown.
