### PR TITLE
tests: enable/disable internet-dependent tests at runtime

### DIFF
--- a/tests/unit/dns_test.cc
+++ b/tests/unit/dns_test.cc
@@ -63,15 +63,20 @@ static future<> test_bad_name(dns_resolver::options opts) {
     });
 }
 
-SEASTAR_TEST_CASE(test_resolve_udp) {
+using enable_if_with_networking = boost::unit_test::enable_if<SEASTAR_TESTING_WITH_NETWORKING>;
+
+SEASTAR_TEST_CASE(test_resolve_udp,
+                  *enable_if_with_networking()) {
     return test_resolve(dns_resolver::options());
 }
 
-SEASTAR_TEST_CASE(test_bad_name_udp) {
+SEASTAR_TEST_CASE(test_bad_name_udp,
+                  *enable_if_with_networking()) {
     return test_bad_name(dns_resolver::options());
 }
 
-SEASTAR_TEST_CASE(test_timeout_udp) {
+SEASTAR_TEST_CASE(test_timeout_udp,
+                  *enable_if_with_networking()) {
     dns_resolver::options opts;
     opts.servers = std::vector<inet_address>({ inet_address("1.2.3.4") }); // not a server
     opts.udp_port = 29953; // not a dns port
@@ -114,13 +119,15 @@ SEASTAR_TEST_CASE(test_connection_refused_tcp) {
     });
 }
 
-SEASTAR_TEST_CASE(test_resolve_tcp) {
+SEASTAR_TEST_CASE(test_resolve_tcp,
+                  *enable_if_with_networking()) {
     dns_resolver::options opts;
     opts.use_tcp_query = true;
     return test_resolve(opts);
 }
 
-SEASTAR_TEST_CASE(test_bad_name_tcp) {
+SEASTAR_TEST_CASE(test_bad_name_tcp,
+                  *enable_if_with_networking()) {
     dns_resolver::options opts;
     opts.use_tcp_query = true;
     return test_bad_name(opts);
@@ -148,12 +155,14 @@ static future<> test_srv() {
     });
 }
 
-SEASTAR_TEST_CASE(test_srv_tcp) {
+SEASTAR_TEST_CASE(test_srv_tcp,
+                  *enable_if_with_networking()) {
     return test_srv();
 }
 
 
-SEASTAR_TEST_CASE(test_parallel_resolve_name) {
+SEASTAR_TEST_CASE(test_parallel_resolve_name,
+                  *enable_if_with_networking()) {
     dns_resolver::options opts;
     opts.use_tcp_query = true;
 
@@ -168,7 +177,8 @@ SEASTAR_TEST_CASE(test_parallel_resolve_name) {
     ).finally([d](auto&&...) {}).discard_result();
 }
 
-SEASTAR_TEST_CASE(test_parallel_resolve_name_udp) {
+SEASTAR_TEST_CASE(test_parallel_resolve_name_udp,
+                  *enable_if_with_networking()) {
     dns_resolver::options opts;
 
     auto d = ::make_lw_shared<dns_resolver>(std::move(opts));

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -130,7 +130,7 @@ static future<> connect_to_ssl_google(::shared_ptr<tls::certificate_credentials>
     });
 }
 
-SEASTAR_TEST_CASE(test_simple_x509_client) {
+SEASTAR_TEST_CASE(test_simple_x509_client_with_google) {
     auto certs = ::make_shared<tls::certificate_credentials>();
     return certs->set_x509_trust_file(certfile("tls-ca-bundle.pem"), tls::x509_crt_format::PEM).then([certs]() {
         return connect_to_ssl_google(certs);
@@ -272,7 +272,7 @@ public:
 
 #if !SEASTAR_TESTING_WITH_NETWORKING
 
-SEASTAR_THREAD_TEST_CASE(test_simple_x509_client) {
+SEASTAR_THREAD_TEST_CASE(test_simple_x509_client_with_local_server) {
     auto certs = ::make_shared<tls::certificate_credentials>();
     https_server server;
     certs->set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();


### PR DESCRIPTION
Previously, some tests in dns_test.cc and tls_test.cc that required internet connectivity were conditionally compiled using `#if SEASTAR_TESTING_WITH_NETWORKING`. However, several other internet-dependent tests were not properly disabled,
causing test failures in environments without internet access.

This change:
- Replaces compile-time guards with runtime conditional execution using `boost::unit_test::enable_if<SEASTAR_TESTING_WITH_NETWORKING>` for tests requiring internet
- Uses `boost::unit_test::enable_if<!SEASTAR_TESTING_WITH_NETWORKING>` for alternative tests that provide equivalent coverage without internet access

This approach improves maintainability, enables running the test suite in offline environments, and makes internet dependencies more explicit in the test code.