### PR TITLE
json2code: optimize string handling using std::string_view

### DIFF
--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -273,7 +273,7 @@ def generate_code_from_enum(nickname, type_name, enums):
     name_list = ',\n'.join(f'"{enum}"' for enum in enums)
     parse_func = Template('''\
     $type_name str2$type_name(const sstring& str) {
-        static const sstring arr[] = {
+        static const std::string_view arr[] = {
             $name_list
         };
         int i;


### PR DESCRIPTION
Replace seastar::sstring with std::string_view for enum string literals in generated C++ service code. Since these strings are only used for comparison with HTTP query parameters and don't require modification, std::string_view provides a more lightweight alternative without the overhead of string allocation and copying.

This change improves both runtime performance and memory efficiency of the generated service code.