### PR TITLE
net/udp: fix ipv4_udp::next_port calculation

### DIFF
--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -212,7 +212,7 @@ void ipv4_udp::send(uint16_t src_port, ipv4_addr dst, packet &&p)
 }
 
 uint16_t ipv4_udp::next_port(uint16_t port) {
-    return (port + 1) == 0 ? min_anonymous_port : port + 1;
+    return (port == std::numeric_limits<decltype(port)>::max()) ? min_anonymous_port : port + 1;
 }
 
 udp_channel


### PR DESCRIPTION
Anonymous ports counting starts from `ipv4_udp::min_anonymous_port = 32768`. If all channels until max uint16_t have been occupied already, ipv4_udp::next_port method will wrap around. Original ternary operator uses `(port + 1) == 0`, which won't work for uint16_t, because `port` will be first promoted to int, thus 0xFFFF+1, becomes 0x10000 != 0, thus method returns 0, instead of ipv4_udp::min_anonymous_port.

This commit fixes aforementioned issue changing ternary operator with check for reaching maximum uint16_t.