### PR TITLE
build: fix P2582R1 detection in GCC compatibility check

### DIFF
--- a/cmake/CheckP2582R1.cmake
+++ b/cmake/CheckP2582R1.cmake
@@ -8,12 +8,12 @@ set (CMAKE_REQUIRED_FLAGS "-std=c++23")
 # check if the compiler implements the inherited vs non-inherited guide
 # tiebreaker specified by P2582R1, see https://wg21.link/P2582R1
 check_cxx_source_compiles ("
-template <typename T> struct B {
-    B(T) {}
+template <typename... T> struct B {
+    B(T...) {}
 };
 
-template <typename T> struct C : public B<T> {
-    using B<T>::B;
+template <typename... T> struct C : public B<T> {
+    using B<T...>::B;
 };
 
 B(int) -> B<char>;


### PR DESCRIPTION
The current P2582R1 support detection fails with GCC 14.2.0 (Ubuntu) and 14.2.1 (Fedora) because these compilers don't properly handle parameter packs during argument deduction, which is a key part of P2582R1.

Update CheckP2582R1.cmake to use a constructor with parameter packs in its test case, which more accurately reflects P2582R1's requirements. This allows the check to correctly identify incomplete P2582R1 support in:
- GCC 14.2.0 on Ubuntu Oracular
- GCC 14.2.1 on Fedora 41

The previous test was producing false positives, leading to build failures in the RPC tests where tuple argument deduction was attempted.

For the build failure with GCC (Ubuntu 14.2.0-4ubuntu2) packaged for Ubuntu:Oracular:

```
/seastar/tests/unit/rpc_test.cc: In lambda function:
/seastar/tests/unit/rpc_test.cc:1369:89: error: class template argument deduction failed:
 1369 |             return make_ready_future<rpc::tuple<int, long>>(rpc::tuple(1, 0x7'0000'0000L));
      |                                                                                         ^
/seastar/tests/unit/rpc_test.cc:1369:89: error: no matching function for call to 'tuple(int, long int)'
In file included from /seastar/include/seastar/rpc/rpc.hh:36,
                 from /seastar/tests/unit/rpc_test.cc:25:
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note: candidate: 'template<class ... T> tuple(std::tuple<_Ts ...>&&)-> seastar::rpc::tuple<T>'
  401 |     tuple(std::tuple<T...>&& x) : std::tuple<T...>(std::move(x)) {}
      |     ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note:   candidate expects 1 argument, 2 provided
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note: candidate: 'template<class ... T> tuple(seastar::rpc::tuple<T>)-> seastar::rpc::tuple<T>'
  398 | class tuple : public std::tuple<T...> {
      |       ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note:   candidate expects 1 argument, 2 provided
/seastar/tests/unit/rpc_test.cc: At global scope:
/seastar/tests/unit/rpc_test.cc:1567:56: error: class template argument deduction failed:
 1567 | static_assert(std::is_same_v<decltype(rpc::tuple(1U, 1L)), rpc::tuple<unsigned, long>>, "rpc::tuple deduction guid not working");
      |                                                        ^
/seastar/tests/unit/rpc_test.cc:1567:56: error: no matching function for call to 'tuple(unsigned int, long int)'
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note: candidate: 'template<class ... T> tuple(std::tuple<_Ts ...>&&)-> seastar::rpc::tuple<T>'
  401 |     tuple(std::tuple<T...>&& x) : std::tuple<T...>(std::move(x)) {}
      |     ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note:   candidate expects 1 argument, 2 provided
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note: candidate: 'template<class ... T> tuple(seastar::rpc::tuple<T>)-> seastar::rpc::tuple<T>'
  398 | class tuple : public std::tuple<T...> {
      |       ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note:   candidate expects 1 argument, 2 provided
/seastar/tests/unit/rpc_test.cc:1567:56: error: class template argument deduction failed:
 1567 | static_assert(std::is_same_v<decltype(rpc::tuple(1U, 1L)), rpc::tuple<unsigned, long>>, "rpc::tuple deduction guid not working");
      |                                                        ^
/seastar/tests/unit/rpc_test.cc:1567:56: error: no matching function for call to 'tuple(unsigned int, long int)'
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note: candidate: 'template<class ... T> tuple(std::tuple<_Ts ...>&&)-> seastar::rpc::tuple<T>'
  401 |     tuple(std::tuple<T...>&& x) : std::tuple<T...>(std::move(x)) {}
      |     ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:401:5: note:   candidate expects 1 argument, 2 provided
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note: candidate: 'template<class ... T> tuple(seastar::rpc::tuple<T>)-> seastar::rpc::tuple<T>'
  398 | class tuple : public std::tuple<T...> {
      |       ^~~~~
/seastar/include/seastar/rpc/rpc_types.hh:398:7: note:   candidate expects 1 argument, 2 provided
/seastar/tests/unit/rpc_test.cc:1567:85: error: template argument 1 is invalid
 1567 | static_assert(std::is_same_v<decltype(rpc::tuple(1U, 1L)), rpc::tuple<unsigned, long>>, "rpc::tuple deduction guid not working");
      |                                                                                     ^~
In file included from /seastar/include/seastar/core/scheduling.hh:31,
                 from /seastar/include/seastar/core/task.hh:24,
                 from /seastar/include/seastar/core/future.hh:36,
                 from /seastar/include/seastar/core/iostream.hh:38,
                 from /seastar/tests/unit/loopback_socket.hh:26,
                 from /seastar/tests/unit/rpc_test.cc:22:
```

Refs #2445