### PR TITLE
treewide: misc fixes for libc++ 19

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -565,7 +565,7 @@ public:
         }
     }
     int compare(std::basic_string_view<char_type, traits_type> x) const noexcept {
-        auto n = traits_type::compare(begin(), x.begin(), std::min(size(), x.size()));
+        auto n = traits_type::compare(begin(), x.data(), std::min(size(), x.size()));
         if (n != 0) {
             return n;
         }
@@ -584,7 +584,7 @@ public:
         }
 
         sz = std::min(size() - pos, sz);
-        auto n = traits_type::compare(begin() + pos, x.begin(), std::min(sz, x.size()));
+        auto n = traits_type::compare(begin() + pos, x.data(), std::min(sz, x.size()));
         if (n != 0) {
             return n;
         }

--- a/include/seastar/net/toeplitz.hh
+++ b/include/seastar/net/toeplitz.hh
@@ -45,13 +45,13 @@
 
 #ifndef SEASTAR_MODULE
 #include <cstdint>
-#include <string_view>
+#include <span>
 #include <vector>
 #endif
 
 namespace seastar {
 
-using rss_key_type = std::basic_string_view<uint8_t>;
+using rss_key_type = std::span<const uint8_t>;
 
 // Mellanox Linux's driver key
 static constexpr uint8_t default_rsskey_40bytes_v[] = {

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -157,7 +157,7 @@ void log_buf::realloc_buffer_and_append(char c) noexcept {
     _alloc_failure = true;
     std::string_view msg = "(log buffer allocation failure)";
     auto can_copy = std::min(msg.size(), size_t(_current - _begin));
-    std::memcpy(_current - can_copy, msg.begin(), can_copy);
+    std::memcpy(_current - can_copy, msg.data(), can_copy);
   }
 }
 


### PR DESCRIPTION
- **sstring: fixes for lib++ 19**
- **log: fixes for libc++ 19**
- **net: switch rss_key_type to std::span instead of std::string_view**
