### PR TITLE
future: Move report_failed_future to internal namespace

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -207,10 +207,6 @@ SEASTAR_MODULE_EXPORT_END
 /// \cond internal
 void engine_exit(std::exception_ptr eptr = {});
 
-void report_failed_future(const std::exception_ptr& ex) noexcept;
-
-void report_failed_future(const future_state_base& state) noexcept;
-
 /// \endcond
 
 /// \brief Exception type for broken promises
@@ -534,11 +530,16 @@ public:
     friend struct futurize;
 };
 
+namespace internal {
+void report_failed_future(const std::exception_ptr& ex) noexcept;
+void report_failed_future(const future_state_base& state) noexcept;
 void report_failed_future(future_state_base::any&& state) noexcept;
+} // internal namespace
+
 
 inline void future_state_base::any::check_failure() noexcept {
     if (failed()) {
-        report_failed_future(std::move(*this));
+        internal::report_failed_future(std::move(*this));
     }
 }
 
@@ -804,7 +805,7 @@ protected:
             // copy of ex and warn in the promise destructor.
             // Since there isn't any way for the user to clear
             // the exception, we issue the warning from here.
-            report_failed_future(val);
+            internal::report_failed_future(val);
         }
     }
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -660,7 +660,7 @@ private:
     friend class scheduling_group;
     friend void internal::add_to_flush_poller(output_stream<char>& os) noexcept;
     friend void seastar::internal::increase_thrown_exceptions_counter() noexcept;
-    friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
+    friend void internal::report_failed_future(const std::exception_ptr& eptr) noexcept;
     metrics::metric_groups _metric_groups;
     friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -225,6 +225,8 @@ void future_state_base::rethrow_exception() const& {
     std::rethrow_exception(_u.ex);
 }
 
+namespace internal {
+
 void report_failed_future(const std::exception_ptr& eptr) noexcept {
     ++engine()._abandoned_failed_futures;
     seastar_logger.warn("Exceptional future ignored: {}, backtrace: {}", eptr, current_backtrace());
@@ -237,6 +239,8 @@ void report_failed_future(const future_state_base& state) noexcept {
 void report_failed_future(future_state_base::any&& state) noexcept {
     report_failed_future(std::move(state).take_exception());
 }
+
+} // internal namespace
 
 void reactor::test::with_allow_abandoned_failed_futures(unsigned count, noncopyable_function<void ()> func) {
     auto before = engine()._abandoned_failed_futures;


### PR DESCRIPTION
It's in fact such, there's even doxygen marking. Also, while at it, collect all the overloads in one code block.