### PR TITLE
gitignore: ignore directories that match "build*"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .cproject
 .project
 .settings
-build
+build*
 build.ninja
 cscope.*
 __pycache__/


### PR DESCRIPTION
To ease local build versioning with git, like build_old and build_new.