### PR TITLE
smp: add a function that barriers memory prefault work

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -374,14 +374,14 @@ private:
         std::atomic<uint64_t> _pending_signals;
         std::unordered_map<int, signal_handler> _signal_handlers;
     };
-
     signals _signals;
     std::unique_ptr<thread_pool> _thread_pool;
+
     friend class thread_pool;
     friend class thread_context;
     friend class internal::cpu_stall_detector;
-
     friend void handle_signal(int signo, noncopyable_function<void ()>&& handler, bool once);
+    friend void barrier_memory_prefault();
 
     uint64_t pending_task_count() const;
     void run_tasks(task_queue& tq);

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -335,6 +335,7 @@ public:
     void cleanup_cpu();
     void arrive_at_event_loop_end();
     void join_all();
+    void join_memory_prefault();
     static bool main_thread() { return std::this_thread::get_id() == _tmain; }
 
     /// Runs a function on a remote core.
@@ -483,6 +484,13 @@ private:
 public:
     static unsigned count;
 };
+
+/// Barriers memory prefault background work. 
+/// This function returns after all memory prefault work is finished. 
+/// It is safe to call from multiple threads.
+/// 
+/// Note: This is a blocking operation, so it should be used with caution.
+void barrier_memory_prefault();
 
 SEASTAR_MODULE_EXPORT_END
 

--- a/src/core/prefault.hh
+++ b/src/core/prefault.hh
@@ -36,11 +36,16 @@ namespace seastar::internal {
 class memory_prefaulter {
     std::atomic<bool> _stop_request = false;
     std::vector<posix_thread> _worker_threads;
+
+    std::mutex join_mtx;
+    bool joined = false;
+    
     // Keep this in object scope to avoid allocating in worker thread
     std::unordered_map<unsigned, std::vector<memory::internal::memory_range>> _layout_by_node_id;
 public:
     explicit memory_prefaulter(const resource::resources& res, memory::internal::numa_layout layout);
     ~memory_prefaulter();
+    void join_all();
 private:
     void work(std::vector<memory::internal::memory_range>& ranges, size_t page_size, std::optional<size_t> huge_page_size_opt);
 };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4637,6 +4637,10 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 }
 
+void barrier_memory_prefault() {
+    engine()._smp->join_memory_prefault();
+}
+
 bool smp::poll_queues() {
     size_t got = 0;
     for (unsigned i = 0; i < count; i++) {


### PR DESCRIPTION
Currently, memory prefault logic is internal and seastar doesnt provide much control to users. In order to improve the situation, I suggest to provide a barrier for the prefault threads. This allows to:

* Prefer predictable low latency and high throughput from the start of request serving, at the cost of a startup delay, depending on machine characteristics and application specific requirements. For example, a fixed capacity on prem db setup, where slower startup can be tolerated. From users perspective, they generally cannot tolerate inconsistency (like spikes in latency).
* Similarly, improve user scheduling decisions, like running less critical tasks while prefault works.
* Reliably test the prefault logic, improving reliability and users trust in seastar.

I tested locally. If you approve, next I will try to submit a prefault test.