### PR TITLE
build: add missing include in program_options.cc

### DIFF
--- a/src/core/program_options.cc
+++ b/src/core/program_options.cc
@@ -29,6 +29,8 @@ module;
 #include <fmt/format.h>
 module seastar;
 #else
+#include <boost/type.hpp>
+
 #include "core/program_options.hh"
 
 #include <seastar/util/log-cli.hh>


### PR DESCRIPTION
With GCC 14.2.1 and Boost 1.86.0 the code failed to compile due to unknown type template `boost::type`. The include has been removed, possibly accidentally, from the non-module build in aa1c8b30fa

I tried it on Arch with GCC and Boost as above. CMake command (from repository root):
`cmake -S . -B build -DSeastar_DOCS=OFF`


```
[  1%] Building CXX object CMakeFiles/seastar.dir/src/core/program_options.cc.o /home/krzaq/code/temp/seastar/src/core/program_options.cc:82:64: error: ‘boost::type’ has not been declared
   82 | memory::alloc_failure_kind from_string(const std::string& val, boost::type<memory::alloc_failure_kind>) {
      |                                                                ^~~~~
/home/krzaq/code/temp/seastar/src/core/program_options.cc:82:75: error: expected ‘,’ or ‘...’ before ‘<’ token
   82 | memory::alloc_failure_kind from_string(const std::string& val, boost::type<memory::alloc_failure_kind>) {
      |                                                                           ^
/home/krzaq/code/temp/seastar/src/core/program_options.cc:93:47: error: ‘boost::type’ has not been declared
   93 | log_level from_string(const std::string& val, boost::type<log_level>) {
      |                                               ^~~~~
/home/krzaq/code/temp/seastar/src/core/program_options.cc:93:58: error: expected ‘,’ or ‘...’ before ‘<’ token
   93 | log_level from_string(const std::string& val, boost::type<log_level>) {
      |                                                          ^
/home/krzaq/code/temp/seastar/src/core/program_options.cc:93:11: error: ambiguating new declaration of ‘seastar::log_level seastar::program_options::{anonymous}::from_string(const std::string&, int)’
   93 | log_level from_string(const std::string& val, boost::type<log_level>) {
      |           ^~~~~~~~~~~
```