### PR TITLE
app-template: remove production warning

### DIFF
--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -188,9 +188,6 @@ app_template::run(int ac, char ** av, std::function<future<> ()>&& func) noexcep
 
 int
 app_template::run_deprecated(int ac, char ** av, std::function<void ()>&& func) noexcept {
-#ifdef SEASTAR_DEBUG
-    fmt::print(std::cerr, "WARNING: debug mode. Not for benchmarking or production\n");
-#endif
     boost::program_options::options_description all_opts;
     all_opts.add(_app_opts);
     all_opts.add(_seastar_opts);


### PR DESCRIPTION
We print a warning when SEASTAR_DEBUG is enabled, saying it's not for production or performance testing. This might be a suitable warning for the application itself to emit, but a framework like seastar should leave that choice up to the application. This warning cannot be supressed and does not follow the normal logging system, so it is unnecessarily noisy and interferes with anything which parses stderr.