### PR TITLE
util: include used header

### DIFF
--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -34,6 +34,7 @@ module;
 #include <vector>
 #include <boost/container/static_vector.hpp>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;


### PR DESCRIPTION
when building the tree with modules support enabled and fmt v11.1.4, it failed to compile:

```
FAILED: src/CMakeFiles/seastar-module.dir/util/backtrace.cc.o
/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTA
R_HAVE_ASAN_FIBER_SUPPORT -DSEASTAR_HAVE_HWLOC -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_MODULE -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -Dseastar_module_EXPORTS -I/home/kefu/dev/seastar/include -I/home/kefu/dev/seastar/build/d
ebug/gen/include -I/home/kefu/dev/seastar/src -g -std=c++23 -fPIC -U_FORTIFY_SOURCE -Wno-include-angled-in-module-purview -MD -MT src/CMakeFiles/seastar-module.dir/util/backtrace.cc.o -MF src/CMakeFiles/seastar-module.dir/util/backtrace.c
c.o.d @src/CMakeFiles/seastar-module.dir/util/backtrace.cc.o.modmap -o src/CMakeFiles/seastar-module.dir/util/backtrace.cc.o -c /home/kefu/dev/seastar/src/util/backtrace.cc
/home/kefu/dev/seastar/src/util/backtrace.cc:199:49: error: no member named 'join' in namespace 'fmt'
  199 |     return fmt::format_to(ctx.out(), "{}", fmt::join(b._frames, " "));
      |                                            ~~~~~^
1 error generated.
```

because `fmt::join()` is declared and implemented in fmt/ranges.h, let's include this header for using `fmt::join()` in `util/backtrace.cc`.