### PR TITLE
core: Fix module linkage by using `inline constexpr` for shared constants

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -131,9 +131,9 @@ namespace memory {
 #define SEASTAR_INTERNAL_ALLOCATOR_PAGE_SIZE 4096
 #endif
 
-static constexpr size_t page_size = SEASTAR_INTERNAL_ALLOCATOR_PAGE_SIZE;
-static constexpr size_t page_bits = log2ceil(page_size);
-static constexpr size_t huge_page_size =
+constexpr inline size_t page_size = SEASTAR_INTERNAL_ALLOCATOR_PAGE_SIZE;
+constexpr inline size_t page_bits = log2ceil(page_size);
+constexpr inline size_t huge_page_size =
 #if defined(__x86_64__) || defined(__i386__) || defined(__s390x__) || defined(__zarch__)
     1 << 21; // 2M
 #elif defined(__aarch64__)

--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -298,7 +298,7 @@ type_id type_id_for(known_type);
 
 using description = seastar::metrics::description;
 
-static constexpr unsigned max_collectd_field_text_len = 63;
+constexpr inline unsigned max_collectd_field_text_len = 63;
 
 class type_instance_id {
     static thread_local unsigned _next_truncated_idx;


### PR DESCRIPTION
Previously, we defined constants shared across translation units (TUs) with `static constexpr`, creating separate copies per TU with internal linkage. When building with C++20 modules support, these variables need module linkage to be visible across module boundaries.

The `static` specifier prevents variables from being visible across TUs, causing build failures with C++20 modules:

```
FAILED: src/CMakeFiles/seastar-module.dir/core/scollectd.cc.o
/home/kefu/.local/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_MODULE -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/release/gen/include -I/home/kefu/dev/seastar/src -O2 -g -DNDEBUG -std=c++23 -U_FORTIFY_SOURCE -Wno-include-angled-in-module-purview -MD -MT src/CMakeFiles/seastar-module.dir/core/scollectd.cc.o -MF src/CMakeFiles/seastar-module.dir/core/scollectd.cc.o.d @src/CMakeFiles/seastar-module.dir/core/scollectd.cc.o.modmap -o src/CMakeFiles/seastar-module.dir/core/scollectd.cc.o -c /home/kefu/dev/seastar/src/core/scollectd.cc
/home/kefu/dev/seastar/src/core/scollectd.cc:55:24: error: use of undeclared identifier 'max_collectd_field_text_len'
   55 |     if (field.size() > max_collectd_field_text_len) {
      |                        ^
```

This change replaces `static constexpr` with `inline constexpr` for constants shared across different TUs. This approach:
1. Allows module linkage in C++20 modules builds
2. Prevents multiple-definition linker errors in traditional builds by instructing the linker to merge identical definitions
3. Maintains constexpr optimization benefits

This fixes build failures with clang-20 and clang-21 when building with C++20 modules while ensuring the compatibility with non-module builds.