### PR TITLE
smp: prefault: decouple _stop_request from join_threads

### DIFF
--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -231,7 +231,6 @@ internal::memory_prefaulter::memory_prefaulter(alien::instance& alien, const res
 
 void
 internal::memory_prefaulter::join_threads() noexcept {
-    _stop_request.store(true, std::memory_order_relaxed);
     for (auto& t : _worker_threads) {
         t.join();
     }
@@ -239,6 +238,7 @@ internal::memory_prefaulter::join_threads() noexcept {
 }
 
 internal::memory_prefaulter::~memory_prefaulter() {
+    _stop_request.store(true, std::memory_order_relaxed);
     join_threads();
 }
 


### PR DESCRIPTION
Requesting the prefaulter to stop is logically separate from joining the threads. Thus, join_threads shouldn't impose a stop request. In the current implementation, it has no effect, but it can cause problems in the future if join _threads is used differently (like stop before finish where not intended).