### PR TITLE
util: logger: remove deprecated set_stdout_enabled and logger_ostream

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -450,10 +450,6 @@ public:
     /// Also output to ostream. default is true
     static void set_ostream_enabled(bool enabled) noexcept;
 
-    /// Also output to stdout. default is true
-    [[deprecated("Use set_ostream_enabled instead")]]
-    static void set_stdout_enabled(bool enabled) noexcept;
-
     /// Also output to syslog. default is false
     ///
     /// NOTE: syslog() can block, which will stall the reactor thread.
@@ -539,10 +535,6 @@ enum class logger_timestamp_style {
 /// \brief Output stream to use for logging.
 enum class logger_ostream_type {
     none,
-#ifdef SEASTAR_LOGGER_TYPE_STDOUT
-    stdout __attribute__ ((deprecated ("use cout instead"))) = 1,
-    stderr __attribute__ ((deprecated ("use cerr instead"))) = 2,
-#endif
     cout = 1,
     cerr = 2,
 };

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -410,11 +410,6 @@ logger::set_ostream_enabled(bool enabled) noexcept {
 }
 
 void
-logger::set_stdout_enabled(bool enabled) noexcept {
-    _ostream.store(enabled, std::memory_order_relaxed);
-}
-
-void
 logger::set_syslog_enabled(bool enabled) noexcept {
     _syslog.store(enabled, std::memory_order_relaxed);
 }


### PR DESCRIPTION

Deprecated since 2019 and 2023.