### PR TITLE
output_stream: Remove unused bits

### DIFF
--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -397,7 +397,6 @@ class output_stream final {
     temporary_buffer<CharType> _buf;
     net::packet _zc_bufs = net::packet::make_null_packet(); //zero copy buffers
     size_t _size = 0;
-    size_t _begin = 0;
     size_t _end = 0;
     bool _trim_to_size = false;
     bool _batch_flushes = false;
@@ -408,7 +407,6 @@ class output_stream final {
     bi::slist_member_hook<> _in_poller;
 
 private:
-    size_t available() const noexcept { return _end - _begin; }
     future<> split_and_put(temporary_buffer<CharType> buf) noexcept;
     future<> put(temporary_buffer<CharType> buf) noexcept;
     void poll_flush() noexcept;


### PR DESCRIPTION
Both are private, no 3rd party code can break by missing it.