### PR TITLE
stall_detector: no backtrace if exception

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1450,7 +1450,11 @@ void cpu_stall_detector::generate_trace() {
     buf.append("Reactor stalled for ");
     buf.append_decimal(uint64_t(delta / 1ms));
     buf.append(" ms");
-    print_with_backtrace(buf, _config.oneline);
+    if (std::uncaught_exceptions() > 0) {
+        buf.append(", backtrace omitted (uncaught exception in progress)\n");
+    } else {
+        print_with_backtrace(buf, _config.oneline);
+    }
     maybe_report_kernel_trace(buf);
 }
 


### PR DESCRIPTION
If a an exception is in progress when a reactor stall is detected, omit taking the backtrace, as this can crash as detailed in #2697.

Add a test which reproduces the issue, and which crashes (sometimes) before this fix and which runs cleanly afterwards.

Fixes #2697.

This is the same fix we have applied in our seastar branch for Redpanda, in order to fix a similar crash in our not-upstreamed CPU profiler which relies on the same mechanism as the stall notifier. We have not seen any issues with that approach and the CPU profiler, when enabled, will take backtraces at a much higher frequency than the stall notifier in general (every 100ms, by default).

Of course, the question is if std::uncaught_exceptions is itself "signal safe" and you won't find any guarantee about it in the C++ standard (which largely ignores the existence of signals). I did check the implementation  of this method in libc++ and libstdc++ and it looks "OK" to me: they both read a single field from an exceptions globals area, which looks to be OK to me.