### PR TITLE
reactor: Move set_current_task() from public reactor API

### DIFF
--- a/include/seastar/coroutine/parallel_for_each.hh
+++ b/include/seastar/coroutine/parallel_for_each.hh
@@ -102,7 +102,7 @@ class [[nodiscard("must co_await an parallel_for_each() object")]] parallel_for_
 
     void resume_or_set_callback() noexcept {
         if (consume_next()) {
-            local_engine->set_current_task(_waiting_task);
+            seastar::internal::set_current_task(_waiting_task);
             _when_ready.resume();
         } else {
             set_callback();

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -256,7 +256,7 @@ thread_context::setup(size_t stack_size) {
 
 void
 thread_context::switch_in() {
-    local_engine->_current_task = nullptr; // thread_wake_task is on the stack and will be invalid when we resume
+    internal::set_current_task(nullptr); // thread_wake_task is on the stack and will be invalid when we resume
     _context.switch_in();
 }
 


### PR DESCRIPTION
This method manipulates the inner guts of reactor and cannot be part of its public API. Move it to internal namespace and update callers (only two of them).

Nice side effect -- thread_context no longer needs to be reactor friend.