### PR TITLE
websocket: Support clients that do not specify subprotocol 

### DIFF
--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -324,6 +324,12 @@ public:
 
     bool is_handler_registered(std::string const& name);
 
+    /*!
+     * \brief Register a handler for specific subprotocol
+     * \param name The name of the subprotocol. If it is empty string, then the handler is used
+     * when the protocol is not specified
+     * \param handler Handler for incoming WebSocket messages.
+     */
     void register_handler(const std::string& name, handler_t handler);
 
     friend class connection;

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -324,7 +324,7 @@ public:
 
     bool is_handler_registered(std::string const& name);
 
-    void register_handler(std::string&& name, handler_t handler);
+    void register_handler(const std::string& name, handler_t handler);
 
     friend class connection;
 protected:

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -414,7 +414,7 @@ bool server::is_handler_registered(std::string const& name) {
     return _handlers.find(name) != _handlers.end();
 }
 
-void server::register_handler(std::string&& name, handler_t handler) {
+void server::register_handler(const std::string& name, handler_t handler) {
     _handlers[name] = handler;
 }
 


### PR DESCRIPTION
According to RFC6455 section 4.1 Sec-WebSocket-Protocol is optional both on client and server side.