### PR TITLE
reactor: Keep task-queues in std::array instead of static_vector

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -62,7 +62,6 @@
 #include "internal/pollable_fd.hh"
 
 #ifndef SEASTAR_MODULE
-#include <boost/container/static_vector.hpp>
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -289,7 +288,7 @@ private:
         void register_stats();
     };
 
-    boost::container::static_vector<std::unique_ptr<task_queue>, max_scheduling_groups()> _task_queues;
+    std::array<std::unique_ptr<task_queue>, max_scheduling_groups()> _task_queues;
     internal::scheduling_group_specific_thread_local_data _scheduling_group_specific_data;
     shared_mutex _scheduling_group_keys_mutex;
     int64_t _last_vruntime = 0;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1053,9 +1053,9 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
      */
     _backend = rbs.create(*this);
     *internal::get_scheduling_group_specific_thread_local_data_ptr() = &_scheduling_group_specific_data;
-    _task_queues.push_back(std::make_unique<task_queue>(0, "main", "main", 1000));
-    _task_queues.push_back(std::make_unique<task_queue>(1, "atexit", "exit", 1000));
-    _at_destroy_tasks = _task_queues.back().get();
+    _task_queues[0] = std::make_unique<task_queue>(0, "main", "main", 1000);
+    _task_queues[1] = std::make_unique<task_queue>(1, "atexit", "exit", 1000);
+    _at_destroy_tasks = _task_queues[1].get();
     set_need_preempt_var(&_preemption_monitor);
     seastar::thread_impl::init();
     _backend->start_tick();
@@ -5039,7 +5039,6 @@ future<>
 reactor::init_scheduling_group(seastar::scheduling_group sg, sstring name, sstring shortname, float shares) {
     return with_shared(_scheduling_group_keys_mutex, [this, sg, name = std::move(name), shortname = std::move(shortname), shares] {
         get_sg_data(sg).queue_is_initialized = true;
-        _task_queues.resize(std::max<size_t>(_task_queues.size(), sg._id + 1));
         _task_queues[sg._id] = std::make_unique<task_queue>(sg._id, name, shortname, shares);
 
         return with_scheduling_group(sg, [this, sg] () {
@@ -5137,8 +5136,8 @@ scheduling_group::name() const noexcept {
 
 const sstring&
 scheduling_group::short_name() const noexcept {
-    if (!engine()._task_queues.empty()) {
-        auto& task_queue = engine()._task_queues[_id];
+    auto& task_queue = engine()._task_queues[_id];
+    if (task_queue) {
         return task_queue->_shortname;
     }
     // we might want to print logging messages before task_queues are ready.


### PR DESCRIPTION
There's no code in reactor that ever needs to know how many elements there are in this vector, so there's no point in keeping it as such. Plain array would work the same.