### PR TITLE
Add source location to task and tasktrace object

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -43,7 +43,6 @@ void free_sized(void* ptr, size_t size);
 
 #endif
 
-
 namespace seastar {
 
 namespace internal {
@@ -194,8 +193,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
-        hndl.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<U> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {
@@ -220,8 +219,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
-        hndl.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<U> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -31,6 +31,7 @@
 #include <coroutine>
 #include <new>
 #include <cstdlib>
+#include <source_location>
 
 #if !(__GLIBC__ == 2 && __GLIBC_MINOR__ >= 43) && !(__GLIBC__ > 2)
 
@@ -193,7 +194,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
+        hndl.promise().update_resume_point(sl);
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {
@@ -218,7 +220,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
+        hndl.promise().update_resume_point(sl);
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -25,12 +25,16 @@
 #include <seastar/util/backtrace.hh>
 
 #include <utility>
+#include <source_location>
 
 namespace seastar {
 
 class task {
+    std::source_location _resume_point = {};
+
 protected:
     scheduling_group _sg;
+
 private:
 #ifdef SEASTAR_TASK_BACKTRACE
     shared_backtrace _bt;
@@ -50,6 +54,8 @@ public:
     virtual void run_and_dispose() noexcept = 0;
     /// Returns the next task which is waiting for this task to complete execution, or nullptr.
     virtual task* waiting_task() noexcept = 0;
+    void update_resume_point(std::source_location sl) { _resume_point = sl; }
+    auto get_resume_point() const { return _resume_point; }
     scheduling_group group() const { return _sg; }
 #ifdef SEASTAR_TASK_BACKTRACE
     void make_backtrace() noexcept;

--- a/include/seastar/coroutine/all.hh
+++ b/include/seastar/coroutine/all.hh
@@ -161,7 +161,9 @@ private:
                 return (... && futures.available());
             }, state._futures);
         }
-        void await_suspend(coroutine_handle_t h) {
+        template <typename U>
+        void await_suspend(std::coroutine_handle<U> h, std::source_location sl = std::source_location::current()) {
+            h.promise().update_resume_point(sl);
             when_ready = h;
             process<0>();
         }

--- a/include/seastar/coroutine/all.hh
+++ b/include/seastar/coroutine/all.hh
@@ -162,8 +162,8 @@ private:
             }, state._futures);
         }
         template <typename U>
-        void await_suspend(std::coroutine_handle<U> h, std::source_location sl = std::source_location::current()) {
-            h.promise().update_resume_point(sl);
+        void await_suspend(std::coroutine_handle<U> h SEASTAR_COROUTINE_LOC_PARAM) {
+            SEASTAR_COROUTINE_LOC_STORE(h.promise());
             when_ready = h;
             process<0>();
         }

--- a/include/seastar/coroutine/as_future.hh
+++ b/include/seastar/coroutine/as_future.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/core/coroutine.hh>
+#include <source_location>
 
 namespace seastar {
 
@@ -42,7 +43,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
+        hndl.promise().update_resume_point(sl);
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {

--- a/include/seastar/coroutine/as_future.hh
+++ b/include/seastar/coroutine/as_future.hh
@@ -43,8 +43,8 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
-        hndl.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<U> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/future.hh>
 #include <coroutine>
 #include <exception>
+#include <source_location>
 
 namespace seastar {
 
@@ -42,8 +43,9 @@ struct exception_awaiter {
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
-      execute_involving_handle_destruction_in_await_suspend([hndl, eptr = std::move(eptr)] () mutable {
+    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
+      execute_involving_handle_destruction_in_await_suspend([sl, hndl, eptr = std::move(eptr)] () mutable {
+        hndl.promise().update_resume_point(sl);
         hndl.promise().set_exception(std::move(eptr));
         hndl.destroy();
       });

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -43,9 +43,9 @@ struct exception_awaiter {
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl, std::source_location sl = std::source_location::current()) noexcept {
-      execute_involving_handle_destruction_in_await_suspend([sl, hndl, eptr = std::move(eptr)] () mutable {
-        hndl.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<U> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+      SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
+      execute_involving_handle_destruction_in_await_suspend([hndl, eptr = std::move(eptr)] () mutable {
         hndl.promise().set_exception(std::move(eptr));
         hndl.destroy();
       });

--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -186,8 +186,8 @@ struct generator_promise_base<Yielded>::yield_awaiter final {
         return false;
     }
     template <typename Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer, std::source_location sl = std::source_location::current()) noexcept {
-        producer.promise().update_resume_point(sl);
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(producer.promise());
         _promise->_waiting_task = &producer.promise();
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
@@ -211,11 +211,10 @@ struct generator_promise_base<Yielded>::copy_awaiter final {
         return false;
     }
     template <typename Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer, std::source_location sl = std::source_location::current()) noexcept {
-        producer.promise().update_resume_point(sl);
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(producer.promise());
         _value_ptr = std::addressof(_value);
         auto& current = producer.promise();
-        current.update_resume_point(sl);
         _promise->_waiting_task = &current;
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
@@ -247,8 +246,8 @@ public:
     }
 
     template <typename Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer, std::source_location sl = std::source_location::current()) noexcept {
-        consumer.promise().update_resume_point(sl);
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(consumer.promise());
         _promise->_consumer = consumer;
         // Check if we need to preempt. If not, directly resume producer.
         // If yes, schedule the producer through the scheduler.
@@ -431,8 +430,8 @@ public:
         }
 
         template <typename Promise>
-        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer, std::source_location sl = std::source_location::current()) noexcept {
-            consumer.promise().update_resume_point(sl);
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+            SEASTAR_COROUTINE_LOC_STORE(consumer.promise());
             auto& promise = _gen->_coro.promise();
             promise._consumer = consumer;
             // Check if we need to preempt. If not, directly resume producer.
@@ -686,8 +685,8 @@ public:
         return !_should_suspend;  // If we shouldn't suspend, we're ready immediately
     }
     template <typename Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer, std::source_location sl = std::source_location::current()) noexcept {
-        producer.promise().update_resume_point(sl);
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(producer.promise());
         _promise->_waiting_task = &producer.promise();
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
@@ -718,8 +717,8 @@ public:
     }
 
     template <typename Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer, std::source_location sl = std::source_location::current()) noexcept {
-        consumer.promise().update_resume_point(sl);
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(consumer.promise());
         _promise->_consumer = consumer;
         // Check if we need to preempt. If not, directly resume producer.
         // If yes, schedule the producer through the scheduler.
@@ -836,8 +835,8 @@ public:
         }
 
         template <typename Promise>
-        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer, std::source_location sl = std::source_location::current()) noexcept {
-            consumer.promise().update_resume_point(sl);
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> consumer SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+            SEASTAR_COROUTINE_LOC_STORE(consumer.promise());
             // Buffer is empty, need to resume producer to get more elements
             auto& promise = _gen->_coro.promise();
             promise._consumer = consumer;

--- a/include/seastar/coroutine/maybe_yield.hh
+++ b/include/seastar/coroutine/maybe_yield.hh
@@ -35,8 +35,8 @@ struct maybe_yield_awaiter final {
     }
 
     template <typename T>
-    void await_suspend(std::coroutine_handle<T> h, std::source_location sl = std::source_location::current()) noexcept {
-        h.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<T> h SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(h.promise());
         schedule(&h.promise());
     }
 

--- a/include/seastar/coroutine/maybe_yield.hh
+++ b/include/seastar/coroutine/maybe_yield.hh
@@ -35,7 +35,8 @@ struct maybe_yield_awaiter final {
     }
 
     template <typename T>
-    void await_suspend(std::coroutine_handle<T> h) {
+    void await_suspend(std::coroutine_handle<T> h, std::source_location sl = std::source_location::current()) noexcept {
+        h.promise().update_resume_point(sl);
         schedule(&h.promise());
     }
 

--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -152,8 +152,8 @@ public:
     }
 
     template<typename T>
-    void await_suspend(std::coroutine_handle<T> h, std::source_location sl = std::source_location::current()) noexcept {
-        h.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<T> h SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(h.promise());
         _when_ready = h;
         _waiting_task = &h.promise();
         resume_or_set_callback();

--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -152,7 +152,8 @@ public:
     }
 
     template<typename T>
-    void await_suspend(std::coroutine_handle<T> h) {
+    void await_suspend(std::coroutine_handle<T> h, std::source_location sl = std::source_location::current()) noexcept {
+        h.promise().update_resume_point(sl);
         _when_ready = h;
         _waiting_task = &h.promise();
         resume_or_set_callback();

--- a/include/seastar/coroutine/switch_to.hh
+++ b/include/seastar/coroutine/switch_to.hh
@@ -70,7 +70,8 @@ public:
     }
 
     template<typename T>
-    void await_suspend(std::coroutine_handle<T> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<T> hndl, std::source_location sl = std::source_location::current()) noexcept {
+        hndl.promise().update_resume_point(sl);
         auto& t = hndl.promise();
         t.set_scheduling_group(_switch_to_sg);
         _task = &t;

--- a/include/seastar/coroutine/switch_to.hh
+++ b/include/seastar/coroutine/switch_to.hh
@@ -70,8 +70,8 @@ public:
     }
 
     template<typename T>
-    void await_suspend(std::coroutine_handle<T> hndl, std::source_location sl = std::source_location::current()) noexcept {
-        hndl.promise().update_resume_point(sl);
+    void await_suspend(std::coroutine_handle<T> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
         auto& t = hndl.promise();
         t.set_scheduling_group(_switch_to_sg);
         _task = &t;

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -151,7 +151,17 @@ public:
 // and information about the chain of tasks waiting for the current operation to complete.
 class tasktrace {
 public:
-    using entry = std::variant<shared_backtrace, task_entry>;
+    struct entry {
+        std::variant<shared_backtrace, task_entry> backtrace_or_task_entry;
+        std::source_location resume_point;
+
+        bool operator == (const entry &other) const {
+            return backtrace_or_task_entry == other.backtrace_or_task_entry
+                    && resume_point.line() == other.resume_point.line()
+                    && resume_point.column() == other.resume_point.column()
+                    && std::string_view{ resume_point.file_name() } == std::string_view{ other.resume_point.file_name() };
+        }
+    };
     using vector_type = boost::container::static_vector<entry, 16>;
 private:
     simple_backtrace _main;


### PR DESCRIPTION
Adds source location of next resume point to `task` objects. When constructing `tasktrace` object, source location of resume points will be added to it. When printing, the source location of next resume point will be printed as well, hopefully improving debug experience.

Example:
```
0x2b3899 /home/y/work/scylladb-test/build/Debug/seastar/libseastar.so+0x454c364 ...
   --------
   test_app/main.cpp:15:15
   seastar::continuation<seastar::internal::promise_base_with_type<void>, ...
```

Partially fixes https://github.com/scylladb/seastar/issues/2381