### PR TITLE
coroutine: ADL

### DIFF
--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -152,10 +152,9 @@ exception return_exception(T&& t) noexcept {
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 
-} // coroutine
-
-inline auto operator co_await(coroutine::exception ex) noexcept {
+inline auto operator co_await(exception ex) noexcept {
     return internal::exception_awaiter(std::move(ex.eptr));
 }
 
+} // coroutine
 } // seastar

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -39,7 +39,25 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/later.hh>
 
-using namespace seastar;
+using seastar::broken_promise;
+using seastar::circular_buffer;
+using seastar::create_scheduling_group;
+using seastar::current_scheduling_group;
+using seastar::default_scheduling_group;
+using seastar::future;
+using seastar::make_exception_future;
+using seastar::make_ready_future;
+using seastar::need_preempt;
+using seastar::promise;
+using seastar::scheduling_group;
+using seastar::semaphore;
+using seastar::semaphore_timed_out;
+using seastar::sleep;
+using seastar::yield;
+
+namespace coroutine = seastar::coroutine;
+namespace testing = seastar::testing;
+
 using namespace std::chrono_literals;
 
 namespace {


### PR DESCRIPTION
every user of the coroutine::exception helpers outside of seastar
namespace has to spell explicitly 'using namespace seastar' statement
to compile their code.
let's move the co_await operator into the exception type namespace to
take advantage of the ADL (argument-dependent lookup) language feature
to give the compiler a hint about the scan scope of the co_await operator.
