### PR TITLE
scripts/seastar-addr2line: change the default addr2line utility to llvm-addr2line

### DIFF
--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -450,9 +450,9 @@ There are three operational modes:
         '--addr2line',
         type=str,
         metavar='CMD_PATH',
-        default='addr2line',
+        default='llvm-addr2line',
         help='The path or name of the addr2line command, which should behave as and '
-        'accept the same options as binutils addr2line or llvm-addr2line.',
+        'accept the same options as binutils addr2line or llvm-addr2line (the default).',
     )
 
     cmdline_parser.add_argument(


### PR DESCRIPTION
The upgrade to clang 20 changed the DWARF in a way such that binutils
addr2line can't decode it properly.
    
Michał Chojnowski <michal.chojnowski@scylladb.com> explains:
> clang encodes the address ranges (DW_AT_ranges) for the missing inlined
> frames with a dwarf 5 construct (DW_FORM_rnglistx) which just hasn't been
> implemented in libbfd (which is what addr2line uses for decoding).
> ...
> So addr2line basically skips over those DW_TAG_inlined_subroutine for
> the purposes of address decoding. They are not inserted into the address maps.
> That's why they don't show up.
>
> So it's more a missing feature in bfd than a bug.

Fixes #2842