### PR TITLE
slab: correct allocation logic and enforce memory limits

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -416,10 +416,8 @@ seastar_add_test (simple_stream
   KIND BOOST
   SOURCES simple_stream_test.cc)
 
-# TODO: Disabled for now. See GH-520.
-# seastar_add_test (slab
-#   SOURCES slab_test.cc
-#   NO_SEASTAR_TESTING_LIBRARY)
+seastar_add_test (slab
+  SOURCES slab_test.cc)
 
 seastar_add_app_test (smp
   SOURCES smp_test.cc)


### PR DESCRIPTION
I was bothered that `slab_test.cc` was excluded from a `glob` in the test build rules for Seastar. An idea popped into my mind to ask Gemini 2.5 Pro if it could find a bug in the slab allocator.

It first found a bug in `can_allocate_page()` and later found the bug described in issues #520 and #105. It also proposed a fix identical to the one described by @yurai007.

It might be worth merging this fix or deleting the code altogether if it's not used anywhere.

---

Fixes two bugs in the slab allocator:

1. Crash on single-object page allocation:

When an object with a size equal to `max_object_size` was requested, a slab page capable of holding only that single object would be created. The logic incorrectly added this page's descriptor to the `_free_slab_pages` list, even though the page was immediately full. The next allocation attempt for this slab class would then try to allocate from this empty free list, triggering an assertion failure in `allocate_object()`:

  seastar/core/slab.hh:111: void* seastar::slab_page_desc::allocate_object(): Assertion `!_free_objects.empty()` failed.

The fix is to only add a new page to the free list if it can hold more than one object.

2. Memory limit violation:

The `can_allocate_page()` method contained a logical flaw. The condition `|| sc.has_no_slab_pages()` allowed the allocation of a new page for a previously unused slab class, even after the global `_available_slab_pages` counter had reached zero. This allowed the allocator to exceed its configured memory `limit` by creating new pages for each distinct slab class.

The fix removes this flawed condition, strictly enforcing the `_available_slab_pages` counter as the guard for the memory limit. A regression test has been added to verify this behavior.