### PR TITLE
pollable_fd: Untangle shutdown()

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -117,6 +117,7 @@ public:
     future<size_t> recvmsg(struct msghdr *msg);
     future<size_t> sendto(socket_address addr, const void* buf, size_t len);
     future<> poll_rdhup();
+    void shutdown(int how);
 
 protected:
     explicit pollable_fd_state(file_desc fd, speculation speculate = speculation())

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1600,6 +1600,10 @@ void pollable_fd_state::forget() {
     engine()._backend->forget(*this);
 }
 
+void pollable_fd_state::shutdown(int how) {
+    fd.shutdown(how);
+}
+
 void intrusive_ptr_release(pollable_fd_state* fd) {
     if (!--fd->_refs) {
         fd->forget();
@@ -1617,7 +1621,7 @@ void pollable_fd::shutdown(int how, shutdown_kernel_only kernel_only) {
         // EAGAIN to ECONNABORT in that case.
         _s->shutdown_mask |= posix::shutdown_mask(how);
     }
-    engine()._backend->shutdown(*_s, how);
+    _s->shutdown(how);
 }
 
 pollable_fd

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -658,10 +658,6 @@ future<> reactor_backend_aio::connect(pollable_fd_state& fd, socket_address& sa)
     return _r.do_connect(fd, sa);
 }
 
-void reactor_backend_aio::shutdown(pollable_fd_state& fd, int how) {
-    fd.fd.shutdown(how);
-}
-
 future<size_t>
 reactor_backend_aio::read(pollable_fd_state& fd, void* buffer, size_t len) {
     return _r.do_read(fd, buffer, len);
@@ -1044,10 +1040,6 @@ reactor_backend_epoll::accept(pollable_fd_state& listenfd) {
 
 future<> reactor_backend_epoll::connect(pollable_fd_state& fd, socket_address& sa) {
     return _r.do_connect(fd, sa);
-}
-
-void reactor_backend_epoll::shutdown(pollable_fd_state& fd, int how) {
-    fd.fd.shutdown(how);
 }
 
 future<size_t>
@@ -1596,9 +1588,6 @@ public:
         auto desc = std::make_unique<connect_completion>(fd, sa);
         auto req = internal::io_request::make_connect(fd.fd.get(), desc->posix_sockaddr(), desc->socklen());
         return submit_request(std::move(desc), std::move(req));
-    }
-    virtual void shutdown(pollable_fd_state& fd, int how) override {
-        fd.fd.shutdown(how);
     }
     virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override {
         return _r.do_read(fd, buffer, len);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -199,7 +199,6 @@ public:
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;
-    virtual void shutdown(pollable_fd_state& fd, int how) = 0;
     virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) = 0;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
@@ -266,7 +265,6 @@ public:
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) override;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
-    virtual void shutdown(pollable_fd_state& fd, int how) override;
     virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
@@ -315,7 +313,6 @@ public:
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) override;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override;
-    virtual void shutdown(pollable_fd_state& fd, int how) override;
     virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override;
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;


### PR DESCRIPTION
The call chain nowadays is

 pollable_fd::shutdown()
 engine -> reactor_backend::shutdown()
 pollable_fd_state -> file_desc -> file_desc::shutdown()

This patch removes reactor and its backend from this sequence.

Other pollable_fd methods are nowadays implemented likewise -- they forward the invocation to pollable_fd_state and the latter, if needed, call reactor backend. Shutdown doesn't need backend, but if it will, it's _state that will need to call backend.