### PR TITLE
rpc: client: support timeout and cancellation

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -583,8 +583,14 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
         auto operator()(rpc::client& dst, rpc_clock_type::time_point timeout, const InArgs&... args) {
             return send(dst, timeout, nullptr, args...);
         }
+        auto operator()(rpc::client& dst, rpc_clock_type::time_point timeout, cancellable& cancel, const InArgs&... args) {
+            return send(dst, timeout, &cancel, args...);
+        }
         auto operator()(rpc::client& dst, rpc_clock_type::duration timeout, const InArgs&... args) {
             return send(dst, relative_timeout_to_absolute(timeout), nullptr, args...);
+        }
+        auto operator()(rpc::client& dst, rpc_clock_type::duration timeout, cancellable& cancel, const InArgs&... args) {
+            return send(dst, relative_timeout_to_absolute(timeout), &cancel, args...);
         }
         auto operator()(rpc::client& dst, cancellable& cancel, const InArgs&... args) {
             return send(dst, {}, &cancel, args...);


### PR DESCRIPTION
Current we support either sending an rpc message
with timeout, or sending it with a `cancellable`
parameter that allows the caller to cancel the rpc.

The caller can implement a client-side timeout
using the cancellable object using an external timer, however, in this case, the timeout value is not
automatically communicated to the message handler
on the receiver side.

To allow users to cancel a verb that already
uses a timeout, add variants of the call operator
that accept both a timeout and a cancellable.

Also, add a respective unit test.