### PR TITLE
io_queue: fix static member access to comply with CWG2813

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -639,10 +639,11 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
      */
     auto update_max_size = [this] (unsigned idx) {
         auto g_idx = _config.duplex ? idx : 0;
-        auto max_cap = _fgs[g_idx].maximum_capacity();
+        const auto& fg = _fgs[g_idx];
+        auto max_cap = fg.maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
             auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
-            auto cap = _fgs[g_idx].tokens_capacity(tokens);
+            auto cap = fg.tokens_capacity(tokens);
             if (cap > max_cap) {
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");


### PR DESCRIPTION
Fix build failure with recent Clang implementations of CWG2813, which makes accessing static members through instance expressions into discarded-value expressions. This caused nodiscard warnings when accessing static member `tokens_capacity()` through `fgs[i]`.

Before:
```c++
  fgs[i].tokens_capacity()  // Warns: ignoring nodiscard return value
```

After:
```c++
  const auto& fg = fgs[i]); // not discarded
  fg.tokens_capacity();     // access static member function
```

Additionally, this refactoring reduces repetition of `fgs[g_idx]` expressions throughout the code.

See:

- https://cplusplus.github.io/CWG/issues/2813.html
- https://eel.is/c++draft/expr.ref#2

Fixes Scylla build failure with the latest Clang, as Scylla enables Seastar_UNUSED_RESULT_ERROR.