### PR TITLE
testing: prevent test scheduling after reactor exit

### DIFF
--- a/include/seastar/testing/test_runner.hh
+++ b/include/seastar/testing/test_runner.hh
@@ -46,7 +46,7 @@ private:
         start_thread_args(int ac_, char** av_) noexcept : ac(ac_), av(av_) {}
     };
     std::unique_ptr<start_thread_args> _st_args;
-    int start_thread(int ac, char** av);
+    bool start_thread(int ac, char** av);
 public:
     // Returns whether initialization was successful.
     // Will return as soon as the seastar::app was started.


### PR DESCRIPTION
Previously, when handling "--help" (introduced in b8a13bebe4), we returned status code 0 but continued scheduling test tasks to the Seastar reactor. This caused test applications to hang since the tasks expected the exchanger 'e' to be available after reactor exit.

Fix this by using the "_done" flag to track reactor state:
- Set "_done" when Seastar application exits
- Skip task scheduling and exchanger wait if "_done" is set
- Change test_runner::start_thread() to return bool indicating successful engine startup instead of exit code (exit code now stored in _exit_code member)

This fixes the regression where "--help" would cause test applications to hang indefinitely.

Fixes #2635
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>