### PR TITLE
fair_queue: make the fair_group token grabbing discipline more fair

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -350,6 +350,8 @@ private:
     };
 
     std::optional<pending> _pending;
+    // Total capacity of all requests waiting in the queue.
+    capacity_t _queued_capacity = 0;
 
     void push_priority_class(priority_class_data& pc) noexcept;
     void push_priority_class_from_idle(priority_class_data& pc) noexcept;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -254,6 +254,7 @@ public:
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
     capacity_t grab_capacity(capacity_t cap) noexcept;
     clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
+    void refund_tokens(capacity_t) noexcept;
     void replenish_capacity(clock_type::time_point now) noexcept;
     void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
 
@@ -331,25 +332,25 @@ private:
     size_t _nr_classes = 0;
     capacity_t _last_accumulated = 0;
 
-    /*
-     * When the shared capacity os over the local queue delays
-     * further dispatching untill better times
-     *
-     * \head  -- the value group head rover is expected to cross
-     * \cap   -- the capacity that's accounted on the group
-     *
-     * The last field is needed to "rearm" the wait in case
-     * queue decides that it wants to dispatch another capacity
-     * in the middle of the waiting
-     */
+    // _pending represents a reservation of tokens from the bucket.
+    //
+    // In the "dispatch timeline" defined by the growing bucket head of the group,
+    // tokens in the range [_pending.head - cap, _pending.head) belong
+    // to this queue.
+    //
+    // For example, if:
+    //    _group._token_bucket.head == 300
+    //    _pending.head == 700
+    //    _pending.cap == 500
+    // then the reservation is [200, 700), 100 tokens are ready to be dispatched by this queue,
+    // and another 400 tokens are going to be appear soon. (And after that, this queue
+    // will be able to make its next reservation).
     struct pending {
-        capacity_t head;
-        capacity_t cap;
-
-        pending(capacity_t t, capacity_t c) noexcept : head(t), cap(c) {}
+        capacity_t head = 0;
+        capacity_t cap = 0;
     };
+    pending _pending;
 
-    std::optional<pending> _pending;
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;
 
@@ -359,9 +360,20 @@ private:
     void plug_priority_class(priority_class_data& pc) noexcept;
     void unplug_priority_class(priority_class_data& pc) noexcept;
 
-    enum class grab_result { grabbed, cant_preempt, pending };
-    grab_result grab_capacity(const fair_queue_entry& ent) noexcept;
-    grab_result grab_pending_capacity(const fair_queue_entry& ent) noexcept;
+    // Replaces _pending with a new reservation starting at the current
+    // group bucket tail.
+    void grab_capacity(capacity_t cap) noexcept;
+    // Shaves off the fulfilled frontal part from `_pending` (if any),
+    // and returns the fulfilled tokens in `ready_tokens`.
+    // Sets `our_turn_has_come` to the truth value of "`_pending` is empty or
+    // there are no unfulfilled reservations (from other shards) earlier than `_pending`".
+    //
+    // Assumes that `_group.maybe_replenish_capacity()` was called recently.
+    struct reap_result {
+        capacity_t ready_tokens;
+        bool our_turn_has_come;
+    };
+    reap_result reap_pending_capacity() noexcept;
 public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -159,6 +159,10 @@ public:
         _rovers.release(tokens);
     }
 
+    void refund(T tokens) noexcept {
+        fetch_add(_rovers.head, tokens);
+    }
+
     void replenish(typename Clock::time_point now) noexcept {
         auto ts = _replenished.load(std::memory_order_relaxed);
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -297,12 +297,14 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
         push_priority_class_from_idle(pc);
     }
     pc._queue.push_back(ent);
+    _queued_capacity += ent.capacity();
 }
 
 void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
 }
 
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {
+    _queued_capacity -= ent._capacity;
     ent._capacity = 0;
 }
 
@@ -375,6 +377,7 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         h._accumulated += req_cost;
         h._pure_accumulated += req_cap;
         dispatched += req_cap;
+        _queued_capacity -= req_cap;
 
         cb(req);
 

--- a/tests/manual/iosched_reproducers/one_cpu_starved_shard_can_still_saturate_io.sh
+++ b/tests/manual/iosched_reproducers/one_cpu_starved_shard_can_still_saturate_io.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test scenario:
+# A single CPU-starved shard has a batch IO job.
+# Goal: it should be able to utilize the entire bandwidth of the disk,
+# despite the rare polls.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 IO_TESTER_EXECUTABLE" >&2
+    exit 1
+fi
+
+"$1" --smp=7 --storage=/dev/null --conf=<(cat <<'EOF'
+- name: tablet-streaming
+  data_size: 1GB
+  shards: [0]
+  type: seqread
+  shard_info:
+    parallelism: 50
+    reqsize: 128kB
+    shares: 200
+- name: cpuhog
+  type: cpu
+  shards: [0]
+  shard_info:
+    parallelism: 1
+    execution_time: 550us
+
+EOF
+) --io-properties-file=<(cat <<'EOF'
+# i4i.2xlarge
+disks:
+- mountpoint: /dev
+  read_bandwidth: 1542559872
+  read_iops: 218786
+  write_bandwidth: 1130867072
+  write_iops: 121499
+EOF
+)

--- a/tests/manual/iosched_reproducers/one_cpu_starved_shard_has_reasonable_fairness.sh
+++ b/tests/manual/iosched_reproducers/one_cpu_starved_shard_has_reasonable_fairness.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test scenario:
+# all shards contend for IO, but one shard is additionally CPU-starved
+# and polls rarely.
+# Goal: it should still be getting a reasonably fair share of disk bandwidth.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 IO_TESTER_EXECUTABLE" >&2
+    exit 1
+fi
+
+"$1" --smp=7 --storage=/dev/null --conf=<(cat <<'EOF'
+- name: tablet-streaming
+  data_size: 1GB
+  shards: all
+  type: seqread
+  shard_info:
+    parallelism: 50
+    reqsize: 128kB
+    shares: 200
+- name: cpuhog
+  type: cpu
+  shards: [0]
+  shard_info:
+    parallelism: 1
+    execution_time: 550us
+
+EOF
+) --io-properties-file=<(cat <<'EOF'
+# i4i.2xlarge
+disks:
+- mountpoint: /dev
+  read_bandwidth: 1542559872
+  read_iops: 218786
+  write_bandwidth: 1130867072
+  write_iops: 121499
+EOF
+) --duration=2

--- a/tests/manual/iosched_reproducers/scylla_tablet_migration.sh
+++ b/tests/manual/iosched_reproducers/scylla_tablet_migration.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Test scenario:
+# Simulation of a ScyllaDB workload which prompted some changes to the IO scheduler:
+# database queries concurrent with tablet streaming.
+# 
+# All 7 shards are running a low-priority (200 shares) batch IO workload
+# and a high-priority (1000 shares), moderate-bandwidth, interactive workload.
+#
+# The interactive workload requires about 30% of the node's
+# total bandwidth (as measured in tokens), in small random reads.
+# The batch workload does large sequential reads and wants to utilize all
+# spare bandwidth.
+#
+# This workload is almost symmetric across shards, but is slightly skewed
+# and shard 0 is slightly more loaded. But even on this shard, the workload
+# doesn't need more than 35% of the fair bandwidth of this shard.
+#
+# Due to the distribution of shares across IO classes, the user expects that
+# the interactive workload should be guaranteed (1000 / (1000 + 200)) == ~84% of 
+# the disk bandwidth on each shard. So if it's only asking for less than 35%,
+# the lower-priority job shouldn't disturb it.
+#
+# But before the relevant IO scheduler changes, this goal wasn't met,
+# and the interactive workload on shard 0 was instead starved for IO
+# by the low-priority workloads on other shards.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 IO_TESTER_EXECUTABLE" >&2
+    exit 1
+fi
+
+"$1" --smp=7 --storage=/dev/null --conf=<(cat <<'EOF'
+- name: tablet-streaming
+  data_size: 1GB
+  shards: all
+  type: seqread
+  shard_info:
+    parallelism: 50
+    reqsize: 128kB
+    shares: 200
+- name: cassandra-stress
+  shards: all
+  type: randread
+  data_size: 1GB
+  shard_info:
+    parallelism: 100
+    reqsize: 1536
+    shares: 1000
+    rps: 75
+  options:
+    pause_distribution: poisson
+    sleep_type: steady
+- name: cassandra-stress-slight-imbalance
+  shards: [0]
+  type: randread
+  data_size: 1GB
+  shard_info:
+    parallelism: 100
+    reqsize: 1536
+    class: cassandra-stress
+    rps: 10
+  options:
+    pause_distribution: poisson
+    sleep_type: steady
+
+EOF
+) --io-properties-file=<(cat <<'EOF'
+# i4i.2xlarge
+disks:
+- mountpoint: /dev
+  read_bandwidth: 1542559872
+  read_iops: 218786
+  write_bandwidth: 1130867072
+  write_iops: 121499
+EOF
+)

--- a/tests/manual/iosched_reproducers/tau_nemesis.sh
+++ b/tests/manual/iosched_reproducers/tau_nemesis.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# There is a `tau` mechanism in `fair_queue` which lets newly-activated
+# IO classes to monopolize the shard's IO queue for a while.
+#
+# This isn't very useful and can result in major performance problems,
+# as this test illustrates. The `highprio` workload could have tail latency
+# of about 2 milliseconds, but the `bursty_lowprio` is allowed by `tau` to butt in
+# periodically and preempt `highprio` for ~30ms, bringing its tail latency
+# to that threshold.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 IO_TESTER_EXECUTABLE" >&2
+    exit 1
+fi
+
+"$1" --smp=7 --storage=/dev/null --conf=<(cat <<'EOF'
+- name: filler
+  data_size: 1GB
+  shards: all
+  type: seqread
+  shard_info:
+    parallelism: 10
+    reqsize: 128kB
+    shares: 10
+- name: bursty_lowprio
+  data_size: 1GB
+  shards: all
+  type: seqread
+  shard_info:
+    parallelism: 1
+    reqsize: 128kB
+    shares: 100
+    batch: 50
+    rps: 8
+- name: highprio
+  shards: all
+  type: randread
+  data_size: 1GB
+  shard_info:
+    parallelism: 100
+    reqsize: 1536
+    shares: 1000
+    rps: 50
+  options:
+    pause_distribution: poisson
+    sleep_type: steady
+EOF
+) --io-properties-file=<(cat <<'EOF'
+# i4i.2xlarge
+disks:
+- mountpoint: /dev
+  read_bandwidth: 1542559872
+  read_iops: 218786
+  write_bandwidth: 1130867072
+  write_iops: 121499
+EOF
+)

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -82,7 +82,14 @@ public:
     test_env(unsigned capacity)
         : _fg(fg_config(capacity), 1)
         , _fq(_fg, fq_config())
-    {}
+    {
+        // Move _fg._replenished_ts() to far future.
+        // This will prevent any `maybe_replenish_capacity` calls (indirectly done by `fair_queue::dispatch_requests()`)
+        // from replenishing tokens on its own, and ensure that the only source of replenishment will be tick().
+        //
+        // Otherwise the rate of replenishment might be greater than expected by the test, breaking the results.
+        _fg.replenish_capacity(fair_group::clock_type::now() + std::chrono::days(1));
+    }
 
     // As long as there is a request sitting in the queue, tick() will process
     // at least one request. The only situation in which tick() will return nothing


### PR DESCRIPTION
The current design of `fair_group` isn't fair enough to shards.
During contention, the group will be -- aproximately -- taking requests
from shards one-by-one, in round robin.

This guarantees that each contender will dispatch an equal *number* of
requests. This is some kind of fairness, but it's not the kind we want,
probably ever.

A better kind of fairness is that under contention each shard should
be guaranteed `1/nr_shards` of the disk's IOPS and/or `1/nr_shards` of
byte-bandwidth, whichever dimension it pressures more.
This is needed so that each shard can be relied on to sustain a certain
rate of requests -- the lower bound of the slowest shard's throughput
usually dictates the throughput of the entire cluster.

But those two kinds of fairness are only the same if all IO requests have
the same size and direction. Otherwise they can be drastically different.

With the current design it's easy to create a situation where a shard receives
an arbitrarily small fraction of both IOPS and bandwidth, despite being
IO-bound. (Example: a node with X shards, where one shard spams only very small
requests and other shards spams only big requests).

This is a problem in practice. In ScyllaDB, we observed IO starvation of
some shards during realistic workloads. While they require some workload
asymmetry to occur, even small asymmetries can cause serious unfairness to occur.
(For example, a shard which receives 6% more of database queries than other
shards can be starved to less than 50% of its fair share of IOPS and/or
bandwidth -- because each of those surplus 1 kiB queries is "fairly" matched with
16x costlier 128 kiB low-priority batch IO requests on other shards).

To improve this, `fair_group` needs a different queueing discipline.
There are many possible ways, but this patch chooses the one which is relatively
the most similar to the current one. The main idea is that we still rely on the
"approximate round robin" of the token bucket as the basis for fairness, but we reserve
a fixed-size batch of tokens at a time, rather than a fixed-size (i.e. 1) batch
of _requests_ at a time. This turns the discipline from request-fair to
token-fair, which is what we want.

The implementation details are non-trivial, though, and should be carefully reviewed.

This change doesn't result in full fairness. The degree of fairness depends on how often
a given shard polls. A continuously-polling shard should get its fair share of disk bandwidth,
but a rarely-polling shard might only get a fraction of its fair share. But with current default values
for IO scheduler parameters, a shard should be guaranteed at least 60% of its fair share
in the worst case, which is decent, and better than the current "arbitrarily-low%".

Also note that by "fair share" we mean 1 / `nr_shards_in_group`, not 1/`nr_actively_contending_shards_in_group`. If there are 30 shards in a group but only 2 are contending for IO — one polling rarely and one polling continuously — the rarely-polling contender will only get ~1/30 of the disk's bandwidth, not ~1/2. This is not a problem for applications where the interactive workloads are mostly symmetric (because then it's the "normal" case that all shards are contending and none can expect more than 1/30), but it's unsatisfying.

Different scheduling algorithms could improve on both of the above. We have some ideas for that. But they would be a bigger departure from status quo, and they should be harder to implement well.