### PR TITLE
Fix for non-json http function_handlers

### DIFF
--- a/include/seastar/http/function_handlers.hh
+++ b/include/seastar/http/function_handlers.hh
@@ -82,7 +82,8 @@ public:
     function_handler(const request_function & _handle, const sstring& type)
             : _f_handle(
                     [_handle](std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
-                        return append_result(std::move(rep), _handle(*req.get()));
+                        rep->_content += _handle(*req.get());
+                        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                     }), _type(type) {
     }
 


### PR DESCRIPTION
In https://github.com/scylladb/seastar/commit/94c4c7a9e98be31ff11b07b8020ccbee7153e672 I introduced a bug where a particular overload of `function_handler` which had an arbitrary (passed-in) content type and which should simply set the body to the string-like content without encoding, would be instead treated as json. This resulted in a spurious pair of quotes added in the encoding process. 

This PR has a fix for that, courtesy of @mmaslankaprv as well as a test to avoid this in the future.