### PR TITLE
gate: make destructor virtual

### DIFF
--- a/include/seastar/core/gate.hh
+++ b/include/seastar/core/gate.hh
@@ -109,7 +109,7 @@ public:
         }
         return *this;
     }
-    ~gate() {
+    virtual ~gate() {
         SEASTAR_ASSERT(!_count && "gate destroyed with outstanding requests");
         assert_not_held_when_destroyed();
     }

--- a/tests/unit/gate_test.cc
+++ b/tests/unit/gate_test.cc
@@ -163,3 +163,11 @@ SEASTAR_TEST_CASE(named_gate_closed_test) {
     move_assigned = named_gate(bar);
     co_await test_named_gate(move_assigned, bar);
 }
+
+SEASTAR_TEST_CASE(unique_named_gate_test) {
+    auto g = std::make_unique<named_gate>("test gate");
+    auto gh = g->hold();
+    gh.release();
+    g.reset();
+    return make_ready_future();
+}


### PR DESCRIPTION
With clang++ / c++23 we see the following error:
```
include/c++/15/bits/unique_ptr.h:93:2: error: delete called on non-final 'seastar::named_gate' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
```