### PR TITLE
reactor: deprecate at_destroy(), at_exit()

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -1175,7 +1175,7 @@ int main(int ac, char** av) {
             }
 
             ctx.start(storage, *st_type, reqs, duration).get();
-            engine().at_exit([&ctx] {
+            internal::at_exit([&ctx] {
                 return ctx.stop();
             });
             std::cout << "Creating initial files..." << std::endl;

--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1454,10 +1454,10 @@ int main(int ac, char** av) {
         ;
 
     return app.run_deprecated(ac, av, [&] {
-        engine().at_exit([&] { return tcp_server.stop(); });
-        engine().at_exit([&] { return udp_server.stop(); });
-        engine().at_exit([&] { return cache_peers.stop(); });
-        engine().at_exit([&] { return system_stats.stop(); });
+        internal::at_exit([&] { return tcp_server.stop(); });
+        internal::at_exit([&] { return udp_server.stop(); });
+        internal::at_exit([&] { return cache_peers.stop(); });
+        internal::at_exit([&] { return system_stats.stop(); });
 
         auto&& config = app.configuration();
         uint16_t port = config["port"].as<uint16_t>();

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -129,6 +129,9 @@ size_t scheduling_group_count();
 
 void increase_thrown_exceptions_counter() noexcept;
 
+template <typename Func>
+void at_destroy(Func&& func);
+
 }
 
 class io_queue;
@@ -162,6 +165,8 @@ private:
     class io_queue_submission_pollfn;
     class syscall_pollfn;
     class execution_stage_pollfn;
+    template <typename Func>
+    friend void internal::at_destroy(Func&&);
     friend class manual_clock;
     friend class file_data_source_impl; // for fstream statistics
     friend class internal::reactor_stall_sampler;
@@ -525,11 +530,26 @@ public:
 
     void at_exit(noncopyable_function<future<> ()> func);
 
+    /// Deprecated. Use following sequence instead:
+    ///
+    /// ```
+    ///    return seastar::app_template::run([] {
+    ///         return seastar::async([] {
+    ///              auto deferred_task = defer(/* the function you want to run at exit */);
+    ///         });
+    ///    });
+    /// ```
     template <typename Func>
+    [[deprecated("Use seastar::app_template::run(), seastar::async(), and seastar::defer() for orderly shutdown")]]
     void at_destroy(Func&& func) {
+        do_at_destroy(std::forward<Func>(func));
+    }
+private:
+    template <typename Func>
+    void do_at_destroy(Func&& func) {
         _at_destroy_tasks->_q.push_back(make_task(default_scheduling_group(), std::forward<Func>(func)));
     }
-
+public:
     task* current_task() const { return _current_task; }
     // If a task wants to resume a different task instead of returning control to the reactor,
     // it should set _current_task to the resumed task.
@@ -687,5 +707,14 @@ inline int hrtimer_signal() {
 
 
 extern logger seastar_logger;
+
+namespace internal {
+
+template <typename Func>
+void at_destroy(Func&& func) {
+    engine().do_at_destroy(std::forward<Func>(func));
+}
+
+} // namespace internal
 
 }

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -166,7 +166,7 @@ int
 app_template::run(int ac, char ** av, std::function<future<int> ()>&& func) noexcept {
     return run_deprecated(ac, av, [func = std::move(func)] () mutable {
         auto func_done = make_lw_shared<promise<>>();
-        engine().at_exit([func_done] { return func_done->get_future(); });
+        internal::at_exit([func_done] { return func_done->get_future(); });
         // No need to wait for this future.
         // func's returned exit_code is communicated via engine().exit()
         (void)futurize_invoke(func).finally([func_done] {

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -247,7 +247,7 @@ device::receive(std::function<future<> (packet)> next_packet) {
 void device::set_local_queue(std::unique_ptr<qp> dev) {
     SEASTAR_ASSERT(!_queues[this_shard_id()]);
     _queues[this_shard_id()] = dev.get();
-    engine().at_destroy([dev = std::move(dev)] {});
+    internal::at_destroy([dev = std::move(dev)] {});
 }
 
 

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -392,7 +392,8 @@ SEASTAR_THREAD_TEST_CASE(sg_key_constructor_exception_when_creating_new_key) {
 SEASTAR_THREAD_TEST_CASE(sg_create_with_destroy_tasks) {
     struct nada{};
 
-    engine().at_destroy([] {}); // nothing really
+    // at_destroy() functionality is deprecated, but test until removed.
+    internal::at_destroy([] {}); // nothing really
 
     scheduling_group_key_config sg_conf = make_scheduling_group_key_config<nada>();
     scheduling_group_key_create(sg_conf).get();


### PR DESCRIPTION
at_destroy() tasks are unordered with respect to each other, so are not very useful. They also consume a scheduling group. at_exit() functions are similar.

Since they are public, we can't remove them outright, but prepare by deprecating the public interface. Internal users are converted to a private interface.

We add a section to the tutorial to explain how modern initialization and cleanup are done.