### PR TITLE
Support chunked_vector and other json/httpd changes

### DIFF
--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -24,6 +24,7 @@
 #ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <cassert>
+#include <iterator>
 #include <type_traits>
 #include <seastar/util/modules.hh>
 #endif
@@ -176,10 +177,11 @@ public:
 public:
     chunked_fifo() noexcept = default;
     chunked_fifo(chunked_fifo&& x) noexcept;
-    chunked_fifo(const chunked_fifo& X) = delete;
+    chunked_fifo(const chunked_fifo&);
     ~chunked_fifo();
-    chunked_fifo& operator=(const chunked_fifo&) = delete;
+    chunked_fifo& operator=(const chunked_fifo&);
     chunked_fifo& operator=(chunked_fifo&&) noexcept;
+    inline bool operator==(const chunked_fifo& rhs) const;
     inline void push_back(const T& data);
     inline void push_back(T&& data);
     T& back() noexcept;
@@ -294,6 +296,25 @@ chunked_fifo<T, items_per_chunk>::chunked_fifo(chunked_fifo&& x) noexcept
     x._nchunks = 0;
     x._free_chunks = nullptr;
     x._nfree_chunks = 0;
+}
+
+template <typename T, size_t items_per_chunk>
+inline
+chunked_fifo<T, items_per_chunk>::chunked_fifo(const chunked_fifo& rhs)
+        : chunked_fifo() {
+    std::copy_n(rhs.begin(), rhs.size(), std::back_inserter(*this));
+}
+
+template <typename T, size_t items_per_chunk>
+inline
+chunked_fifo<T, items_per_chunk>&
+chunked_fifo<T, items_per_chunk>::operator=(const chunked_fifo& rhs) {
+    if (&rhs != this) {
+        clear();
+        std::copy_n(rhs.begin(), rhs.size(), std::back_inserter(*this));
+        shrink_to_fit();
+    }
+    return *this;
 }
 
 template <typename T, size_t items_per_chunk>
@@ -453,6 +474,11 @@ chunked_fifo<T, items_per_chunk>::emplace_back(Args&&... args) {
         throw;
     }
     ++_back_chunk->end;
+}
+
+template <typename T, size_t items_per_chunk>
+inline bool chunked_fifo<T, items_per_chunk>::operator==(const chunked_fifo& rhs) const {
+    return size() == rhs.size() && std::equal(begin(), end(), rhs.begin());
 }
 
 template <typename T, size_t items_per_chunk>

--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -43,7 +43,7 @@ namespace internal {
 
 template<typename T>
 concept is_map = requires {
-    typename T::mapped_type;
+    typename std::remove_reference_t<T>::mapped_type;
 };
 
 template<typename T>
@@ -357,8 +357,8 @@ public:
      */
     template<std::ranges::input_range Range>
     requires (!internal::is_string_like<Range>)
-    static future<> write(output_stream<char>& s, const Range& range) {
-        return do_with(std::move(range), [&s] (const auto& range) {
+    static future<> write(output_stream<char>& s, Range&& range) {
+        return do_with(std::forward<Range>(range), [&s] (const auto& range) {
             if constexpr (internal::is_map<Range>) {
                 return write(s, state::map, std::ranges::begin(range), std::ranges::end(range));
             } else {

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -368,8 +368,8 @@ std::function<future<>(output_stream<char>&&)> stream_range_as_array(Container v
 template<class T>
 std::function<future<>(output_stream<char>&&)> stream_object(T val) {
     return [val = std::move(val)](output_stream<char>&& s) mutable {
-        return do_with(output_stream<char>(std::move(s)), T(std::move(val)), [](output_stream<char>& s, const T& val){
-            return formatter::write(s, val).finally([&s] {
+        return do_with(output_stream<char>(std::move(s)), T(std::move(val)), [](output_stream<char>& s, T& val){
+            return formatter::write(s, std::move(val)).finally([&s] {
                 return s.close();
             });
         });

--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -24,8 +24,6 @@
 #ifndef SEASTAR_MODULE
 #include <string>
 #include <vector>
-#include <time.h>
-#include <sstream>
 #endif
 
 #include <seastar/core/do_with.hh>

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -677,9 +677,8 @@ def parse_file(param, combined):
         if (combined):
             fprintln(combined, '#include "', base_file_name, ".cc", '"')
         create_h_file(data, hfile_name, api_name, init_method, base_api)
-    except:
-        type, value, tb = sys.exc_info()
-        print("Error while parsing JSON file '" + param + "' error ", value.message)
+    except Exception as e:
+        print("Error while parsing JSON file '" + param + "' error " + str(e))
         sys.exit(-1)
 
 if "indir" in config and config.indir != '':

--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -97,9 +97,14 @@ def valid_type(param):
     trace_err("Type [", param, "] not defined")
     return param
 
+# Map from json list types to the C++ implementing type
+LIST_TO_IMPL = {"array": "json_list", "chunked_array": "json_chunked_list"}
 
-def type_change(param, member):
-    if param == "array":
+def is_array_type(type: str):
+    return type in LIST_TO_IMPL
+
+def type_change(param: str, member):
+    if is_array_type(param):
         if "items" not in member:
             trace_err("array without item declaration in ", param)
             return ""
@@ -111,7 +116,8 @@ def type_change(param, member):
         else:
             trace_err("array items with no type or ref declaration ", param)
             return ""
-        return "json_list< " + valid_type(t) + " >"
+        return LIST_TO_IMPL[param] + "< " + valid_type(t) + " >"
+
     return "json_element< " + valid_type(param) + " >"
 
 
@@ -371,7 +377,7 @@ def is_model_valid(name, model):
     properties = getitem(model[name], "properties", name)
     for var in properties:
         type = getitem(properties[var], "type", name + ":" + var)
-        if type == "array":
+        if is_array_type(type):
             items = getitem(properties[var], "items", name + ":" + var)
             try:
                 type = getitem(items, "type", name + ":" + var + ":items")

--- a/tests/unit/api.json
+++ b/tests/unit/api.json
@@ -82,6 +82,18 @@
             "VAL2",
             "VAL3"
           ]
+        },
+        "array_var": {
+          "type": "array",
+          "items": {
+            "type": "int"
+          }
+        },
+        "chunked_array_var": {
+          "type": "chunked_array",
+          "items": {
+            "type": "int"
+          }
         }
       }
     }

--- a/tests/unit/api.json
+++ b/tests/unit/api.json
@@ -47,6 +47,14 @@
                 "VAL2",
                 "VAL3"
               ]
+            },
+            {
+              "name": "use_streaming",
+              "description": "Whether to return the response as a stream_object",
+              "required": true,
+              "allowMultiple": false,
+              "type": "boolean",
+              "paramType": "query"
             }
           ]
         }

--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -52,25 +52,19 @@ class TestJson2Code(unittest.TestCase):
         var1 = 'bon'
         var2 = 'jour'
         query_enum = 'VAL2'
-        params = urllib.parse.urlencode({'query_enum': query_enum})
-        url = f'http://localhost:{self.port}/hello/world/{var1}/{var2}?{params}'
-        with urllib.request.urlopen(url) as f:
-            response = json.loads(f.read().decode('utf-8'))
-            self.assertEqual(response['var1'], f'/{var1}')
-            self.assertEqual(response['var2'], f'/{var2}')
-            self.assertEqual(response['enum_var'], query_enum)
+        response = self._do_query(var1, var2, query_enum)
+        self.assertEqual(response['var1'], f'/{var1}')
+        self.assertEqual(response['var2'], f'/{var2}')
+        self.assertEqual(response['enum_var'], query_enum)
 
     def test_bad_enum(self):
         var1 = 'bon'
         var2 = 'jour'
         query_enum = 'unknown value'
-        params = urllib.parse.urlencode({'query_enum': query_enum})
-        url = f'http://localhost:{self.port}/hello/world/{var1}/{var2}?{params}'
-        with urllib.request.urlopen(url) as f:
-            response = json.loads(f.read().decode('utf-8'))
-            self.assertEqual(response['var1'], f'/{var1}')
-            self.assertEqual(response['var2'], f'/{var2}')
-            self.assertEqual(response['enum_var'], 'Unknown')
+        response = self._do_query(var1, var2, query_enum)
+        self.assertEqual(response['var1'], f'/{var1}')
+        self.assertEqual(response['var2'], f'/{var2}')
+        self.assertEqual(response['enum_var'], 'Unknown')
 
     def test_missing_path_param(self):
         query_enum = 'VAL2'
@@ -84,6 +78,12 @@ class TestJson2Code(unittest.TestCase):
             response = json.loads(ex.read().decode('utf-8'))
             self.assertEqual(response['message'], 'Not found')
             self.assertEqual(response['code'], 404)
+
+    def _do_query(self, var1: str, var2: str, query_enum: str):
+        params = urllib.parse.urlencode({'query_enum': query_enum})
+        url = f'http://localhost:{self.port}/hello/world/{var1}/{var2}?{params}'
+        with urllib.request.urlopen(url) as f:
+            return json.loads(f.read().decode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -79,6 +79,13 @@ class TestJson2Code(unittest.TestCase):
             self.assertEqual(response['message'], 'Not found')
             self.assertEqual(response['code'], 404)
 
+    def test_arrays(self):
+        response = self._do_query('x', 'x', 'VAL2')
+        expected = [1, 2, 3]
+
+        self.assertEqual(response['array_var'], expected)
+        self.assertEqual(response['chunked_array_var'], expected)
+
     def _do_query(self, var1: str, var2: str, query_enum: str):
         def query(streaming: bool = False):
             params = urllib.parse.urlencode({

--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -80,10 +80,20 @@ class TestJson2Code(unittest.TestCase):
             self.assertEqual(response['code'], 404)
 
     def _do_query(self, var1: str, var2: str, query_enum: str):
-        params = urllib.parse.urlencode({'query_enum': query_enum})
-        url = f'http://localhost:{self.port}/hello/world/{var1}/{var2}?{params}'
-        with urllib.request.urlopen(url) as f:
-            return json.loads(f.read().decode('utf-8'))
+        def query(streaming: bool = False):
+            params = urllib.parse.urlencode({
+                'query_enum': query_enum,
+                'use_streaming': str(streaming).lower()
+            })
+            url = f'http://localhost:{self.port}/hello/world/{var1}/{var2}?{params}'
+            with urllib.request.urlopen(url) as f:
+                return json.load(f)
+
+        # always query both the streaming and not-streaming variations and
+        # ensure their output is the same
+        stream_no, stream_yes = query(False), query(True)
+        self.assertEqual(stream_no, stream_yes)
+        return stream_no
 
 
 if __name__ == '__main__':

--- a/tests/unit/rest_api_httpd.cc
+++ b/tests/unit/rest_api_httpd.cc
@@ -50,7 +50,12 @@ void set_routes(routes& r) {
         query_enum v = str2query_enum(req.query_parameters.at("query_enum"));
         // This demonstrate enum conversion
         obj.enum_var = v;
-        stream_enum is_streaming =str2stream_enum(req.query_parameters.at("stream_enum"));
+
+        std::vector<int> vec123{1, 2, 3};
+        obj.array_var = vec123;
+        obj.chunked_array_var = vec123;
+
+        auto use_streaming = req.query_parameters.at("use_streaming");
 
         if (use_streaming != "false" && use_streaming != "true") {
             throw bad_param_exception("param use_streaming must be true or false");


### PR DESCRIPTION
This series came out of an effort to squash large allocations in a json httpd endpoint in redpanda: the basic idea is to optionally use chunked_fifo instead of std::vector as the underlying type in the json2code generation.

Some other bugs I ran into along the the way are also fixed, and even code that doesn't use chunked_fifo should get some benefits from the addition of move support on the json response hot path.

Test cases added where I thought it made sense.