### PR TITLE
util: make SEASTAR_ASSERT() failure generate SIGABRT

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -125,7 +125,7 @@ namespace internal {
 
 [[noreturn]] void assert_fail(const char* msg, const char* file, int line, const char* func) {
     printf("%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
-    __builtin_trap();
+    std::terminate();
 }
 
 void log_buf::free_buffer() noexcept {


### PR DESCRIPTION
Recently commit 7a91062 introduced SEASTAR_ASSERT to replace assert() and BOOST_ASSERT() - but unlike the latters it ignores NDEBUG and unconditionally checks the condition.

When the new SEASTAR_ASSERT() fails, it called __builtin_trap(), which generates a SIGILL (Illegal Instruction) signal. This is surprising and counter-intutive, because C / C++ developers are used to assertion failures always generating SIGABRT, not SIGILL.

Fix this by calling std::terminate() instead of __builtin_trap().

Fixes #2832