### PR TITLE
fix missing span include

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -38,6 +38,7 @@
 #include <optional>
 #include <thread>
 #include <ranges>
+#include <span>
 #endif
 
 /// \file


### PR DESCRIPTION
At least on ubuntu 22.0.4 build fails
Corresponding issue - [2807](https://github.com/scylladb/seastar/issues/2807)

This pull request includes a minor change to the `include/seastar/core/smp.hh` file. 
The change adds the `#include <span>` directive to expand the available standard library headers

Closes #2807 