### PR TITLE
httpd: drop unnecessary dependencies from httpd.hh

### DIFF
--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -26,6 +26,7 @@
 #include <seastar/http/file_handler.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/app-template.hh>
 #include "demo.json.hh"
 #include <seastar/http/api_docs.hh>
 #include <seastar/core/thread.hh>

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -31,8 +31,6 @@
 #include <seastar/http/request.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/app-template.hh>
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/gate.hh>

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 
 #include <seastar/core/metrics_api.hh>
+#include <seastar/core/scollectd.hh>
 #include <seastar/http/function_handlers.hh>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>

--- a/tests/unit/rest_api_httpd.cc
+++ b/tests/unit/rest_api_httpd.cc
@@ -27,6 +27,7 @@
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/file_handler.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/app-template.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/net/inet_address.hh>


### PR DESCRIPTION
Downstream files are updated to re-add necessary dependencies.

This reduces include load, especially app-template.hh, which pulls in a bunch of boost dependencies.