### PR TITLE
rpc: remove deprecated logging function support

### DIFF
--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1542,15 +1542,6 @@ SEASTAR_TEST_CASE(test_loggers) {
         proto.set_logger(&log);
         logger(dummy_addr, "Hello2");
         logger(dummy_addr, log_level::debug, "Hello3");
-        // We *want* to test the deprecated API, don't spam warnings about it.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        proto.set_logger([] (const sstring& str) {
-            log.info("Test: {}", str);
-        });
-#pragma GCC diagnostic pop
-        logger(dummy_addr, "Hello4");
-        logger(dummy_addr, log_level::debug, "Hello5");
         proto.set_logger(nullptr);
         logger(dummy_addr, "Hello6");
         logger(dummy_addr, log_level::debug, "Hello7");


### PR DESCRIPTION
rpc switched to logging via a seastar::logger 5 years ago, so remove the deprecated older method.