### PR TITLE
httpd: Remove unused connection::_req member

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -74,7 +74,6 @@ class connection : public boost::intrusive::list_base_hook<> {
     static constexpr size_t limit = 4096;
     using tmp_buf = temporary_buffer<char>;
     http_request_parser _parser;
-    std::unique_ptr<http::request> _req;
     std::unique_ptr<http::reply> _resp;
     // null element marks eof
     queue<std::unique_ptr<http::reply>> _replies { 10 };


### PR DESCRIPTION
It is (was?) supposed to hold the request being processed, but in fact server just carries the unique_ptr<request> around the continuation chains, so the field is unused.