### PR TITLE
reactor: Remove min_vruntime() declaration

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -414,7 +414,6 @@ private:
     future<> init_new_scheduling_group_key(scheduling_group_key key, scheduling_group_key_config cfg);
     future<> destroy_scheduling_group(scheduling_group sg) noexcept;
     uint64_t tasks_processed() const;
-    uint64_t min_vruntime() const;
     void request_preemption();
     void start_handling_signal();
     void reset_preemption_monitor();


### PR DESCRIPTION
This method doesn't exist in reactor nowadays