### PR TITLE
reactor: Simplify network stack creation and initialization

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -244,7 +244,6 @@ private:
     std::optional<future<std::unique_ptr<network_stack>>> _network_stack_ready;
     int _return = 0;
     promise<> _start_promise;
-    semaphore _cpu_started;
     internal::preemption_monitor _preemption_monitor{};
     uint64_t _global_tasks_processed = 0;
     uint64_t _polls = 0;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1042,7 +1042,6 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     , _notify_eventfd(file_desc::eventfd(0, EFD_CLOEXEC))
     , _task_quota_timer(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC))
     , _id(id)
-    , _cpu_started(0)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
     , _reuseport(posix_reuseport_detect())
     , _thread_pool(std::make_unique<thread_pool>(*this, seastar::format("syscall-{}", id))) {
@@ -3202,20 +3201,22 @@ int reactor::do_run() {
        _signals.handle_signal_once(SIGTERM, [this] { stop(); });
     }
 
-    // Start initialization in the background.
-    // Communicate when done using _start_promise.
-    (void)_cpu_started.wait(smp::count).then([this] {
-        (void)_network_stack->initialize().then([this] {
-            _start_promise.set_value();
+    if (_id == 0) {
+        // Start initialization in the background.
+        // Wait for network stack to appear on all cpus.
+        // Communicate when done using _start_promise
+        (void)smp::invoke_on_all([] {
+            return engine()._network_stack_ready->then([] (std::unique_ptr<network_stack> stack) {
+                engine()._network_stack = std::move(stack);
+            });
+        }).then([] {
+            return smp::invoke_on_all([] {
+                return engine()._network_stack->initialize().then([] {
+                    engine()._start_promise.set_value();
+                });
+            });
         });
-    });
-    // Wait for network stack in the background and then signal all cpus.
-    (void)_network_stack_ready->then([this] (std::unique_ptr<network_stack> stack) {
-        _network_stack = std::move(stack);
-        return smp::invoke_on_all([] {
-            engine()._cpu_started.signal();
-        });
-    });
+    }
 
     poller syscall_poller(std::make_unique<syscall_pollfn>(*this));
 


### PR DESCRIPTION
When reactor starts it spawns two fibers on each shard.

First waits for the local semaphore to acquire smp::count units, then calls network_stack->initialize(), then wakes up start_promise.

Second waits for network_stack_ready promise to resolve, moves the promised stack unique_ptr onto reactor, then gives one unit to the aforementioned semaphore on all cpus.

All those fibers run in the background.

The same goal can be achieved without semaphore and with less cross-shards invocations.

Spawn an invoke_on_all fiber that waits for network_stack_ready promises on all shards. It will resolve after all shards' promise is resolved.

Then() invoke_on_all again, call initialize() on each network_stack, then resolve the start_promise.