### PR TITLE
test: Add direct exception passing for awaits for perf test

### DIFF
--- a/tests/perf/future_util_perf.cc
+++ b/tests/perf/future_util_perf.cc
@@ -24,6 +24,7 @@
 
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/util/later.hh>
@@ -82,6 +83,25 @@ struct chain {
             co_await std::move(w);
         }
     }
+
+    [[gnu::noinline]]
+    future<std::nullopt_t> do_await_as_future(future<std::nullopt_t> w, int depth = scale) {
+        if (depth > 0) {
+            auto fut = co_await coroutine::as_future<std::nullopt_t>(do_await_as_future(std::move(w), depth - 1));
+            if (fut.failed()) {
+                co_await seastar::coroutine::return_exception_ptr(fut.get_exception());
+            }
+            value += 1;
+            perf_tests::do_not_optimize(value);
+            co_return fut.get();
+        } else {
+            auto fut = co_await coroutine::as_future<std::nullopt_t>(std::move(w));
+            if (fut.failed()) {
+                co_await seastar::coroutine::return_exception_ptr(fut.get_exception());
+            }
+            co_return fut.get();
+        }
+    }
 };
 
 PERF_TEST_F(chain, then_value)
@@ -100,6 +120,14 @@ PERF_TEST_F(chain, await_value)
     return f.then([] { return scale; });
 }
 
+PERF_TEST_F(chain, await_value_as_future)
+{
+    promise<std::nullopt_t> p;
+    auto f = do_await_as_future(p.get_future());
+    p.set_value(std::nullopt);
+    return f.then([](std::nullopt_t) { return scale; });
+}
+
 PERF_TEST_F(chain, then_exception)
 {
     promise<> p;
@@ -115,6 +143,17 @@ PERF_TEST_F(chain, await_exception)
 {
     promise<> p;
     auto f = do_await(p.get_future());
+    p.set_exception(std::runtime_error(""));
+    return f.then_wrapped([] (auto x) {
+        x.ignore_ready_future();
+        return scale;
+    });
+}
+
+PERF_TEST_F(chain, await_exception_as_future)
+{
+    promise<std::nullopt_t> p;
+    auto f = do_await_as_future(p.get_future());
     p.set_exception(std::runtime_error(""));
     return f.then_wrapped([] (auto x) {
         x.ignore_ready_future();


### PR DESCRIPTION
Added direct exception passing case for coroutines. Exception are are passed directly after awaited future has been resolved with return_exception_ptr. This option can be a balance between of need frequent exception passing and convenience of using coroutines. The limitations of a such usage the return_exception_ptr cannot be used with void futures.

test                             iterations      median         mad         min         max      allocs       tasks        inst      cycles
chain.then_value                   33390016    29.930ns     0.198ns    29.257ns    30.128ns       1.031       1.062         0.0         0.0
chain.await_value                  21439200    46.201ns     0.055ns    46.146ns    46.681ns       1.063       1.094         0.0         0.0
chain.await_value_as_future        20355264    48.615ns     0.052ns    48.563ns    48.962ns       1.063       1.094         0.0         0.0
chain.then_exception               32634272    30.095ns     0.041ns    30.001ns    30.565ns       1.063       1.062         0.0         0.0
chain.await_exception                538272     1.813us     8.183ns     1.803us     1.834us       2.125       1.094         0.0         0.0
chain.await_exception_as_future    19190272    52.005ns     0.064ns    51.941ns    54.699ns       1.094       1.094         0.0         0.0