### PR TITLE
core: Don't keep internal errors counter on reactor

### DIFF
--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -72,5 +72,9 @@ void on_internal_error_noexcept(logger& logger, std::string_view reason) noexcep
 /// This overload can be used to replace SEASTAR_ASSERT().
 [[noreturn]] void on_fatal_internal_error(logger& logger, std::string_view reason) noexcept;
 
+namespace internal {
+extern thread_local uint64_t internal_errors;
+}
+
 SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -263,7 +263,6 @@ private:
     io_stats _io_stats;
     uint64_t _fsyncs = 0;
     uint64_t _cxx_exceptions = 0;
-    uint64_t _internal_errors = 0;
     uint64_t _abandoned_failed_futures = 0;
     struct task_queue {
         explicit task_queue(unsigned id, sstring name, sstring shortname, float shares);

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -33,7 +33,6 @@ module;
 module seastar;
 #else
 #include <seastar/core/on_internal_error.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
 #endif
@@ -46,8 +45,11 @@ bool seastar::set_abort_on_internal_error(bool do_abort) noexcept {
     return abort_on_internal_error.exchange(do_abort);
 }
 
-void internal::increase_internal_errors_counter() noexcept{
-    seastar::engine()._internal_errors++;
+namespace seastar::internal {
+thread_local uint64_t internal_errors = 0;
+void increase_internal_errors_counter() noexcept {
+    internal_errors++;
+}
 }
 
 template <typename Message>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2600,7 +2600,7 @@ void reactor::register_metrics() {
             sm::make_counter("logging_failures", [] { return logging_failures; }, sm::description("Total number of logging failures")),
             // total_operations value:DERIVE:0:U
             sm::make_counter("cpp_exceptions", _cxx_exceptions, sm::description("Total number of C++ exceptions")),
-            sm::make_counter("internal_errors", _internal_errors, sm::description("Total number of internal errors (subset of cpp_exceptions) that usually indicate malfunction in the code")),
+            sm::make_counter("internal_errors", internal::internal_errors, sm::description("Total number of internal errors (subset of cpp_exceptions) that usually indicate malfunction in the code")),
             sm::make_counter("abandoned_failed_futures", _abandoned_failed_futures, sm::description("Total number of abandoned failed futures, futures destroyed while still containing an exception")),
     });
 


### PR DESCRIPTION
Sometimes the on_internal_error set of helpers is called without starting seastar app, thus the engine is not initialized. To allow seastar library users still use the internal error machinery (and preserve potential bugwards compatibility) keep the counter as global thread local variable.