### PR TITLE
json: json_elements: add generate_array

### DIFF
--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -389,8 +389,8 @@ json_return_type::body_writer_type stream_range_as_array(Container val, Func fun
  * \brief consume jsonable values from a coroutine generator \c gen and write them
  * onto the \c out output_stream as a json array.
  */
-template<Jsonable T>
-future<> generate_array_element(output_stream<char>& out, coroutine::experimental::generator<T>& gen) {
+template<Jsonable T, template<typename> class Container>
+future<> generate_array_element(output_stream<char>& out, coroutine::experimental::generator<T, Container>& gen) {
     bool first = true;
     co_await out.write("[");
     while (auto val = co_await gen()) {
@@ -418,8 +418,8 @@ future<> generate_array_element(output_stream<char>& out, coroutine::experimenta
  * Note that \c gen is passed by reference since we need to return a copyable function but generators cannot be copied.
  * So the caller is responsible for ensuring that the generator remains valid for the lifetime of the returned function.
  */
-template<Jsonable T>
-json_return_type::body_writer_type generate_array(coroutine::experimental::generator<T> gen) {
+template<Jsonable T, template<typename> class Container>
+json_return_type::body_writer_type generate_array(coroutine::experimental::generator<T, Container> gen) {
     return [gen_ = std::move(gen)] (output_stream<char>&& s) mutable -> future<> {
         auto gen = std::move(gen_);
         auto out = std::move(s);


### PR DESCRIPTION
Add a helper function to generate a json array gently by consuming its items from a coroutine generator.

The motivation for this change is to avoid large allocations that are needed for generating a long json array (See https://github.com/scylladb/scylladb/pull/24261).

With the coroutine generator, we can consume and process the array elements one at a time (optionally using a small buffer to reduce context switches between the generator and the consumer), and stream them as json, say to an output file, or to a socket, as part of a higher level protocol.
