### PR TITLE
Add assertion to `get_local_service` in `sharded` module.

### DIFF
--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -526,6 +526,7 @@ private:
     }
 
     shared_ptr<Service> get_local_service() {
+	SEASTAR_ASSERT(local_is_initialized());
         auto inst = _instances[this_shard_id()].service;
         if (!inst) {
             throw no_sharded_instance_exception(pretty_type_name(typeid(Service)));
@@ -534,6 +535,7 @@ private:
     }
 
     shared_ptr<const Service> get_local_service() const {
+	SEASTAR_ASSERT(local_is_initialized());
         auto inst = _instances[this_shard_id()].service;
         if (!inst) {
             throw no_sharded_instance_exception(pretty_type_name(typeid(Service)));


### PR DESCRIPTION
Ensure that the local instance exists and is initialized before accessing it in `get_local_service`.