### PR TITLE
Fix high load at idle on high core count machies

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -647,6 +647,10 @@ private:
     bool queue_timer(timer<manual_clock>*) noexcept;
     void del_timer(timer<manual_clock>*) noexcept;
 
+    bool pollers_enter_interrupt_mode();
+    void pollers_exit_interrupt_mode();
+    void wait_and_process_events();
+
     future<> run_exit_tasks();
     void stop();
     friend class pollable_fd;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3298,15 +3298,20 @@ int reactor::do_run() {
             if (go_to_sleep) {
                 internal::cpu_relax();
                 if (idle_end - idle_start > _cfg.max_poll_time) {
-                    // Turn off the task quota timer to avoid spurious wakeups
-                    struct itimerspec zero_itimerspec = {};
-                    _task_quota_timer.timerfd_settime(0, zero_itimerspec);
-                    _cpu_stall_detector->start_sleep();
-                    try_sleep();
-                    _cpu_stall_detector->end_sleep();
-                    // We may have slept for a while, so freshen idle_end
-                    idle_end = now();
-                    _task_quota_timer.timerfd_settime(0, task_quote_itimerspec);
+                    if(pollers_enter_interrupt_mode()) {
+                        // Turn off the task quota timer to avoid spurious wakeups
+                        struct itimerspec zero_itimerspec = {};
+                        _task_quota_timer.timerfd_settime(0, zero_itimerspec);
+                        _cpu_stall_detector->start_sleep();
+
+                        wait_and_process_events();
+                        pollers_exit_interrupt_mode();
+
+                        _cpu_stall_detector->end_sleep();
+                        // We may have slept for a while, so freshen idle_end
+                        idle_end = now();
+                        _task_quota_timer.timerfd_settime(0, task_quote_itimerspec);
+                    }
                 }
             } else {
                 // We previously ran pure_check_for_work(), might not actually have performed
@@ -3323,24 +3328,40 @@ int reactor::do_run() {
     return _return;
 }
 
-
-void
-reactor::try_sleep() {
+bool
+reactor::pollers_enter_interrupt_mode() {
     for (auto i = _pollers.begin(); i != _pollers.end(); ++i) {
         auto ok = (*i)->try_enter_interrupt_mode();
         if (!ok) {
             while (i != _pollers.begin()) {
                 (*--i)->exit_interrupt_mode();
             }
-            return;
+            return false;
         }
     }
 
-    _backend->wait_and_process_events(&_active_sigmask);
+    return true;
+}
 
+void
+reactor::pollers_exit_interrupt_mode() {
     for (auto i = _pollers.rbegin(); i != _pollers.rend(); ++i) {
         (*i)->exit_interrupt_mode();
     }
+}
+
+void
+reactor::wait_and_process_events() {
+    _backend->wait_and_process_events(&_active_sigmask);
+}
+
+void
+reactor::try_sleep() {
+    if(!pollers_enter_interrupt_mode()) {
+        return;
+    }
+    wait_and_process_events();
+    pollers_exit_interrupt_mode();
 }
 
 bool


### PR DESCRIPTION
# TLDR
Sorry for the long PR message on this one. Basically at idle on a 96 core machine we were noticing CPU usage of ~85%. Being at idle there was no I/O or tasks so we expected the reactor threads to sleep and CPU usage to be much lower.

After investigating we found that it was due to seastar often failing to sleep with each reactor thread was trying to sleep ~2k times a second. Each of these failed attempts issue a syscall to enable/disable the timer for the stall detector. These syscalls in turn ended up causing a lot of contention on a spin-lock in the kernel. And from that most of the CPU usage we were seeing.

This PR aims to improve the situation here by only disabling the timers after all the pollers have entered interrupt mode. From testing this reduces CPU usage at idle from ~85% to ~20% on a 96 core machine.

# Detailed Explanation 
While running a seastar application at idle on a high core count machine recent we noticed that nearly all of the cores were at ~85% CPU usage. This is even though there were no pending tasks or IO so we'd expect seastar to put the reactor thread to sleep:
![image](https://github.com/user-attachments/assets/1220a730-4af1-49dc-9473-0b028475f763)

Taking a profile of application it can be seen that nearly all of the use is coming from a contended lock in the kernel for setting a POSIX timer:
![image](https://github.com/user-attachments/assets/915ceda4-148a-4161-9be0-2991f59d0a96)

Which in turn is from `seastar: :internal::cpu_stall_detector_posix_timer::start_sleep`:
<img width="1800" alt="Screenshot 2025-05-07 at 8 08 53 PM" src="https://github.com/user-attachments/assets/51dce013-2d03-44e6-9b08-a5a2a3a31424" />


Using BCC to measure the latency of `reactor_backend_aio::wait_and_process_events` relative to wall clock time we can look at how long the reactors tend to actually sleep:
```
ubuntu@ip-172-31-18-219:~/bcc$ sudo python3 tools/funclatency.py -p $(pgrep redpanda) ""
Tracing 0 functions for ""... Hit Ctrl-C to end.
^C
     nsecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 317      |*                                       |
      2048 -> 4095       : 1890     |**********                              |
      4096 -> 8191       : 321      |*                                       |
      8192 -> 16383      : 58       |                                        |
     16384 -> 32767      : 35       |                                        |
     32768 -> 65535      : 138      |                                        |
     65536 -> 131071     : 332      |*                                       |
    131072 -> 262143     : 583      |***                                     |
    262144 -> 524287     : 900      |*****                                   |
    524288 -> 1048575    : 632      |***                                     |
   1048576 -> 2097151    : 715      |****                                    |
   2097152 -> 4194303    : 1390     |*******                                 |
   4194304 -> 8388607    : 2462     |**************                          |
   8388608 -> 16777215   : 4008     |**********************                  |
  16777216 -> 33554431   : 6099     |**********************************      |
  33554432 -> 67108863   : 6997     |****************************************|
  67108864 -> 134217727  : 1002     |*****                                   |

avg = 22546393 nsecs, total: 628570913282 nsecs, count: 27879
```

or an average of 23ms of sleep time before waking up again. So a reactor is sleeping/waking ~44 times a second. Furthermore reactors themselves will often fail to fall asleep due to the a poller failing to enter interrupt mode. Looking at the per-call latency relative to wall clock time for `reactor::try_sleep` we see:
```
ubuntu@ip-172-31-18-219:~/bcc$ sudo python3 tools/funclatency.py -p $(pgrep redpanda) ""
Tracing 0 functions for ""... Hit Ctrl-C to end.
^C
     nsecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 2803     |                                        |
       512 -> 1023       : 304681   |****************************************|
      1024 -> 2047       : 94321    |************                            |
      2048 -> 4095       : 26094    |***                                     |
      4096 -> 8191       : 15366    |**                                      |
      8192 -> 16383      : 11357    |*                                       |
     16384 -> 32767      : 8836     |*                                       |
     32768 -> 65535      : 6451     |                                        |
     65536 -> 131071     : 4359     |                                        |
    131072 -> 262143     : 2211     |                                        |
    262144 -> 524287     : 1081     |                                        |
    524288 -> 1048575    : 523      |                                        |
   1048576 -> 2097151    : 280      |                                        |
   2097152 -> 4194303    : 508      |                                        |
   4194304 -> 8388607    : 1022     |                                        |
   8388608 -> 16777215   : 1642     |                                        |
  16777216 -> 33554431   : 2005     |                                        |
  33554432 -> 67108863   : 2394     |                                        |
  67108864 -> 134217727  : 426      |                                        |

avg = 465856 nsecs, total: 226575130895 nsecs, count: 486362
```

So `try_sleep` is being called at a frequency of ~2.1kHz per shard. And hence the POSIX timer is being set a similar frequency. `try_sleep` seems to fail most often due to the `smp_pollfn`’s contention over a global mutex to issue a systemwide memory barrier. This was determined by adding a USDT to specify the reason for a failed sleep attempt with the following mapping:
```
reactor_stall_sampler - 0
signal_pollfn - 1
reap_kernel_completions_pollfn - 2
io_queue_submission_pollfn - 3
lowres_timer_pollfn - 4
smp_pollfn - 5
execution_stage_pollfn - 6
syscall_pollfn - 7
kernel_submit_work_pollfn - 8
batch_flush_pollfn - 9
drain_cross_cpu_freelist_pollfn - 10
the_pollfn - 11
```

And the following BCC script:
```
ubuntu@ip-172-31-18-219:~/bcc$ sudo python3 tools/argdist.py -p $(pgrep redpanda) -C 'u:/opt/redpanda/libexec/redpanda:reactor_try_sleep_early_return():int:arg1' -c
[00:04:12]
u:/opt/redpanda/libexec/redpanda:reactor_try_sleep_early_return():int:arg1
        COUNT      EVENT
        214094     arg1 = 5
```
Hence, it appears like seastar is trying to sleep as expected. However, the pollers are often failing to enter interrupt mode and therefore seastar is causing a lot of contention in the kernel layer.