### PR TITLE
Relax reactor coupling with file_data_source_impl

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -171,7 +171,6 @@ private:
     friend void internal::at_destroy(Func&&);
     friend void internal::at_exit(noncopyable_function<future<> ()> func);
     friend class manual_clock;
-    friend class file_data_source_impl; // for fstream statistics
     friend class internal::reactor_stall_sampler;
     friend class preempt_io_context;
     friend struct hrtimer_aio_completion;
@@ -201,6 +200,10 @@ public:
         uint64_t fstream_read_bytes_blocked = 0;
         uint64_t fstream_read_aheads_discarded = 0;
         uint64_t fstream_read_ahead_discarded_bytes = 0;
+
+    private:
+        friend class file_data_source_impl;
+        static io_stats& local() noexcept;
     };
     /// Scheduling statistics.
     struct sched_stats {

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -77,6 +77,10 @@ inline internal::maybe_priority_class_ref get_io_priority(const Options& opts) {
     return internal::maybe_priority_class_ref{};
 }
 
+inline auto reactor::io_stats::local() noexcept -> io_stats& {
+    return engine()._io_stats;
+}
+
 class file_data_source_impl : public data_source_impl {
     struct issued_read {
         uint64_t _pos;
@@ -87,7 +91,7 @@ class file_data_source_impl : public data_source_impl {
             : _pos(pos), _size(size), _ready(std::move(f)) { }
     };
 
-    reactor::io_stats& _stats = engine()._io_stats;
+    reactor::io_stats& _stats = reactor::io_stats::local();
     file _file;
     file_input_stream_options _options;
     uint64_t _pos;


### PR DESCRIPTION
This friendship is only needed to allow data source in question manipulate io_stats that sit on reactor. This PR does two things: replaces reference to reactor from file_data_source_impl to point to io_stats itself, and moves the friendship from reactor to io_stats too, thus making it much narrower.