### PR TITLE
demos/tcp_sctp_server_demo:  Modernize with seastar::async and proper teardown

### DIFF
--- a/demos/tcp_sctp_server_demo.cc
+++ b/demos/tcp_sctp_server_demo.cc
@@ -24,8 +24,11 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/print.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/util/closeable.hh>
 #include <vector>
 #include <iostream>
+#include "../apps/lib/stop_signal.hh"
 
 using namespace seastar;
 
@@ -45,6 +48,9 @@ static bool enable_sctp = false;
 class tcp_server {
     std::vector<server_socket> _tcp_listeners;
     std::vector<server_socket> _sctp_listeners;
+    std::optional<future<>> _tcp_task;
+    std::optional<future<>> _sctp_task;
+
 public:
     future<> listen(ipv4_addr addr) {
         if (enable_tcp) {
@@ -52,7 +58,7 @@ public:
             lo.proto = transport::TCP;
             lo.reuse_address = true;
             _tcp_listeners.push_back(seastar::listen(make_ipv4_address(addr), lo));
-            do_accepts(_tcp_listeners);
+            _tcp_task = do_accepts(_tcp_listeners);
         }
 
         if (enable_sctp) {
@@ -60,20 +66,20 @@ public:
             lo.proto = transport::SCTP;
             lo.reuse_address = true;
             _sctp_listeners.push_back(seastar::listen(make_ipv4_address(addr), lo));
-            do_accepts(_sctp_listeners);
+            _sctp_task = do_accepts(_sctp_listeners);
         }
         return make_ready_future<>();
     }
 
-    // FIXME: We should properly tear down the service here.
     future<> stop() {
-        return make_ready_future<>();
+        co_await do_stop(_tcp_listeners, _tcp_task);
+        co_await do_stop(_sctp_listeners, _sctp_task);
     }
 
-    void do_accepts(std::vector<server_socket>& listeners) {
+    future<> do_accepts(std::vector<server_socket>& listeners) {
         int which = listeners.size() - 1;
         // Accept in the background.
-        (void)listeners[which].accept().then([this, &listeners] (accept_result ar) mutable {
+        return listeners[which].accept().then([this, &listeners] (accept_result ar) mutable {
             connected_socket fd = std::move(ar.connection);
             socket_address addr = std::move(ar.remote_address);
             auto conn = new connection(*this, std::move(fd), addr);
@@ -85,7 +91,7 @@ public:
                     std::cout << "request error " << ex.what() << "\n";
                 }
             });
-            do_accepts(listeners);
+            return do_accepts(listeners);
         }).then_wrapped([] (auto&& f) {
             try {
                 f.get();
@@ -94,6 +100,16 @@ public:
             }
         });
     }
+
+    static future<> do_stop(std::vector<server_socket>& listeners, std::optional<future<>>& task) {
+        for (auto& listener : listeners) {
+            listener.abort_accept();
+        }
+        if (auto fut = std::exchange(task, {})) {
+            co_await std::move(*fut);
+        }
+    }
+
     class connection {
         connected_socket _fd;
         input_stream<char> _read_buf;
@@ -182,24 +198,27 @@ int main(int ac, char** av) {
         ("port", bpo::value<uint16_t>()->default_value(10000), "TCP server port")
         ("tcp", bpo::value<std::string>()->default_value("yes"), "tcp listen")
         ("sctp", bpo::value<std::string>()->default_value("no"), "sctp listen") ;
-    return app.run_deprecated(ac, av, [&] {
-        auto&& config = app.configuration();
-        uint16_t port = config["port"].as<uint16_t>();
-        enable_tcp = config["tcp"].as<std::string>() == "yes";
-        enable_sctp = config["sctp"].as<std::string>() == "yes";
-        if (!enable_tcp && !enable_sctp) {
-            fmt::print(std::cerr, "Error: no protocols enabled. Use \"--tcp yes\" and/or \"--sctp yes\" to enable\n");
-            return engine().exit(1);
-        }
-        auto server = new distributed<tcp_server>;
-        (void)server->start().then([server = std::move(server), port] () mutable {
-            engine().at_exit([server] {
-                return server->stop();
-            });
+    return app.run(ac, av, [&] {
+        return async([&app] {
+            seastar_apps_lib::stop_signal stop_signal;
+
+            auto&& config = app.configuration();
+            uint16_t port = config["port"].as<uint16_t>();
+            enable_tcp = config["tcp"].as<std::string>() == "yes";
+            enable_sctp = config["sctp"].as<std::string>() == "yes";
+            if (!enable_tcp && !enable_sctp) {
+                fmt::print(std::cerr, "Error: no protocols enabled. Use \"--tcp yes\" and/or \"--sctp yes\" to enable\n");
+                return 1;
+            }
+            distributed<tcp_server> server;
+            server.start().get();
+            auto stop_server = deferred_stop(server);
             // Start listening in the background.
-            (void)server->invoke_on_all(&tcp_server::listen, ipv4_addr{port});
-        }).then([port] {
-            std::cout << "Seastar TCP server listening on port " << port << " ...\n";
+            server.invoke_on_all(&tcp_server::listen, ipv4_addr{port}).get();
+            fmt::print("Seastar TCP server listening on port {} ...\n", port);
+
+            stop_signal.wait().get();
+            return 0;
         });
     });
 }


### PR DESCRIPTION
Replace deprecated at_exit() with the recommended seastar::async + defer() pattern. This change:

- Captures background task future as member variable for proper cleanup
- Implements complete service teardown sequence (abort accept → wait for task)
- Upgrades to app.run() from deprecated app.run_deprecated()
- Uses stop_signal for clean shutdown handling

The demo now follows current Seastar best practices for initialization, resource management, and graceful termination.
stop using at_exit().

Ref eefe659521. which deprecated `at_exit()`.