### PR TITLE
file, scheduling_specific, memory: fix build failures with musl libc

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -36,6 +36,7 @@
 #ifndef SEASTAR_MODULE
 #include <sys/statvfs.h>
 #include <sys/ioctl.h>
+#include <sys/types.h>
 #include <linux/fs.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -65,7 +66,7 @@ struct directory_entry {
 struct group_details {
     sstring group_name;
     sstring group_passwd;
-    __gid_t group_id;
+    gid_t group_id;
     std::vector<sstring> group_members;
 };
 

--- a/include/seastar/core/scheduling_specific.hh
+++ b/include/seastar/core/scheduling_specific.hh
@@ -25,6 +25,7 @@
 #include <seastar/util/assert.hh>
 #include <seastar/util/modules.hh>
 #include <array>
+#include <cstdlib>
 #include <map>
 #include <typeindex>
 #include <vector>
@@ -44,6 +45,10 @@ struct scheduling_group_specific_thread_local_data {
     struct specific_val {
         val_ptr valp;
         cfg_ptr cfg;
+
+        static void free(void* ptr) noexcept {
+            std::free(ptr);
+        }
 
         specific_val() : valp(nullptr, &free), cfg(nullptr) {}
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2365,11 +2365,13 @@ int __libc_posix_memalign(void** ptr, size_t align, size_t size) noexcept;
 extern "C"
 [[gnu::visibility("default")]]
 [[gnu::malloc]]
-#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 30)
+#if defined(__GLIBC__)
+#if __GLIBC_PREREQ(2, 30)
 [[gnu::alloc_size(2)]]
 #endif
-#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 35)
+#if __GLIBC_PREREQ(2, 35)
 [[gnu::alloc_align(1)]]
+#endif
 #endif
 void* memalign(size_t align, size_t size) noexcept {
     if (try_trigger_error_injector()) {
@@ -2392,11 +2394,13 @@ extern "C"
 [[gnu::alias("memalign")]]
 [[gnu::visibility("default")]]
 [[gnu::malloc]]
-#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 30)
+#if defined(__GLIBC__)
+#if __GLIBC_PREREQ(2, 30)
 [[gnu::alloc_size(2)]]
 #endif
-#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 35)
+#if __GLIBC_PREREQ(2, 35)
 [[gnu::alloc_align(1)]]
+#endif
 #endif
 void* __libc_memalign(size_t align, size_t size) noexcept;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4900,7 +4900,7 @@ allocate_scheduling_group_specific_data(scheduling_group sg, unsigned long key_i
     using val_ptr = internal::scheduling_group_specific_thread_local_data::val_ptr;
     using specific_val = internal::scheduling_group_specific_thread_local_data::specific_val;
 
-    val_ptr valp(aligned_alloc(cfg->alignment, cfg->allocation_size), &free);
+    val_ptr valp(aligned_alloc(cfg->alignment, cfg->allocation_size), &specific_val::free);
     if (!valp) {
         throw std::runtime_error("memory allocation failed");
     }


### PR DESCRIPTION
This pull request contains a series of improvements to address the build failures with musl libc.

- file: Replace `__gid_t` with standard POSIX `gid_t`
- scheduling_specific: Add `noexcept` wrapper for `free()`
- memory: guard `__GLIBC_PREREQ` usage with `__GLIBC__` check

Fixes #2667