### PR TITLE
build: use path to libraries in .pc

### DIFF
--- a/pkgconfig/seastar-testing.pc.in
+++ b/pkgconfig/seastar-testing.pc.in
@@ -9,7 +9,7 @@ Version: @PROJECT_VERSION@
 
 # Dependencies.
 boost_cflags=-I$<JOIN:@Boost_INCLUDE_DIRS@, -I>
-boost_unit_test_libs=@Boost_UNIT_TEST_FRAMEWORK_LIBRARY@
+boost_unit_test_libs=$<TARGET_PROPERTY:Boost::unit_test_framework,LOCATION>
 
 # Us.
 seastar_testing_cflags=

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -18,8 +18,8 @@ boost_system_libs=@Boost_SYSTEM_LIBRARY@
 
 # Dependencies.
 boost_cflags=-I$<JOIN:@Boost_INCLUDE_DIRS@, -I>
-boost_program_options_libs=@Boost_PROGRAM_OPTIONS_LIBRARY@
-boost_thread_libs=${boost_system_libs} @Boost_THREAD_LIBRARY@
+boost_program_options_libs=$<TARGET_PROPERTY:Boost::program_options,LOCATION>
+boost_thread_libs=${boost_system_libs} $<TARGET_PROPERTY:Boost::thread,LOCATION>
 c_ares_cflags=-I$<JOIN:@c-ares_INCLUDE_DIRS@, -I>
 c_ares_libs=$<JOIN:@c-ares_LIBRARIES@, >
 fmt_cflags=-I$<JOIN:$<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>, -I>


### PR DESCRIPTION
After removing the "MODULE" parameter from find_package(Boost) in af9b804253, the build started using Boost's native package config instead of cmake-boost. This caused seastar.pc to contain target references (e.g. Boost::program_options) rather than actual library paths, breaking builds of projects consuming seastar via pkg-config:

```
/usr/bin/clang++ ... \
  Boost::program_options Boost::thread /usr/lib64/libcares.so /usr/lib64/libfmt.so.11.0.2 -L/usr/lib64 -llz4 -Xlinker --dependency-file -Xlinker CMakeFiles/scylla.dir/Debug/link.d CMakeFiles/scylla_version.dir/Debug/release.cc.o CMakeFiles/scylla.dir/Debug/main.cc.o \
  ...
clang++: error: no such file or directory: 'Boost::program_options'
clang++: error: no such file or directory: 'Boost::thread'
```

In this change, use generator expressions to obtain the actual library paths for pkg-config files, ensuring correct linking for downstream projects.

This should address the regression introduced by af9b804253.