### PR TITLE
http: Add test for improper client handling of aborted requests

### DIFF
--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -55,7 +55,7 @@ public:
     };
 private:
     bool _aborted = false;
-    queue<temporary_buffer<char>> _q{1};
+    queue<temporary_buffer<char>> _q{128};
     loopback_error_injector* _error_injector;
     type _type;
     std::optional<promise<>> _shutdown;


### PR DESCRIPTION
Introduce a test to demonstrate the client's incorrect behavior when a socket is drained or closed before all request data is read.

This test serves as a showcase of the issue and does not include a fix, which will be addressed in a subsequent PR.