### PR TITLE
reactor: Remove write-only _thread_id

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -326,7 +326,6 @@ private:
     sched_clock::time_point _start_time = now();
     output_stream<char>::batch_flush_list_t _flush_batching;
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
-    pthread_t _thread_id alignas(seastar::cache_line_size) = pthread_self();
     std::atomic<bool> _dying{false};
     gate _background_gate;
 


### PR DESCRIPTION
It was used to wakeup() reactor, now event fd does it.