### PR TITLE
reactor: Remove global task_quota extern declaration

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -703,7 +703,6 @@ public:
 };
 
 extern __thread reactor* local_engine;
-extern __thread size_t task_quota;
 
 SEASTAR_MODULE_EXPORT
 inline reactor& engine() {


### PR DESCRIPTION
Seem to be a leftover from some ancient days. There's no such variable any longer, the task_quota exists only on reactor config.