### PR TITLE
Share IO queues between mountpoints

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -58,9 +58,11 @@ int main(int ac, char** av) {
                             auto& ioq = engine().get_io_queue(st.st_dev);
                             auto& cfg = ioq.get_config();
 
+                            out << YAML::Key << "device" << YAML::Value << st.st_dev;
                             out << YAML::Key << "io_latency_goal_ms" << YAML::Value <<
                                     std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(cfg.rate_limit_duration).count();
                             out << YAML::Key << "io_queue" << YAML::BeginMap;
+                            out << YAML::Key << "id" << YAML::Value << ioq.id();
                             out << YAML::Key << "req_count_rate" << YAML::Value << cfg.req_count_rate;
                             out << YAML::Key << "blocks_count_rate" << YAML::Value << cfg.blocks_count_rate;
                             out << YAML::Key << "disk_req_write_to_read_multiplier" << YAML::Value << cfg.disk_req_write_to_read_multiplier;

--- a/doc/io-properties-file.md
+++ b/doc/io-properties-file.md
@@ -39,3 +39,23 @@ disks:
     write_bandwidth: 510M
     write_saturation_length: 64k
 ```
+
+Optionally, instead of the "mountpoint" there can be the "mountpoints" (plural)
+entry in the list element being a list itself and listing more than one path. As
+a result all the listed mountpoints will share the corresponding internal IO queue.
+
+Example:
+
+```
+disks:
+  - mountpoints:
+      - /var/lib/some_seastar_app/sub_one
+      - /var/lib/some_seastar_app/sub_two
+    read_iops: 95000
+    ...
+```
+
+An example when this configuration is applicable can be an LLVM set of volumes
+from one disk each being mounted at its own path. In that case, different mount
+points would have different (virtual) block devices, yet, they will share the
+same physical disk and thus need to run over one shared IO queue.

--- a/include/seastar/core/io_intent.hh
+++ b/include/seastar/core/io_intent.hh
@@ -43,12 +43,12 @@ namespace seastar {
 SEASTAR_MODULE_EXPORT
 class io_intent {
     struct intents_for_queue {
-        dev_t dev;
+        unsigned qid;
         io_priority_class_id cid;
         internal::cancellable_queue cq;
 
-        intents_for_queue(dev_t dev_, io_priority_class_id cid_) noexcept
-            : dev(dev_), cid(cid_), cq() {}
+        intents_for_queue(unsigned qid_, io_priority_class_id cid_) noexcept
+            : qid(qid_), cid(cid_), cq() {}
 
         intents_for_queue(intents_for_queue&&) noexcept = default;
         intents_for_queue& operator=(intents_for_queue&&) noexcept = default;
@@ -96,14 +96,14 @@ public:
     }
 
     /// @private
-    internal::cancellable_queue& find_or_create_cancellable_queue(dev_t dev, io_priority_class_id cid) {
+    internal::cancellable_queue& find_or_create_cancellable_queue(unsigned qid, io_priority_class_id cid) {
         for (auto&& i : _intents) {
-            if (i.dev == dev && i.cid == cid) {
+            if (i.qid == qid && i.cid == cid) {
                 return i.cq;
             }
         }
 
-        _intents.emplace_back(dev, cid);
+        _intents.emplace_back(qid, cid);
         return _intents.back().cq;
     }
 };

--- a/include/seastar/core/io_intent.hh
+++ b/include/seastar/core/io_intent.hh
@@ -44,11 +44,11 @@ SEASTAR_MODULE_EXPORT
 class io_intent {
     struct intents_for_queue {
         dev_t dev;
-        io_priority_class_id qid;
+        io_priority_class_id cid;
         internal::cancellable_queue cq;
 
-        intents_for_queue(dev_t dev_, io_priority_class_id qid_) noexcept
-            : dev(dev_), qid(qid_), cq() {}
+        intents_for_queue(dev_t dev_, io_priority_class_id cid_) noexcept
+            : dev(dev_), cid(cid_), cq() {}
 
         intents_for_queue(intents_for_queue&&) noexcept = default;
         intents_for_queue& operator=(intents_for_queue&&) noexcept = default;
@@ -96,14 +96,14 @@ public:
     }
 
     /// @private
-    internal::cancellable_queue& find_or_create_cancellable_queue(dev_t dev, io_priority_class_id qid) {
+    internal::cancellable_queue& find_or_create_cancellable_queue(dev_t dev, io_priority_class_id cid) {
         for (auto&& i : _intents) {
-            if (i.dev == dev && i.qid == qid) {
+            if (i.dev == dev && i.cid == cid) {
                 return i.cq;
             }
         }
 
-        _intents.emplace_back(dev, qid);
+        _intents.emplace_back(dev, cid);
         return _intents.back().cq;
     }
 };

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -181,7 +181,7 @@ public:
     fair_queue_entry::capacity_t request_capacity(internal::io_direction_and_length dnl) const noexcept;
 
     sstring mountpoint() const;
-    dev_t dev_id() const noexcept;
+    unsigned id() const noexcept { return _id; }
 
     void update_shares_for_class(internal::priority_class pc, size_t new_shares);
     future<> update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth);
@@ -232,10 +232,6 @@ inline const io_queue::config& io_queue::get_config() const noexcept {
 
 inline sstring io_queue::mountpoint() const {
     return get_config().mountpoint;
-}
-
-inline dev_t io_queue::dev_id() const noexcept {
-    return get_config().devid;
 }
 
 namespace internal {

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -81,6 +81,7 @@ public:
 private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     io_group_ptr _group;
+    const unsigned _id;
     boost::container::static_vector<fair_queue, 2> _streams;
     internal::io_sink& _sink;
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -131,7 +131,7 @@ public:
     static constexpr unsigned block_size_shift = 9;
 
     struct config {
-        dev_t devid;
+        unsigned id;
         unsigned long req_count_rate = std::numeric_limits<int>::max();
         unsigned long blocks_count_rate = std::numeric_limits<int>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -230,7 +230,7 @@ private:
     static constexpr unsigned max_aio = max_aio_per_queue * max_queues;
 
     // Each mountpouint is controlled by its own io_queue, but ...
-    std::unordered_map<dev_t, std::unique_ptr<io_queue>> _io_queues;
+    std::unordered_map<dev_t, seastar::shared_ptr<io_queue>> _io_queues;
     // ... when dispatched all requests get into this single sink
     internal::io_sink _io_sink;
     unsigned _num_io_groups = 0;

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/util/spinlock.hh>
 #include <seastar/util/modules.hh>
+#include <seastar/core/shared_ptr.hh>
 #ifndef SEASTAR_MODULE
 #include <cassert>
 #include <cstdlib>
@@ -108,7 +109,7 @@ struct memory {
 };
 
 struct io_queue_topology {
-    std::vector<std::unique_ptr<io_queue>> queues;
+    std::vector<seastar::shared_ptr<io_queue>> queues;
     std::vector<unsigned> shard_to_group;
     std::vector<unsigned> shards_in_group;
     std::vector<std::shared_ptr<io_group>> groups;

--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -97,7 +97,7 @@ struct configuration {
     size_t cpus;
     cpuset cpu_set;
     bool assign_orphan_cpus = false;
-    std::vector<dev_t> devices;
+    std::vector<unsigned> io_queues;
     unsigned num_io_groups;
     hwloc::internal::topology_holder topology;
 };
@@ -129,7 +129,7 @@ struct cpu {
 
 struct resources {
     std::vector<cpu> cpus;
-    std::unordered_map<dev_t, io_queue_topology> ioq_topology;
+    std::unordered_map<unsigned, io_queue_topology> ioq_topology;
     std::unordered_map<unsigned /* numa node id */, cpuset> numa_node_id_to_cpuset;
 };
 

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -73,6 +73,7 @@ public:
 class posix_file_impl : public file_impl {
     std::atomic<unsigned>* _refcount = nullptr;
     const bool _nowait_works;
+    const dev_t _device_id;
     io_queue& _io_queue;
     const open_flags _open_flags;
 protected:

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -116,7 +116,8 @@ file_handle::to_file() && {
 
 posix_file_impl::posix_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, bool nowait_works)
         : _nowait_works(nowait_works)
-        , _io_queue(engine().get_io_queue(device_id))
+        , _device_id(device_id)
+        , _io_queue(engine().get_io_queue(_device_id))
         , _open_flags(f)
         , _fd(fd)
 {
@@ -165,7 +166,7 @@ posix_file_impl::dup() {
     if (!_refcount) {
         _refcount = new std::atomic<unsigned>(1u);
     }
-    auto ret = std::make_unique<posix_file_handle_impl>(_fd, _open_flags, _refcount, _io_queue.dev_id(),
+    auto ret = std::make_unique<posix_file_handle_impl>(_fd, _open_flags, _refcount, _device_id,
             _memory_dma_alignment, _disk_read_dma_alignment, _disk_write_dma_alignment, _disk_overwrite_dma_alignment,
             _nowait_works);
     _refcount->fetch_add(1, std::memory_order_relaxed);
@@ -180,7 +181,8 @@ posix_file_impl::posix_file_impl(int fd, open_flags f, std::atomic<unsigned>* re
         bool nowait_works)
         : _refcount(refcount)
         , _nowait_works(nowait_works)
-        , _io_queue(engine().get_io_queue(device_id))
+        , _device_id(device_id)
+        , _io_queue(engine().get_io_queue(_device_id))
         , _open_flags(f)
         , _fd(fd) {
     _memory_dma_alignment = memory_dma_alignment;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -865,7 +865,7 @@ future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direc
         auto queued_req = std::make_unique<queued_io_request>(std::move(req), *this, cap, pclass, std::move(dnl), std::move(iovs));
         auto fut = queued_req->get_future();
         if (intent != nullptr) {
-            auto& cq = intent->find_or_create_cancellable_queue(dev_id(), pc.id());
+            auto& cq = intent->find_or_create_cancellable_queue(_id, pc.id());
             queued_req->set_intent(cq);
         }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -627,7 +627,7 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
 
     auto goal = io_latency_goal();
     auto lvl = goal > 1.1 * _config.rate_limit_duration ? log_level::warn : log_level::debug;
-    seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for device {}", goal.count() * 1000, _config.devid);
+    seastar_logger.log(lvl, "IO queue uses {:.2f}ms latency goal for {}", goal.count() * 1000, _config.mountpoint);
 
     /*
      * The maximum request size shouldn't result in the capacity that would

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -230,11 +230,11 @@ public:
         , _fq_capacity(cap)
         , _iovs(std::move(iovs))
     {
-        io_log.trace("dev {} : req {} queue  len {} capacity {}", _ioq.dev_id(), fmt::ptr(this), _dnl.length(), _fq_capacity);
+        io_log.trace("dev {} : req {} queue  len {} capacity {}", _ioq.id(), fmt::ptr(this), _dnl.length(), _fq_capacity);
     }
 
     virtual void set_exception(std::exception_ptr eptr) noexcept override {
-        io_log.trace("dev {} : req {} error", _ioq.dev_id(), fmt::ptr(this));
+        io_log.trace("dev {} : req {} error", _ioq.id(), fmt::ptr(this));
         _pclass.on_error();
         _ioq.complete_request(*this, std::chrono::duration<double>(0.0));
         _pr.set_exception(eptr);
@@ -242,7 +242,7 @@ public:
     }
 
     virtual void complete(size_t res) noexcept override {
-        io_log.trace("dev {} : req {} complete", _ioq.dev_id(), fmt::ptr(this));
+        io_log.trace("dev {} : req {} complete", _ioq.id(), fmt::ptr(this));
         auto now = io_queue::clock_type::now();
         auto delay = std::chrono::duration_cast<std::chrono::duration<double>>(now - _ts);
         _pclass.on_complete(delay);
@@ -258,7 +258,7 @@ public:
     }
 
     void dispatch() noexcept {
-        io_log.trace("dev {} : req {} submit", _ioq.dev_id(), fmt::ptr(this));
+        io_log.trace("dev {} : req {} submit", _ioq.id(), fmt::ptr(this));
         auto now = io_queue::clock_type::now();
         _pclass.on_dispatch(_dnl, std::chrono::duration_cast<std::chrono::duration<double>>(now - _ts));
         _ts = now;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -568,7 +568,7 @@ fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring
 io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     : _priority_classes()
     , _group(std::move(group))
-    , _id(_group->_config.devid)
+    , _id(_group->_config.id)
     , _sink(sink)
     , _averaging_decay_timer([this] {
         update_flow_ratio();
@@ -601,7 +601,7 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
 
 fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {
     fair_group::config cfg;
-    cfg.label = fmt::format("io-queue-{}", qcfg.devid);
+    cfg.label = fmt::format("io-queue-{}", qcfg.id);
     double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
     cfg.min_tokens = min_weight / qcfg.req_count_rate + min_size / qcfg.blocks_count_rate;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -568,6 +568,7 @@ fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring
 io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     : _priority_classes()
     , _group(std::move(group))
+    , _id(_group->_config.devid)
     , _sink(sink)
     , _averaging_decay_timer([this] {
         update_flow_ratio();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4552,7 +4552,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 group = iog;
             }
 
-            io_info.queues[shard] = std::make_unique<io_queue>(std::move(group), engine()._io_sink);
+            io_info.queues[shard] = seastar::make_shared<io_queue>(std::move(group), engine()._io_sink);
             seastar_logger.debug("attached {} queue to {} IO group, dev {}", shard, group_idx, dev);
         }
     };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4154,20 +4154,20 @@ public:
                 unsigned queue_id_gen = 1;
                 std::unordered_set<dev_t> devices;
                 for (auto& d : disks) {
-                  for (auto mp : d.mountpoints) {
-                    struct ::stat buf;
-                    auto ret = stat(mp.c_str(), &buf);
-                    if (ret < 0) {
-                        throw std::runtime_error(fmt::format("Couldn't stat {}", mp));
-                    }
+                    for (auto mp : d.mountpoints) {
+                        struct ::stat buf;
+                        auto ret = stat(mp.c_str(), &buf);
+                        if (ret < 0) {
+                            throw std::runtime_error(fmt::format("Couldn't stat {}", mp));
+                        }
 
-                    auto st_dev = S_ISBLK(buf.st_mode) ? buf.st_rdev : buf.st_dev;
-                    d.devices.push_back(st_dev);
-                    auto [ it, inserted ] = devices.insert(st_dev);
-                    if (!inserted) {
-                        throw std::runtime_error(fmt::format("Mountpoint {}, device {} already configured", mp, st_dev));
+                        auto st_dev = S_ISBLK(buf.st_mode) ? buf.st_rdev : buf.st_dev;
+                        d.devices.push_back(st_dev);
+                        auto [ it, inserted ] = devices.insert(st_dev);
+                        if (!inserted) {
+                            throw std::runtime_error(fmt::format("Mountpoint {}, device {} already configured", mp, st_dev));
+                        }
                     }
-                  }
 
                     if (_disks.size() >= _max_queues) {
                         throw std::runtime_error(fmt::format("Configured number of queues {} is larger than the maximum {}",

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -715,8 +715,8 @@ resources allocate(configuration& c) {
     }
 
     unsigned last_node_idx = 0;
-    for (auto devid : c.devices) {
-        ret.ioq_topology.emplace(devid, allocate_io_queues(topology, ret.cpus, cpu_to_node, c.num_io_groups, last_node_idx));
+    for (auto q : c.io_queues) {
+        ret.ioq_topology.emplace(q, allocate_io_queues(topology, ret.cpus, cpu_to_node, c.num_io_groups, last_node_idx));
     }
 
     ret.numa_node_id_to_cpuset = numa_node_id_to_cpuset(topology);


### PR DESCRIPTION
Currently, IO-queues assignment is done per-mountpoint. The mountpoint paths are read from io-properties.yaml file, for each the underlying device number is stat()-ed, then devive -> io_queue mapping is established. When opening a file, seastar stat()-s the filepath and finds the io_queue for the found device number.

It's nonetheless possible to have one physical disk be "split" into several virtual block devices, and to mount each into its own mountpoint. In order to configure io-scheduler for this setup the only option is to have two mountpoints in io_properties.yaml. With that, seastar will create two io_queues for both mountpoints, but it's not correct, since underlying physical disk is still the same.

This PR extends the io-properties.yaml configuration so that one disk entry in it can specify a list of mountpoints this disk configuration applies to. When met such a record, seastar would create a single io_queue object, but will map all mountpoints' device numbers to it.

The change has two main parts. First, the smaller one, reactor's map<device, io_queue> now may have several devices point to one shared io_queue object. So than when two files are opened on different mountpoints with, respectively, different device numbers, they both will get reference to the same io_queue. Second, the larger change, is that io_queue internal "identification" changes from the underlying device number to abstract integer value. That's not a breaking change, however, device numbers were not present in any APIs or metric labels. Only in logs.

fixes #2733