### PR TITLE
fair_queue: Remove queued/executing resource counters

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -180,8 +180,6 @@ private:
     };
 
     config _config;
-    fair_queue_ticket _resources_executing;
-    fair_queue_ticket _resources_queued;
     priority_queue _handles;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     size_t _nr_classes = 0;
@@ -219,10 +217,12 @@ public:
     void update_shares_for_class(class_id c, uint32_t new_shares);
 
     /// \return how much resources (weight, size) are currently queued for all classes.
-    fair_queue_ticket resources_currently_waiting() const;
+    [[deprecated("Ticket resources are not accounted for any longer")]]
+    fair_queue_ticket resources_currently_waiting() const { return fair_queue_ticket(); }
 
     /// \return the amount of resources (weight, size) currently executing
-    fair_queue_ticket resources_currently_executing() const;
+    [[deprecated("Ticket resources are not accounted for any longer")]]
+    fair_queue_ticket resources_currently_executing() const { return fair_queue_ticket(); }
 
     /// Queue the entry \c ent through this class' \ref fair_queue
     ///

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -224,14 +224,6 @@ void fair_queue::update_shares_for_class(class_id id, uint32_t shares) {
     pc->update_shares(shares);
 }
 
-fair_queue_ticket fair_queue::resources_currently_waiting() const {
-    return _resources_queued;
-}
-
-fair_queue_ticket fair_queue::resources_currently_executing() const {
-    return _resources_executing;
-}
-
 void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
     priority_class_data& pc = *_priority_classes[id];
     // We need to return a future in this function on which the caller can wait.


### PR DESCRIPTION
They have not been accounted for a long time already and are always zero. Drop both and deprecate the getters to be removed later.