### PR TITLE
httpd: Don't let body into the HEAD replies output

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -155,6 +155,7 @@ struct reply {
     sstring _content;
     size_t content_length = 0; // valid when received via client connection
     size_t consumed_content = 0;
+    bool _skip_body = false;
 
     sstring _response_line;
     std::unordered_map<sstring, sstring> trailing_headers;
@@ -269,6 +270,12 @@ struct reply {
      * with any additional information that is needed to send the message.
      */
     void write_body(const sstring& content_type, sstring content);
+
+    // RFC7231 Sec. 4.3.2
+    // For HEAD replies collect everything from the handler, but don't write the body itself
+    void skip_body() noexcept {
+        _skip_body = true;
+    }
 
 private:
     future<> write_reply_to_connection(httpd::connection& con);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -107,9 +107,8 @@ future<> connection::start_response() {
                 _replies.abort(std::make_exception_ptr(std::logic_error("Unknown exception during body creation")));
                 _replies.push(std::unique_ptr<http::reply>());
                 f.ignore_ready_future();
-                return make_ready_future<>();
             }
-            return _write_buf.write("0\r\n\r\n", 5);
+            return make_ready_future<>();
         }).then_wrapped([this ] (auto f) {
             if (f.failed()) {
                 // We could not write the closing sequence

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -131,7 +131,9 @@ future<> reply::write_reply_to_connection(httpd::connection& con) {
     }).then([&con] () mutable {
         return con.out().write("\r\n", 2);
     }).then([this, &con] () mutable {
-        return _body_writer(http::internal::make_http_chunked_output_stream(con.out()));
+        return _body_writer(http::internal::make_http_chunked_output_stream(con.out())).then([&con] {
+            return con.out().write("0\r\n\r\n", 5);
+        });
     });
 
 }

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -131,6 +131,9 @@ future<> reply::write_reply_to_connection(httpd::connection& con) {
     }).then([&con] () mutable {
         return con.out().write("\r\n", 2);
     }).then([this, &con] () mutable {
+        if (_skip_body) {
+            return make_ready_future<>();
+        }
         return _body_writer(http::internal::make_http_chunked_output_stream(con.out())).then([&con] {
             return con.out().write("0\r\n\r\n", 5);
         });

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1424,6 +1424,64 @@ future<> check_http_reply (std::vector<sstring>&& req_parts, std::vector<std::st
     });
 };
 
+future<> head_handler_no_body(bool chunked) {
+    return seastar::async([chunked] {
+        loopback_connection_factory lcf(1);
+        http_server server("test");
+        loopback_socket_impl lsi(lcf);
+        httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
+
+        future<> client = seastar::async([&lsi, chunked] {
+            connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
+            input_stream<char> input(c_socket.input());
+            output_stream<char> output(c_socket.output());
+
+            output.write(sstring("HEAD /test HTTP/1.1\r\nHost: test\r\nContent-Length: 1\r\n\r\nA")).get();
+            output.flush().get();
+            auto resp = input.read().get();
+            auto resp_s = std::string(resp.get(), resp.size());
+            fmt::print("resp:[{}]", resp_s);
+            BOOST_REQUIRE_NE(resp_s.find("200 OK"), std::string::npos);
+
+            // RFC7231 section 4.3.2
+            // The HEAD method is identical to GET except that the server MUST NOT
+            // send a message body in the response (i.e., the response terminates at
+            // the end of the header section).
+            //
+            // The server SHOULD send the same header fields in response to a HEAD
+            // request as it would have sent if the request had been a GET, except
+            // that the payload header fields MAY be omitted
+
+            // Seastar HTTPD doesn't omit header fields ..
+            if (chunked) {
+                BOOST_REQUIRE_NE(resp_s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
+            } else {
+                BOOST_REQUIRE_NE(resp_s.find("Content-Length: 1\r\n"), std::string::npos);
+            }
+
+            // ... but does omit the body itself
+            BOOST_REQUIRE_EQUAL(resp_s.find("\r\n\r\n"), resp_s.size() - 4);
+
+            input.close().get();
+            output.close().get();
+        });
+
+        server._routes.put(HEAD, "/test", new echo_string_handler(chunked));
+        server.do_accepts(0).get();
+
+        client.get();
+        server.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(head_handler_no_body_content_length) {
+    return head_handler_no_body(false);
+}
+
+SEASTAR_TEST_CASE(head_handler_no_body_chunked) {
+    return head_handler_no_body(true);
+}
+
 static future<> test_basic_content(bool streamed, bool chunked_reply) {
     return seastar::async([streamed, chunked_reply] {
         loopback_connection_factory lcf(1);


### PR DESCRIPTION
RFC 7231 Section 4.3.2

>  The HEAD method is identical to GET except that the server MUST NOT
>  send a message body in the response (i.e., the response terminates at
>  the end of the header section).

Seastar HTTPD doesn't respect that `MUST NOT` thing and allows body content in case handler requested for it.

Fix by explicitly skipping the body regardless of what handler put on it. Since replies are written back to connection in a separate fiber where the initial request is no longer available, add the "skip body" marking on the reply itself.