### PR TITLE
Improve io-queue cost model

### DIFF
--- a/include/seastar/core/disk_params.hh
+++ b/include/seastar/core/disk_params.hh
@@ -47,6 +47,7 @@ struct disk_params {
     uint64_t write_saturation_length = std::numeric_limits<uint64_t>::max();
     bool duplex = false;
     float rate_factor = 1.0;
+    bool max_cost_function = true;
 };
 
 SEASTAR_MODULE_EXPORT

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -194,6 +194,7 @@ public:
         double flow_ratio_backpressure_threshold = 1.1;
         std::chrono::milliseconds stall_threshold = std::chrono::milliseconds(100);
         std::chrono::microseconds tau = std::chrono::milliseconds(5);
+        bool max_cost_function = true;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/src/core/disk_params.cc
+++ b/src/core/disk_params.cc
@@ -71,6 +71,9 @@ struct convert<seastar::internal::disk_params> {
         if (node["rate_factor"]) {
             mp.rate_factor = node["rate_factor"].as<float>();
         }
+        if (node["max_cost_function"]) {
+            mp.max_cost_function = node["max_cost_function"].as<bool>();
+        }
         return true;
     }
 };
@@ -201,6 +204,8 @@ struct io_queue::config disk_config_params::generate_config(const disk_params& p
     // be better to sacrifice some IO latency, but allow for larger concurrency
     cfg.block_count_limit_min = (64 << 10) >> io_queue::block_size_shift;
     cfg.stall_threshold = stall_threshold();
+
+    cfg.max_cost_function = p.max_cost_function;
 
     return cfg;
 }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -903,7 +903,9 @@ double internal::request_tokens(io_direction_and_length dnl, const io_queue::con
 
     const auto& m = mult[dnl.rw_idx()];
 
-    return double(m.weight) / cfg.req_count_rate + double(m.size) * (dnl.length() >> io_queue::block_size_shift) / cfg.blocks_count_rate;
+    double iops_cost = double(m.weight) / cfg.req_count_rate;
+    double tp_cost = double(m.size) * (dnl.length() >> io_queue::block_size_shift) / cfg.blocks_count_rate;
+    return iops_cost + tp_cost;
 }
 
 fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length dnl) const noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -905,7 +905,11 @@ double internal::request_tokens(io_direction_and_length dnl, const io_queue::con
 
     double iops_cost = double(m.weight) / cfg.req_count_rate;
     double tp_cost = double(m.size) * (dnl.length() >> io_queue::block_size_shift) / cfg.blocks_count_rate;
-    return iops_cost + tp_cost;
+    if (cfg.max_cost_function) {
+        return std::max(iops_cost, tp_cost);
+    } else {
+        return iops_cost + tp_cost;
+    }
 }
 
 fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length dnl) const noexcept {


### PR DESCRIPTION
This PR proposes and initiates a discussion to change the io-queue cost
model by making its costing less pessimistic and hence work around cases 
where the io-queue is massively limiting disk performance when io-properties
are applied.

Currently the IO request cost in the io-queue is defined as such:

```math
cost = 1 * X + S * Y
```


X and Y representing the cost of a single IOP and a byte of throughput
are defined as such:

```math
X = 1 / IOPS
```
```math
Y = 1 / TP
```

With `IOPS` and `TP` being the IOPS and throughput measurement values
from io-properties.

This results in a fairly simple model that doesn't really represent how
modern SSDs work. Often the IOP and bandwidth cost isn't additive but
rather independent. As a consequence, they get heavily throttled by the
io-queue (as seen for example in https://github.com/scylladb/seastar/issues/2771). In such cases we might only reach 
around 60% of the IOPS that are specified in io-properties.

To work around this issue we introduce a more complete cost model which
fully models the above equation based on the two measurements that we
have in io-properties.

The only two additional values that we need are the IOP sizes in use
during both the IOP test (`IOPS_IOP_SIZE`) and throughput test
(`TP_IOP_SIZE`) from iotune. Possibly these can be provided by iotune
as well (implemented in the first commit). For correctness and performance 
of the model it's important that these two values limit our min IOP size
(`IOPS_IOP_SIZE` as as seen in the IOPS test) and our max IOP size 
(`TP_IOP_SIZE` as seen in the throughput test).

With those two additional values we can solve the system of two equations
and unknowns based on our two iotune measurements:

```math
IOPS * X + IOPS * \text{IOPS\_IOP\_SIZE} * Y = 1
```
```math
\frac{TP}{\text{TP\_IOP\_SIZE}} * X + TP * Y = 1
```

Again X represents the cost of an IOP and Y the weight of a byte of
throughput. However, in contrast to the simple model a factor is applied
to either side such that each doesn't contribute in full. We can
solve the above to:


```math
X = \frac{\frac{1}{\text{IOPS}} - \frac{\text{IOPS\_IOP\_SIZE}}{\text{TP}}}{1 - \frac{\text{IOPS\_TP} \cdot \text{IOPS\_IOP\_SIZE}}{\text{TP}}}
```
```math
Y = \frac{1 - \text{X} \cdot \text{IOPS\_TP}}{\text{TP}}
```

leaving us with more accurate cost approximations than the simple one
mentioned above that always weighs an IOP/byte at full cost.

This partially solves the issue described above of the io-queue severly
limiting performance as it's a lot less pessimistic. 

Below is some data from some experiments using io-tester with the
following config (with reqsize 4kB, 16kB and 128kB) respectively:

```
- name: highprio
  shards: [0]
  type: randwrite
  shard_info:
    parallelism: 32
    reqsize: 4kB|16kB|128kB
    shares: 1000
    think_time: 0

- name: lowprio
  shards: [0]
  type: randwrite
  shard_info:
    parallelism: 32
    reqsize: 4kB|16kB|128kB
    shares: 100
    think_time: 0
```

It's important that we use two separate priority groups here to show
that scheduling is still working as expected (without io-properties we
generally get the best performance but scheduling doesn't work at all).

We test on four different systems (all on AWS):

 - m7gd.4xlarge: 135k IOPS (at 4k IOP size) / 604MB/s (at 128k IOP size)
 - standardish EBS: 3k IOPS / 125 MB/s
 - high throughput EBS: 4k IOPS / 1000MB/s
 - m8gd.4xlarge: 135k IOPS (at 4k IOP size) / 907MB/s (at 128k IOP size)

We use `min_iop_size=4k` for all and `max_iop_size=128k` for the dedicated
instances and 256k for EBS.

Below is the data across all systems. The data is in MB/s and split
into the separate priority groups (again to show that scheduling still
works) with the total of both next to it.

NOIP: Without using io-properties
IPSM: Using io-properties with the current simple model
IPFM: Using io-properties with the full model

m7gd.4xlarge:

|       | 4k        |           |         | 16k       |           |         | 128k      |           |         |
|-------|-----------|-----------|---------|-----------|-----------|---------|-----------|-----------|---------|
|       | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   |
| NOIP  | 303       | 287       | 591     | 299       | 292       | 591     | 295       | 295       | 590     |
| IPSM  | 262       | 28        | 290     | 432       | 44        | 476     | 528       | 53        | 581     |
| IPFM  | 477       | 56        | **533**     | 540       | 55        | **595**     | 544       | 55        | 599     |

On m7gd at small write sizes is where we see a massive difference.
Because m7gd basically behaves as if everything can be costed in terms
of 4k IOPS the full model behaves a lot better and we get basically 80%
more performance.

m8gd.4xlarge:

|       | 4k        |           |         | 16k       |           |         | 128k      |           |         |
|-------|-----------|-----------|---------|-----------|-----------|---------|-----------|-----------|---------|
|       | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   |
| NOIP  | 319       | 290       | 609     | 445       | 441       | 886     | 443       | 443       | 886     |
| IPSM  | 331       | 33        | 364     | 599       | 60        | 660     | 786       | 79        | 865     |
| IPFM  | 486       | 105       | **591**     | 741       | 75        | **816**     | 823       | 83        | 905     |

Similarly on m8gd we see quite the performance improvement. m8gd has
this bimodal distribution where at 8k IOP size you get ~80% more
throughput than at 4k IOP. Hence we do also see an improvement at 16k
IOP size though it doesn't reach the full throughput.

standard EBS:

|       | 4k        |           |         | 16k       |           |         | 128k      |           |         |
|-------|-----------|-----------|---------|-----------|-----------|---------|-----------|-----------|---------|
|       | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   |
| NOIP  | 7         | 7         | 13      | 27        | 26        | 53      | 64        | 63        | 127     |
| IPSM  | 11        | 1         | 12      | 34        | 3         | 37      | 72        | 7         | 79      |
| IPFM  | 12        | 1         | 13      | 39        | 4         | 43      | 91        | 9         | **100**     |

On a fairly standard EBS drive we do also see some improvement even at
128k IOP size. These "in-between" disk types show where the model is
still performing the worst. Even with the full model we only get around
80% of the throughput that the disk provides.

high throughput EBS:

|       | 4k        |           |         | 16k       |           |         | 128k      |           |         |
|-------|-----------|-----------|---------|-----------|-----------|---------|-----------|-----------|---------|
|       | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   | High Prio | Low Prio  | Total   |
| NOIP  | 8         | 8         | 16      | 32        | 32        | 64      | 259       | 253       | 512     |
| IPSM  | 14        | 1         | 16      | 55        | 5         | 60      | 311       | 31        | 343     |
| IPFM  | 15        | 1         | 16      | 58        | 6         | 64      | 465       | 47        | **512**     |

On throughput sided EBS setups we again get a fairly large improvement
of a 50% throughput (this time at large IOP sizes).

There is an open question as to how `min_iop_size` and `max_iop_size` should be
provided. This PR provides a commit where they are being set (fairly
pessimistically) directly and by default by iotune. As an alternative this could
happen only conditionally based on a cli flag. Which would leave the full model
off by default. Alternatively they could be fully provided by the user. Chosing
them correctly is important for the accuracy of the full model.

Also we could split the two parameters also across read and write which I haven't 
done in this first draft.