### PR TITLE
util/variant: make seastar::visit perfectly forward the value argument

### DIFF
--- a/include/seastar/util/variant_utils.hh
+++ b/include/seastar/util/variant_utils.hh
@@ -70,7 +70,7 @@ inline auto visit(Variant&& variant, Args&&... args)
     static_assert(sizeof...(Args) > 0, "At least one lambda must be provided for visitation");
     return std::visit(
         make_visitor(std::forward<Args>(args)...),
-        variant);
+        std::forward<Variant>(variant));
 }
 
 namespace internal {


### PR DESCRIPTION
Internally we only use it for lvalue references, so passing the argument to std::visit as is looks relevant. However, since seastar::visit accepts universal reference it should handle it appropriately for not to surprise callers by copying its argument implicitly.