### PR TITLE
doc: Update documentation after removing build.sh

### DIFF
--- a/doc/building-docker.md
+++ b/doc/building-docker.md
@@ -20,16 +20,3 @@ $ seabuild() { docker run -v $HOME/seastar/:/seastar -u $(id -u):$(id -g) -w /se
 $ seabuild ./configure.py
 $ seabuild ninja -C build/release
 ```
-
-Alternatively there's a `scripts/build.sh` script with the usage of
-
-```
-build.sh <mode> [<compiler>] [<compiler version>] [<c++ dialect>]
-```
-
-that will do the above steps itself, e.g. the above example would be like
-
-```
-$ scripts/build.sh release
-```
-

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -85,7 +85,8 @@ To compile this program (it's present in the `demos/hello-world.cc` file) you ca
 
 ```
 $ docker build -t seastar-dev  -f ./docker/dev/Dockerfile .
-$ scripts/build.sh dev
+$ docker run -it --rm -v $(pwd):/seastar seastar-dev /seastar/configure --mode=dev --cook=c-ares
+$ docker run -it --rm -v $(pwd):/seastar seastar-dev ninja -C /seastar/build/dev
 $ docker run -it --rm -v $(pwd):/seastar seastar-dev /seastar/build/dev/demos/hello-world_demo -c1
 ```
 


### PR DESCRIPTION
In 5634985c, scripts/build.sh was removed, but related documentation wasn’t updated. This change revises the docs to reflect that removal. Additionally, to address c-ares incompatibility in the container image, the updated command in doc/tutorial.md now builds a compatible c-ares version from source.