### PR TITLE
tests: relax test_file_system_space check for empty filesystems

### DIFF
--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -959,8 +959,8 @@ SEASTAR_TEST_CASE(test_file_system_space) {
         auto si = file_system_space(name).get();
 
         BOOST_REQUIRE_EQUAL(st.f_blocks * st.f_frsize, si.capacity);
-        BOOST_REQUIRE_LT(si.free, si.capacity);
-        BOOST_REQUIRE_LT(si.available, si.capacity);
+        BOOST_REQUIRE_LE(si.free, si.capacity);
+        BOOST_REQUIRE_LE(si.available, si.capacity);
         BOOST_REQUIRE_LE(si.available, si.free);
     });
 }


### PR DESCRIPTION
When statvfs reports information about a mounted filesystem, it populates a structure with several fields including:

- f_blocks: the total data blocks in the filesystem
- f_bfree: the available free blocks

On empty filesystems or those containing only empty files/directories, f_blocks and f_bfree can be identical since empty files and directories in Linux typically only consume inodes rather than data blocks.

This was causing test failures on Linux systems with no non-empty files under "/tmp":

```
/home/kefu/dev/seastar/tests/unit/file_io_test.cc(962): fatal error: in "test_file_system_space": critical check si.free < si.capacity has failed [100030640128 >= 100030640128]
```

This change relaxes the test to accommodate filesystems where all blocks are free, preventing false failures when "/tmp" contains no actual file data.