### PR TITLE
reactor: Drop _reuseport boolean

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -309,7 +309,6 @@ private:
     std::unique_ptr<network_stack> _network_stack;
     lowres_clock::time_point _lowres_next_timeout = lowres_clock::time_point::max();
     std::optional<pollable_fd> _aio_eventfd;
-    const bool _reuseport;
     circular_buffer<double> _loads;
     double _load = 0;
     // Next two fields are required to enforce the monotonicity of total_steal_time()
@@ -480,7 +479,9 @@ public:
 
     pollable_fd posix_listen(socket_address sa, listen_options opts = {});
 
-    bool posix_reuseport_available() const { return _reuseport; }
+    // FIXME: reuseport currently leads to heavy load imbalance.
+    // Until we fix that, just disable it unconditionally.
+    bool posix_reuseport_available() const { return false; }
 
     pollable_fd make_pollable_fd(socket_address sa, int proto);
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1044,7 +1044,6 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     , _id(id)
     , _cpu_started(0)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
-    , _reuseport(posix_reuseport_detect())
     , _thread_pool(std::make_unique<thread_pool>(*this, seastar::format("syscall-{}", id))) {
     /*
      * The _backend assignment is here, not on the initialization list as
@@ -1560,9 +1559,6 @@ reactor::posix_listen(socket_address sa, listen_options opts) {
         fd.setsockopt(SOL_SOCKET, SO_RCVBUF, *opts.so_rcvbuf);
     }
 
-    if (_reuseport && !sa.is_af_unix())
-        fd.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1);
-
     try {
         fd.bind(sa.u.sa, sa.length());
 
@@ -1583,19 +1579,6 @@ reactor::posix_listen(socket_address sa, listen_options opts) {
     }
 
     return pollable_fd(std::move(fd));
-}
-
-bool
-reactor::posix_reuseport_detect() {
-    return false; // FIXME: reuseport currently leads to heavy load imbalance. Until we fix that, just
-                  // disable it unconditionally.
-    try {
-        file_desc fd = file_desc::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-        fd.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1);
-        return true;
-    } catch(std::system_error& e) {
-        return false;
-    }
 }
 
 void pollable_fd_state::maybe_no_more_recv() {


### PR DESCRIPTION
The reuseport is temporarily disabled since 2015 (86ffe72b5b). Dropping all related functionality would be too much, but at least it's worth not spoiling reactor with immutable fields.