### PR TITLE
thread_pool: Relax coupling with reactor

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -391,7 +391,6 @@ private:
 
     signals _signals;
     std::unique_ptr<thread_pool> _thread_pool;
-    friend class thread_pool;
     friend class thread_context;
     friend class internal::cpu_stall_detector;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1043,7 +1043,7 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     , _task_quota_timer(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC))
     , _id(id)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
-    , _thread_pool(std::make_unique<thread_pool>(*this, seastar::format("syscall-{}", id))) {
+    , _thread_pool(std::make_unique<thread_pool>(seastar::format("syscall-{}", id), _notify_eventfd)) {
     /*
      * The _backend assignment is here, not on the initialization list as
      * the chosen backend constructor may want to handle signals and thus

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -25,7 +25,7 @@
 
 namespace seastar {
 
-class reactor;
+class file_desc;
 
 namespace internal {
 // Reasons for why a function had to be submitted to the thread_pool 
@@ -53,14 +53,14 @@ public:
 } // namespace internal
 
 class thread_pool {
-    reactor& _reactor;
+    file_desc& _notify_eventfd;
     internal::submit_metrics metrics;
     syscall_work_queue inter_thread_wq;
     posix_thread _worker_thread;
     std::atomic<bool> _stopped = { false };
     std::atomic<bool> _main_thread_idle = { false };
 public:
-    explicit thread_pool(reactor& r, sstring thread_name);
+    explicit thread_pool(sstring thread_name, file_desc& notify);
     ~thread_pool();
     template <typename T, typename Func>
     future<T> submit(internal::thread_pool_submit_reason reason, Func func) noexcept {


### PR DESCRIPTION
The thread_pool class is friend of reactor and includes reactor.hh to "know" the reactor class layout. However, the only thing thread_pool needs from reactor is the notification event-fd.

This patch makes thread_pool reference only the required eventfd desc and removes no longer needed reactor.hh from thread_pool.cc and removes thread_pool itself from the (long enough) list of reactor friends.