### PR TITLE
Allow http exceptions to have content type

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -43,6 +43,16 @@ public:
             : _msg(msg), _status(status) {
     }
 
+    /**
+     * A base_exception with a content_type is specifying a full response body, whereas
+     * a base_exception with only a _status is specifying a string that may be wrapped
+     * in e.g. a json_exception.
+     */
+    base_exception(const std::string& msg, http::reply::status_type status, const std::string &content_type)
+            : _msg(msg), _status(status), _content_type(content_type) {
+    }
+
+
     virtual const char* what() const noexcept {
         return _msg.c_str();
     }
@@ -54,9 +64,14 @@ public:
     virtual const std::string& str() const {
         return _msg;
     }
+
+    const std::string& content_type() const {
+        return _content_type;
+    }
 private:
     std::string _msg;
     http::reply::status_type _status;
+    std::string _content_type;
 
 };
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -119,7 +119,7 @@ public:
     future<> start_response();
 
     future<bool> generate_reply(std::unique_ptr<http::request> req);
-    void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg);
+    void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg, const sstring &content_type={});
 
     future<> write_body();
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -203,11 +203,14 @@ set_request_content(std::unique_ptr<http::request> req, input_stream<char>* cont
     }
 }
 
-void connection::generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg) {
+void connection::generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg, const sstring &content_type) {
     auto resp = std::make_unique<http::reply>();
     // TODO: Handle HTTP/2.0 when it releases
     resp->set_version(req->_version);
     resp->set_status(status, msg);
+    if (!content_type.empty()) {
+        resp->set_content_type(content_type);
+    }
     resp->done();
     _done = true;
     _replies.push(std::move(resp));
@@ -293,7 +296,7 @@ future<> connection::read_one() {
                     // before passing the request to handler - when we were parsing chunks
                     auto err_req = std::make_unique<http::request>();
                     err_req->_version = version;
-                    generate_error_reply_and_close(std::move(err_req), e.status(), e.str());
+                    generate_error_reply_and_close(std::move(err_req), e.status(), e.str(), e.content_type());
                 });
             });
         });

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -58,6 +58,7 @@ routes::~routes() {
 
 std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
     auto rep = std::make_unique<http::reply>();
+    sstring content_type = "json";
     try {
         // go over the register exception handler
         // if one of them handle the exception, return.
@@ -76,13 +77,18 @@ std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
        rep.reset(new http::reply());
        rep->add_header("Location", _e.url).set_status(_e.status());
     } catch (const base_exception& e) {
-        rep->set_status(e.status(), json_exception(e).to_json());
+        if (e.content_type().size()) {
+            rep->set_status(e.status(), e.str());
+            content_type = e.content_type();
+        } else {
+            rep->set_status(e.status(), json_exception(e).to_json());
+        }
     } catch (...) {
         rep->set_status(http::reply::status_type::internal_server_error,
                 json_exception(std::current_exception()).to_json());
     }
 
-    rep->done("json");
+    rep->done(content_type);
     return rep;
 }
 


### PR DESCRIPTION
This PR allows httpd exceptions to optionally have a content type: if present the usual json encoding of the error reply is disabled and the body is used as is, and the response is set to the specified content type. Nothing changes for clients which don't set the content type.
 
This allows httpd to support non-json content when an error occurs, as it is already does for non-error replies. It also allows it to support json exceptions where the except message is already fully-formed json, to be emitted into the body as-is, rather than a simple string to be used in the `to_json_exception` format.

We have been using this patch for a few years in production w/o issue.

Copilot says:

Key updates include modifications to the `base_exception` class, updates to the `generate_error_reply_and_close` method, and adjustments to error handling logic in various components.

### Enhancements to HTTP error handling:

#### Updates to `base_exception`:
* Added a new constructor to `base_exception` that accepts a `content_type` parameter, enabling the specification of a full response body format.
* Introduced a `content_type()` method in `base_exception` to retrieve the `content_type` value.

#### Modifications to error reply generation:
* Updated the `generate_error_reply_and_close` method in `httpd.hh` and `httpd.cc` to include a `content_type` parameter, which is used to set the content type of error replies. [[1]](diffhunk://#diff-fcaeaad69059b06ac52a9c2232f991adbc20e1b4ad142e43c9be240de9c492c1L122-R122) [[2]](diffhunk://#diff-7ea19841c89a6d665298b3e426bb2745445ca10abcbfbe7af47d9b05f085fcdaL206-R213)
* Enhanced the `read_one()` method in `httpd.cc` to pass the `content_type` from exceptions to the `generate_error_reply_and_close` method.

#### Adjustments to exception handling in routes:
* Modified the `exception_reply` method in `routes.cc` to check for the presence of a `content_type` in `base_exception` and set the error reply accordingly. If no `content_type` is provided, the error message is wrapped in a JSON response.