### PR TITLE
docker: update LLVM debian repo for Ubuntu Orcular migration

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,35 @@
+name: Verify Dockerfile Build
+
+on:
+  pull_request:
+    paths:
+      - 'docker/dev/Dockerfile'
+      - 'install-dependencies.sh'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  build:
+    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docker/dev/Dockerfile
+            install-dependencies.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/dev/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,9 +6,9 @@ RUN --mount=type=bind,source=./install-dependencies.sh,target=/install-dependenc
     apt-get update && apt-get install -y \
     curl \
     gnupg \
-    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-oracular-18 main" \
+    && echo "deb http://apt.llvm.org/oracular/ llvm-toolchain-oracular-18 main" \
     >> /etc/apt/sources.list.d/llvm.list \
-    && echo "deb http://apt.llvm.org/mantic/ llvm-toolchain-oracular-19 main" \
+    && echo "deb http://apt.llvm.org/oracular/ llvm-toolchain-oracular-19 main" \
     >> /etc/apt/sources.list.d/llvm.list \
     && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && apt-get update && apt-get install -y \


### PR DESCRIPTION
When migrating from Ubuntu Matis to Orcular in afea41b1, the LLVM debian package repository configuration wasn't updated accordingly. This caused Docker builds to fail.

This commit updates the repository configuration to match the new Ubuntu Orcular base image.

Fixes #2656