### PR TITLE
http_client: Improve handling of server response parsing errors

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -122,6 +122,11 @@ public:
     }
 };
 
+class response_parsing_exception : public server_error_exception {
+public:
+    explicit response_parsing_exception(const std::string& msg) : server_error_exception(msg) {}
+};
+
 class json_exception : public json::json_base {
 public:
     json::json_element<std::string> _msg;


### PR DESCRIPTION
Handle cases where the server response might be broken due to a server-side bug or transient error. Retrying in such cases may still be meaningful. Replace `runtime_error`, which prevents retries, with `system_error`, allowing the client to retry the request once using a new connection.

Enhance the response parser to generate more verbose error messages, providing additional context that may help identify the root cause of the issue.

This change addresses an observed issue where the MinIO server returns garbage responses (potentially a server bug), but the same request succeeds when retried.