### PR TITLE
temporary_buffer: include cstring for std::memcpy

### DIFF
--- a/include/seastar/core/temporary_buffer.hh
+++ b/include/seastar/core/temporary_buffer.hh
@@ -24,6 +24,7 @@
 #ifndef SEASTAR_MODULE
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <string_view>
 #include <malloc.h>
 #endif
@@ -225,7 +226,7 @@ public:
             throw std::bad_alloc();
         }
         auto buf = static_cast<CharType*>(ptr);
-        memcpy(buf, view.data(), view.size());
+        std::memcpy(buf, view.data(), view.size());
         return temporary_buffer(buf, view.size(), make_free_deleter(buf));
     }
 


### PR DESCRIPTION
fixes compilation error:

seastar/core/temporary_buffer.hh:228:9: error: call to function 'memcpy' that is neither visible in the template definition nor found by argument-dependent lookup
  228 |         memcpy(buf, view.data(), view.size());

also changed `memcpy` to `std::memcpy`