### PR TITLE
net: replace deprecated ip::address_v4::from_string()

### DIFF
--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -41,7 +41,7 @@ namespace net {
 
 ipv4_address::ipv4_address(const std::string& addr) {
     boost::system::error_code ec;
-    auto ipv4 = boost::asio::ip::address_v4::from_string(addr, ec);
+    auto ipv4 = boost::asio::ip::make_address_v4(addr, ec);
     if (ec) {
         throw std::runtime_error(
             fmt::format("Wrong format for IPv4 address {}. Please ensure it's in dotted-decimal format", addr));

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -57,17 +57,17 @@ ipv4_addr::ipv4_addr(const std::string &addr) {
     std::vector<std::string> items;
     boost::split(items, addr, boost::is_any_of(":"));
     if (items.size() == 1) {
-        ip = boost::asio::ip::address_v4::from_string(addr).to_ulong();
+        ip = boost::asio::ip::make_address_v4(addr).to_ulong();
         port = 0;
     } else if (items.size() == 2) {
-        ip = boost::asio::ip::address_v4::from_string(items[0]).to_ulong();
+        ip = boost::asio::ip::make_address_v4(items[0]).to_ulong();
         port = std::stoul(items[1]);
     } else {
         throw std::invalid_argument("invalid format: " + addr);
     }
 }
 
-ipv4_addr::ipv4_addr(const std::string &addr, uint16_t port_) : ip(boost::asio::ip::address_v4::from_string(addr).to_ulong()), port(port_) {}
+ipv4_addr::ipv4_addr(const std::string &addr, uint16_t port_) : ip(boost::asio::ip::make_address_v4(addr).to_ulong()), port(port_) {}
 
 ipv4_addr::ipv4_addr(const net::inet_address& a, uint16_t port)
     : ipv4_addr(::in_addr(a), port)


### PR DESCRIPTION
`boost::asio::ip::address_v4::from_string()` was removed in boost 1.87, leading to compilation failures:
```
src/seastar/src/net/ip.cc:44:46: error: no member named 'from_string' in 'boost::asio::ip::address_v4'
    auto ipv4 = boost::asio::ip::address_v4::from_string(addr, ec);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```
prior to 1.87, the function had been [documented as deprecated](https://www.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/ip__address_v4/from_string.html):

> (Deprecated: Use make_address_v4().)