### PR TITLE
Add missing include in dpdk_rte.hh

### DIFF
--- a/include/seastar/core/dpdk_rte.hh
+++ b/include/seastar/core/dpdk_rte.hh
@@ -20,6 +20,7 @@
 #ifdef SEASTAR_HAVE_DPDK
 
 #include <bitset>
+#include <optional>
 #include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_version.h>


### PR DESCRIPTION
std::optional is used in the file. The build does not break at the moment because all source files that include this header also include <optional> some other way.