### PR TITLE
http: in the client, fix malforming of requests with zero-sized bodies

### DIFF
--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -113,7 +113,11 @@ void request::write_body(const sstring& content_type, noncopyable_function<futur
 void request::write_body(const sstring& content_type, size_t len, noncopyable_function<future<>(output_stream<char>&&)>&& body_writer) {
     set_content_type(content_type);
     content_length = len;
-    this->body_writer = std::move(body_writer);
+    if (len > 0) {
+        // At the time of this writing, connection::write_body()
+        // assumes that `body_writer` is unset if `content_length` is 0.
+        this->body_writer = std::move(body_writer);
+    }
 }
 
 void request::set_expects_continue() {


### PR DESCRIPTION
`connection::write_body` assumes that `req.content_length == 0` implies that chunked encoding has been selected.

Indeed, one variant of `request::write_body` sets
`_headers["Transfer-Encoding"] = "chunked"` and doesn't set `.content_length`, while the other variant
doesn't set `Transfer-Encoding`, but sets `.content_length`.

So the following is true: if `.content_length` wasn't set, then chunked encoding was selected.
That's what `connection::write_body` is trying to depend on.

The problem is that `req.content_length == 0` does not mean that `req.content_length` wasn't set. It could have just been set to 0.

If that happens, the client sends a request with no `Content-Length`, no `Transfer-Encoding`, and a body equal to "0\r\n\r\n", and that's a malformed request.

We fix this by making `request::write_body` keep the `request::body_writer` unset if the declared content length is 0.