### PR TITLE
addr2line timing and optimizations

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -268,7 +268,7 @@ class BacktraceResolver:
                 addresses.append({'path': m.group(1) or default_path, 'addr': m.group(2)})
             return addresses
 
-        def __call__(self, line: str):
+        def __call__(self, line: str) -> dict[str, Any] | None:
 
             def get_prefix(s: Optional[str]):
                 if s is not None:

--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -241,6 +241,12 @@ class BacktraceResolver:
             token = fr"(?:{path}\+)?{addr}"
             full_addr_match = fr"(?:(?P<path>{path})\s*\+\s*)?(?P<addr>{addr})"
             ignore_addr_match = fr"(?:(?P<path>{path})\s*\+\s*)?(?:{addr})"
+
+            self.asan_ignore_re = re.compile(f"^=.*$", flags=re.IGNORECASE)
+            self.separator_re = re.compile(r'^\W*-+\W*$')
+
+            # All of the below except for separator_re must only match lines containing 0x in them
+            # as we use that as a quick first filter
             self.oneline_re = re.compile(
                 fr"^((?:.*(?:(?:at|backtrace):?|:))?(?:\s+))?({token}(?:\s+{token})*)(?:\).*|\s*)$",
                 flags=re.IGNORECASE,
@@ -255,9 +261,7 @@ class BacktraceResolver:
                 fr"^(?:.*\s+)\({full_addr_match}\)(\s+\(BuildId: [0-9a-fA-F]+\))?$",
                 flags=re.IGNORECASE,
             )
-            self.asan_ignore_re = re.compile(f"^=.*$", flags=re.IGNORECASE)
             self.generic_re = re.compile(fr"^(?:.*\s+){full_addr_match}\s*$", flags=re.IGNORECASE)
-            self.separator_re = re.compile(r'^\W*-+\W*$')
 
         def split_addresses(self, addrstring: str, default_path: Optional[str] = None):
             addresses: list[dict[str, Any]] = []
@@ -269,6 +273,12 @@ class BacktraceResolver:
             return addresses
 
         def __call__(self, line: str) -> dict[str, Any] | None:
+
+            # quick up front check to eliminate a line from contention, which is at least
+            # 30x faster than just diving into the regex matching (for one test file)
+            if not ("0x" in line or "0X" in line or self.separator_re.match(line)):
+                # no addresses in this line, so it is not a backtrace line
+                return None
 
             def get_prefix(s: Optional[str]):
                 if s is not None:

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -496,7 +496,7 @@ There are three operational modes:
         lines = args.addresses
     else:
         if sys.stdin.isatty():
-            lines = read_backtrace(sys.stdin)
+            lines = list(read_backtrace(sys.stdin))
         else:
             lines = sys.stdin
 
@@ -509,7 +509,7 @@ There are three operational modes:
         cmd_path=args.addr2line,
         debug=args.debug,
     ) as resolve:
-        for line in list(lines):
+        for line in lines:
             resolve(line.strip() + '\n')
 
 

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -469,6 +469,10 @@ There are three operational modes:
     )
 
     cmdline_parser.add_argument(
+        '--timing', action='store_true', help='Emit timing information to stderr.'
+    )
+
+    cmdline_parser.add_argument(
         '-t', '--test', action='store_true', default=False, help='Self-test'
     )
 
@@ -508,9 +512,13 @@ There are three operational modes:
         verbose=args.verbose,
         cmd_path=args.addr2line,
         debug=args.debug,
+        timing=args.timing,
     ) as resolve:
+        resolve_start = resolve.timing_now()
         for line in lines:
             resolve(line.strip() + '\n')
+        resolve.timing_print_from_start(resolve_start, 'full resolve loop')
+        resolve.print_resolve_time()
 
 
 if __name__ == '__main__':

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -72,7 +72,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_addresses_only(self):
-        data = [
+        data: TestList = [
             (
                 '0x12f34',
                 {
@@ -123,7 +123,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_without_prefix(self):
-        data = [
+        data: TestList = [
             (
                 'Some prefix 0x12f34',
                 {
@@ -144,7 +144,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_reactor_stall_reports(self):
-        data = [
+        data: TestList = [
             (
                 'Reactor stalled on shard 1. Backtrace: 0x12f34',
                 {
@@ -189,7 +189,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_boost_failure(self):
-        data = [
+        data: TestList = [
             (
                 'Expected partition_end(), but got end of stream, at 0xa1234 0xb5678 /my/path+0xabcd',
                 {
@@ -206,7 +206,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_asan_failure(self):
-        data = [
+        data: TestList = [
             (
                 '==16118==ERROR: AddressSanitizer: heap-use-after-free on address 0x60700019c710 at pc 0x000014d24643 bp 0x7ffc51f72220 sp 0x7ffc51f72218',
                 None,
@@ -242,7 +242,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_thrown_exception(self):
-        data = [
+        data: TestList = [
             (
                 'seastar::internal::backtraced<std::runtime_error> (throw_with_backtrace_exception_logging Backtrace: 0x42bc95 /lib64/libc.so.6+0x281e1 0x412cfd)',
                 {
@@ -285,7 +285,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_assertion_failure(self):
-        data = [
+        data: TestList = [
             (
                 "2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO | "
                 "scylla: sstables/consumer.hh:610: future<> data_consumer::continuous_data_consumer"
@@ -322,7 +322,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_segfault_failure(self):
-        data = [
+        data: TestList = [
             ('[2022-04-19T23:09:28.311Z] Segmentation fault on shard 1.', None),
             ('[2022-04-19T23:09:28.311Z] Backtrace:', None),
             (


### PR DESCRIPTION
We sometimes parse large logfiles thorugh addr2line and noted that it can be quite slow and consume a large amount of memory. E.g., 3-15 minutes (the high end on memory constrained host) and 2.1 GB RSS in order to parse a 1.6 GB file.

The changes here improve that to 100 MB (probably almost all in the child addr2line process) and ~7s parsing time (split 6/1 in the Python code and addr2line itself).

Key perf changes are to not load the entire file into a `list` up front and to do a quick filter on each line to see if we should even bother applying the regexes. Details in individual commits.

### Performance and Timing Enhancements:
* [`scripts/addr2line.py`](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R356-R360): Added timing functionality to measure and log the duration of address resolution and subprocess execution. Introduced methods like `timing_now`, `timing_print`, and `print_resolve_time` for timing-related operations. Updated `resolve_address` to track and accumulate resolution time. [[1]](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R356-R360) [[2]](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R386-R398) [[3]](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8L397-R426)

### Regex Optimization:
* [`scripts/addr2line.py`](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8L271-R281): Added a quick upfront check in the `__call__` method to filter lines without address patterns, significantly improving regex matching performance.

### Type Annotations and Test Enhancements:
* [`scripts/seastar-addr2line`](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL75-R74): Added type annotations to test data structures (`TestList`) in the `TestStringMethods` class for clarity and improved code reliability. [[1]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL75-R74) [[2]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL126-R125) [[3]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL147-R146) [[4]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL192-R191) [[5]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL209-R208) [[6]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL245-R244) [[7]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL288-R287) [[8]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL325-R324)

### Operational Mode Enhancements:
* [`scripts/seastar-addr2line`](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caR470-R473): Added a new `--timing` command-line argument to enable timing information output. Updated the main loop to log the total resolution time and the duration of the full resolve loop. [[1]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caR470-R473) [[2]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caR514-R520)
