### PR TITLE
core: function_traits noexcept specializations

### DIFF
--- a/include/seastar/core/function_traits.hh
+++ b/include/seastar/core/function_traits.hh
@@ -57,6 +57,18 @@ template <typename T, typename Ret, typename... Args>
 struct function_traits<Ret(T::*)(Args...) const> : public function_traits<Ret(Args...)>
 {};
 
+template<typename Ret, typename... Args>
+struct function_traits<Ret(*)(Args...) noexcept> : public function_traits<Ret(Args...)>
+{};
+
+template <typename T, typename Ret, typename... Args>
+struct function_traits<Ret(T::*)(Args...) noexcept> : public function_traits<Ret(Args...)>
+{};
+
+template <typename T, typename Ret, typename... Args>
+struct function_traits<Ret(T::*)(Args...) const noexcept> : public function_traits<Ret(Args...)>
+{};
+
 template <typename T>
 struct function_traits : public function_traits<decltype(&T::operator())>
 {};


### PR DESCRIPTION
starting from 17th standard noexcept-specification is a part of the function type. function_traits doesn't have specializations
for noexcept function types thus cannot resolve the traits.
adding noexcept specializations allows function_traits for a larger class of function types fi noexcept future exception continuations. seastar supports 20th standard and newer thus there is no need to worry about compatibility.
