### PR TITLE
net: replace deprecated ip::address_v4::to_ulong() 

### DIFF
--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -46,7 +46,7 @@ ipv4_address::ipv4_address(const std::string& addr) {
         throw std::runtime_error(
             fmt::format("Wrong format for IPv4 address {}. Please ensure it's in dotted-decimal format", addr));
     }
-    ip = static_cast<uint32_t>(std::move(ipv4).to_ulong());
+    ip = static_cast<uint32_t>(std::move(ipv4).to_uint());
 }
 
 ipv4::ipv4(interface* netif)

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -57,17 +57,17 @@ ipv4_addr::ipv4_addr(const std::string &addr) {
     std::vector<std::string> items;
     boost::split(items, addr, boost::is_any_of(":"));
     if (items.size() == 1) {
-        ip = boost::asio::ip::make_address_v4(addr).to_ulong();
+        ip = boost::asio::ip::make_address_v4(addr).to_uint();
         port = 0;
     } else if (items.size() == 2) {
-        ip = boost::asio::ip::make_address_v4(items[0]).to_ulong();
+        ip = boost::asio::ip::make_address_v4(items[0]).to_uint();
         port = std::stoul(items[1]);
     } else {
         throw std::invalid_argument("invalid format: " + addr);
     }
 }
 
-ipv4_addr::ipv4_addr(const std::string &addr, uint16_t port_) : ip(boost::asio::ip::make_address_v4(addr).to_ulong()), port(port_) {}
+ipv4_addr::ipv4_addr(const std::string &addr, uint16_t port_) : ip(boost::asio::ip::make_address_v4(addr).to_uint()), port(port_) {}
 
 ipv4_addr::ipv4_addr(const net::inet_address& a, uint16_t port)
     : ipv4_addr(::in_addr(a), port)


### PR DESCRIPTION
boost::asio::ip::address_v4:to_ulong() was deprecated in 1.87 See https://github.com/boostorg/asio/commit/60b86035b3ff80d5fecebd8ae753becb9d9688c5

follow-up to: 11d17017fd1d135ce979e3fbff0adc4f71501bc6