### PR TITLE
Improve log output in reactor-stalled situations

### DIFF
--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -166,6 +166,8 @@ private:
             return _head != _tail;
         }
     };
+
+    virtual void maybe_report_kernel_trace() override;
 public:
     static std::unique_ptr<cpu_stall_detector_linux_perf_event> try_make(cpu_stall_detector_config cfg = {});
     explicit cpu_stall_detector_linux_perf_event(file_desc fd, cpu_stall_detector_config cfg = {});
@@ -173,7 +175,6 @@ public:
     virtual void arm_timer() override;
     virtual void start_sleep() override;
     virtual bool is_spurious_signal() override;
-    virtual void maybe_report_kernel_trace() override;
 };
 
 std::unique_ptr<cpu_stall_detector> make_cpu_stall_detector(cpu_stall_detector_config cfg = {});

--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -40,6 +40,7 @@ namespace seastar {
 
 class reactor;
 class thread_cputime_clock;
+class backtrace_buffer;
 
 namespace internal {
 
@@ -73,7 +74,7 @@ protected:
     virtual bool is_spurious_signal() {
         return false;
     }
-    virtual void maybe_report_kernel_trace() {}
+    virtual void maybe_report_kernel_trace(backtrace_buffer& buf) {}
 private:
     void maybe_report();
     virtual void arm_timer() = 0;
@@ -167,7 +168,7 @@ private:
         }
     };
 
-    virtual void maybe_report_kernel_trace() override;
+    virtual void maybe_report_kernel_trace(backtrace_buffer& buf) override;
 public:
     static std::unique_ptr<cpu_stall_detector_linux_perf_event> try_make(cpu_stall_detector_config cfg = {});
     explicit cpu_stall_detector_linux_perf_event(file_desc fd, cpu_stall_detector_config cfg = {});

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -848,7 +848,6 @@ static void print_with_backtrace(backtrace_buffer& buf, bool oneline) noexcept {
     buf.append_backtrace_oneline();
     buf.append("\n");
   }
-    buf.flush();
 }
 
 static void print_with_backtrace(const char* cause, bool oneline = false) noexcept {
@@ -1223,7 +1222,6 @@ void cpu_stall_detector::report_suppressions(sched_clock::time_point now) {
             buf.append(" on shard ");
             buf.append_decimal(_shard_id);
             buf.append("\n");
-            buf.flush();
         }
         reset_suppression_state(now);
     }
@@ -1360,7 +1358,6 @@ cpu_stall_detector_linux_perf_event::maybe_report_kernel_trace(backtrace_buffer&
             }
             buf.append("\n");
         }
-        buf.flush();
     };
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -767,9 +767,16 @@ class backtrace_buffer {
     unsigned _pos = 0;
     char _buf[_max_size];
 public:
+    backtrace_buffer() = default;
+    ~backtrace_buffer() {
+        flush();
+    }
+
     void flush() noexcept {
-        print_safe(_buf, _pos);
-        _pos = 0;
+        if (_pos > 0) {
+            print_safe(_buf, _pos);
+            _pos = 0;
+        }
     }
 
     void reserve(size_t len) noexcept {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -772,6 +772,12 @@ public:
         flush();
     }
 
+    // copying / moving 2^13 bytes not useful, compiler will help us here
+    backtrace_buffer(const backtrace_buffer &) = delete;
+    backtrace_buffer(backtrace_buffer &&) = delete;
+    backtrace_buffer &operator = (const backtrace_buffer &) = delete;
+    backtrace_buffer &operator = (backtrace_buffer &&) = delete;
+
     void flush() noexcept {
         if (_pos > 0) {
             print_safe(_buf, _pos);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1330,7 +1330,7 @@ cpu_stall_detector_linux_perf_event::is_spurious_signal() {
 }
 
 void
-cpu_stall_detector_linux_perf_event::maybe_report_kernel_trace() {
+cpu_stall_detector_linux_perf_event::maybe_report_kernel_trace(backtrace_buffer& buf) {
     data_area_reader reader(*this);
     auto current_record = [&] () -> ::perf_event_header {
         return reader.read_struct<perf_event_header>();
@@ -1345,7 +1345,6 @@ cpu_stall_detector_linux_perf_event::maybe_report_kernel_trace() {
         }
 
         auto nr = reader.read_u64();
-        backtrace_buffer buf;
         if (nr > 0) {
             buf.append("kernel callstack:");
             for (uint64_t i = 0; i < nr; ++i) {
@@ -1442,7 +1441,7 @@ void cpu_stall_detector::generate_trace() {
     buf.append_decimal(uint64_t(delta / 1ms));
     buf.append(" ms");
     print_with_backtrace(buf, _config.oneline);
-    maybe_report_kernel_trace();
+    maybe_report_kernel_trace(buf);
 }
 
 } // internal namespace

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1346,12 +1346,14 @@ cpu_stall_detector_linux_perf_event::maybe_report_kernel_trace() {
 
         auto nr = reader.read_u64();
         backtrace_buffer buf;
-        buf.append("kernel callstack:");
-        for (uint64_t i = 0; i < nr; ++i) {
-            buf.append(" 0x");
-            buf.append_hex(uintptr_t(reader.read_u64()));
+        if (nr > 0) {
+            buf.append("kernel callstack:");
+            for (uint64_t i = 0; i < nr; ++i) {
+                buf.append(" 0x");
+                buf.append_hex(uintptr_t(reader.read_u64()));
+            }
+            buf.append("\n");
         }
-        buf.append("\n");
         buf.flush();
     };
 }


### PR DESCRIPTION
- fix `backtrace_buffer` class to print log on destruction, if the log wasn't printed before (this is what comment suggests should happen)
- `maybe_report_kernel_trace` function will be now called with `backtrace_buffer` object allocated by caller. This will "glue" kernel trace to the rest of the log, making sure the output stays together in the log file.
- `maybe_report_kernel_trace` function will no longer print empty `kernel callstack: ` messages.