### PR TITLE
tests/unit: Fix exception verification in json2code_test.py

### DIFF
--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -79,11 +79,11 @@ class TestJson2Code(unittest.TestCase):
         with self.assertRaises(urllib.error.HTTPError) as e:
             with urllib.request.urlopen(url):
                 pass
-            ex = e.exception
-            self.assertEqual(ex.code, 404)
-            response = json.loads(ex.read().decode('utf-8'))
-            self.assertEqual(response['message'], 'Not found')
-            self.assertEqual(response['code'], 404)
+        ex = e.exception
+        self.assertEqual(ex.code, 404)
+        response = json.loads(ex.read().decode('utf-8'))
+        self.assertEqual(response['message'], 'Not found')
+        self.assertEqual(response['code'], 404)
 
 
 if __name__ == '__main__':

--- a/tests/unit/json2code_test.py
+++ b/tests/unit/json2code_test.py
@@ -27,6 +27,7 @@ import sys
 import unittest
 import urllib.request
 import urllib.parse
+from http import HTTPStatus
 
 
 class TestJson2Code(unittest.TestCase):
@@ -80,10 +81,10 @@ class TestJson2Code(unittest.TestCase):
             with urllib.request.urlopen(url):
                 pass
         ex = e.exception
-        self.assertEqual(ex.code, 404)
+        self.assertEqual(ex.code, HTTPStatus.NOT_FOUND)
         response = json.loads(ex.read().decode('utf-8'))
         self.assertEqual(response['message'], 'Not found')
-        self.assertEqual(response['code'], 404)
+        self.assertEqual(response['code'], HTTPStatus.NOT_FOUND)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, exception verification code was placed after the function call
within assertRaises(), making it unreachable. This caused the test to
pass without actually verifying the exception details.

Move the verification code outside the assertRaises() block by capturing
the exception first. This ensures the test properly validates both the
exception type and its attributes.

Example:
Before:
```py
  with self.assertRaises(ValueError):
    function_call()
    self.assertEqual(exc.message, "expected message")  # Never executed
```
After:
```py
  with self.assertRaises(ValueError) as e:
    function_call()

  self.assertEqual(e.exception.message, "expected message")  # Executed
```