### PR TITLE
aio_storage_context: Rename iocb_pool::_iocb_pool to _all_iocbs

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -113,7 +113,7 @@ void prepare_iocb(const io_request& req, io_completion* desc, iocb& iocb) {
 
 aio_storage_context::iocb_pool::iocb_pool() {
     for (unsigned i = 0; i != max_aio; ++i) {
-        _free_iocbs.push(&_iocb_pool[i]);
+        _free_iocbs.push(&_all_iocbs[i]);
     }
 }
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -63,7 +63,7 @@ class aio_storage_context {
     static constexpr unsigned max_aio = 1024;
 
     class iocb_pool {
-        alignas(cache_line_size) std::array<internal::linux_abi::iocb, max_aio> _iocb_pool;
+        alignas(cache_line_size) std::array<internal::linux_abi::iocb, max_aio> _all_iocbs;
         std::stack<internal::linux_abi::iocb*, boost::container::static_vector<internal::linux_abi::iocb*, max_aio>> _free_iocbs;
     public:
         iocb_pool();


### PR DESCRIPTION
The field of the same name is aio_storage_context member of this very class. When reading the code these two fields of the same name mix with each other and confuse (a bit).