### PR TITLE
build: fix P2582R1 detection for GCC compiler compatibility

### DIFF
--- a/cmake/CheckP2582R1.cmake
+++ b/cmake/CheckP2582R1.cmake
@@ -12,8 +12,9 @@ template <typename... T> struct B {
     B(T...) {}
 };
 
-template <typename... T> struct C : public B<T> {
+template <typename... T> struct C : public B<T...> {
     using B<T...>::B;
+    C(B<T...>) {}
 };
 
 B(int) -> B<char>;


### PR DESCRIPTION
In commit a1f1642f, we attempted to improve detection of compiler support for P2582R1 (class template argument deduction for alias templates). However, the implementation was flawed because we failed to update class `C` to pass variadic template parameters to base class `B`.

As a result, the test incorrectly indicated that GCC 14.2.1 didn't support P2582R1 (when it actually does), causing an unnecessary deduction guide to be added. This led to ambiguous call errors in rpc_test.cc:

```
FAILED: tests/unit/CMakeFiles/test_unit_rpc.dir/rpc_test.cc.o
/usr/lib64/ccache/g++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_NO_LIB -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_DEPRECATED_OSTREAM_FORMATTERS -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DSEASTAR_TESTING_MAIN -DSEASTAR_TESTING_WITH_NETWORKING=1 -I/home/kefu/dev/seastar/tests/unit -I/home/kefu/dev/seastar/src -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/debug/gen/include -I/home/kefu/dev/seastar/build/debug/gen/src -O3 -DNDEBUG -std=gnu++23 -Wno-maybe-uninitialized -Wno-error=unused-result -fno-semantic-interposition -Wall -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -Wno-error=stringop-overflow -Wno-error=array-bounds -Wdeprecated-declarations -Wno-error=deprecated-declarations -fvisibility=hidden -gz -MD -MT tests/unit/CMakeFiles/test_unit_rpc.dir/rpc_test.cc.o -MF tests/unit/CMakeFiles/test_unit_rpc.dir/rpc_test.cc.o.d -o tests/unit/CMakeFiles/test_unit_rpc.dir/rpc_test.cc.o -c /home/kefu/dev/seastar/tests/unit/rpc_test.cc
/home/kefu/dev/seastar/tests/unit/rpc_test.cc: In lambda function:
/home/kefu/dev/seastar/tests/unit/rpc_test.cc:1369:89: error: class template argument deduction failed:
 1369 |             return make_ready_future<rpc::tuple<int, long>>(rpc::tuple(1, 0x7'0000'0000L));
      |                                                                                         ^
/home/kefu/dev/seastar/tests/unit/rpc_test.cc:1369:89: error: call of overloaded ‘tuple(int, long int)’ is ambiguous
```

This commit corrects the P2582R1 detection test, ensuring proper compiler feature detection and fixing the build failure in rpc_test.