### PR TITLE
resource: Rework condition for sysconf fallback

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -335,6 +335,7 @@ static size_t alloc_from_node(cpu& this_cpu, hwloc_obj_t node, std::unordered_ma
         auto node_id = hwloc_bitmap_first(node->nodeset);
         SEASTAR_ASSERT(node_id != -1);
         this_cpu.mem.push_back({taken, unsigned(node_id)});
+        seastar_logger.debug("CPU{} allocated {} bytes from NODE{}", this_cpu.cpu_id, taken, node_id);
     }
     return taken;
 }

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -603,17 +603,15 @@ resources allocate(configuration& c) {
     }
 
     if (!available_memory) {
-
-    auto machine_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_MACHINE);
-    SEASTAR_ASSERT(hwloc_get_nbobjs_by_depth(topology, machine_depth) == 1);
-    auto machine = hwloc_get_obj_by_depth(topology, machine_depth, 0);
-    available_memory = get_memory_from_hwloc_obj(machine);
-    if (!available_memory) {
-        available_memory = get_machine_memory_from_sysconf();
-        set_memory_to_hwloc_obj(machine, available_memory);
-        seastar_logger.warn("hwloc failed to detect machine-wide memory size, using memory size fetched from sysconf");
-    }
-
+        auto machine_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_MACHINE);
+        SEASTAR_ASSERT(hwloc_get_nbobjs_by_depth(topology, machine_depth) == 1);
+        auto machine = hwloc_get_obj_by_depth(topology, machine_depth, 0);
+        available_memory = get_memory_from_hwloc_obj(machine);
+        if (!available_memory) {
+            available_memory = get_machine_memory_from_sysconf();
+            set_memory_to_hwloc_obj(machine, available_memory);
+            seastar_logger.warn("hwloc failed to detect machine-wide memory size, using memory size fetched from sysconf");
+        }
     }
 
     size_t mem = calculate_memory(c, std::min(available_memory,


### PR DESCRIPTION
The resource allocation fallback code assumes that the number of numa nodes detected by hwloc is 1 (see b0a9f89a7). However, here's my node:

```
Machine (126GB total) + Package L#0
  Die L#0
    NUMANode L#0 (P#0 63GB)
    L3 L#0 (8192KB)
      L2 L#0 (512KB) + L1d L#0 (32KB) + L1i L#0 (64KB) + Core L#0
        PU L#0 (P#0)
        PU L#1 (P#24)
      L2 L#1 (512KB) + L1d L#1 (32KB) + L1i L#1 (64KB) + Core L#1
        PU L#2 (P#1)
        PU L#3 (P#25)
      L2 L#2 (512KB) + L1d L#2 (32KB) + L1i L#2 (64KB) + Core L#2
        PU L#4 (P#2)
        PU L#5 (P#26)
    L3 L#1 (8192KB)
      L2 L#3 (512KB) + L1d L#3 (32KB) + L1i L#3 (64KB) + Core L#3
        PU L#6 (P#3)
        PU L#7 (P#27)
      L2 L#4 (512KB) + L1d L#4 (32KB) + L1i L#4 (64KB) + Core L#4
        PU L#8 (P#4)
        PU L#9 (P#28)
      L2 L#5 (512KB) + L1d L#5 (32KB) + L1i L#5 (64KB) + Core L#5
        PU L#10 (P#5)
        PU L#11 (P#29)
    HostBridge
      PCIBridge
        PCI 01:00.1 (SATA)
        PCIBridge
          PCIBridge
            PCI 03:00.0 (Network)
              Net "wlp3s0"
          PCIBridge
            PCI 04:00.0 (Network)
              Net "wlp4s0"
          PCIBridge
            PCI 05:00.0 (Ethernet)
              Net "enp5s0"
          PCIBridge
            PCI 07:00.0 (Ethernet)
              Net "enp7s0"
      PCIBridge
        PCI 0a:00.2 (SATA)
  Die L#1
    NUMANode L#1 (P#2 63GB)
    L3 L#2 (8192KB)
      L2 L#6 (512KB) + L1d L#6 (32KB) + L1i L#6 (64KB) + Core L#6
        PU L#12 (P#6)
        PU L#13 (P#30)
      L2 L#7 (512KB) + L1d L#7 (32KB) + L1i L#7 (64KB) + Core L#7
        PU L#14 (P#7)
        PU L#15 (P#31)
      L2 L#8 (512KB) + L1d L#8 (32KB) + L1i L#8 (64KB) + Core L#8
        PU L#16 (P#8)
        PU L#17 (P#32)
    L3 L#3 (8192KB)
      L2 L#9 (512KB) + L1d L#9 (32KB) + L1i L#9 (64KB) + Core L#9
        PU L#18 (P#9)
        PU L#19 (P#33)
      L2 L#10 (512KB) + L1d L#10 (32KB) + L1i L#10 (64KB) + Core L#10
        PU L#20 (P#10)
        PU L#21 (P#34)
      L2 L#11 (512KB) + L1d L#11 (32KB) + L1i L#11 (64KB) + Core L#11
        PU L#22 (P#11)
        PU L#23 (P#35)
    HostBridge
      PCIBridge
        PCI 41:00.0 (NVMExp)
          Block(Disk) "nvme0n1"
      PCIBridge
        PCI 42:00.0 (VGA)
      PCIBridge
        PCI 44:00.2 (SATA)
  Die L#2
    NUMANode L#2 (P#1)
    L3 L#4 (8192KB)
      L2 L#12 (512KB) + L1d L#12 (32KB) + L1i L#12 (64KB) + Core L#12
        PU L#24 (P#12)
        PU L#25 (P#36)
      L2 L#13 (512KB) + L1d L#13 (32KB) + L1i L#13 (64KB) + Core L#13
        PU L#26 (P#13)
        PU L#27 (P#37)
      L2 L#14 (512KB) + L1d L#14 (32KB) + L1i L#14 (64KB) + Core L#14
        PU L#28 (P#14)
        PU L#29 (P#38)
    L3 L#5 (8192KB)
      L2 L#15 (512KB) + L1d L#15 (32KB) + L1i L#15 (64KB) + Core L#15
        PU L#30 (P#15)
        PU L#31 (P#39)
      L2 L#16 (512KB) + L1d L#16 (32KB) + L1i L#16 (64KB) + Core L#16
        PU L#32 (P#16)
        PU L#33 (P#40)
      L2 L#17 (512KB) + L1d L#17 (32KB) + L1i L#17 (64KB) + Core L#17
        PU L#34 (P#17)
        PU L#35 (P#41)
  Die L#3
    NUMANode L#3 (P#3)
    L3 L#6 (8192KB)
      L2 L#18 (512KB) + L1d L#18 (32KB) + L1i L#18 (64KB) + Core L#18
        PU L#36 (P#18)
        PU L#37 (P#42)
      L2 L#19 (512KB) + L1d L#19 (32KB) + L1i L#19 (64KB) + Core L#19
        PU L#38 (P#19)
        PU L#39 (P#43)
      L2 L#20 (512KB) + L1d L#20 (32KB) + L1i L#20 (64KB) + Core L#20
        PU L#40 (P#20)
        PU L#41 (P#44)
    L3 L#7 (8192KB)
      L2 L#21 (512KB) + L1d L#21 (32KB) + L1i L#21 (64KB) + Core L#21
        PU L#42 (P#21)
        PU L#43 (P#45)
      L2 L#22 (512KB) + L1d L#22 (32KB) + L1i L#22 (64KB) + Core L#22
        PU L#44 (P#22)
        PU L#45 (P#46)
      L2 L#23 (512KB) + L1d L#23 (32KB) + L1i L#23 (64KB) + Core L#23
        PU L#46 (P#23)
        PU L#47 (P#47)
```

There are 4 nodes, and some of them are empty. So resource allocation code finds the zero-mem node, tries to fallback and asserts that the number of nodes is not 1.

The fix is to fallback to sysconf only if all found nodes report zero memory.
