### PR TITLE
fstream: Export functions for making file_data_source

### DIFF
--- a/include/seastar/core/fstream.hh
+++ b/include/seastar/core/fstream.hh
@@ -93,6 +93,12 @@ input_stream<char> make_file_input_stream(
 input_stream<char> make_file_input_stream(
         file file, file_input_stream_options = {});
 
+/// Create a data_source for reading the given offset:len range from the file
+data_source make_file_data_source(file, uint64_t offset, uint64_t len, file_input_stream_options);
+
+/// Create a data_source for reading the whole file from start to end
+data_source make_file_data_source(file, file_input_stream_options);
+
 struct file_output_stream_options {
     // For small files, setting preallocation_size can make it impossible for XFS to find
     // an aligned extent. On the other hand, without it, XFS will divide the file into

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -342,17 +342,17 @@ private:
     }
 };
 
-class file_data_source : public data_source {
-public:
-    file_data_source(file f, uint64_t offset, uint64_t len, file_input_stream_options options)
-        : data_source(std::make_unique<file_data_source_impl>(
-                std::move(f), offset, len, options)) {}
-};
+data_source make_file_data_source(file f, uint64_t offset, uint64_t len, file_input_stream_options opt) {
+    return data_source(std::make_unique<file_data_source_impl>(std::move(f), offset, len, std::move(opt)));
+}
 
+data_source make_file_data_source(file f, file_input_stream_options opt) {
+    return make_file_data_source(std::move(f), 0, std::numeric_limits<uint64_t>::max(), std::move(opt));
+}
 
 input_stream<char> make_file_input_stream(
         file f, uint64_t offset, uint64_t len, file_input_stream_options options) {
-    return input_stream<char>(file_data_source(std::move(f), offset, len, std::move(options)));
+    return input_stream<char>(make_file_data_source(std::move(f), offset, len, std::move(options)));
 }
 
 input_stream<char> make_file_input_stream(


### PR DESCRIPTION
This is to facilitate making different sources depending on the actual file "type" and letting the caller wrap it into the input_stream().

Symmetrical make_file_data_sink was introduced by 52e0a763e87, not it's file_data_source turn.

Previous attempt to help file->source/sink conversion was #1419