### PR TITLE
change format to sesatar::format

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -676,7 +676,7 @@ auto recv_helper(signature<Ret (InArgs...)> sig, Func&& func, WantClientInfo, Wa
             // FIXME: future is discarded
             (void)try_with_gate(client->get_server().reply_gate(), [client, timeout, msg_id, err = std::move(err)] {
                 return reply<Serializer>(wait_style(), futurize<Ret>::make_exception_future(std::runtime_error(err.c_str())), msg_id, client, timeout, std::nullopt).handle_exception([client, msg_id] (std::exception_ptr eptr) {
-                    client->get_logger()(client->info(), msg_id, format("got exception while processing an oversized message: {}", eptr));
+                    client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing an oversized message: {}", eptr));
                 });
             }).handle_exception_type([] (gate_closed_exception&) {/* ignore */});
             return make_ready_future();
@@ -690,11 +690,11 @@ auto recv_helper(signature<Ret (InArgs...)> sig, Func&& func, WantClientInfo, Wa
                         auto start = rpc_clock_type::now();
                         return apply(func, client->info(), timeout, WantClientInfo(), WantTimePoint(), signature(), std::move(args)).then_wrapped([client, timeout, msg_id, permit = std::move(permit), start] (futurize_t<Ret> ret) mutable {
                             return reply<Serializer>(wait_style(), std::move(ret), msg_id, client, timeout, rpc_clock_type::now() - start).handle_exception([permit = std::move(permit), client, msg_id] (std::exception_ptr eptr) {
-                                client->get_logger()(client->info(), msg_id, format("got exception while processing a message: {}", eptr));
+                                client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing a message: {}", eptr));
                             });
                         });
                     } catch (...) {
-                        client->get_logger()(client->info(), msg_id, format("caught exception while processing a message: {}", std::current_exception()));
+                        client->get_logger()(client->info(), msg_id, seastar::format("caught exception while processing a message: {}", std::current_exception()));
                         return make_ready_future();
                     }
                 }).handle_exception_type([g = std::move(g)] (gate_closed_exception&) {/* ignore */});

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -230,7 +230,7 @@ static void shutdown_socket_fd(pollable_fd& fd, int how) noexcept {
         // EBADF (invalid file descriptor) -- irretrievable
         fd.shutdown(how);
     } catch (...) {
-        on_internal_error(seastar_logger, format("socket shutdown({}, {}) failed: {}", fd.get_file_desc().fdinfo(), how, std::current_exception()));
+        on_internal_error(seastar_logger, seastar::format("socket shutdown({}, {}) failed: {}", fd.get_file_desc().fdinfo(), how, std::current_exception()));
     }
 }
 


### PR DESCRIPTION
Fixes the libc++ build.

The bare format call is ambiguous in the presence of std::format. This fails on libc++, but maybe not libstd++ because it depends on whether std::format actually gets included in the file in question which is not defined and may vary by implementation.