### PR TITLE
http/client: Fix content length body overflow check (and a bit more)

### DIFF
--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -188,7 +188,7 @@ public:
 
         auto size = buf.size();
         if (_bytes_written + size > _limit) {
-            return make_exception_future<>(std::runtime_error(format("body conent length overflow: want {} limit {}", _bytes_written + buf.size(), _limit)));
+            return make_exception_future<>(std::runtime_error(format("body content length overflow: want {} limit {}", _bytes_written + buf.size(), _limit)));
         }
 
         return _out.write(buf.get(), size).then([this, size] {

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -182,11 +182,11 @@ public:
     }
     using data_sink_impl::put;
     virtual future<> put(temporary_buffer<char> buf) override {
-        if (buf.size() == 0 || _bytes_written == _limit) {
+        auto size = buf.size();
+        if (size == 0) {
             return make_ready_future<>();
         }
 
-        auto size = buf.size();
         if (_bytes_written + size > _limit) {
             return make_exception_future<>(std::runtime_error(format("body content length overflow: want {} limit {}", _bytes_written + buf.size(), _limit)));
         }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2181,3 +2181,47 @@ SEASTAR_TEST_CASE(test_client_close_connection) {
         }
     });
 }
+
+SEASTAR_THREAD_TEST_CASE(test_content_length_data_sink) {
+    auto do_check = [] (size_t len, sstring value, bool zero_copy) {
+        size_t written = 32;
+        size_t expected = 0;
+        std::stringstream ss;
+        sstring expected_ss;
+        output_stream<char> data = output_stream<char>(memory_data_sink(ss));
+        output_stream<char> out = http::internal::make_http_content_length_output_stream(data, len, written);
+        BOOST_CHECK_EQUAL(written, 0);
+
+        unsigned values = 0;
+        while (true) {
+            expected += value.size();
+            if (zero_copy) {
+                out.write(temporary_buffer<char>(value.c_str(), value.size())).get();
+            } else {
+                out.write(value).get();
+            }
+            auto f = out.flush();
+            if (expected > len) {
+                BOOST_CHECK_EXCEPTION(f.get(), std::runtime_error, [] (const auto& e) { return sstring(e.what()).starts_with("body content length overflow"); });
+                BOOST_CHECK_EQUAL(written, expected - value.size());
+                break;
+            }
+
+            f.get();
+            BOOST_CHECK_EQUAL(written, expected);
+            data.flush().get();
+            expected_ss += value;
+            values++;
+        }
+
+        BOOST_CHECK_EQUAL(values, len / value.size());
+        BOOST_CHECK_EQUAL(ss.str(), expected_ss);
+    };
+
+    do_check(2, "1", false);
+    do_check(2, "12", false);
+    do_check(2, "123", false);
+    do_check(2, "1", true);
+    do_check(2, "12", true);
+    do_check(2, "123", true);
+}

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -382,8 +382,7 @@ public:
     memory_data_sink_impl(std::stringstream& ss) : _ss(ss) {
     }
     virtual future<> put(net::packet data)  override {
-        abort();
-        return make_ready_future<>();
+        return data_sink_impl::fallback_put(std::move(data));
     }
     virtual future<> put(temporary_buffer<char> buf) override {
         _ss.write(buf.get(), buf.size());
@@ -395,6 +394,10 @@ public:
 
     virtual future<> close() override {
         return make_ready_future<>();
+    }
+
+    virtual size_t buffer_size() const noexcept override {
+        return 1024;
     }
 };
 


### PR DESCRIPTION
When writing a data over specified content length, the helper output_stream throws. However, there's a corner case when it doesn't -- when the body is byte-to-byte full and extra bytes are put, they are silently ignored.

This PR fixes it and adds a unit test for that corner case. Also the test covers zero-copy behavior.