### PR TITLE
Handle ENOENT in getgrnam

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2139,7 +2139,9 @@ future<std::optional<struct group_details>> reactor::getgrnam(std::string_view n
             return wrap_syscall(ret, std::optional<struct group_details>(gd));
         });
 
-    if (sr.result != 0) {
+    // Non-existent groups may return 0, or they may return ENOENT, depending on the
+    // configuration of the system, see seastar#2793. Treat both as "not found".
+    if (sr.result != 0 && sr.result != ENOENT) {
         throw std::system_error(sr.ec());
     }
 


### PR DESCRIPTION
When calling getgrnam_r, handle the case where the group does not exist (ENOENT) gracefully instead of treating it as a fatal error (which throws). The man page isn't completely clear on this, but it is clear that in practice with some packages installed like sssd this libc call stops returning 0 and starts returning ENOENT for getgrnam_r.

Fixes #2793.