### PR TITLE
scheduling: auto-detect scheduling group key rename() method

### DIFF
--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -238,6 +238,9 @@ SEASTAR_MODULE_EXPORT_BEGIN
  * This configuration is used by the infrastructure to allocate memory for the values
  * and initialize or deinitialize them when they are created or destroyed.
  *
+ * If the type T has a member function T::rename()
+ * then it will be called after the scheduling group is renamed.
+ *
  * @tparam T - the type for the newly created value.
  * @tparam ...ConstructorArgs - the types for the constructor parameters (should be deduced)
  * @param args - The parameters for the constructor.
@@ -255,6 +258,11 @@ make_scheduling_group_key_config(ConstructorArgs... args) {
     sgkc.destructor = [] (void* p) {
         static_cast<T*>(p)->~T();
     };
+    if constexpr (requires(T key) { key.rename(); }) {
+        sgkc.rename = [] (void* p) {
+            static_cast<T*>(p)->rename();
+        };
+    }
     return sgkc;
 }
 

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -305,9 +305,6 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     };
 
     scheduling_group_key_config key_conf = make_scheduling_group_key_config<value>();
-    key_conf.rename = [] (void* ptr) {
-        reinterpret_cast<value*>(ptr)->rename();
-    };
 
     std::vector<scheduling_group_key> keys;
     for (size_t i = 0; i < 3; ++i) {


### PR DESCRIPTION
make_scheduling_group_key_config() is able to create a fully functional scheduling_group_key_config, apart from the rename() method. Provide for that by detecting if the type has a rename() method and if so, create a thunk for it.

This is kept optional for backward compatibility.