### PR TITLE
build: fix CMAKE_REQUIRED_FLAGS format for sanitizer detection

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -50,7 +50,6 @@ include(CMakePushCheckState)
 # the combination of the compiler options.
 cmake_push_check_state()
 string (REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${Sanitizers_COMPILE_OPTIONS}")
-set(CMAKE_REQUIRED_FLAGS ${Sanitizers_COMPILE_OPTIONS})
 check_cxx_source_compiles("int main() {}"
   Sanitizers_SUPPORTED)
 if (Sanitizers_SUPPORTED)


### PR DESCRIPTION
Use space-delimited string instead of semicolon-separated list for `CMAKE_REQUIRED_FLAGS` as specified in the CheckCXXSourceCompiles documentation. This fixes sanitizer detection by correctly passing compiler flags when checking for sanitizer support.

Previously, we incorrectly converted a space-delimited string to a semicolon-list by replacing spaces in `Sanitizers_COMPILE_OPTIONS`, preventing proper detection of combined sanitizer configurations.

Reference: https://cmake.org/cmake/help/latest/module/CheckCXXSourceCompiles.html