### PR TITLE
httpd: allow associating a tag with each listener

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
 
 #include <seastar/core/sstring.hh>
@@ -41,6 +42,22 @@ output_stream<char> make_http_content_length_output_stream(output_stream<char>& 
 
 namespace httpd {
 
+/// An opaque value the caller may associate with an http_server listener.
+///
+/// The value is attached to a listener by passing it to \ref
+/// http_server::listen(); every request received on a connection accepted by
+/// that listener reports it via \ref http::request::get_listener_tag(). Seastar
+/// attaches no meaning to the value: use it as an index into the caller's own
+/// array of per-endpoint state, or hold a pointer to such state in it (hence
+/// the uintptr_t representation).
+///
+/// Requests arriving on a listener created without a tag report \ref
+/// no_listener_tag.
+enum class listener_tag : uintptr_t {};
+
+/// The tag reported for a request that arrived on a listener created without
+/// one, or that was not received by an http_server at all.
+constexpr listener_tag no_listener_tag{};
 
 class parameters {
     // Note: the path matcher adds parameters with the '/' prefix into the params map (eg. "/param1"), and some getters

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -77,26 +77,30 @@ class connection : public boost::intrusive::list_base_hook<> {
     queue<std::unique_ptr<http::reply>> _replies { 10 };
     bool _done = false;
     const bool _tls;
+    const listener_tag _listener_tag;
 public:
-    connection(http_server& server, connected_socket&& fd, bool tls)
+    connection(http_server& server, connected_socket&& fd, bool tls, listener_tag tag = no_listener_tag)
             : _server(server)
             , _fd(std::move(fd))
             , _read_buf(_fd.input())
             , _write_buf(_fd.output())
             , _client_addr(_fd.remote_address())
             , _server_addr(_fd.local_address())
-            , _tls(tls) {
+            , _tls(tls)
+            , _listener_tag(tag) {
         on_new_connection();
     }
     connection(http_server& server, connected_socket&& fd,
-            socket_address client_addr, socket_address server_addr, bool tls)
+            socket_address client_addr, socket_address server_addr, bool tls,
+            listener_tag tag = no_listener_tag)
             : _server(server)
             , _fd(std::move(fd))
             , _read_buf(_fd.input())
             , _write_buf(_fd.output())
             , _client_addr(std::move(client_addr))
             , _server_addr(std::move(server_addr))
-            , _tls(tls) {
+            , _tls(tls)
+            , _listener_tag(tag) {
         on_new_connection();
     }
     ~connection();
@@ -124,6 +128,10 @@ class http_server_tester;
 
 class http_server {
     std::vector<server_socket> _listeners;
+    // Tags associated with the listeners, in the same order. May be shorter
+    // than _listeners if listeners were added directly (e.g. via
+    // http_server_tester); missing entries mean no_listener_tag.
+    std::vector<listener_tag> _listener_tags;
     http_stats _stats;
     uint64_t _total_connections = 0;
     uint64_t _current_connections = 0;
@@ -185,10 +193,17 @@ public:
     /// scheduling group.
     void set_request_scheduling_group(scheduling_group sg);
 
-    future<> listen(socket_address addr, server_credentials_ptr credentials);
-    future<> listen(socket_address addr, listen_options lo, server_credentials_ptr credentials);
-    future<> listen(socket_address addr, listen_options lo);
-    future<> listen(socket_address addr);
+    /// Start listening on the given address.
+    ///
+    /// \param tag an opaque value associated with this listener. Every request
+    ///     received on a connection accepted by this listener exposes it via
+    ///     \ref http::request::get_listener_tag(), letting a handler tell
+    ///     listeners apart (e.g. to apply a different authentication policy per
+    ///     endpoint). See \ref listener_tag.
+    future<> listen(socket_address addr, server_credentials_ptr credentials, listener_tag tag = no_listener_tag);
+    future<> listen(socket_address addr, listen_options lo, server_credentials_ptr credentials, listener_tag tag = no_listener_tag);
+    future<> listen(socket_address addr, listen_options lo, listener_tag tag = no_listener_tag);
+    future<> listen(socket_address addr, listener_tag tag = no_listener_tag);
     future<> stop();
 
     future<> do_accepts(int which);
@@ -206,7 +221,7 @@ public:
     static sstring http_date();
 private:
     future<> do_accept_one(int which, bool with_tls);
-    future<> do_process_connection(connected_socket conn_fd, socket_address remote_address, bool tls);
+    future<> do_process_connection(connected_socket conn_fd, socket_address remote_address, bool tls, listener_tag tag);
     boost::intrusive::list<connection> _connections;
     friend class seastar::httpd::connection;
     friend class http_server_tester;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -91,6 +91,11 @@ struct request {
     /// owned by a "connection" object, which is held alive while processing
     /// a request.
     const std::vector<tls::subject_alt_name>* tls_san = nullptr;
+    /// Tag of the listener that accepted the connection this request arrived
+    /// on, as passed to httpd::http_server::listen(). httpd::no_listener_tag
+    /// when the listener was created without a tag, or when the request was not
+    /// received by an http_server (e.g. client-side requests).
+    httpd::listener_tag listener_tag = httpd::no_listener_tag;
     http::body_writer_type body_writer; // for client
 
     using query_parameters_type = std::unordered_map<sstring, std::vector<sstring>, seastar::internal::string_view_hash, std::equal_to<>>;
@@ -121,6 +126,16 @@ public:
      */
     const socket_address & get_server_address() const {
         return _server_address;
+    }
+
+    /**
+     * Get the tag of the listener that accepted the connection this request
+     * arrived on, as passed to \ref httpd::http_server::listen().
+     * @return the listener tag, or \ref httpd::no_listener_tag if no tag was
+     * passed to listen() or the request was not received by an http_server
+     */
+    httpd::listener_tag get_listener_tag() const {
+        return listener_tag;
     }
 
     /**

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -212,6 +212,7 @@ future<> connection::read_one() {
 
         req->_server_address = this->_server_addr;
         req->_client_address = this->_client_addr;
+        req->listener_tag = _listener_tag;
 
         if (_tls) {
             req->protocol_name = "https";
@@ -425,30 +426,32 @@ void http_server::set_request_scheduling_group(scheduling_group sg) {
 }
 
 future<> http_server::listen(socket_address addr, listen_options lo,
-            server_credentials_ptr listener_credentials) {
+            server_credentials_ptr listener_credentials, listener_tag tag) {
     if (listener_credentials) {
         _listeners.push_back(seastar::tls::listen(listener_credentials, addr, lo));
     } else {
         _listeners.push_back(seastar::listen(addr, lo));
     }
+    _listener_tags.resize(_listeners.size(), no_listener_tag);
+    _listener_tags.back() = tag;
     return do_accepts(_listeners.size() - 1, listener_credentials != nullptr);
 }
 
-future<> http_server::listen(socket_address addr, listen_options lo) {
-    return listen(addr, lo, _credentials);
+future<> http_server::listen(socket_address addr, listen_options lo, listener_tag tag) {
+    return listen(addr, lo, _credentials, tag);
 }
 
 future<> http_server::listen(socket_address addr,
-            server_credentials_ptr listener_credentials) {
+            server_credentials_ptr listener_credentials, listener_tag tag) {
     listen_options lo;
     lo.reuse_address = true;
-    return listen(addr, lo, listener_credentials);
+    return listen(addr, lo, listener_credentials, tag);
 }
 
-future<> http_server::listen(socket_address addr) {
+future<> http_server::listen(socket_address addr, listener_tag tag) {
     listen_options lo;
     lo.reuse_address = true;
-    return listen(addr, lo);
+    return listen(addr, lo, tag);
 }
 future<> http_server::stop() {
     future<> tasks_done = _task_gate.close();
@@ -501,23 +504,26 @@ future<> http_server::do_accept_one(int which, bool tls) {
         ar.connection.set_keepalive(true);
         ar.connection.set_keepalive_parameters(_keepalive_params.value());
     }
+    // Listeners added directly to _listeners (e.g. via http_server_tester)
+    // have no matching tag entry; treat those as untagged.
+    auto tag = static_cast<size_t>(which) < _listener_tags.size() ? _listener_tags[which] : no_listener_tag;
     // The lambda passed to try_with_gate must not be a coroutine,
     // because try_with_gate invokes it but does not store it: a coroutine
     // lambda would be destroyed while its frame is still running.
     (void)try_with_gate(_task_gate,
             [this, conn_fd = std::move(ar.connection),
-             remote_address = std::move(ar.remote_address), tls]() mutable {
-        return do_process_connection(std::move(conn_fd), std::move(remote_address), tls);
+             remote_address = std::move(ar.remote_address), tls, tag]() mutable {
+        return do_process_connection(std::move(conn_fd), std::move(remote_address), tls, tag);
     }).handle_exception_type([] (const gate_closed_exception& e) {});
 }
 
 // Named member coroutine for per-connection processing, called from the
 // non-coroutine lambda in try_with_gate inside do_accept_one(). Parameters
 // are passed by value so they live safely in the coroutine frame.
-future<> http_server::do_process_connection(connected_socket conn_fd, socket_address remote_address, bool tls) {
+future<> http_server::do_process_connection(connected_socket conn_fd, socket_address remote_address, bool tls, listener_tag tag) {
     auto local_address = conn_fd.local_address();
     auto conn = std::make_unique<connection>(*this, std::move(conn_fd),
-            std::move(remote_address), std::move(local_address), tls);
+            std::move(remote_address), std::move(local_address), tls, tag);
     try {
         co_await conn->prepare();
     } catch (...) {
@@ -591,19 +597,19 @@ future<> http_server_control::set_routes(std::function<void(routes& r)> fun) {
 }
 
 future<> http_server_control::listen(socket_address addr) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address)>(&http_server::listen, addr);
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listener_tag)>(&http_server::listen, addr, no_listener_tag);
 }
 
 future<> http_server_control::listen(socket_address addr, http_server::server_credentials_ptr credentials) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, http_server::server_credentials_ptr)>(&http_server::listen, addr, credentials);
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, http_server::server_credentials_ptr, listener_tag)>(&http_server::listen, addr, credentials, no_listener_tag);
 }
 
 future<> http_server_control::listen(socket_address addr, listen_options lo) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options)>(&http_server::listen, addr, lo);
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, listener_tag)>(&http_server::listen, addr, lo, no_listener_tag);
 }
 
 future<> http_server_control::listen(socket_address addr, listen_options lo, http_server::server_credentials_ptr credentials) {
-    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, http_server::server_credentials_ptr)>(&http_server::listen, addr, lo, credentials);
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, http_server::server_credentials_ptr, listener_tag)>(&http_server::listen, addr, lo, credentials, no_listener_tag);
 }
 
 sharded<http_server>& http_server_control::server() {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -931,6 +931,53 @@ SEASTAR_TEST_CASE(content_length_limit) {
     });
 }
 
+SEASTAR_TEST_CASE(test_listener_tag) {
+    return seastar::async([] {
+        // The tag is opaque to seastar; here it is used the way a caller with
+        // per-endpoint configuration would use it: as an index into its own
+        // array. Index 0 is left unused so that an untagged listener, which
+        // reports no_listener_tag, is distinguishable.
+        const std::vector<sstring> endpoint_names = { "unused", "first", "second" };
+
+        http_server server("test");
+        server._routes.put(GET, "/tag", new function_handler([&endpoint_names] (const_req req) -> sstring {
+            auto tag = req.get_listener_tag();
+            if (tag == no_listener_tag) {
+                return "no-tag";
+            }
+            return endpoint_names.at(static_cast<size_t>(tag));
+        }, "txt"));
+
+        auto addr = socket_address(ipv4_addr("127.0.0.1", 0));
+        listen_options lo;
+        lo.reuse_address = true;
+        lo.set_fixed_cpu(this_shard_id());
+        server.listen(addr, lo, listener_tag{1}).get();
+        server.listen(addr, lo, listener_tag{2}).get();
+        server.listen(addr, lo).get(); // no tag
+
+        auto fetch_tag = [&server] (int idx) {
+            auto cln = http::client(http_server_tester::listeners(server)[idx].local_address());
+            sstring body;
+            cln.make_request(http::request::make("GET", "test", "/tag"),
+                    [&body] (const http::reply& rep, input_stream<char>&& in) {
+                return seastar::async([&body, in = std::move(in)] () mutable {
+                    body = util::read_entire_stream_contiguous(in).get();
+                    in.close().get();
+                });
+            }, http::reply::status_type::ok).get();
+            cln.close().get();
+            return body;
+        };
+
+        BOOST_REQUIRE_EQUAL(fetch_tag(0), "first");
+        BOOST_REQUIRE_EQUAL(fetch_tag(1), "second");
+        BOOST_REQUIRE_EQUAL(fetch_tag(2), "no-tag");
+
+        server.stop().get();
+    });
+}
+
 SEASTAR_TEST_CASE(test_client_unexpected_reply_status) {
     return seastar::async([] {
         class handl : public httpd::handler_base {


### PR DESCRIPTION
Seastar's http server supports listening on multiple addresses, but a request handler cannot tell which listener a request arrived on. Redpanda needs this to apply a different authentication method per endpoint (we have carried a variant of this in our fork for several years).

Looking up the server address of the request does not work in general: a listener bound to a wildcard address reports the resolved interface address on accepted connections, so there is no way to map a request back to the address that was configured.

So `http_server::listen()` now takes an optional tag:

```cpp
enum class listener_tag : uintptr_t {};
constexpr listener_tag no_listener_tag{};

future<> listen(socket_address addr, listen_options lo, listener_tag tag = no_listener_tag);
```

Connections accepted by that listener carry the tag, and every request received on such a connection reports it via `http::request::get_listener_tag()`. A request that arrived on a listener created without a tag, or that was not received by an `http_server` at all, reports `no_listener_tag`.

The representation is `uintptr_t` so the caller can either use the tag as an index into its own per-endpoint state or hold a pointer to that state in it. Seastar attaches no meaning to the value; the strong enum just keeps it from being confused with an unrelated integer at the call site.

`http_server_control::listen()` is intentionally left alone: a sharded server that wants tags can go through `server()` and set up the per-shard `http_server` directly.

Revisions, for anyone reading the discussion below out of order:

1. exposed the listener index.
2. took a `std::any`, which accepted a value of any type but pulled `<any>` into the public headers and made the accessor hand back a reference to `any_cast`.
3. (this one) a strong type over `uintptr_t`, as suggested by @avikivity. No type erasure, and no ownership or lifetime question, since the tag is a trivially copyable value held by value.

Tested by a new `test_listener_tag` unit test: two tagged listeners plus one untagged one, checking that each request reports the tag of the listener that accepted it.
