### PR TITLE
memory: Report oversized alloc count as metric

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2569,7 +2569,8 @@ void reactor::register_metrics() {
             sm::make_current_bytes("total_memory", [] { return memory::stats().total_memory(); }, sm::description("Total memory size in bytes")),
             sm::make_current_bytes("allocated_memory", [] { return memory::stats().allocated_memory(); }, sm::description("Allocated memory size in bytes")),
             sm::make_counter("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations")),
-            sm::make_counter("malloc_failed", [] { return memory::stats().failed_allocations(); }, sm::description("Total count of failed memory allocations"))
+            sm::make_counter("malloc_failed", [] { return memory::stats().failed_allocations(); }, sm::description("Total count of failed memory allocations")),
+            sm::make_counter("oversized_allocs", [] { return memory::stats().large_allocations(); }, sm::description("Total count of oversized memory allocations"))
     });
 
     _metric_groups.add_group("reactor", {


### PR DESCRIPTION
Oversized allocs are already tracked in the stats object.

Export the count in the memory metrics as well.