### PR TITLE
Nested scheduling groups (IO classes)

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -39,6 +39,10 @@ namespace bi = boost::intrusive;
 
 namespace seastar {
 
+namespace testing {
+class fair_queue_test;
+}
+
 /// \brief describes a request that passes through the \ref fair_queue.
 ///
 /// A ticket is specified by a \c weight and a \c size. For example, one can specify a request of \c weight
@@ -164,6 +168,7 @@ private:
 
     class priority_entry {
         friend class fair_queue;
+        friend testing::fair_queue_test;
     protected:
         uint32_t _shares = 0;
         capacity_t _accumulated = 0;
@@ -200,6 +205,7 @@ private:
 
     class priority_class_group_data final : public priority_entry {
         friend class fair_queue;
+        friend testing::fair_queue_test;
         priority_queue _children;
         capacity_t _last_accumulated = 0;
         size_t _nr_children = 0;
@@ -229,6 +235,7 @@ private:
     config _config;
     priority_class_group_data _root;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
+    friend testing::fair_queue_test;
 
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -185,6 +185,7 @@ private:
     class priority_class_group_data final : public priority_entry {
         friend class fair_queue;
         priority_queue _children;
+        capacity_t _last_accumulated = 0;
     };
 
     class priority_class_data;
@@ -193,7 +194,6 @@ private:
     priority_class_group_data _root;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     size_t _nr_classes = 0;
-    capacity_t _last_accumulated = 0;
 
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -164,6 +164,9 @@ private:
         friend class fair_queue;
     protected:
         uint32_t _shares = 0;
+        capacity_t _accumulated = 0;
+        bool _queued = false;
+        uint32_t _activations = 0;
         priority_entry(uint32_t shares) noexcept
                 : _shares(std::max(shares, 1u))
         {}

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -162,6 +162,11 @@ public:
 private:
     class priority_entry {
         friend class fair_queue;
+    protected:
+        uint32_t _shares = 0;
+        priority_entry(uint32_t shares) noexcept
+                : _shares(std::max(shares, 1u))
+        {}
     };
 
     using clock_type = std::chrono::steady_clock;
@@ -186,6 +191,13 @@ private:
         friend class fair_queue;
         priority_queue _children;
         capacity_t _last_accumulated = 0;
+    public:
+        priority_class_group_data(uint32_t shares) noexcept
+                : priority_entry(shares)
+        {
+        }
+        priority_class_group_data(const priority_class_group_data&) = delete;
+        priority_class_group_data(priority_class_group_data&&) = delete;
     };
 
     class priority_class_data;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -201,6 +201,10 @@ private:
         }
         priority_class_group_data(const priority_class_group_data&) = delete;
         priority_class_group_data(priority_class_group_data&&) = delete;
+
+        void reserve(size_t len) {
+            _children.reserve(len);
+        }
     };
 
     class priority_class_data;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -234,6 +234,7 @@ private:
 
     config _config;
     priority_class_group_data _root;
+    std::vector<std::unique_ptr<priority_class_group_data>> _priority_groups;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     friend testing::fair_queue_test;
 
@@ -256,7 +257,10 @@ public:
     /// Registers a priority class against this fair queue.
     ///
     /// \param shares how many shares to create this class with
-    void register_priority_class(class_id c, uint32_t shares);
+    void register_priority_class(class_id c, uint32_t shares, std::optional<unsigned> group_idx = {});
+
+    /// Makes sure class groups exists
+    void ensure_priority_group(unsigned index, uint32_t shares);
 
     /// Unregister a priority class.
     ///

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -202,6 +202,7 @@ private:
         friend class fair_queue;
         priority_queue _children;
         capacity_t _last_accumulated = 0;
+        size_t _nr_children = 0;
     public:
         priority_class_group_data(uint32_t shares, priority_class_group_data* p) noexcept
                 : priority_entry(shares, p)
@@ -216,8 +217,8 @@ private:
         fair_queue_entry* top() override;
         std::pair<bool, capacity_t> pop_front() override;
 
-        void reserve(size_t len) {
-            _children.reserve(len);
+        void reserve() {
+            _children.reserve(_nr_children + 1);
         }
 
         void push_from_idle(priority_entry&, const config&) noexcept;
@@ -228,7 +229,6 @@ private:
     config _config;
     priority_class_group_data _root;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
-    size_t _nr_classes = 0;
 
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -156,13 +156,16 @@ public:
     };
 
     using class_id = unsigned int;
-    class priority_class_data;
     using capacity_t = fair_queue_entry::capacity_t;
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:
+    class priority_entry {
+        friend class fair_queue;
+    };
+
     using clock_type = std::chrono::steady_clock;
-    using priority_entry_ptr = priority_class_data*;
+    using priority_entry_ptr = priority_entry*;
     struct class_compare {
         bool operator() (const priority_entry_ptr& lhs, const priority_entry_ptr & rhs) const noexcept;
     };
@@ -178,6 +181,8 @@ private:
             SEASTAR_ASSERT(c.size() < c.capacity());
         }
     };
+
+    class priority_class_data;
 
     config _config;
     priority_queue _handles;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -183,6 +183,10 @@ private:
         virtual fair_queue_entry* top() = 0;
         virtual std::pair<bool, capacity_t> pop_front() = 0;
         void wakeup(const config&) noexcept;
+
+        void update_shares(uint32_t shares) noexcept {
+            _shares = (std::max(shares, 1u));
+        }
     };
 
     using clock_type = std::chrono::steady_clock;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -174,6 +174,8 @@ private:
                 : _shares(std::max(shares, 1u))
                 , _parent(p)
         {}
+    public:
+        virtual fair_queue_entry* top() = 0;
     };
 
     using clock_type = std::chrono::steady_clock;
@@ -208,6 +210,8 @@ private:
         }
         priority_class_group_data(const priority_class_group_data&) = delete;
         priority_class_group_data(priority_class_group_data&&) = delete;
+
+        fair_queue_entry* top() override;
 
         void reserve(size_t len) {
             _children.reserve(len);

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -162,13 +162,13 @@ public:
 
 private:
     using clock_type = std::chrono::steady_clock;
-    using priority_class_ptr = priority_class_data*;
+    using priority_entry_ptr = priority_class_data*;
     struct class_compare {
-        bool operator() (const priority_class_ptr& lhs, const priority_class_ptr & rhs) const noexcept;
+        bool operator() (const priority_entry_ptr& lhs, const priority_entry_ptr & rhs) const noexcept;
     };
 
-    class priority_queue : public std::priority_queue<priority_class_ptr, std::vector<priority_class_ptr>, class_compare> {
-        using super = std::priority_queue<priority_class_ptr, std::vector<priority_class_ptr>, class_compare>;
+    class priority_queue : public std::priority_queue<priority_entry_ptr, std::vector<priority_entry_ptr>, class_compare> {
+        using super = std::priority_queue<priority_entry_ptr, std::vector<priority_entry_ptr>, class_compare>;
     public:
         void reserve(size_t len) {
             c.reserve(len);

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -160,6 +160,8 @@ public:
     using signed_capacity_t = std::make_signed_t<capacity_t>;
 
 private:
+    class priority_class_group_data;
+
     class priority_entry {
         friend class fair_queue;
     protected:
@@ -167,8 +169,10 @@ private:
         capacity_t _accumulated = 0;
         bool _queued = false;
         uint32_t _activations = 0;
-        priority_entry(uint32_t shares) noexcept
+        priority_class_group_data* _parent = nullptr;
+        priority_entry(uint32_t shares, priority_class_group_data* p) noexcept
                 : _shares(std::max(shares, 1u))
+                , _parent(p)
         {}
     };
 
@@ -195,9 +199,12 @@ private:
         priority_queue _children;
         capacity_t _last_accumulated = 0;
     public:
-        priority_class_group_data(uint32_t shares) noexcept
-                : priority_entry(shares)
+        priority_class_group_data(uint32_t shares, priority_class_group_data* p) noexcept
+                : priority_entry(shares, p)
         {
+            if (_parent == nullptr) {
+                _queued = true;
+            }
         }
         priority_class_group_data(const priority_class_group_data&) = delete;
         priority_class_group_data(priority_class_group_data&&) = delete;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -182,10 +182,15 @@ private:
         }
     };
 
+    class priority_class_group_data final : public priority_entry {
+        friend class fair_queue;
+        priority_queue _children;
+    };
+
     class priority_class_data;
 
     config _config;
-    priority_queue _handles;
+    priority_class_group_data _root;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     size_t _nr_classes = 0;
     capacity_t _last_accumulated = 0;

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -177,6 +177,7 @@ private:
     public:
         virtual fair_queue_entry* top() = 0;
         virtual std::pair<bool, capacity_t> pop_front() = 0;
+        void wakeup(const config&) noexcept;
     };
 
     using clock_type = std::chrono::steady_clock;
@@ -218,6 +219,8 @@ private:
         void reserve(size_t len) {
             _children.reserve(len);
         }
+
+        void push_from_idle(priority_entry&, const config&) noexcept;
     };
 
     class priority_class_data;
@@ -230,7 +233,6 @@ private:
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;
 
-    void push_priority_class_from_idle(priority_class_data& pc) noexcept;
     void plug_priority_class(priority_class_data& pc) noexcept;
     void unplug_priority_class(priority_class_data& pc) noexcept;
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -230,9 +230,7 @@ private:
     // Total capacity of all requests waiting in the queue.
     capacity_t _queued_capacity = 0;
 
-    void push_priority_class(priority_class_data& pc) noexcept;
     void push_priority_class_from_idle(priority_class_data& pc) noexcept;
-    void pop_priority_class(priority_class_data& pc) noexcept;
     void plug_priority_class(priority_class_data& pc) noexcept;
     void unplug_priority_class(priority_class_data& pc) noexcept;
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -176,6 +176,7 @@ private:
         {}
     public:
         virtual fair_queue_entry* top() = 0;
+        virtual std::pair<bool, capacity_t> pop_front() = 0;
     };
 
     using clock_type = std::chrono::steady_clock;
@@ -212,6 +213,7 @@ private:
         priority_class_group_data(priority_class_group_data&&) = delete;
 
         fair_queue_entry* top() override;
+        std::pair<bool, capacity_t> pop_front() override;
 
         void reserve(size_t len) {
             _children.reserve(len);

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -219,6 +219,7 @@ public:
     unsigned id() const noexcept { return _id; }
 
     void update_shares_for_class(internal::priority_class pc, size_t new_shares);
+    void update_shares_for_class_group(unsigned index, size_t new_shares);
     future<> update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth);
     void rename_priority_class(internal::priority_class pc, sstring new_name);
     void throttle_priority_class(const priority_class_data& pc) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -498,6 +498,7 @@ private:
     future<> update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth);
     void rename_queues(internal::priority_class pc, sstring new_name);
     void update_shares_for_queues(internal::priority_class pc, uint32_t shares);
+    void update_group_shares_for_queues(unsigned, uint32_t shares);
 
 public:
     server_socket listen(socket_address sa, listen_options opts = {});

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -100,7 +100,6 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
 // Priority class, to be used with a given fair_queue
 class fair_queue::priority_class_data final : public priority_entry {
     friend class fair_queue;
-    uint32_t _shares = 0;
     capacity_t _accumulated = 0;
     capacity_t _pure_accumulated = 0;
     fair_queue_entry::container_list_t _queue;
@@ -109,7 +108,7 @@ class fair_queue::priority_class_data final : public priority_entry {
     uint32_t _activations = 0;
 
 public:
-    explicit priority_class_data(uint32_t shares) noexcept : _shares(std::max(shares, 1u)) {}
+    explicit priority_class_data(uint32_t shares) noexcept : priority_entry(shares) {}
     priority_class_data(const priority_class_data&) = delete;
     priority_class_data(priority_class_data&&) = delete;
 
@@ -124,6 +123,7 @@ bool fair_queue::class_compare::operator() (const priority_entry_ptr& lhs, const
 
 fair_queue::fair_queue(config cfg)
     : _config(std::move(cfg))
+    , _root(0)
 {
 }
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -100,12 +100,9 @@ fair_queue_ticket wrapping_difference(const fair_queue_ticket& a, const fair_que
 // Priority class, to be used with a given fair_queue
 class fair_queue::priority_class_data final : public priority_entry {
     friend class fair_queue;
-    capacity_t _accumulated = 0;
     capacity_t _pure_accumulated = 0;
     fair_queue_entry::container_list_t _queue;
-    bool _queued = false;
     bool _plugged = true;
-    uint32_t _activations = 0;
 
 public:
     explicit priority_class_data(uint32_t shares) noexcept : priority_entry(shares) {}
@@ -118,7 +115,7 @@ public:
 };
 
 bool fair_queue::class_compare::operator() (const priority_entry_ptr& lhs, const priority_entry_ptr& rhs) const noexcept {
-    return reinterpret_cast<priority_class_data*>(lhs)->_accumulated > reinterpret_cast<priority_class_data*>(rhs)->_accumulated;
+    return lhs->_accumulated > rhs->_accumulated;
 }
 
 fair_queue::fair_queue(config cfg)

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -151,20 +151,20 @@ void fair_queue::priority_entry::wakeup(const fair_queue::config& cfg) noexcept 
 }
 
 void fair_queue::priority_class_group_data::push_from_idle(priority_entry& pc, const fair_queue::config& cfg) noexcept {
-        // Don't let the newcomer monopolize the disk for more than tau
-        // duration. For this estimate how many capacity units can be
-        // accumulated with the current class shares per rate resulution
-        // and scale it up to tau.
-        // On start this deviation can go to negative values, so not to
-        // introduce extra if's for that short corner case, use signed
-        // arithmetics and make sure the _accumulated value doesn't grow
-        // over signed maximum (see overflow check below)
-        pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - cfg.forgiving_factor / pc._shares, pc._accumulated);
-        _children.assert_enough_capacity();
-        _children.push(&pc);
-        pc._queued = true;
-        pc._activations++;
-        wakeup(cfg);
+    // Don't let the newcomer monopolize the disk for more than tau
+    // duration. For this estimate how many capacity units can be
+    // accumulated with the current class shares per rate resulution
+    // and scale it up to tau.
+    // On start this deviation can go to negative values, so not to
+    // introduce extra if's for that short corner case, use signed
+    // arithmetics and make sure the _accumulated value doesn't grow
+    // over signed maximum (see overflow check below)
+    pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - cfg.forgiving_factor / pc._shares, pc._accumulated);
+    _children.assert_enough_capacity();
+    _children.push(&pc);
+    pc._queued = true;
+    pc._activations++;
+    wakeup(cfg);
 }
 
 void fair_queue::plug_priority_class(priority_class_data& pc) noexcept {

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -150,7 +150,7 @@ void fair_queue::push_priority_class_from_idle(priority_class_data& pc) noexcept
         // introduce extra if's for that short corner case, use signed
         // arithmetics and make sure the _accumulated value doesn't grow
         // over signed maximum (see overflow check below)
-        pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - _config.forgiving_factor / pc._shares, pc._accumulated);
+        pc._accumulated = std::max<signed_capacity_t>(_root._last_accumulated - _config.forgiving_factor / pc._shares, pc._accumulated);
         _root._children.assert_enough_capacity();
         _root._children.push(&pc);
         pc._queued = true;
@@ -261,7 +261,7 @@ fair_queue_entry* fair_queue::top() {
 void fair_queue::pop_front() {
     auto& h = *reinterpret_cast<priority_class_data*>(_root._children.top());
 
-    _last_accumulated = std::max(h._accumulated, _last_accumulated);
+    _root._last_accumulated = std::max(h._accumulated, _root._last_accumulated);
     pop_priority_class(h);
 
     auto& req = h._queue.front();

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -118,7 +118,7 @@ public:
     }
 };
 
-bool fair_queue::class_compare::operator() (const priority_class_ptr& lhs, const priority_class_ptr & rhs) const noexcept {
+bool fair_queue::class_compare::operator() (const priority_entry_ptr& lhs, const priority_entry_ptr& rhs) const noexcept {
     return lhs->_accumulated > rhs->_accumulated;
 }
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -207,16 +207,18 @@ void fair_queue::register_priority_class(class_id id, uint32_t shares) {
         SEASTAR_ASSERT(!_priority_classes[id]);
     }
 
-    _root.reserve(_nr_classes + 1);
-    _priority_classes[id] = std::make_unique<priority_class_data>(shares, &_root);
-    _nr_classes++;
+    priority_class_group_data* pg = &_root;
+
+    pg->reserve();
+    _priority_classes[id] = std::make_unique<priority_class_data>(shares, pg);
+    pg->_nr_children++;
 }
 
 void fair_queue::unregister_priority_class(class_id id) {
     auto& pclass = _priority_classes[id];
     SEASTAR_ASSERT(pclass);
+    pclass->_parent->_nr_children--;
     pclass.reset();
-    _nr_classes--;
 }
 
 void fair_queue::update_shares_for_class(class_id id, uint32_t shares) {

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -105,7 +105,7 @@ class fair_queue::priority_class_data final : public priority_entry {
     bool _plugged = true;
 
 public:
-    explicit priority_class_data(uint32_t shares) noexcept : priority_entry(shares) {}
+    explicit priority_class_data(uint32_t shares, priority_class_group_data* p) noexcept : priority_entry(shares, p) {}
     priority_class_data(const priority_class_data&) = delete;
     priority_class_data(priority_class_data&&) = delete;
 
@@ -120,7 +120,7 @@ bool fair_queue::class_compare::operator() (const priority_entry_ptr& lhs, const
 
 fair_queue::fair_queue(config cfg)
     : _config(std::move(cfg))
-    , _root(0)
+    , _root(0, nullptr)
 {
 }
 
@@ -203,7 +203,7 @@ void fair_queue::register_priority_class(class_id id, uint32_t shares) {
     }
 
     _root.reserve(_nr_classes + 1);
-    _priority_classes[id] = std::make_unique<priority_class_data>(shares);
+    _priority_classes[id] = std::make_unique<priority_class_data>(shares, &_root);
     _nr_classes++;
 }
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -202,7 +202,7 @@ void fair_queue::register_priority_class(class_id id, uint32_t shares) {
         SEASTAR_ASSERT(!_priority_classes[id]);
     }
 
-    _root._children.reserve(_nr_classes + 1);
+    _root.reserve(_nr_classes + 1);
     _priority_classes[id] = std::make_unique<priority_class_data>(shares);
     _nr_classes++;
 }

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -109,10 +109,6 @@ public:
     priority_class_data(const priority_class_data&) = delete;
     priority_class_data(priority_class_data&&) = delete;
 
-    void update_shares(uint32_t shares) noexcept {
-        _shares = (std::max(shares, 1u));
-    }
-
     fair_queue_entry* top() override;
     std::pair<bool, capacity_t> pop_front() override;
 };
@@ -223,6 +219,8 @@ void fair_queue::ensure_priority_group(unsigned index, uint32_t shares) {
         _root.reserve();
         _priority_groups[index] = std::make_unique<priority_class_group_data>(shares, &_root);
         _root._nr_children++;
+    } else {
+        _priority_groups[index]->update_shares(shares);
     }
 }
 

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -144,13 +144,6 @@ fair_queue::~fair_queue() {
     }
 }
 
-void fair_queue::push_priority_class(priority_class_data& pc) noexcept {
-    SEASTAR_ASSERT(pc._plugged && !pc._queued);
-    _root._children.assert_enough_capacity();
-    _root._children.push(&pc);
-    pc._queued = true;
-}
-
 void fair_queue::push_priority_class_from_idle(priority_class_data& pc) noexcept {
     if (!pc._queued) {
         // Don't let the newcomer monopolize the disk for more than tau
@@ -167,13 +160,6 @@ void fair_queue::push_priority_class_from_idle(priority_class_data& pc) noexcept
         pc._queued = true;
         pc._activations++;
     }
-}
-
-// ATTN: This can only be called on pc that is from _root._children.top()
-void fair_queue::pop_priority_class(priority_class_data& pc) noexcept {
-    SEASTAR_ASSERT(pc._queued);
-    pc._queued = false;
-    _root._children.pop();
 }
 
 void fair_queue::plug_priority_class(priority_class_data& pc) noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -844,11 +844,11 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         //
         // This conveys all the information we need and allows one to easily group all classes from
         // the same I/O queue (by filtering by shard)
-        for (auto&& s : _streams) {
-            s.fq.register_priority_class(id, shares);
-        }
         auto& pg = _group->find_or_create_class(pc);
         auto pc_data = std::make_unique<priority_class_data>(pc, shares, *this, pg);
+        for (auto&& s : _streams) {
+            s.fq.register_priority_class(pc_data->fq_class(), shares);
+        }
         register_stats(name, *pc_data);
 
         _priority_classes[id] = std::move(pc_data);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -1109,6 +1109,13 @@ io_queue::update_shares_for_class(internal::priority_class pc, size_t new_shares
     }
 }
 
+
+void io_queue::update_shares_for_class_group(unsigned index, size_t new_shares) {
+    for (auto&& s : _streams) {
+        s.fq.ensure_priority_group(index, new_shares);
+    }
+}
+
 future<> io_queue::update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth) {
     return futurize_invoke([this, pc, new_bandwidth] {
         if (_group->_allocated_on == this_shard_id()) {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -738,11 +738,6 @@ io_queue::~io_queue() {
     }
 }
 
-std::tuple<unsigned, sstring> get_class_info(io_priority_class_id pc) {
-    auto sg = internal::scheduling_group_from_index(pc);
-    return std::make_tuple(sg.get_shares(), sg.name());
-}
-
 std::vector<seastar::metrics::impl::metric_definition_impl> io_queue::priority_class_data::metrics() {
     namespace sm = seastar::metrics;
     return std::vector<sm::impl::metric_definition_impl>({
@@ -828,7 +823,7 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         _priority_classes.resize(id + 1);
     }
     if (!_priority_classes[id]) {
-        auto [ shares, name ] = get_class_info(pc.id());
+        auto sg = internal::scheduling_group_from_index(id);
 
         // A note on naming:
         //
@@ -845,11 +840,13 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         // This conveys all the information we need and allows one to easily group all classes from
         // the same I/O queue (by filtering by shard)
         auto& pg = _group->find_or_create_class(pc);
+
+        auto shares = sg.get_shares();
         auto pc_data = std::make_unique<priority_class_data>(pc, shares, *this, pg);
         for (auto&& s : _streams) {
             s.fq.register_priority_class(pc_data->fq_class(), shares);
         }
-        register_stats(name, *pc_data);
+        register_stats(sg.name(), *pc_data);
 
         _priority_classes[id] = std::move(pc_data);
     }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -824,6 +824,7 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
     }
     if (!_priority_classes[id]) {
         auto sg = internal::scheduling_group_from_index(id);
+        auto ssg = internal::scheduling_supergroup_for(sg);
 
         // A note on naming:
         //
@@ -841,10 +842,18 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         // the same I/O queue (by filtering by shard)
         auto& pg = _group->find_or_create_class(pc);
 
+        std::optional<unsigned> group_index;
+        if (!ssg.is_root()) {
+            group_index = ssg.index();
+            for (auto&& s : _streams) {
+                s.fq.ensure_priority_group(*group_index, ssg.get_shares());
+            }
+        }
+
         auto shares = sg.get_shares();
         auto pc_data = std::make_unique<priority_class_data>(pc, shares, *this, pg);
         for (auto&& s : _streams) {
-            s.fq.register_priority_class(pc_data->fq_class(), shares);
+            s.fq.register_priority_class(pc_data->fq_class(), shares, group_index);
         }
         register_stats(sg.name(), *pc_data);
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -207,6 +207,12 @@ void reactor::update_shares_for_queues(internal::priority_class pc, uint32_t sha
     }
 }
 
+void reactor::update_group_shares_for_queues(unsigned index, uint32_t shares) {
+    for (auto&& q : _io_queues) {
+        q.second->update_shares_for_class_group(index, shares);
+    }
+}
+
 future<> reactor::update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth) {
     return smp::invoke_on_all([pc, bandwidth = bandwidth / _num_io_groups] {
         return parallel_for_each(engine()._io_queues, [pc, bandwidth] (auto& queue) {
@@ -5053,6 +5059,7 @@ future<> scheduling_group::update_io_bandwidth(uint64_t bandwidth) const {
 void scheduling_supergroup::set_shares(float shares) noexcept {
     if (!is_root()) {
         engine()._supergroups[index()]->set_shares(shares);
+        engine().update_group_shares_for_queues(index(), shares);
     }
 }
 

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -201,6 +201,18 @@ public:
             BOOST_CHECK_LE(dev, error);
         }
     }
+
+    void verify_x(sstring name, std::vector<int> values) {
+        SEASTAR_ASSERT(values.size() == _results.size());
+        auto str = name + ":";
+        for (auto i = 0ul; i < _results.size(); ++i) {
+            str += format(" r[{:d}] = {:d}", i, _results[i]);
+        }
+        std::cout << str <<std::endl;
+        for (unsigned i = 0; i < _results.size(); i++) {
+            BOOST_CHECK_EQUAL(_results[i], values[i]);
+        }
+    }
 };
 
 // Equal ratios. Expected equal results.
@@ -338,6 +350,105 @@ SEASTAR_THREAD_TEST_CASE(test_fair_queue_forgiving_queue) {
     env.tick(100);
     // 50 requests should be passed from b, other 100 should be shared 1:1
     env.verify("forgiving_queue", {1, 3}, 2);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fair_queue_forgiving_group) {
+    test_env env;
+
+    auto g = env.register_priority_group(10);
+    auto a = env.register_priority_class(10, g);
+    auto b = env.register_priority_class(10, g);
+    auto c = env.register_priority_class(10);
+
+    auto step = [&env] (std::string name, unsigned pc, unsigned nr, std::vector<int> results) {
+        for (unsigned i = 0; i < nr; i++) {
+            env.do_op(pc, 1);
+        }
+        env.tick(100);
+        env.verify_x("forgiving_group_" + name, std::move(results));
+    };
+
+    auto drain = [&] () {
+        env.tick(300);
+        env.reset_results(a);
+        env.reset_results(b);
+        env.reset_results(c);
+    };
+
+    // Test one -- activate in top-nesetd-nested order
+    {
+        // Step-1 -- let the top-level clas work on its own and dispatch 100
+        // requests. At this point those 100 requests will be dispatched.
+        step("1_top", c, 300, {0, 0, 100});
+
+        // Step-2 -- activate a sub-class and its class group, then dispatch
+        // 100 more requests. Queue fogrives 50 requests to the group upon
+        // activation, then dispatches remaining 50 in 1:1 proportion between
+        // two active classes.
+        step("1_nest_1", a, 200, {75, 0, 125});
+
+        // Step-3 -- activate another sub-class, then dispatch 100 more requests.
+        // This time queue forgives 50 requests to the sub-class, but not to the
+        // group, because it's still active since previous step. After it, the
+        // top-level class and a subgroup are dispatched in 1:1 ratio, but since
+        // the newly activated sub-class has 50 forgiven requests, only _this_
+        // class will be dispatched from in this group, the other sub-class would
+        // remain idle during this 100-requests dispatch.
+        step("1_nest_2", b, 100, {75, 50, 175});
+
+        // Finally, continue dispatching. At this point no more "forgiven" requests
+        // are left and all three classes are dispatched from according to their
+        // shares. Given it's {1:1}:2 ratios, the addition should be {25, 25, 50}
+        step("1_cont", 0, 0, {100, 75, 225});
+
+        drain();
+    }
+
+    // Test two -- activate in nested-outer-nested order
+    {
+        // Step-1 -- netsted class works on its own and dispatches
+        // all the requests it wants.
+        step("2_nest_1", a, 300, {100, 0, 0});
+
+        // Step-2 -- top-level class activates and gets 50 fogiven requests.
+        // 50 remaining are shared between a and c in 1:1 proportion, just like
+        // it was in the top-nest-nest sequence above, no difference here
+        step("2_top", c, 200, {125, 0, 75});
+
+        // Step-3 -- another nested class activates and gets 50 forgiven
+        // requests. 100 requests are shared between c and {a+b} in 1:1
+        // fraction, so c gets 50 and a+b get another 50 which all go to
+        // b class for its "forgiven" credit
+        step("2_nest_2", b, 100, {125, 50, 125});
+
+        // Remaining requests are shared as in test-1 above: {25, 25, 50}
+        step("2_cont", 0, 0, {150, 75, 175});
+
+        drain();
+    }
+
+    // Test two -- activate in nested-nested-outer order
+    {
+        // First two steps don't differ from the previous runs -- first
+        // class gets 100 requests, then the 2nd activates and gets 50
+        // forgiven and remaining 50 are split evenly.
+        step("3_nest_1", a, 300, {100, 0, 0});
+        step("3_nest_2", b, 200, {125, 75, 0});
+
+        // Step-3 -- top level class activates and get 50 forgiven
+        // requests. After it remaining 50 are divided between it and
+        // the a+b group in 1:1 fraction, so class c gets 25 more.
+        // Classes in group shared the remaining 25 requests in 1:1 as
+        // well, so one class get 12 requests and another one gets 13.
+        step("3_top", c, 100, {137, 88, 75});
+
+        // The remaining requests are as well shared in {25, 25, 50}
+        // proportion just as before (give c more requests so that it
+        // can dispatch its goal).
+        step("3_cont", c, 50, {162, 113, 125});
+
+        drain();
+    }
 }
 
 // Classes push requests and then update swap their shares. In the end, should have executed


### PR DESCRIPTION
Add one-level nesting support for IO priority classes. Since all shares-based scheduling of IO happens inside fair_queue code, this PR mainly updates it. The io_queue code is touched to propagate scheduling_supergroup hierarchy and changes down to the fair_queue. This change follows those made for CPU task_queues.

Currently, the scheduling_groups is backed by reactor::task_queue object for CPU scheduler and by fair_queue::priority_class_data for IO. For nesting, the scheduling_supergroup was added (see #2823) at the API level. It was then backed by the reactor::task_queue_group in the CPU scheduler, where both task_queue and task_queue_group inherit from sched_entity abstraction. On the IO side supergroup maps to fair_queue::priority_class_group_data and both, priority_class_data and _group_data inherit from fair_queue::priority_entry abstraction.

At the IO-queue level itself, as was said, the only change made is to construct the priority_class_data and _group_data hierarchy upon class creation. On this level the priority_class_data also exists and corresponds to scheduling_group. This object is used to reference fair_queue class data, track IO statistics, and -- the IO bandwidth limiting. Unlike fair_queue level, IO queue level does _not_ gain its _group_data, which in turn means, that IO statistics for supergroups is not available, IO bandwidth limiting for supergroups doesn't appear either (a (in)visible sign of it is that update_io_bandwidth() is the method of scheduling_group, not scheduling_supergroup).