### PR TITLE
http: Introduce retry strategy machinery for http client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,7 @@ add_library (seastar
   src/http/url.cc
   src/http/client.cc
   src/http/request.cc
+  src/http/retry_strategy.cc
   src/json/formatter.cc
   src/json/json_elements.cc
   src/net/arp.cc

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -183,7 +183,8 @@ private:
     requires std::invocable<Fn, connection&>
     auto with_new_connection(Fn&& fn, abort_source*);
 
-    future<> do_make_request(connection& con, request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
+    future<> do_make_request(connection& con, request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected) const;
+    future<> do_make_request(connection& con, request& req, reply_handler& handle, const retry_strategy& strategy, abort_source*, std::optional<reply::status_type> expected) const;
 
 public:
     /**
@@ -269,6 +270,7 @@ public:
      * in the middle of operation
      */
     future<> make_request(request&& req, reply_handler&& handle, std::optional<reply::status_type>&& expected = std::nullopt, abort_source* as = nullptr);
+    future<> make_request(request&& req, reply_handler&& handle, const retry_strategy& strategy, std::optional<reply::status_type>&& expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Send the request and handle the response (abortable), same as \ref make_request()
@@ -278,6 +280,7 @@ public:
      * are referencing valid instances
      */
     future<> make_request(request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
+    future<> make_request(request& req, reply_handler& handle, const retry_strategy& strategy, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Updates the maximum number of connections a client may have

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -27,6 +27,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/http/connection_factory.hh>
 #include <seastar/http/reply.hh>
+#include <seastar/http/retry_strategy.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/modules.hh>
@@ -164,7 +165,7 @@ private:
     unsigned _max_connections;
     size_t _max_bytes_to_drain;
     unsigned long _total_new_connections = 0;
-    const retry_requests _retry;
+    std::unique_ptr<retry_strategy> _retry_strategy;
     condition_variable _wait_con;
     connections_list_t _pool;
 
@@ -219,7 +220,7 @@ public:
      * \param f -- the factory pointer
      * \param max_connections -- maximum number of connection a client is allowed to maintain
      * (both active and cached in pool)
-     * \param retry -- whether or not to retry requests on connection IO errors
+     * \param retry_strategy -- optional custom logic for retrying failed requests
      *
      * The client uses connections provided by factory to send requests over and receive responses
      * back. Once request-response cycle is over the connection used for that is kept by a client
@@ -248,6 +249,7 @@ public:
      * second attempt fails, this error is reported back to user.
      */
     explicit client(std::unique_ptr<connection_factory> f, unsigned max_connections = default_max_connections, retry_requests retry = retry_requests::no, size_t max_bytes_to_drain = default_max_bytes_to_drain);
+    client(std::unique_ptr<connection_factory> f, unsigned max_connections, size_t max_bytes_to_drain, std::unique_ptr<retry_strategy>&& retry_strategy);
 
     /**
      * \brief Send the request and handle the response

--- a/include/seastar/http/retry_strategy.hh
+++ b/include/seastar/http/retry_strategy.hh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+#include <seastar/core/future.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/util/modules.hh>
+
+namespace seastar {
+SEASTAR_MODULE_EXPORT_BEGIN
+
+namespace http::experimental {
+
+class retry_strategy {
+public:
+    virtual ~retry_strategy() = default;
+    // Returns true if the error can be retried given the error and the number of times already tried.
+    virtual future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const = 0;
+    virtual future<input_stream<char>> analyze_reply(std::optional<reply::status_type> expected, const http::reply& rep, input_stream<char>&& in) const = 0;
+
+    // Calculates the time in milliseconds the client should wait before attempting another request based on the error and attempted_retries count.
+    [[nodiscard]] virtual std::chrono::milliseconds delay_before_retry(std::exception_ptr error, unsigned attempted_retries) const = 0;
+
+    [[nodiscard]] virtual unsigned get_max_retries() const noexcept = 0;
+};
+
+class default_retry_strategy : public retry_strategy {
+private:
+    unsigned _max_retries;
+    unsigned _scale_factor;
+
+public:
+    default_retry_strategy();
+    default_retry_strategy(unsigned max_retries, unsigned scale_factor);
+
+    future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+    future<input_stream<char>> analyze_reply(std::optional<reply::status_type> expected, const http::reply& rep, input_stream<char>&& in) const override;
+
+    [[nodiscard]] std::chrono::milliseconds delay_before_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+
+    [[nodiscard]] unsigned get_max_retries() const noexcept override;
+};
+
+class no_retry_strategy : public default_retry_strategy {
+
+public:
+    future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+    [[nodiscard]] std::chrono::milliseconds delay_before_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+
+    [[nodiscard]] unsigned get_max_retries() const noexcept override;
+};
+}
+
+SEASTAR_MODULE_EXPORT_END
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources (seastar-module
     http/mime_types.cc
     http/reply.cc
     http/request.cc
+    http/retry_strategy.cc
     http/routes.cc
     http/transformers.cc
     http/url.cc

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -341,6 +341,9 @@ future<> client::make_request(request& req, reply_handler& handle, std::optional
 }
 
 future<> client::make_request(request& req, reply_handler& handle, const retry_strategy& strategy, std::optional<reply::status_type> expected, abort_source* as) {
+    if (as && as->abort_requested()) {
+        return make_exception_future(as->abort_requested_exception_ptr());
+    }
     return with_connection([this, &req, &handle, &strategy, as, expected] (connection& con) {
         return do_make_request(con, req, handle, strategy, as, expected);
     }, as).handle_exception([this, &req, &handle, &strategy, as, expected] (std::exception_ptr ex) {

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <chrono>
+#include <coroutine>
+#include <gnutls/gnutls.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/http/exception.hh>
+#include <seastar/http/retry_strategy.hh>
+#include <seastar/util/short_streams.hh>
+
+#endif
+
+using namespace std::chrono_literals;
+
+namespace seastar {
+extern logger http_log;
+
+namespace http::experimental {
+logger rs_logger("default_http_retry_strategy");
+
+extern bool is_retryable_exception(std::exception_ptr ex);
+
+default_retry_strategy::default_retry_strategy(unsigned max_retries, unsigned scale_factor)
+    : _max_retries(max_retries), _scale_factor(scale_factor) {
+}
+
+default_retry_strategy::default_retry_strategy()
+    : default_retry_strategy(2, 25) /* Default overall retry time to fail is 50ms (0ms)+((1<<1)*25)ms) */ {
+}
+
+future<bool> default_retry_strategy::should_retry(std::exception_ptr error, unsigned attempted_retries) const {
+    if (attempted_retries >= get_max_retries()) {
+        rs_logger.warn("Retries exhausted. Retry# {}", attempted_retries);
+        co_return false;
+    }
+
+    co_return is_retryable_exception(error);
+}
+
+future<input_stream<char>> default_retry_strategy::analyze_reply(std::optional<reply::status_type> expected, const reply& rep, input_stream<char>&& in) const {
+    co_return std::move(in);
+}
+
+std::chrono::milliseconds default_retry_strategy::delay_before_retry(std::exception_ptr, unsigned attempted_retries) const {
+    if (attempted_retries <= 1) {
+        // On first attempt, we do not delay
+        return 0ms;
+    }
+
+    return std::chrono::milliseconds((1UL << (attempted_retries - 1)) * _scale_factor);
+}
+
+unsigned default_retry_strategy::get_max_retries() const noexcept {
+    return _max_retries;
+}
+
+future<bool> no_retry_strategy::should_retry(std::exception_ptr error, unsigned attempted_retries) const {
+    return make_ready_future<bool>(false);
+}
+
+std::chrono::milliseconds no_retry_strategy::delay_before_retry(std::exception_ptr error, unsigned attempted_retries) const {
+    return 0ms;
+}
+
+unsigned no_retry_strategy::get_max_retries() const noexcept {
+    return 0;
+}
+}
+}

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -31,7 +31,38 @@ extern logger http_log;
 namespace http::experimental {
 logger rs_logger("default_http_retry_strategy");
 
-extern bool is_retryable_exception(std::exception_ptr ex);
+static bool is_retryable_exception(std::exception_ptr ex) {
+    while (ex) {
+        try {
+            std::rethrow_exception(ex);
+        } catch (const std::system_error& sys_err) {
+            auto code = sys_err.code().value();
+            if (code == EPIPE || code == ECONNABORTED || code == ECONNRESET || code == GNUTLS_E_PREMATURE_TERMINATION) {
+                return true;
+            }
+            try {
+                std::rethrow_if_nested(sys_err);
+            } catch (...) {
+                ex = std::current_exception();
+                continue;
+            }
+            return false;
+        } catch (const httpd::response_parsing_exception&) {
+            return true;
+        } catch (const std::exception& e) {
+            try {
+                std::rethrow_if_nested(e);
+            } catch (...) {
+                ex = std::current_exception();
+                continue;
+            }
+            return false;
+        } catch (...) {
+            return false;
+        }
+    }
+    return false;
+}
 
 default_retry_strategy::default_retry_strategy(unsigned max_retries, unsigned scale_factor)
     : _max_retries(max_retries), _scale_factor(scale_factor) {


### PR DESCRIPTION
Introduce extensible retry strategy machinery for the HTTP client to simplify adding new retry conditions. Rather than modifying seastar code to support additional error types, users can now provide their own custom implementations of the retry strategy—offering flexibility without repeated code changes.

Fixes: https://github.com/scylladb/seastar/issues/2803
