### PR TITLE
http::reply: Add 308 (permanent redirect) and make pretty-print handle unknown values

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -79,6 +79,7 @@ struct reply {
         not_modified = 304, //!< not_modified
         use_proxy = 305, //!< use_proxy
         temporary_redirect = 307, //!< temporary_redirect
+        permanent_redirect = 308, //!< permanent_redirect
         bad_request = 400, //!< bad_request
         unauthorized = 401, //!< unauthorized
         payment_required = 402, //!< payment_required


### PR DESCRIPTION
Fixes #2829

The HTTP status enum in http::reply::status_type is missing 308 "permanent redirect". This is a useful error code. It should be there.

What is worse however is that IFF a HTTP reponse comes back, containing say a 308, the pretty-printers in reply.cc (ostream operator and response_line() will lie about the error code, and print it as 500 internal error.

This is very misleading and not great. If the pretty-printer does not find a code in its number-to-string mapping, it should at least just print the number as is, and not confuse hard-working programmers trying to read logs.

This adds the 308 entry to status_type, and makes the printer-code print the actual value in case of an unknown error code (jumping through hoops to avoid creating string objects).