### PR TITLE
smp: prefault: clear memory map after threads join

### DIFF
--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -235,6 +235,7 @@ internal::memory_prefaulter::join_threads() noexcept {
         t.join();
     }
     _worker_threads.clear();
+    _layout_by_node_id.clear();
 }
 
 internal::memory_prefaulter::~memory_prefaulter() {


### PR DESCRIPTION
On memory prefaulter, it is safe and logical to also clear the memory range map after the threads are joined, because the map is not accessed post join and is tighly coupled to the threads work.