### PR TITLE
tls: Add a way to inspect peer certificate chain

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -494,6 +494,19 @@ namespace tls {
     */
     future<std::vector<subject_alt_name>> get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types = {});
 
+    using certificate_data = std::vector<uint8_t>;
+
+    /**
+     * Get the raw certificate (chain) that the connected peer is using.
+     * This function forces the TLS handshake. If the handshake didn't happen before the
+     * call to 'get_peer_certificate_chain' it will be completed when the returned future
+     * will become ready.
+     * The function returns the certificate chain on success. If the peer didn't send the
+     * certificate during the handshake, the function returns an empty certificate chain.
+     * If the socket is not connected the system_error exception will be thrown.
+     */
+    future<std::vector<certificate_data>> get_peer_certificate_chain(connected_socket& socket);
+
     /**
      * Checks if the socket was connected using session resume.
      * Will force handshake if not already done.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -541,6 +541,7 @@ function(seastar_add_certgen name)
   set(CERT_PRIVKEY ${CERT_NAME}.key)
   set(CERT_REQ ${CERT_NAME}.csr)
   set(CERT_CERT ${CERT_NAME}.crt)
+  set(CERT_CERT_DER ${CERT_NAME}.crt.der)
 
   set(CERT_CAPRIVKEY ca${CERT_NAME}.key)
   set(CERT_CAROOT ca${CERT_NAME}.pem)
@@ -581,8 +582,14 @@ function(seastar_add_certgen name)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-  add_custom_target(${name}
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT_DER}"
+    COMMAND ${OPENSSL} x509 -in ${CERT_CERT} -out ${CERT_CERT_DER} -outform der
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  add_custom_target(${name}
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT_DER}"
   )
 endfunction()
 


### PR DESCRIPTION
Seastar currently offers the following three functions that enable inspection of part of the certificate chain presented by and accepted from the peer during a TLS handshake using X.509 certificate credentials.
- `seastar::tls::certificate_credentials::set_dn_verification_callback`
- `seastar::tls::get_dn_information`
- `seastar::tls::get_alt_name_information`
These function only provide access to the Distinguished Name of the subject and the issuer and the Subject Alternative Name of the leaf certificate accepted during the handshake. Applications may have a need to inspect other properties of the certificate or certificate chain as as accepted during the TLS handshake.

Here, we propose to introduce the function `seastar::tls::get_peer_certificate_chain` to inspect the raw peer certificate chain data as presented and accepted during the TLS handshake. We propose not to introduce any additional abstractions to the intentionally simple existing Seastar TLS interface and to return the raw certificate data as a sequence of sequence of bytes.

We attempt to retain existing Seastar implementation conventions as much as possible, by closely mimicking the existing implementation and documentation of `seastar::tls::get_dn_information` and `seastar::tls::session::get_peer_certificate`. This leads to some minor code duplication between `seastar::tls::session::get_peer_certificate` and `seastar::tls::session::get_peer_certificate_chain`, which we propose not to resolve as these two superficially similar functions serve different purposes and return incompatible types.

We propose to introduce a single test case, `test_peer_certificate_chain_handling`, mostly mimicking the `test_alt_names` test case. For this we also propose to generate simple additional certificate test data.

Please let me know if this is suitable for inclusion upstream. I'm happy to clarify design decisions and/or update my pull request according to your guidance.

Kind regards,

Niels