### PR TITLE
http/client: Pass abort source by pointer

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -180,7 +180,6 @@ private:
     requires std::invocable<Fn, connection&>
     auto with_new_connection(Fn&& fn, abort_source*);
 
-    future<> do_make_request(request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
     future<> do_make_request(connection& con, request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
 
 public:
@@ -259,33 +258,13 @@ public:
      * \param req -- request to be sent
      * \param handle -- the response handler
      * \param expected -- the optional expected reply status code, default is std::nullopt
+     * \param as -- abort source that aborts the request
      *
      * Note that the handle callback should be prepared to be called more than once, because
      * client may restart the whole request processing in case server closes the connection
      * in the middle of operation
      */
-    future<> make_request(request&& req, reply_handler&& handle, std::optional<reply::status_type>&& expected = std::nullopt);
-
-    /**
-     * \brief Send the request and handle the response (abortable)
-     *
-     * Same as previous method, but aborts the request upon as.request_abort() call
-     *
-     * \param req -- request to be sent
-     * \param handle -- the response handler
-     * \param as -- abort source that aborts the request
-     * \param expected -- the optional expected reply status code, default is std::nullopt
-     */
-    future<> make_request(request&& req, reply_handler&& handle, abort_source& as, std::optional<reply::status_type>&& expected = std::nullopt);
-
-    /**
-     * \brief Send the request and handle the response, same as \ref make_request()
-     *
-     *  @attention Note that the method does not take the ownership of the
-     * `request and the `handle`, it caller's responsibility the make sure they
-     * are referencing valid instances
-     */
-    future<> make_request(request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt);
+    future<> make_request(request&& req, reply_handler&& handle, std::optional<reply::status_type>&& expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Send the request and handle the response (abortable), same as \ref make_request()
@@ -294,7 +273,7 @@ public:
      * `request and the `handle`, it caller's responsibility the make sure they
      * are referencing valid instances
      */
-    future<> make_request(request& req, reply_handler& handle, abort_source& as, std::optional<reply::status_type> expected = std::nullopt);
+    future<> make_request(request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Updates the maximum number of connections a client may have

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1050,7 +1050,7 @@ SEASTAR_TEST_CASE(test_client_abort_new_conn) {
         abort_source as;
         auto f = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
             return make_exception_future<>(std::runtime_error("Shouldn't happen"));
-        }, as, http::reply::status_type::ok);
+        }, http::reply::status_type::ok, &as);
 
         as.request_abort();
         BOOST_REQUIRE_THROW(f.get(), abort_requested_exception);
@@ -1086,7 +1086,7 @@ SEASTAR_TEST_CASE(test_client_abort_cached_conn) {
             abort_source as;
             auto f2 = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
-            }, as, http::reply::status_type::ok);
+            }, http::reply::status_type::ok, &as);
 
             as.request_abort();
             BOOST_REQUIRE_THROW(f2.get(), abort_requested_exception);
@@ -1132,7 +1132,7 @@ SEASTAR_TEST_CASE(test_client_abort_send_request) {
             });
             auto f = cln.make_request(std::move(req), [] (const auto& rep, auto&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
-            }, as, http::reply::status_type::ok);
+            }, http::reply::status_type::ok, &as);
             client_paused.get_future().get();
             as.request_abort();
             client_resume.set_value();
@@ -1166,7 +1166,7 @@ SEASTAR_TEST_CASE(test_client_abort_recv_response) {
             abort_source as;
             auto f = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
-            }, as, http::reply::status_type::ok);
+            }, http::reply::status_type::ok, &as);
             server_paused.get_future().get();
             as.request_abort();
             BOOST_REQUIRE_THROW(f.get(), abort_requested_exception);


### PR DESCRIPTION
Currently the client API suggest passing it by reference and for those, that don't want to abort requests there's 2nd set of calls that don't have abort source at all. Internally the reference is converted into a pointer, and the 2nd set of calls passes nullptr.

At the same time users of this API (scylla S3 client) make the reverse "choice" -- it passes abort source by pointer all the way down to http client and then decides which API to call, with abort source reference or without it.

Fix this mess by making client accept abort source by pointer.