### PR TITLE
Rework scheduling group API

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -1152,7 +1152,7 @@ int main(int ac, char** av) {
                     return make_ready_future<>();
                 }
 
-                return seastar::create_scheduling_group(r.name, r.shard_info.shares).then([&r, &sched_classes] (seastar::scheduling_group sg) {
+                return seastar::scheduling_group::create(r.name, r.shard_info.shares).then([&r, &sched_classes] (seastar::scheduling_group sg) {
                     sched_classes.insert(std::make_pair(r.name, sched_class {
                         .sg = sg,
                     }));

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -716,7 +716,7 @@ int main(int ac, char** av) {
                 jc.duration = duration;
                 if (groups.count(jc.sg_name) == 0) {
                     fmt::print("Make sched group {}, {} shares\n", jc.sg_name, jc.shares);
-                    groups[jc.sg_name] = create_scheduling_group(jc.sg_name, jc.shares).get();
+                    groups[jc.sg_name] = scheduling_group::create(jc.sg_name, jc.shares).get();
                 }
                 jc.sg = groups[jc.sg_name];
             }

--- a/demos/scheduling_group_demo.cc
+++ b/demos/scheduling_group_demo.cc
@@ -141,11 +141,11 @@ int main(int ac, char** av) {
     return app.run(ac, av, [] {
         return seastar::async([] {
             auto sg100 = seastar::scheduling_group::create("sg100", 100).get();
-            auto ksg100 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg100).get(); });
+            auto ksg100 = seastar::defer([&] () noexcept { seastar::scheduling_group::destroy(sg100).get(); });
             auto sg20 = seastar::scheduling_group::create("sg20", 20).get();
-            auto ksg20 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg20).get(); });
+            auto ksg20 = seastar::defer([&] () noexcept { seastar::scheduling_group::destroy(sg20).get(); });
             auto sg50 = seastar::scheduling_group::create("sg50", 50).get();
-            auto ksg50 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg50).get(); });
+            auto ksg50 = seastar::defer([&] () noexcept { seastar::scheduling_group::destroy(sg50).get(); });
 
             bool done = false;
             auto end = timer<>([&done] {

--- a/demos/scheduling_group_demo.cc
+++ b/demos/scheduling_group_demo.cc
@@ -140,11 +140,11 @@ int main(int ac, char** av) {
     app_template app;
     return app.run(ac, av, [] {
         return seastar::async([] {
-            auto sg100 = seastar::create_scheduling_group("sg100", 100).get();
+            auto sg100 = seastar::scheduling_group::create("sg100", 100).get();
             auto ksg100 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg100).get(); });
-            auto sg20 = seastar::create_scheduling_group("sg20", 20).get();
+            auto sg20 = seastar::scheduling_group::create("sg20", 20).get();
             auto ksg20 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg20).get(); });
-            auto sg50 = seastar::create_scheduling_group("sg50", 50).get();
+            auto sg50 = seastar::scheduling_group::create("sg50", 50).get();
             auto ksg50 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg50).get(); });
 
             bool done = false;

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2380,8 +2380,8 @@ Now let's create two scheduling groups, and run `loop(1)` in the first schedulin
 ```cpp
 seastar::future<> f() {
     return seastar::when_all_succeed(
-            seastar::create_scheduling_group("loop1", 100),
-            seastar::create_scheduling_group("loop2", 100)).then_unpack(
+            seastar::scheduling_group::create("loop1", 100),
+            seastar::scheduling_group::create("loop2", 100)).then_unpack(
         [] (seastar::scheduling_group sg1, seastar::scheduling_group sg2) {
         return seastar::do_with(false, [sg1, sg2] (bool& stop) {
             seastar::sleep(std::chrono::seconds(10)).then([&stop] {
@@ -2397,7 +2397,7 @@ seastar::future<> f() {
 ```
 Here we created two scheduling groups, `sg1` and `sg2`. Each scheduling group has an arbitrary name (which is used for diagnostic purposes only), and a number of *shares*, a number traditionally between 1 and 1000: If one scheduling group has twice the number of shares than a second scheduling group, it will get twice the amount of CPU time. In this example, we used the same number of shares (100) for both groups, so they should get equal CPU time.
 
-Unlike most objects in Seastar which are separate per shard, Seastar wants the identities and numbering of the scheduling groups to be the same on all shards, because it is important when invoking tasks on remote shards. For this reason, the function to create a scheduling group, `seastar::create_scheduling_group()`, is an asynchronous function returning a `future<scheduling_group>`.
+Unlike most objects in Seastar which are separate per shard, Seastar wants the identities and numbering of the scheduling groups to be the same on all shards, because it is important when invoking tasks on remote shards. For this reason, the function to create a scheduling group, `seastar::scheduling_group::create()`, is an asynchronous function returning a `future<scheduling_group>`.
 
 Running the above example, with both scheduling group set up with the same number of shares (100), indeed results in both scheduling groups getting the same amount of CPU time:
 ```

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -663,7 +663,6 @@ private:
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
     metrics::metric_groups _metric_groups;
 
-    friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
     friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
     friend seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const task_queue& tq);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -663,7 +663,6 @@ private:
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
     metrics::metric_groups _metric_groups;
 
-    friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
     friend seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const task_queue& tq);
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -662,7 +662,7 @@ private:
     friend void seastar::internal::increase_thrown_exceptions_counter() noexcept;
     friend void report_failed_future(const std::exception_ptr& eptr) noexcept;
     metrics::metric_groups _metric_groups;
-    friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
+
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
     friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -343,7 +343,8 @@ public:
     /// \return a future that is ready when the bandwidth update is applied
     future<> update_io_bandwidth(uint64_t bandwidth) const;
 
-    friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
+    static future<scheduling_group> create(sstring name, float shares, sstring short_name = {}) noexcept;
+
     friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;
     friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend class reactor;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -115,6 +115,7 @@ future<> destroy_scheduling_group(scheduling_group sg) noexcept;
 /// \param sg The scheduling group to be renamed
 /// \param new_name The new name for the scheduling group.
 /// \return a future that is ready when the scheduling group has been renamed
+[[deprecated("Use scheduling_group::rename()")]]
 future<> rename_scheduling_group(scheduling_group sg, sstring new_name) noexcept;
 /// Rename scheduling group.
 ///
@@ -127,6 +128,7 @@ future<> rename_scheduling_group(scheduling_group sg, sstring new_name) noexcept
 /// \param new_name The new name for the scheduling group.
 /// \param new_shortname The new shortname for the scheduling group.
 /// \return a future that is ready when the scheduling group has been renamed
+[[deprecated("Use scheduling_group::rename()")]]
 future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
 
 
@@ -373,6 +375,17 @@ public:
     /// \return a future that is ready when the scheduling group has been torn down
     static future<> destroy(scheduling_group) noexcept;
 
+    /// Rename scheduling group.
+    ///
+    /// Renames a \ref scheduling_group previously created with create_scheduling_group().
+    ///
+    /// The operation is global and affects all shards.
+    /// The operation affects the exported statistics labels.
+    ///
+    /// \param sg The scheduling group to be renamed
+    /// \param new_name The new name for the scheduling group.
+    /// \param new_shortname The new shortname for the scheduling group.
+    /// \return a future that is ready when the scheduling group has been renamed
     static future<> rename(scheduling_group, sstring new_name, sstring new_shortname = {}) noexcept;
 
     friend class reactor;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -359,6 +359,7 @@ public:
     ///                  logging message aside of the shard id. please note, the
     ///                  \c short_name will be truncated to 4 characters.
     /// \return a scheduling group that can be used on any shard
+
     static future<scheduling_group> create(sstring name, float shares, sstring short_name = {}) noexcept;
 
     /// Destroys a scheduling group.
@@ -372,7 +373,8 @@ public:
     /// \return a future that is ready when the scheduling group has been torn down
     static future<> destroy(scheduling_group) noexcept;
 
-    friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
+    static future<> rename(scheduling_group, sstring new_name, sstring new_shortname = {}) noexcept;
+
     friend class reactor;
     friend unsigned internal::scheduling_group_index(scheduling_group sg) noexcept;
     friend scheduling_group internal::scheduling_group_from_index(unsigned index) noexcept;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -102,6 +102,7 @@ future<scheduling_group> create_scheduling_group(sstring name, sstring shortname
 ///
 /// \param sg The scheduling group to be destroyed
 /// \return a future that is ready when the scheduling group has been torn down
+[[deprecated("Use scheduling_group::destroy()")]]
 future<> destroy_scheduling_group(scheduling_group sg) noexcept;
 
 /// Rename scheduling group.
@@ -359,6 +360,16 @@ public:
     ///                  \c short_name will be truncated to 4 characters.
     /// \return a scheduling group that can be used on any shard
     static future<scheduling_group> create(sstring name, float shares, sstring short_name = {}) noexcept;
+
+    /// Destroys a scheduling group.
+    ///
+    /// Destroys a \ref scheduling_group previously created with create_scheduling_group().
+    /// The destroyed group must not be currently in use and must not be used later.
+    ///
+    /// The operation is global and affects all shards.
+    ///
+    /// \param sg The scheduling group to be destroyed
+    /// \return a future that is ready when the scheduling group has been torn down
     static future<> destroy(scheduling_group) noexcept;
 
     friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -74,6 +74,7 @@ SEASTAR_MODULE_EXPORT_BEGIN
 /// \param shares number of shares of the CPU time allotted to the group;
 ///              Use numbers in the 1-1000 range (but can go above).
 /// \return a scheduling group that can be used on any shard
+[[deprecated("Use scheduling_group::create()")]]
 future<scheduling_group> create_scheduling_group(sstring name, float shares) noexcept;
 
 /// Creates a scheduling group with a specified number of shares.
@@ -89,6 +90,7 @@ future<scheduling_group> create_scheduling_group(sstring name, float shares) noe
 /// \param shares number of shares of the CPU time allotted to the group;
 ///              Use numbers in the 1-1000 range (but can go above).
 /// \return a scheduling group that can be used on any shard
+[[deprecated("Use scheduling_group::create()")]]
 future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
 
 /// Destroys a scheduling group.
@@ -343,6 +345,19 @@ public:
     /// \return a future that is ready when the bandwidth update is applied
     future<> update_io_bandwidth(uint64_t bandwidth) const;
 
+    /// Creates a scheduling group with a specified number of shares.
+    ///
+    /// The operation is global and affects all shards. The returned scheduling
+    /// group can then be used in any shard.
+    ///
+    /// \param name A name that identifiers the group; will be used as a label
+    ///             in the group's metrics
+    /// \param shares number of shares of the CPU time allotted to the group;
+    ///              Use numbers in the 1-1000 range (but can go above).
+    /// \param short_name A name that identifies the group; will be printed in the
+    ///                  logging message aside of the shard id. please note, the
+    ///                  \c short_name will be truncated to 4 characters.
+    /// \return a scheduling group that can be used on any shard
     static future<scheduling_group> create(sstring name, float shares, sstring short_name = {}) noexcept;
 
     friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -359,8 +359,8 @@ public:
     ///                  \c short_name will be truncated to 4 characters.
     /// \return a scheduling group that can be used on any shard
     static future<scheduling_group> create(sstring name, float shares, sstring short_name = {}) noexcept;
+    static future<> destroy(scheduling_group) noexcept;
 
-    friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;
     friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend class reactor;
     friend unsigned internal::scheduling_group_index(scheduling_group sg) noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5127,8 +5127,7 @@ scheduling_group_key_create(scheduling_group_key_config cfg) noexcept {
     });
 }
 
-future<>
-destroy_scheduling_group(scheduling_group sg) noexcept {
+future<> scheduling_group::destroy(scheduling_group sg) noexcept {
     if (sg == default_scheduling_group()) {
         return make_exception_future<>(make_backtraced_exception_ptr<std::runtime_error>("Attempt to destroy the default scheduling group"));
     }
@@ -5140,6 +5139,11 @@ destroy_scheduling_group(scheduling_group sg) noexcept {
     }).then([sg] {
         deallocate_scheduling_group_id(sg._id);
     });
+}
+
+future<>
+destroy_scheduling_group(scheduling_group sg) noexcept {
+    return scheduling_group::destroy(sg);
 }
 
 future<>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5148,11 +5148,15 @@ destroy_scheduling_group(scheduling_group sg) noexcept {
 
 future<>
 rename_scheduling_group(scheduling_group sg, sstring new_name) noexcept {
-    return rename_scheduling_group(sg, new_name, {});
+    return scheduling_group::rename(sg, std::move(new_name));
 }
 
 future<>
 rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept {
+    return scheduling_group::rename(sg, std::move(new_name), std::move(new_shortname));
+}
+
+future<> scheduling_group::rename(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept {
     if (sg == default_scheduling_group()) {
         return make_exception_future<>(make_backtraced_exception_ptr<std::runtime_error>("Attempt to rename the default scheduling group"));
     }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5092,8 +5092,7 @@ future<> scheduling_group::update_io_bandwidth(uint64_t bandwidth) const {
     return engine().update_bandwidth_for_queues(internal::priority_class(*this), bandwidth);
 }
 
-future<scheduling_group>
-create_scheduling_group(sstring name, sstring shortname, float shares) noexcept {
+future<scheduling_group> scheduling_group::create(sstring name, float shares, sstring shortname) noexcept {
     auto aid = allocate_scheduling_group_id();
     if (aid < 0) {
         return make_exception_future<scheduling_group>(std::runtime_error(fmt::format("Scheduling group limit exceeded while creating {}", name)));
@@ -5109,8 +5108,13 @@ create_scheduling_group(sstring name, sstring shortname, float shares) noexcept 
 }
 
 future<scheduling_group>
+create_scheduling_group(sstring name, sstring shortname, float shares) noexcept {
+    return scheduling_group::create(std::move(name), shares, std::move(shortname));
+}
+
+future<scheduling_group>
 create_scheduling_group(sstring name, float shares) noexcept {
-    return create_scheduling_group(name, {}, shares);
+    return scheduling_group::create(name, shares);
 }
 
 future<scheduling_group_key>

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -41,7 +41,6 @@
 
 using seastar::broken_promise;
 using seastar::circular_buffer;
-using seastar::create_scheduling_group;
 using seastar::current_scheduling_group;
 using seastar::default_scheduling_group;
 using seastar::future;
@@ -140,7 +139,7 @@ SEASTAR_TEST_CASE(test_abandond_coroutine) {
 }
 
 SEASTAR_TEST_CASE(test_scheduling_group) {
-    auto other_sg = co_await create_scheduling_group("the other group", 10.f);
+    auto other_sg = co_await scheduling_group::create("the other group", 10.f);
     std::exception_ptr ex;
 
     try {
@@ -192,9 +191,9 @@ future<scheduling_group> switch_to_with_context(scheduling_group& sg) {
 }
 
 SEASTAR_TEST_CASE(test_switch_to) {
-    auto other_sg0 = co_await create_scheduling_group("other group 0", 10.f);
-    auto other_sg1 = co_await create_scheduling_group("other group 1", 10.f);
-    auto other_sg2 = co_await create_scheduling_group("other group 2", 10.f);
+    auto other_sg0 = co_await scheduling_group::create("other group 0", 10.f);
+    auto other_sg1 = co_await scheduling_group::create("other group 1", 10.f);
+    auto other_sg2 = co_await scheduling_group::create("other group 2", 10.f);
     std::exception_ptr ex;
 
     try {
@@ -250,7 +249,7 @@ future<> switch_to_sg_and_perform_inheriting_checks(scheduling_group base_sg, sc
 }
 
 SEASTAR_TEST_CASE(test_switch_to_sg_restoration_and_inheriting) {
-    auto new_sg = co_await create_scheduling_group("other group 0", 10.f);
+    auto new_sg = co_await scheduling_group::create("other group 0", 10.f);
     std::exception_ptr ex;
 
     try {

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -178,7 +178,7 @@ SEASTAR_TEST_CASE(test_scheduling_group) {
     } catch (...) {
         ex = std::current_exception();
     }
-    co_await destroy_scheduling_group(other_sg);
+    co_await scheduling_group::destroy(other_sg);
     if (ex) {
         std::rethrow_exception(std::move(ex));
     }
@@ -219,8 +219,8 @@ SEASTAR_TEST_CASE(test_switch_to) {
         ex = std::current_exception();
     }
 
-    co_await destroy_scheduling_group(other_sg1);
-    co_await destroy_scheduling_group(other_sg0);
+    co_await scheduling_group::destroy(other_sg1);
+    co_await scheduling_group::destroy(other_sg0);
     if (ex) {
         std::rethrow_exception(std::move(ex));
     }
@@ -271,7 +271,7 @@ SEASTAR_TEST_CASE(test_switch_to_sg_restoration_and_inheriting) {
         ex = std::current_exception();
     }
 
-    co_await destroy_scheduling_group(new_sg);
+    co_await scheduling_group::destroy(new_sg);
     if (ex) {
         std::rethrow_exception(std::move(ex));
     }

--- a/tests/unit/execution_stage_test.cc
+++ b/tests/unit/execution_stage_test.cc
@@ -294,9 +294,9 @@ SEASTAR_TEST_CASE(test_unique_stage_names_are_enforced) {
 
 SEASTAR_THREAD_TEST_CASE(test_inheriting_concrete_execution_stage) {
     auto sg1 = seastar::scheduling_group::create("sg1", 300).get();
-    auto ksg1 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg1).get(); });
+    auto ksg1 = seastar::defer([&] () noexcept { seastar::scheduling_group::destroy(sg1).get(); });
     auto sg2 = seastar::scheduling_group::create("sg2", 100).get();
-    auto ksg2 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg2).get(); });
+    auto ksg2 = seastar::defer([&] () noexcept { seastar::scheduling_group::destroy(sg2).get(); });
     auto check_sg = [] (seastar::scheduling_group sg) {
         BOOST_REQUIRE(seastar::current_scheduling_group() == sg);
     };

--- a/tests/unit/execution_stage_test.cc
+++ b/tests/unit/execution_stage_test.cc
@@ -293,9 +293,9 @@ SEASTAR_TEST_CASE(test_unique_stage_names_are_enforced) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_inheriting_concrete_execution_stage) {
-    auto sg1 = seastar::create_scheduling_group("sg1", 300).get();
+    auto sg1 = seastar::scheduling_group::create("sg1", 300).get();
     auto ksg1 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg1).get(); });
-    auto sg2 = seastar::create_scheduling_group("sg2", 100).get();
+    auto sg2 = seastar::scheduling_group::create("sg2", 100).get();
     auto ksg2 = seastar::defer([&] () noexcept { seastar::destroy_scheduling_group(sg2).get(); });
     auto check_sg = [] (seastar::scheduling_group sg) {
         BOOST_REQUIRE(seastar::current_scheduling_group() == sg);

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -238,8 +238,8 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
     fake_file file;
 
     io_queue_for_tests tio;
-    auto pc0 = internal::priority_class(create_scheduling_group("a", 100).get());
-    auto pc1 = internal::priority_class(create_scheduling_group("b", 100).get());
+    auto pc0 = internal::priority_class(scheduling_group::create("a", 100).get());
+    auto pc1 = internal::priority_class(scheduling_group::create("b", 100).get());
 
     size_t idx = 0;
     int val = 100;

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -93,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
         const char* name = i%2 ? name1 : name2;
         const char* prev_name = i%2 ? name2 : name1;
         sleep(std::chrono::microseconds(100000/(i+1))).get();
-        rename_scheduling_group(sg, name).get();
+        scheduling_group::rename(sg, name).get();
         std::set<sstring> label_vals = get_label_values(sstring("scheduler_shares"), sstring("group"));
         // validate that the name that we *renamed to* is in the stats
         BOOST_REQUIRE(label_vals.find(sstring(name)) != label_vals.end());
@@ -109,7 +109,7 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
             // is a chance of collision.
             return do_for_each(rng, [sg, &dist] (auto i) {
                 bool odd = dist(seastar::testing::local_random_engine)%2;
-                return rename_scheduling_group(sg, odd ? name1 : name2);
+                return scheduling_group::rename(sg, odd ? name1 : name2);
             });
         });
     }).get();

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -84,7 +84,7 @@ SEASTAR_THREAD_TEST_CASE(test_renaming_scheuling_groups) {
 
     static const char* name1 = "A";
     static const char* name2 = "B";
-    scheduling_group sg =  create_scheduling_group("hello", 111).get();
+    scheduling_group sg = scheduling_group::create("hello", 111).get();
     auto rng = std::views::iota(0, 1000);
     // repeatedly change the group name back and forth in
     // decresing time intervals to see if it generate double

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -770,7 +770,7 @@ SEASTAR_TEST_CASE(test_rpc_server_send_glitch) {
 
 SEASTAR_TEST_CASE(test_rpc_scheduling) {
     return rpc_test_env<>::do_with_thread(rpc_test_config(), [] (rpc_test_env<>& env, test_rpc_proto::client& c1) {
-        auto sg = create_scheduling_group("rpc", 100).get();
+        auto sg = scheduling_group::create("rpc", 100).get();
         env.register_handler(1, sg, [] () {
             return make_ready_future<unsigned>(internal::scheduling_group_index(current_scheduling_group()));
         }).get();
@@ -781,9 +781,9 @@ SEASTAR_TEST_CASE(test_rpc_scheduling) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based) {
-    auto sg1 = create_scheduling_group("sg1", 100).get();
+    auto sg1 = scheduling_group::create("sg1", 100).get();
     auto sg1_kill = defer([&] () noexcept { destroy_scheduling_group(sg1).get(); });
-    auto sg2 = create_scheduling_group("sg2", 100).get();
+    auto sg2 = scheduling_group::create("sg2", 100).get();
     auto sg2_kill = defer([&] () noexcept { destroy_scheduling_group(sg2).get(); });
     rpc::resource_limits limits;
     limits.isolate_connection = [sg1, sg2] (sstring cookie) {
@@ -821,9 +821,9 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility) {
-    auto sg1 = create_scheduling_group("sg1", 100).get();
+    auto sg1 = scheduling_group::create("sg1", 100).get();
     auto sg1_kill = defer([&] () noexcept { destroy_scheduling_group(sg1).get(); });
-    auto sg2 = create_scheduling_group("sg2", 100).get();
+    auto sg2 = scheduling_group::create("sg2", 100).get();
     auto sg2_kill = defer([&] () noexcept { destroy_scheduling_group(sg2).get(); });
     rpc::resource_limits limits;
     limits.isolate_connection = [sg1, sg2] (sstring cookie) {
@@ -885,7 +885,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_async) {
         future<seastar::scheduling_group> get_scheduling_group = make_ready_future<>().then([&sg1, &sg2, cookie] {
             if (cookie == "sg1") {
                 if (sg1 == default_scheduling_group()) {
-                    return create_scheduling_group("sg1", 100).then([&sg1] (seastar::scheduling_group sg) {
+                    return scheduling_group::create("sg1", 100).then([&sg1] (seastar::scheduling_group sg) {
                         sg1 = sg;
                         return sg;
                     });
@@ -894,7 +894,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_async) {
                 }
             } else if (cookie == "sg2") {
                 if (sg2 == default_scheduling_group()) {
-                    return create_scheduling_group("sg2", 100).then([&sg2] (seastar::scheduling_group sg) {
+                    return scheduling_group::create("sg2", 100).then([&sg2] (seastar::scheduling_group sg) {
                         sg2 = sg;
                         return sg;
                     });
@@ -937,7 +937,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_async) {
 SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility_async) {
     scheduling_group sg1 = default_scheduling_group();
     scheduling_group sg2 = default_scheduling_group();
-    scheduling_group sg3 = create_scheduling_group("sg3", 100).get();
+    scheduling_group sg3 = scheduling_group::create("sg3", 100).get();
     auto sg1_kill = defer([&] () noexcept {
         if (sg1 != default_scheduling_group())  {
             destroy_scheduling_group(sg1).get();
@@ -954,7 +954,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility_asyn
         future<seastar::scheduling_group> get_scheduling_group = make_ready_future<>().then([&sg1, &sg2, cookie] {
             if (cookie == "sg1") {
                 if (sg1 == default_scheduling_group()) {
-                    return create_scheduling_group("sg1", 100).then([&sg1] (seastar::scheduling_group sg) {
+                    return scheduling_group::create("sg1", 100).then([&sg1] (seastar::scheduling_group sg) {
                         sg1 = sg;
                         return sg;
                     });
@@ -963,7 +963,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility_asyn
                 }
             } else if (cookie == "sg2") {
                 if (sg2 == default_scheduling_group()) {
-                    return create_scheduling_group("sg2", 100).then([&sg2] (seastar::scheduling_group sg) {
+                    return scheduling_group::create("sg2", 100).then([&sg2] (seastar::scheduling_group sg) {
                         sg2 = sg;
                         return sg;
                     });

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -782,9 +782,9 @@ SEASTAR_TEST_CASE(test_rpc_scheduling) {
 
 SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based) {
     auto sg1 = scheduling_group::create("sg1", 100).get();
-    auto sg1_kill = defer([&] () noexcept { destroy_scheduling_group(sg1).get(); });
+    auto sg1_kill = defer([&] () noexcept { scheduling_group::destroy(sg1).get(); });
     auto sg2 = scheduling_group::create("sg2", 100).get();
-    auto sg2_kill = defer([&] () noexcept { destroy_scheduling_group(sg2).get(); });
+    auto sg2_kill = defer([&] () noexcept { scheduling_group::destroy(sg2).get(); });
     rpc::resource_limits limits;
     limits.isolate_connection = [sg1, sg2] (sstring cookie) {
         auto sg = current_scheduling_group();
@@ -822,9 +822,9 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based) {
 
 SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility) {
     auto sg1 = scheduling_group::create("sg1", 100).get();
-    auto sg1_kill = defer([&] () noexcept { destroy_scheduling_group(sg1).get(); });
+    auto sg1_kill = defer([&] () noexcept { scheduling_group::destroy(sg1).get(); });
     auto sg2 = scheduling_group::create("sg2", 100).get();
-    auto sg2_kill = defer([&] () noexcept { destroy_scheduling_group(sg2).get(); });
+    auto sg2_kill = defer([&] () noexcept { scheduling_group::destroy(sg2).get(); });
     rpc::resource_limits limits;
     limits.isolate_connection = [sg1, sg2] (sstring cookie) {
         auto sg = current_scheduling_group();
@@ -872,12 +872,12 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_async) {
     scheduling_group sg2 = default_scheduling_group();
     auto sg1_kill = defer([&] () noexcept {
         if (sg1 != default_scheduling_group())  {
-            destroy_scheduling_group(sg1).get();
+            scheduling_group::destroy(sg1).get();
         }
     });
     auto sg2_kill = defer([&] () noexcept {
         if (sg2 != default_scheduling_group()) {
-            destroy_scheduling_group(sg2).get();
+            scheduling_group::destroy(sg2).get();
         }
     });
     rpc::resource_limits limits;
@@ -940,15 +940,15 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_scheduling_connection_based_compatibility_asyn
     scheduling_group sg3 = scheduling_group::create("sg3", 100).get();
     auto sg1_kill = defer([&] () noexcept {
         if (sg1 != default_scheduling_group())  {
-            destroy_scheduling_group(sg1).get();
+            scheduling_group::destroy(sg1).get();
         }
     });
     auto sg2_kill = defer([&] () noexcept {
         if (sg2 != default_scheduling_group()) {
-            destroy_scheduling_group(sg2).get();
+            scheduling_group::destroy(sg2).get();
         }
     });
-    auto sg3_kill = defer([&] () noexcept { destroy_scheduling_group(sg3).get(); });
+    auto sg3_kill = defer([&] () noexcept { scheduling_group::destroy(sg3).get(); });
     rpc::resource_limits limits;
     limits.isolate_connection = [&sg1, &sg2] (sstring cookie) {
         future<seastar::scheduling_group> get_scheduling_group = make_ready_future<>().then([&sg1, &sg2, cookie] {

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -55,7 +55,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
 
     const auto destroy_scheduling_groups = defer([&sgs] () noexcept {
        for (scheduling_group sg : sgs) {
-           destroy_scheduling_group(sg).get();
+           scheduling_group::destroy(sg).get();
        }
     });
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<int>();
@@ -109,7 +109,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
     std::vector<scheduling_group> sgs;
     const auto destroy_scheduling_groups = defer([&sgs] () noexcept {
        for (scheduling_group sg : sgs) {
-           destroy_scheduling_group(sg).get();
+           scheduling_group::destroy(sg).get();
        }
     });
     scheduling_group_key_config key1_conf = make_scheduling_group_key_config<int>();
@@ -167,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
     std::vector<scheduling_group> sgs;
     const auto destroy_scheduling_groups = defer([&sgs] () noexcept {
        for (scheduling_group sg : sgs) {
-           destroy_scheduling_group(sg).get();
+           scheduling_group::destroy(sg).get();
        }
     });
 
@@ -223,7 +223,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
  */
 SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) {
     scheduling_group sg = scheduling_group::create("sg0", 100).get();
-    auto cleanup = defer([&] () noexcept { destroy_scheduling_group(sg).get(); });
+    auto cleanup = defer([&] () noexcept { scheduling_group::destroy(sg).get(); });
     thread_attributes attr = {};
     attr.sched_group = sg;
     seastar::async(attr, [attr] {
@@ -244,7 +244,7 @@ SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) 
 
 SEASTAR_THREAD_TEST_CASE(yield_preserves_sg) {
     scheduling_group sg = scheduling_group::create("sg", 100).get();
-    auto cleanup = defer([&] () noexcept { destroy_scheduling_group(sg).get(); });
+    auto cleanup = defer([&] () noexcept { scheduling_group::destroy(sg).get(); });
     with_scheduling_group(sg, [&] {
         return yield().then([&] {
             BOOST_REQUIRE_EQUAL(
@@ -261,7 +261,7 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
         scheduling_group_destroyer(scheduling_group sg) : _sg(sg) {}
         scheduling_group_destroyer(const scheduling_group_destroyer&) = default;
         ~scheduling_group_destroyer() {
-            destroy_scheduling_group(_sg).get();
+            scheduling_group::destroy(_sg).get();
         }
     };
 
@@ -314,7 +314,7 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     std::vector<scheduling_group> sgs;
     const auto destroy_sgs = defer([&sgs] () noexcept {
         for (auto sg : sgs) {
-           destroy_scheduling_group(sg).get();
+           scheduling_group::destroy(sg).get();
         }
     });
     for (size_t s = 0; s < 3; ++s) {
@@ -368,7 +368,7 @@ SEASTAR_THREAD_TEST_CASE(sg_create_and_key_create_in_parallel) {
     }).get();
 
     for (scheduling_group sg : sgs) {
-        destroy_scheduling_group(sg).get();
+        scheduling_group::destroy(sg).get();
     }
 }
 

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -331,7 +331,7 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     }).get();
 
     for (size_t s = 0; s < std::size(sgs); ++s) {
-        rename_scheduling_group(sgs[s], fmt::format("sg-new-{}", s)).get();
+        scheduling_group::rename(sgs[s], fmt::format("sg-new-{}", s)).get();
     }
 
     smp::invoke_on_all([&sgs, &keys] () {

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -118,8 +118,8 @@ struct timer_test {
                 }
                 OK();
             }).get();
-            destroy_scheduling_group(sg1).get();
-            destroy_scheduling_group(sg2).get();
+            scheduling_group::destroy(sg1).get();
+            scheduling_group::destroy(sg2).get();
         });
     }
 };

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -94,8 +94,8 @@ struct timer_test {
 
     future<> test_timer_with_scheduling_groups() {
         return async([] {
-            auto sg1 = create_scheduling_group("sg1", 100).get();
-            auto sg2 = create_scheduling_group("sg2", 100).get();
+            auto sg1 = scheduling_group::create("sg1", 100).get();
+            auto sg2 = scheduling_group::create("sg2", 100).get();
             thread_attributes t1attr;
             t1attr.sched_group = sg1;
             auto expirations = 0;


### PR DESCRIPTION
The core part is class scheduling_group which is really a "handle" with sched group ID that can be easily coped around. To create, destroy and rename one there are three standalone functions in seastar namespace. To do their work, the functions are declared as friends for scheduling_group class itself.

This friendship is not really required. In order to take control over scheduling_group class lifetime, those functions should rather be static methods of that class and that's it. This is what this PR does. Old API methods are deprecated. As a nice side effect, two creation methods are squashed into one with default "shortname" argument.

Other than being friends to scheduling_group, the API methods are also friends of reactor class. Also reactor has scheduling_group itself as a friend. This all is to manipulate reactor's task queues. Once API methods are turned in scheduling_group static methods, that friendship becomes not needed and can be removed.