### PR TITLE
Move output IO throttler to IO queue level

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -79,7 +79,7 @@ int main(int ac, char** av) {
                             }
                             out << YAML::EndMap;
 
-                            const auto& fg = internal::get_fair_group(ioq, internal::io_direction_and_length::write_idx);
+                            const auto& fg = internal::get_throttler(ioq, internal::io_direction_and_length::write_idx);
                             out << YAML::Key << "per_tick_grab_threshold" << YAML::Value << fg.per_tick_grab_threshold();
 
                             const auto& tb = fg.token_bucket();

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -385,8 +385,11 @@ public:
     fair_queue_entry* top();
     void pop_front();
 
-    std::vector<seastar::metrics::impl::metric_definition_impl> metrics(class_id c);
     capacity_t queued_capacity() const noexcept { return _queued_capacity; }
+
+    capacity_t accumulated(class_id cid) const noexcept;
+    capacity_t pure_accumulated(class_id cid) const noexcept;
+    unsigned activations(class_id cid) const noexcept;
 };
 /// @}
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -296,7 +296,7 @@ public:
     /// \related fair_queue
     struct config {
         sstring label = "";
-        std::chrono::microseconds tau = std::chrono::milliseconds(5);
+        uint64_t forgiving_factor = 0;
     };
 
     using class_id = unsigned int;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -27,7 +27,6 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/util/assert.hh>
-#include <seastar/util/shared_token_bucket.hh>
 
 #include <chrono>
 #include <cstdint>
@@ -126,149 +125,6 @@ public:
     capacity_t capacity() const noexcept { return _capacity; }
 };
 
-/// \brief Group of queues class
-///
-/// This is a fair group. It's attached by one or mode fair queues. On machines having the
-/// big* amount of shards, queues use the group to borrow/lend the needed capacity for
-/// requests dispatching.
-///
-/// * Big means that when all shards sumbit requests alltogether the disk is unable to
-/// dispatch them efficiently. The inability can be of two kinds -- either disk cannot
-/// cope with the number of arriving requests, or the total size of the data withing
-/// the given time frame exceeds the disk throughput.
-class io_throttler {
-public:
-    using capacity_t = fair_queue_entry::capacity_t;
-    using clock_type = std::chrono::steady_clock;
-
-    /*
-     * tldr; The math
-     *
-     *    Bw, Br -- write/read bandwidth (bytes per second)
-     *    Ow, Or -- write/read iops (ops per second)
-     *
-     *    xx_max -- their maximum values (configured)
-     *
-     * Throttling formula:
-     *
-     *    Bw/Bw_max + Br/Br_max + Ow/Ow_max + Or/Or_max <= K
-     *
-     * where K is the scalar value <= 1.0 (also configured)
-     *
-     * Bandwidth is bytes time derivatite, iops is ops time derivative, i.e.
-     * Bx = d(bx)/dt, Ox = d(ox)/dt. Then the formula turns into
-     *
-     *   d(bw/Bw_max + br/Br_max + ow/Ow_max + or/Or_max)/dt <= K
-     *
-     * Fair queue tickets are {w, s} weight-size pairs that are
-     *
-     *   s = read_base_count * br, for reads
-     *       Br_max/Bw_max * read_base_count * bw, for writes
-     *
-     *   w = read_base_count, for reads
-     *       Or_max/Ow_max * read_base_count, for writes
-     *
-     * Thus the formula turns into
-     *
-     *   d(sum(w/W + s/S))/dr <= K
-     *
-     * where {w, s} is the ticket value if a request and sum summarizes the
-     * ticket values from all the requests seen so far, {W, S} is the ticket
-     * value that corresonds to a virtual summary of Or_max requests of
-     * Br_max size total.
-     */
-
-    /*
-     * The normalization results in a float of the 2^-30 seconds order of
-     * magnitude. Not to invent float point atomic arithmetics, the result
-     * is converted to an integer by multiplying by a factor that's large
-     * enough to turn these values into a non-zero integer.
-     *
-     * Also, the rates in bytes/sec when adjusted by io-queue according to
-     * multipliers become too large to be stored in 32-bit ticket value.
-     * Thus the rate resolution is applied. The t.bucket is configured with a
-     * time period for which the speeds from F (in above formula) are taken.
-     */
-
-    static constexpr float fixed_point_factor = float(1 << 24);
-    using rate_resolution = std::milli;
-    using token_bucket_t = internal::shared_token_bucket<capacity_t, rate_resolution, internal::capped_release::no>;
-
-private:
-
-    /*
-     * The dF/dt <= K limitation is managed by the modified token bucket
-     * algo where tokens are ticket.normalize(cost_capacity), the refill
-     * rate is K.
-     *
-     * The token bucket algo must have the limit on the number of tokens
-     * accumulated. Here it's configured so that it accumulates for the
-     * latency_goal duration.
-     *
-     * The replenish threshold is the minimal number of tokens to put back.
-     * It's reserved for future use to reduce the load on the replenish
-     * timestamp.
-     *
-     * The timestamp, in turn, is the time when the bucket was replenished
-     * last. Every time a shard tries to get tokens from bucket it first
-     * tries to convert the time that had passed since this timestamp
-     * into more tokens in the bucket.
-     */
-
-    token_bucket_t _token_bucket;
-    const capacity_t _per_tick_threshold;
-
-public:
-
-    // Convert internal capacity value back into the real token
-    static double capacity_tokens(capacity_t cap) noexcept {
-        return (double)cap / fixed_point_factor / token_bucket_t::rate_cast(std::chrono::seconds(1)).count();
-    }
-
-    // Convert floating-point tokens into the token bucket capacity
-    static capacity_t tokens_capacity(double tokens) noexcept {
-        return tokens * token_bucket_t::rate_cast(std::chrono::seconds(1)).count() * fixed_point_factor;
-    }
-
-    auto capacity_duration(capacity_t cap) const noexcept {
-        return _token_bucket.duration_for(cap);
-    }
-
-    struct config {
-        sstring label = "";
-        /*
-         * There are two "min" values that can be configured. The former one
-         * is the minimal weight:size pair that the upper layer is going to
-         * submit. However, it can submit _larger_ values, and the fair queue
-         * must accept those as large as the latter pair (but it can accept
-         * even larger values, of course)
-         */
-        double min_tokens = 0.0;
-        double limit_min_tokens = 0.0;
-        std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
-    };
-
-    explicit io_throttler(config cfg, unsigned nr_queues);
-    io_throttler(io_throttler&&) = delete;
-
-    capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
-    capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
-    capacity_t grab_capacity(capacity_t cap) noexcept;
-    clock_type::time_point replenished_ts() const noexcept { return _token_bucket.replenished_ts(); }
-    void refund_tokens(capacity_t) noexcept;
-    void replenish_capacity(clock_type::time_point now) noexcept;
-    void maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept;
-
-    capacity_t capacity_deficiency(capacity_t from) const noexcept;
-
-    std::chrono::duration<double> rate_limit_duration() const noexcept {
-        std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
-        return std::chrono::duration_cast<std::chrono::duration<double>>(dur);
-    }
-
-    const token_bucket_t& token_bucket() const noexcept { return _token_bucket; }
-};
-
 /// \brief Fair queuing class
 ///
 /// This is a fair queue, allowing multiple request producers to queue requests
@@ -301,7 +157,7 @@ public:
 
     using class_id = unsigned int;
     class priority_class_data;
-    using capacity_t = io_throttler::capacity_t;
+    using capacity_t = fair_queue_entry::capacity_t;
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -324,7 +324,6 @@ private:
     };
 
     config _config;
-    io_throttler& _group;
     fair_queue_ticket _resources_executing;
     fair_queue_ticket _resources_queued;
     priority_queue _handles;
@@ -345,7 +344,7 @@ public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///
     /// \param cfg an instance of the class \ref config
-    explicit fair_queue(io_throttler& shared, config cfg);
+    explicit fair_queue(config cfg);
     fair_queue(fair_queue&&) = delete;
     ~fair_queue();
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -370,10 +370,10 @@ private:
         capacity_t ready_tokens;
         bool our_turn_has_come;
     };
+public:
     enum class grab_result { ok, stop, again };
     reap_result reap_pending_capacity() noexcept;
     grab_result grab_capacity(capacity_t cap, reap_result& available);
-public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///
     /// \param cfg an instance of the class \ref config
@@ -422,9 +422,6 @@ public:
     /// \param desc an instance of \c fair_queue_ticket structure describing the request that just finished.
     void notify_request_finished(fair_queue_entry::capacity_t cap) noexcept;
     void notify_request_cancelled(fair_queue_entry& ent) noexcept;
-
-    /// Try to execute new requests if there is capacity left in the queue.
-    void dispatch_requests(std::function<void(fair_queue_entry&)> cb);
 
     fair_queue_entry* top();
     void pop_front();

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -426,6 +426,9 @@ public:
     /// Try to execute new requests if there is capacity left in the queue.
     void dispatch_requests(std::function<void(fair_queue_entry&)> cb);
 
+    fair_queue_entry* top();
+    void pop_front();
+
     clock_type::time_point next_pending_aio() const noexcept;
 
     std::vector<seastar::metrics::impl::metric_definition_impl> metrics(class_id c);

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -136,7 +136,7 @@ public:
 /// dispatch them efficiently. The inability can be of two kinds -- either disk cannot
 /// cope with the number of arriving requests, or the total size of the data withing
 /// the given time frame exceeds the disk throughput.
-class fair_group {
+class io_throttler {
 public:
     using capacity_t = fair_queue_entry::capacity_t;
     using clock_type = std::chrono::steady_clock;
@@ -248,8 +248,8 @@ public:
         std::chrono::duration<double> rate_limit_duration = std::chrono::milliseconds(1);
     };
 
-    explicit fair_group(config cfg, unsigned nr_queues);
-    fair_group(fair_group&&) = delete;
+    explicit io_throttler(config cfg, unsigned nr_queues);
+    io_throttler(io_throttler&&) = delete;
 
     capacity_t maximum_capacity() const noexcept { return _token_bucket.limit(); }
     capacity_t per_tick_grab_threshold() const noexcept { return _per_tick_threshold; }
@@ -301,7 +301,7 @@ public:
 
     using class_id = unsigned int;
     class priority_class_data;
-    using capacity_t = fair_group::capacity_t;
+    using capacity_t = io_throttler::capacity_t;
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:
@@ -324,7 +324,7 @@ private:
     };
 
     config _config;
-    fair_group& _group;
+    io_throttler& _group;
     clock_type::time_point _group_replenish;
     fair_queue_ticket _resources_executing;
     fair_queue_ticket _resources_queued;
@@ -379,7 +379,7 @@ public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///
     /// \param cfg an instance of the class \ref config
-    explicit fair_queue(fair_group& shared, config cfg);
+    explicit fair_queue(io_throttler& shared, config cfg);
     fair_queue(fair_queue&&) = delete;
     ~fair_queue();
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -342,7 +342,6 @@ private:
     void unplug_priority_class(priority_class_data& pc) noexcept;
 
 public:
-    enum class grab_result { ok, stop, again };
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///
     /// \param cfg an instance of the class \ref config

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -325,7 +325,6 @@ private:
 
     config _config;
     io_throttler& _group;
-    clock_type::time_point _group_replenish;
     fair_queue_ticket _resources_executing;
     fair_queue_ticket _resources_queued;
     priority_queue _handles;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -369,14 +369,6 @@ public:
     /// \return the amount of resources (weight, size) currently executing
     fair_queue_ticket resources_currently_executing() const;
 
-    capacity_t tokens_capacity(double tokens) const noexcept {
-        return _group.tokens_capacity(tokens);
-    }
-
-    capacity_t maximum_capacity() const noexcept {
-        return _group.maximum_capacity();
-    }
-
     /// Queue the entry \c ent through this class' \ref fair_queue
     ///
     /// The user of this interface is supposed to call \ref notify_requests_finished when the

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -374,7 +374,9 @@ private:
         capacity_t ready_tokens;
         bool our_turn_has_come;
     };
+    enum class grab_result { ok, stop, again };
     reap_result reap_pending_capacity() noexcept;
+    grab_result grab_capacity(capacity_t cap, reap_result& available);
 public:
     /// Constructs a fair queue with configuration parameters \c cfg.
     ///

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -361,9 +361,6 @@ private:
     void plug_priority_class(priority_class_data& pc) noexcept;
     void unplug_priority_class(priority_class_data& pc) noexcept;
 
-    // Replaces _pending with a new reservation starting at the current
-    // group bucket tail.
-    void grab_capacity(capacity_t cap) noexcept;
     // Shaves off the fulfilled frontal part from `_pending` (if any),
     // and returns the fulfilled tokens in `ready_tokens`.
     // Sets `our_turn_has_come` to the truth value of "`_pending` is empty or

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -127,6 +127,8 @@ private:
         clock_type::time_point next_pending_aio() const noexcept;
         reap_result reap_pending_capacity() noexcept;
         grab_result grab_capacity(capacity_t cap, reap_result& available);
+
+        std::vector<seastar::metrics::impl::metric_definition_impl> metrics(const priority_class_data&);
     };
     boost::container::static_vector<stream, 2> _streams;
     internal::io_sink& _sink;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -107,7 +107,7 @@ private:
         };
         pending _pending;
         stream(io_throttler& t, fair_queue::config cfg)
-            : fq(t, std::move(cfg))
+            : fq(std::move(cfg))
             , replenish(clock_type::now())
             , out(t)
         {}

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -43,7 +43,7 @@ namespace seastar {
 
 class io_queue;
 namespace internal {
-const io_throttler& get_fair_group(const io_queue& ioq, unsigned stream);
+const io_throttler& get_throttler(const io_queue& ioq, unsigned stream);
 }
 
 SEASTAR_MODULE_EXPORT
@@ -86,7 +86,7 @@ private:
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;
-    friend const io_throttler& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const io_throttler& internal::get_throttler(const io_queue& ioq, unsigned stream);
 
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
@@ -213,7 +213,7 @@ public:
 private:
     friend class io_queue;
     friend struct ::io_queue_for_tests;
-    friend const io_throttler& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const io_throttler& internal::get_throttler(const io_queue& ioq, unsigned stream);
 
     const io_queue::config _config;
     size_t _max_request_length[2];

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -43,7 +43,7 @@ namespace seastar {
 
 class io_queue;
 namespace internal {
-const fair_group& get_fair_group(const io_queue& ioq, unsigned stream);
+const io_throttler& get_fair_group(const io_queue& ioq, unsigned stream);
 }
 
 SEASTAR_MODULE_EXPORT
@@ -86,7 +86,7 @@ private:
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;
-    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const io_throttler& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
     priority_class_data& find_or_create_class(internal::priority_class pc);
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
@@ -213,16 +213,16 @@ public:
 private:
     friend class io_queue;
     friend struct ::io_queue_for_tests;
-    friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
+    friend const io_throttler& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
     const io_queue::config _config;
     size_t _max_request_length[2];
-    boost::container::static_vector<fair_group, 2> _fgs;
+    boost::container::static_vector<io_throttler, 2> _fgs;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;
     const shard_id _allocated_on;
 
-    static fair_group::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
+    static io_throttler::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);
 };
 

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -77,6 +77,7 @@ public:
 class io_queue {
 public:
     class priority_class_data;
+    using clock_type = std::chrono::steady_clock;
 
 private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
@@ -84,8 +85,12 @@ private:
     const unsigned _id;
     struct stream {
         fair_queue fq;
+        clock_type::time_point replenish;
+        io_throttler& out;
         stream(io_throttler& t, fair_queue::config cfg)
             : fq(t, std::move(cfg))
+            , replenish(clock_type::now())
+            , out(t)
         {}
     };
     boost::container::static_vector<stream, 2> _streams;
@@ -122,8 +127,6 @@ private:
 
     metrics::metric_groups _metric_groups;
 public:
-
-    using clock_type = std::chrono::steady_clock;
 
     // We want to represent the fact that write requests are (maybe) more expensive
     // than read requests. To avoid dealing with floating point math we will scale one

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -122,10 +122,11 @@ private:
             capacity_t ready_tokens;
             bool our_turn_has_come;
         };
+        enum class grab_result { ok, stop, again };
 
         clock_type::time_point next_pending_aio() const noexcept;
         reap_result reap_pending_capacity() noexcept;
-        fair_queue::grab_result grab_capacity(capacity_t cap, reap_result& available);
+        grab_result grab_capacity(capacity_t cap, reap_result& available);
     };
     boost::container::static_vector<stream, 2> _streams;
     internal::io_sink& _sink;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -155,6 +155,7 @@ public:
         double flow_ratio_ema_factor = 0.95;
         double flow_ratio_backpressure_threshold = 1.1;
         std::chrono::milliseconds stall_threshold = std::chrono::milliseconds(100);
+        std::chrono::microseconds tau = std::chrono::milliseconds(5);
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -82,7 +82,13 @@ private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     io_group_ptr _group;
     const unsigned _id;
-    boost::container::static_vector<fair_queue, 2> _streams;
+    struct stream {
+        fair_queue fq;
+        stream(io_throttler& t, fair_queue::config cfg)
+            : fq(t, std::move(cfg))
+        {}
+    };
+    boost::container::static_vector<stream, 2> _streams;
     internal::io_sink& _sink;
 
     friend struct ::io_queue_for_tests;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -222,7 +222,7 @@ private:
     util::spinlock _lock;
     const shard_id _allocated_on;
 
-    static io_throttler::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
+    static io_throttler::config configure_throttler(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);
 };
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -355,6 +355,7 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         if (req._capacity <= available.ready_tokens) {
             // We can dispatch the request immediately.
             // We do that after the if-else.
+            available.ready_tokens -= req._capacity;
         } else if (req._capacity <= available.ready_tokens + _pending.cap || _pending.cap >= max_unamortized_reservation) {
             // We can't dispatch the request yet, but we already have a pending reservation
             // which will provide us with enough tokens for it eventually,
@@ -394,8 +395,6 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
             SEASTAR_ASSERT(available.ready_tokens == 0);
             break;
         }
-
-        available.ready_tokens -= req._capacity;
 
         _last_accumulated = std::max(h._accumulated, _last_accumulated);
         pop_priority_class(h);

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -164,7 +164,6 @@ bool fair_queue::class_compare::operator() (const priority_class_ptr& lhs, const
 fair_queue::fair_queue(io_throttler& group, config cfg)
     : _config(std::move(cfg))
     , _group(group)
-    , _group_replenish(clock_type::now())
 {
 }
 
@@ -386,8 +385,6 @@ auto fair_queue::grab_capacity(capacity_t cap, reap_result& available) -> grab_r
 // a CPU-starved shard should still be able to grab at least ~30% of its fair share in the worst case.
 // This is far from ideal, but it's something.
 void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
-    _group.maybe_replenish_capacity(_group_replenish);
-
     auto available = reap_pending_capacity();
 
     while (!_handles.empty()) {

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -430,11 +430,11 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         h._pure_accumulated += req_cap;
         _queued_capacity -= req_cap;
 
-        cb(req);
-
-        if (h._plugged && !h._queue.empty()) {
+        if (!h._queue.empty()) {
             push_priority_class(h);
         }
+
+        cb(req);
     }
 
     SEASTAR_ASSERT(_handles.empty() || available.ready_tokens == 0);

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -186,12 +186,11 @@ void fair_queue::push_priority_class_from_idle(priority_class_data& pc) noexcept
         // duration. For this estimate how many capacity units can be
         // accumulated with the current class shares per rate resulution
         // and scale it up to tau.
-        capacity_t max_deviation = io_throttler::fixed_point_factor / pc._shares * io_throttler::token_bucket_t::rate_cast(_config.tau).count();
         // On start this deviation can go to negative values, so not to
         // introduce extra if's for that short corner case, use signed
         // arithmetics and make sure the _accumulated value doesn't grow
         // over signed maximum (see overflow check below)
-        pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - max_deviation, pc._accumulated);
+        pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - _config.forgiving_factor / pc._shares, pc._accumulated);
         _handles.assert_enough_capacity();
         _handles.push(&pc);
         pc._queued = true;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -320,6 +320,55 @@ fair_queue::clock_type::time_point fair_queue::next_pending_aio() const noexcept
     return std::chrono::steady_clock::time_point::max();
 }
 
+auto fair_queue::grab_capacity(capacity_t cap, reap_result& available) -> grab_result {
+    const uint64_t max_unamortized_reservation = _group.per_tick_grab_threshold();
+
+    if (cap <= available.ready_tokens) {
+        // We can dispatch the request immediately.
+        // We do that after the if-else.
+        available.ready_tokens -= cap;
+        return grab_result::ok;
+    } else if (cap <= available.ready_tokens + _pending.cap || _pending.cap >= max_unamortized_reservation) {
+        // We can't dispatch the request yet, but we already have a pending reservation
+        // which will provide us with enough tokens for it eventually,
+        // or our reservation is already max-size and we can't reserve more tokens until we reap some.
+        // So we should just wait.
+        // We return any immediately-available tokens back to `_pending`
+        // and we bail. The next `dispatch_request` will again take those tokens
+        // (possibly joined by some newly-granted tokens) and retry.
+        _pending.cap += available.ready_tokens;
+        available.ready_tokens = 0;
+        return grab_result::stop;
+    } else if (available.our_turn_has_come) {
+        // The current reservation isn't enough to fulfill the next request,
+        // and we can cancel it (because `our_turn_has_come == true`) and make a bigger one
+        // (because `_pending.cap < can_grab_this_tick`).
+        // So we cancel it and do a bigger one.
+
+        // We do token recycling here: we return the tokens which we have available, and the tokens we have reserved
+        // immediately after the group head, and we return them to the bucket, immediately grabbing the same amount from the tail.
+        // This is neutral to fairness. The bandwidth we consume is still influenced only by the
+        // `max_unarmortized_reservation` portions.
+        auto recycled = available.ready_tokens + _pending.cap;
+        capacity_t grab_amount = std::min<capacity_t>(recycled + max_unamortized_reservation, _queued_capacity);
+        // There's technically nothing wrong with grabbing more than `_group.maximum_capacity()`,
+        // but the token bucket has an assert for that, and its a reasonable expectation, so let's respect that limit.
+        // It shouldn't matter in practice.
+        grab_amount = std::min<capacity_t>(grab_amount, _group.maximum_capacity());
+        _group.refund_tokens(recycled);
+        grab_capacity(grab_amount);
+        available = reap_pending_capacity();
+        return grab_result::again;
+    } else {
+        // We can already see that our current reservation is going to be insufficient
+        // for the highest-priority request as of now. But since group head didn't touch
+        // it yet, there's no good way to cancel it, so we have no choice but to wait
+        // until the touch time.
+        SEASTAR_ASSERT(available.ready_tokens == 0);
+        return grab_result::stop;
+    }
+}
+
 // This function is called by the shard on every poll.
 // It picks up tokens granted by the group, spends available tokens on IO dispatches,
 // and makes a reservation for more tokens, if needed.
@@ -341,7 +390,6 @@ fair_queue::clock_type::time_point fair_queue::next_pending_aio() const noexcept
 void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
     _group.maybe_replenish_capacity(_group_replenish);
 
-    const uint64_t max_unamortized_reservation = _group.per_tick_grab_threshold();
     auto available = reap_pending_capacity();
 
     while (!_handles.empty()) {
@@ -352,48 +400,13 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         }
 
         auto& req = h._queue.front();
-        if (req._capacity <= available.ready_tokens) {
-            // We can dispatch the request immediately.
-            // We do that after the if-else.
-            available.ready_tokens -= req._capacity;
-        } else if (req._capacity <= available.ready_tokens + _pending.cap || _pending.cap >= max_unamortized_reservation) {
-            // We can't dispatch the request yet, but we already have a pending reservation
-            // which will provide us with enough tokens for it eventually,
-            // or our reservation is already max-size and we can't reserve more tokens until we reap some.
-            // So we should just wait.
-            // We return any immediately-available tokens back to `_pending`
-            // and we bail. The next `dispatch_request` will again take those tokens
-            // (possibly joined by some newly-granted tokens) and retry.
-            _pending.cap += available.ready_tokens;
-            available.ready_tokens = 0;
-            break;
-        } else if (available.our_turn_has_come) {
-            // The current reservation isn't enough to fulfill the next request,
-            // and we can cancel it (because `our_turn_has_come == true`) and make a bigger one
-            // (because `_pending.cap < can_grab_this_tick`).
-            // So we cancel it and do a bigger one.
 
-            // We do token recycling here: we return the tokens which we have available, and the tokens we have reserved
-            // immediately after the group head, and we return them to the bucket, immediately grabbing the same amount from the tail.
-            // This is neutral to fairness. The bandwidth we consume is still influenced only by the
-            // `max_unarmortized_reservation` portions.
-            auto recycled = available.ready_tokens + _pending.cap;
-            capacity_t grab_amount = std::min<capacity_t>(recycled + max_unamortized_reservation, _queued_capacity);
-            // There's technically nothing wrong with grabbing more than `_group.maximum_capacity()`,
-            // but the token bucket has an assert for that, and its a reasonable expectation, so let's respect that limit.
-            // It shouldn't matter in practice.
-            grab_amount = std::min<capacity_t>(grab_amount, _group.maximum_capacity());
-            _group.refund_tokens(recycled);
-            grab_capacity(grab_amount);
-            available = reap_pending_capacity();
-            continue;
-        } else {
-            // We can already see that our current reservation is going to be insufficient
-            // for the highest-priority request as of now. But since group head didn't touch
-            // it yet, there's no good way to cancel it, so we have no choice but to wait
-            // until the touch time.
-            SEASTAR_ASSERT(available.ready_tokens == 0);
+        auto result = grab_capacity(req._capacity, available);
+        if (result == grab_result::stop) {
             break;
+        }
+        if (result == grab_result::again) {
+            continue;
         }
 
         _last_accumulated = std::max(h._accumulated, _last_accumulated);

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -97,45 +97,6 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
             std::max<int32_t>(a._size - b._size, 0));
 }
 
-io_throttler::io_throttler(config cfg, unsigned nr_queues)
-        : _token_bucket(fixed_point_factor,
-                        std::max<capacity_t>(fixed_point_factor * token_bucket_t::rate_cast(cfg.rate_limit_duration).count(), tokens_capacity(cfg.limit_min_tokens)),
-                        tokens_capacity(cfg.min_tokens)
-                       )
-        , _per_tick_threshold(_token_bucket.limit() / nr_queues)
-{
-    if (tokens_capacity(cfg.min_tokens) > _token_bucket.threshold()) {
-        throw std::runtime_error("Fair-group replenisher limit is lower than threshold");
-    }
-}
-
-auto io_throttler::grab_capacity(capacity_t cap) noexcept -> capacity_t {
-    SEASTAR_ASSERT(cap <= _token_bucket.limit());
-    return _token_bucket.grab(cap);
-}
-
-void io_throttler::replenish_capacity(clock_type::time_point now) noexcept {
-    _token_bucket.replenish(now);
-}
-
-void io_throttler::refund_tokens(capacity_t cap) noexcept {
-    _token_bucket.refund(cap);
-}
-
-void io_throttler::maybe_replenish_capacity(clock_type::time_point& local_ts) noexcept {
-    auto now = clock_type::now();
-    auto extra = _token_bucket.accumulated_in(now - local_ts);
-
-    if (extra >= _token_bucket.threshold()) {
-        local_ts = now;
-        replenish_capacity(now);
-    }
-}
-
-auto io_throttler::capacity_deficiency(capacity_t from) const noexcept -> capacity_t {
-    return _token_bucket.deficiency(from);
-}
-
 // Priority class, to be used with a given fair_queue
 class fair_queue::priority_class_data {
     friend class fair_queue;

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -41,8 +41,6 @@ module seastar;
 #endif
 #include <seastar/util/assert.hh>
 
-#include <seastar/core/io_queue.hh> // temporary
-
 namespace seastar {
 
 static_assert(sizeof(fair_queue_ticket) == sizeof(uint64_t), "unexpected fair_queue_ticket size");
@@ -228,20 +226,6 @@ void fair_queue::unplug_class(class_id cid) noexcept {
     unplug_priority_class(*_priority_classes[cid]);
 }
 
-auto io_queue::stream::reap_pending_capacity() noexcept -> reap_result {
-    auto& _group = out;
-    auto result = reap_result{.ready_tokens = 0, .our_turn_has_come = true};
-    if (_pending.cap) {
-        capacity_t deficiency = _group.capacity_deficiency(_pending.head);
-        result.our_turn_has_come = deficiency <= _pending.cap;
-        if (result.our_turn_has_come) {
-            result.ready_tokens = _pending.cap - deficiency;
-            _pending.cap = deficiency;
-        }
-    }
-    return result;
-}
-
 void fair_queue::register_priority_class(class_id id, uint32_t shares) {
     if (id >= _priority_classes.size()) {
         _priority_classes.resize(id + 1);
@@ -294,82 +278,6 @@ void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexc
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {
     _queued_capacity -= ent._capacity;
     ent._capacity = 0;
-}
-
-io_queue::clock_type::time_point io_queue::stream::next_pending_aio() const noexcept {
-    auto& _group = out;
-    if (_pending.cap) {
-        /*
-         * We expect the disk to release the ticket within some time,
-         * but it's ... OK if it doesn't -- the pending wait still
-         * needs the head rover value to be ahead of the needed value.
-         *
-         * It may happen that the capacity gets released before we think
-         * it will, in this case we will wait for the full value again,
-         * which's sub-optimal. The expectation is that we think disk
-         * works faster, than it really does.
-         */
-        auto over = _group.capacity_deficiency(_pending.head);
-        auto ticks = _group.capacity_duration(over);
-        return std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::microseconds>(ticks);
-    }
-
-    return std::chrono::steady_clock::time_point::max();
-}
-
-auto io_queue::stream::grab_capacity(capacity_t cap, reap_result& available) -> fair_queue::grab_result {
-    using grab_result = fair_queue::grab_result;
-    auto& _group = out;
-    auto _queued_capacity = fq.queued_capacity();
-    const uint64_t max_unamortized_reservation = _group.per_tick_grab_threshold();
-
-    if (cap <= available.ready_tokens) {
-        // We can dispatch the request immediately.
-        // We do that after the if-else.
-        available.ready_tokens -= cap;
-        return grab_result::ok;
-    } else if (cap <= available.ready_tokens + _pending.cap || _pending.cap >= max_unamortized_reservation) {
-        // We can't dispatch the request yet, but we already have a pending reservation
-        // which will provide us with enough tokens for it eventually,
-        // or our reservation is already max-size and we can't reserve more tokens until we reap some.
-        // So we should just wait.
-        // We return any immediately-available tokens back to `_pending`
-        // and we bail. The next `dispatch_request` will again take those tokens
-        // (possibly joined by some newly-granted tokens) and retry.
-        _pending.cap += available.ready_tokens;
-        available.ready_tokens = 0;
-        return grab_result::stop;
-    } else if (available.our_turn_has_come) {
-        // The current reservation isn't enough to fulfill the next request,
-        // and we can cancel it (because `our_turn_has_come == true`) and make a bigger one
-        // (because `_pending.cap < can_grab_this_tick`).
-        // So we cancel it and do a bigger one.
-
-        // We do token recycling here: we return the tokens which we have available, and the tokens we have reserved
-        // immediately after the group head, and we return them to the bucket, immediately grabbing the same amount from the tail.
-        // This is neutral to fairness. The bandwidth we consume is still influenced only by the
-        // `max_unarmortized_reservation` portions.
-        auto recycled = available.ready_tokens + _pending.cap;
-        capacity_t grab_amount = std::min<capacity_t>(recycled + max_unamortized_reservation, _queued_capacity);
-        // There's technically nothing wrong with grabbing more than `_group.maximum_capacity()`,
-        // but the token bucket has an assert for that, and its a reasonable expectation, so let's respect that limit.
-        // It shouldn't matter in practice.
-        grab_amount = std::min<capacity_t>(grab_amount, _group.maximum_capacity());
-        _group.refund_tokens(recycled);
-        // Replace _pending with a new reservation starting at the current
-        // group bucket tail.
-        capacity_t want_head = _group.grab_capacity(grab_amount);
-        _pending = pending{want_head, grab_amount};
-        available = reap_pending_capacity();
-        return grab_result::again;
-    } else {
-        // We can already see that our current reservation is going to be insufficient
-        // for the highest-priority request as of now. But since group head didn't touch
-        // it yet, there's no good way to cancel it, so we have no choice but to wait
-        // until the touch time.
-        SEASTAR_ASSERT(available.ready_tokens == 0);
-        return grab_result::stop;
-    }
 }
 
 fair_queue_entry* fair_queue::top() {

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -161,9 +161,8 @@ bool fair_queue::class_compare::operator() (const priority_class_ptr& lhs, const
     return lhs->_accumulated > rhs->_accumulated;
 }
 
-fair_queue::fair_queue(io_throttler& group, config cfg)
+fair_queue::fair_queue(config cfg)
     : _config(std::move(cfg))
-    , _group(group)
 {
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -562,6 +562,7 @@ io_queue::complete_request(io_desc_read_write& desc, std::chrono::duration<doubl
 fair_queue::config io_queue::make_fair_queue_config(const config& iocfg, sstring label) {
     fair_queue::config cfg;
     cfg.label = label;
+    cfg.forgiving_factor = io_throttler::fixed_point_factor * io_throttler::token_bucket_t::rate_cast(iocfg.tau).count();
     return cfg;
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -973,7 +973,7 @@ future<size_t> io_queue::submit_io_write(internal::priority_class pc, size_t len
 void io_queue::poll_io_queue() {
     for (auto&& st : _streams) {
         st.out.maybe_replenish_capacity(st.replenish);
-        auto available = st.fq.reap_pending_capacity();
+        auto available = st.reap_pending_capacity();
 
         while (true) {
             auto* ent = st.fq.top();
@@ -982,7 +982,7 @@ void io_queue::poll_io_queue() {
                 break;
             }
 
-            auto result = st.fq.grab_capacity(ent->capacity(), available);
+            auto result = st.grab_capacity(ent->capacity(), available);
             if (result == fair_queue::grab_result::stop) {
                 break;
             }
@@ -1025,7 +1025,7 @@ io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {
     clock_type::time_point next = clock_type::time_point::max();
 
     for (const auto& s : _streams) {
-        clock_type::time_point n = s.fq.next_pending_aio();
+        clock_type::time_point n = s.next_pending_aio();
         if (n < next) {
             next = std::move(n);
         }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -952,6 +952,7 @@ future<size_t> io_queue::submit_io_write(internal::priority_class pc, size_t len
 
 void io_queue::poll_io_queue() {
     for (auto&& st : _streams) {
+        st.out.maybe_replenish_capacity(st.replenish);
         st.fq.dispatch_requests([] (fair_queue_entry& fqe) {
             queued_io_request::from_fq_entry(fqe).dispatch();
         });

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -520,7 +520,7 @@ sstring io_request::opname() const {
     std::abort();
 }
 
-const fair_group& get_fair_group(const io_queue& ioq, unsigned stream) {
+const io_throttler& get_fair_group(const io_queue& ioq, unsigned stream) {
     return ioq._group->_fgs[stream];
 }
 
@@ -599,8 +599,8 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     });
 }
 
-fair_group::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {
-    fair_group::config cfg;
+io_throttler::config io_group::make_fair_group_config(const io_queue::config& qcfg) noexcept {
+    io_throttler::config cfg;
     cfg.label = fmt::format("io-queue-{}", qcfg.id);
     double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
     double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -983,10 +983,10 @@ void io_queue::poll_io_queue() {
             }
 
             auto result = st.grab_capacity(ent->capacity(), available);
-            if (result == fair_queue::grab_result::stop) {
+            if (result == stream::grab_result::stop) {
                 break;
             }
-            if (result == fair_queue::grab_result::again) {
+            if (result == stream::grab_result::again) {
                 continue;
             }
 
@@ -1112,8 +1112,7 @@ io_queue::clock_type::time_point io_queue::stream::next_pending_aio() const noex
     return std::chrono::steady_clock::time_point::max();
 }
 
-auto io_queue::stream::grab_capacity(capacity_t cap, reap_result& available) -> fair_queue::grab_result {
-    using grab_result = fair_queue::grab_result;
+auto io_queue::stream::grab_capacity(capacity_t cap, reap_result& available) -> grab_result {
     const uint64_t max_unamortized_reservation = out.per_tick_grab_threshold();
 
     if (cap <= available.ready_tokens) {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -841,12 +841,12 @@ fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length 
     const auto& cfg = get_config();
     auto tokens = internal::request_tokens(dnl, cfg);
     if (_flow_ratio <= cfg.flow_ratio_backpressure_threshold) {
-        return _streams[request_stream(dnl)].fq.tokens_capacity(tokens);
+        return _streams[request_stream(dnl)].out.tokens_capacity(tokens);
     }
 
     auto stream = request_stream(dnl);
-    auto cap = _streams[stream].fq.tokens_capacity(tokens * _flow_ratio);
-    auto max_cap = _streams[stream].fq.maximum_capacity();
+    auto cap = _streams[stream].out.tokens_capacity(tokens * _flow_ratio);
+    auto max_cap = _streams[stream].out.maximum_capacity();
     return std::min(cap, max_cap);
 }
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -520,7 +520,7 @@ sstring io_request::opname() const {
     std::abort();
 }
 
-const io_throttler& get_fair_group(const io_queue& ioq, unsigned stream) {
+const io_throttler& get_throttler(const io_queue& ioq, unsigned stream) {
     return ioq._group->_fgs[stream];
 }
 

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -99,7 +99,7 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(std::views::iota(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto cap = local.queue(loc).tokens_capacity(double(1) / std::numeric_limits<int>::max() + double(1) / std::numeric_limits<int>::max());
+            auto cap = io_throttler::capacity_t(1);
             auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
                 local.queue(loc).notify_request_finished(cap);

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -32,19 +32,19 @@
 static constexpr fair_queue::class_id cid = 0;
 
 struct local_fq_and_class {
-    seastar::fair_group fg;
+    seastar::io_throttler fg;
     seastar::fair_queue fq;
     seastar::fair_queue sfq;
     unsigned executed = 0;
 
-    static fair_group::config fg_config() {
-        fair_group::config cfg;
+    static io_throttler::config fg_config() {
+        io_throttler::config cfg;
         return cfg;
     }
 
     seastar::fair_queue& queue(bool local) noexcept { return local ? fq : sfq; }
 
-    local_fq_and_class(seastar::fair_group& sfg)
+    local_fq_and_class(seastar::io_throttler& sfg)
         : fg(fg_config(), 1)
         , fq(fg, seastar::fair_queue::config())
         , sfq(sfg, seastar::fair_queue::config())
@@ -75,10 +75,10 @@ struct perf_fair_queue {
 
     seastar::sharded<local_fq_and_class> local_fq;
 
-    seastar::fair_group shared_fg;
+    seastar::io_throttler shared_fg;
 
-    static fair_group::config fg_config() {
-        fair_group::config cfg;
+    static io_throttler::config fg_config() {
+        io_throttler::config cfg;
         return cfg;
     }
 

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -84,7 +84,7 @@ future<> perf_fair_queue::test(bool loc) {
 
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(std::views::iota(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
-            auto cap = io_throttler::capacity_t(1);
+            auto cap = fair_queue_entry::capacity_t(1);
             auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
                 local.executed++;
                 local.queue(loc).notify_request_finished(cap);

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -46,8 +46,8 @@ struct local_fq_and_class {
 
     local_fq_and_class(seastar::io_throttler& sfg)
         : fg(fg_config(), 1)
-        , fq(fg, seastar::fair_queue::config())
-        , sfq(sfg, seastar::fair_queue::config())
+        , fq(seastar::fair_queue::config())
+        , sfq(seastar::fair_queue::config())
     {
         fq.register_priority_class(cid, 1);
         sfq.register_priority_class(cid, 1);

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -56,6 +56,8 @@ struct request {
     }
 };
 
+constexpr unsigned test_weight_scale = 1000;
+
 class test_env {
     io_throttler _fg;
     fair_queue _fq;
@@ -72,7 +74,7 @@ class test_env {
 
     static fair_queue::config fq_config() {
         fair_queue::config cfg;
-        cfg.forgiving_factor = io_throttler::fixed_point_factor * io_throttler::token_bucket_t::rate_cast(std::chrono::microseconds(50)).count();
+        cfg.forgiving_factor = 50 * test_weight_scale;
         return cfg;
     }
 
@@ -155,7 +157,7 @@ public:
 
     void do_op(fair_queue::class_id id, unsigned weight) {
         unsigned index = id;
-        auto cap = _fq.tokens_capacity(double(weight) / 1'000'000);
+        auto cap = io_throttler::capacity_t(test_weight_scale * weight);
         auto req = std::make_unique<request>(cap, index, [this, index] (request& req) mutable noexcept {
             try {
                 _inflight.push_back(std::move(req));

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -72,7 +72,7 @@ class test_env {
 
     static fair_queue::config fq_config() {
         fair_queue::config cfg;
-        cfg.tau = std::chrono::microseconds(50);
+        cfg.forgiving_factor = io_throttler::fixed_point_factor * io_throttler::token_bucket_t::rate_cast(std::chrono::microseconds(50)).count();
         return cfg;
     }
 

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -141,7 +141,7 @@ public:
 
     void do_op(fair_queue::class_id id, unsigned weight) {
         unsigned index = id;
-        auto cap = io_throttler::capacity_t(test_weight_scale * weight);
+        auto cap = fair_queue_entry::capacity_t(test_weight_scale * weight);
         auto req = std::make_unique<request>(cap, index, [this, index] (request& req) mutable noexcept {
             try {
                 _inflight.push_back(std::move(req));

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -57,15 +57,15 @@ struct request {
 };
 
 class test_env {
-    fair_group _fg;
+    io_throttler _fg;
     fair_queue _fq;
     std::vector<int> _results;
     std::vector<std::vector<std::exception_ptr>> _exceptions;
     fair_queue::class_id _nr_classes = 0;
     std::vector<request> _inflight;
 
-    static fair_group::config fg_config(unsigned cap) {
-        fair_group::config cfg;
+    static io_throttler::config fg_config(unsigned cap) {
+        io_throttler::config cfg;
         cfg.rate_limit_duration = std::chrono::microseconds(cap);
         return cfg;
     }
@@ -89,7 +89,7 @@ public:
         // from replenishing tokens on its own, and ensure that the only source of replenishment will be tick().
         //
         // Otherwise the rate of replenishment might be greater than expected by the test, breaking the results.
-        _fg.replenish_capacity(fair_group::clock_type::now() + std::chrono::days(1));
+        _fg.replenish_capacity(io_throttler::clock_type::now() + std::chrono::days(1));
     }
 
     // As long as there is a request sitting in the queue, tick() will process

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -84,7 +84,7 @@ class test_env {
 public:
     test_env(unsigned capacity)
         : _fg(fg_config(capacity), 1)
-        , _fq(_fg, fq_config())
+        , _fq(fq_config())
     {
         // Move _fg._replenished_ts() to far future.
         // This will prevent any `maybe_replenish_capacity` calls (indirectly done by `fair_queue::dispatch_requests()`)


### PR DESCRIPTION
IO queue is responsible for two things:

* cross-class shares-based fair balancing
* throttling the flow of dispatching requests to obey disk model

The former is done with the help of fair_queue that implements rather simple "virtual capacity" model. The latter is done with the help of shared token bucket, but historically the throttling code was implemented as a part of fair_queue. That's not correct, fair queue has nothing to do with output flow control. This PR moves the throttling code out of fair_queue and makes IO-queue own it and use.

As the result the fair_queue code is, again, simple priority queue with the ability to plug/unplug classes for the sake of IO throughput limiting. This will help with nested sched groups. Right now it does helps fair_queue unit test, which uses several "magic" constants to combine one-by-one request dispatching the outgoing throttler time-driven model.

Another nice side effect is that dispatching requests from the fair queue now happens without the help of abstract std::function passing around.

refs: #2332 (previous, not successful attempt)
refs: #1070
