### PR TITLE
doc/io-properties-file.md: correct a typo

### DIFF
--- a/doc/io-properties-file.md
+++ b/doc/io-properties-file.md
@@ -55,7 +55,7 @@ disks:
     ...
 ```
 
-An example when this configuration is applicable can be an LLVM set of volumes
+An example when this configuration is applicable can be an LVM set of volumes
 from one disk each being mounted at its own path. In that case, different mount
 points would have different (virtual) block devices, yet, they will share the
 same physical disk and thus need to run over one shared IO queue.


### PR DESCRIPTION
Replace incorrect "LLVM" with "LVM" (Logical Volume Manager). This avoids confusion with the unrelated LLVM compiler project.