### PR TITLE
build: Include DPDK dependency libraries in Seastar linkage

### DIFF
--- a/cmake/Finddpdk.cmake
+++ b/cmake/Finddpdk.cmake
@@ -184,9 +184,9 @@ if (dpdk_FOUND AND NOT (TARGET dpdk))
         INTERFACE_LINK_LIBRARIES "${dpdk_dependencies}"
         IMPORTED_OBJECTS ${dpdk_object_path}
         ${compile_options})
-    # we include dpdk in seastar already, so no need to expose it with
-    # dpdk_LIBRARIES
-    set (dpdk_LIBRARIES "")
+    # we include dpdk in seastar already, but we need to pull in the
+    # dependency libraries linked by dpdk
+    list(TRANSFORM dpdk_dependencies PREPEND "-l" OUTPUT_VARIABLE dpdk_LIBRARIES)
     add_library (DPDK::dpdk ALIAS dpdk)
   else ()
     set (dpdk_LIBRARIES ${dpdk_PC_LDFLAGS})


### PR DESCRIPTION
In commit f62d1c70, we removed numa from Seastar's linkage. However, DPDK still links against it, causing linkage failures in Seastar applications built with DPDK enabled. For example:

```
ld.lld: error: undefined symbol: numa_available
>>> referenced by sfc_efx_mcdi.c
>>>               dpdk.o:(eal_memalloc_alloc_seg_bulk) in archive /jenkins/workspace/scylla-master/scylla-ci/scylla/build/release/seastar/libseastar.a
```

The issue stems from the `seastar.pc` file, which did not include the necessary linked libraries. Previously, the `dpdk_LIBRARIES` variable used for interpolation was reset when static DPDK libraries were found, omitting critical dependencies.

This change updates the build process to properly incorporate the dependency libraries linked by DPDK via `dpdk_LIBRARIES`, ensuring successful linkage for Seastar applications.

Refs f62d1c70
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>