### PR TITLE
Fix hang in io_queue for big write ioproperties numbers

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -183,8 +183,8 @@ public:
         unsigned id;
         unsigned long req_count_rate = std::numeric_limits<int>::max();
         unsigned long blocks_count_rate = std::numeric_limits<int>::max();
-        unsigned disk_req_write_to_read_multiplier = read_request_base_count;
-        unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
+        double disk_req_write_to_read_multiplier = read_request_base_count;
+        double disk_blocks_write_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();
         size_t disk_write_saturation_length = std::numeric_limits<size_t>::max();
         sstring mountpoint = "undefined";

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -642,11 +642,11 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
 io_throttler::config io_group::configure_throttler(const io_queue::config& qcfg) noexcept {
     io_throttler::config cfg;
     cfg.label = fmt::format("io-queue-{}", qcfg.id);
-    double min_weight = std::min(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    double min_size = std::min(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier);
+    double min_weight = std::min(static_cast<double>(io_queue::read_request_base_count), qcfg.disk_req_write_to_read_multiplier);
+    double min_size = std::min(static_cast<double>(io_queue::read_request_base_count), qcfg.disk_blocks_write_to_read_multiplier);
     cfg.min_tokens = min_weight / qcfg.req_count_rate + min_size / qcfg.blocks_count_rate;
-    double limit_min_weight = std::max(io_queue::read_request_base_count, qcfg.disk_req_write_to_read_multiplier);
-    double limit_min_size = std::max(io_queue::read_request_base_count, qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
+    double limit_min_weight = std::max(static_cast<double>(io_queue::read_request_base_count), qcfg.disk_req_write_to_read_multiplier);
+    double limit_min_size = std::max(static_cast<double>(io_queue::read_request_base_count), qcfg.disk_blocks_write_to_read_multiplier) * qcfg.block_count_limit_min;
     cfg.limit_min_tokens = limit_min_weight / qcfg.req_count_rate + limit_min_size / qcfg.blocks_count_rate;
     cfg.rate_limit_duration = qcfg.rate_limit_duration;
     return cfg;
@@ -685,7 +685,9 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
         for (unsigned shift = 0; ; shift++) {
             auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
             auto cap = fg.tokens_capacity(tokens);
+
             if (cap > max_cap) {
+
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");
                 }
@@ -858,8 +860,8 @@ stream_id io_queue::request_stream(io_direction_and_length dnl) const noexcept {
 
 double internal::request_tokens(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
     struct {
-        unsigned weight;
-        unsigned size;
+        double weight;
+        double size;
     } mult[2];
 
     mult[io_direction_write] = {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4275,11 +4275,11 @@ public:
 
         if (p.read_bytes_rate != std::numeric_limits<uint64_t>::max()) {
             cfg.blocks_count_rate = (io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_bytes_rate, nr_groups)) >> io_queue::block_size_shift;
-            cfg.disk_blocks_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_bytes_rate) / p.write_bytes_rate;
+            cfg.disk_blocks_write_to_read_multiplier = (static_cast<double>(io_queue::read_request_base_count) * p.read_bytes_rate) / p.write_bytes_rate;
         }
         if (p.read_req_rate != std::numeric_limits<uint64_t>::max()) {
             cfg.req_count_rate = io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_req_rate, nr_groups);
-            cfg.disk_req_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_req_rate) / p.write_req_rate;
+            cfg.disk_req_write_to_read_multiplier = (static_cast<double>(io_queue::read_request_base_count) * p.read_req_rate) / p.write_req_rate;
         }
         if (p.read_saturation_length != std::numeric_limits<uint64_t>::max()) {
             cfg.disk_read_saturation_length = p.read_saturation_length;


### PR DESCRIPTION
This patch fixes an infinite loop in `io_queue` reproducible when io-properties are configured with some big numbers for write requests.

`disk_req_write_to_read_multiplier` ends up being 0 when assigned the result of `io_queue::read_request_base_count * p.read_req_rate) / p.write_req_rate` in reactor code. Same for
`disk_blocks_write_to_read_multiplier`.
Both of them equal to 0 means `internal::request_tokens` always renders 0 tokens, thus capacity 0 and the consequence is an infinite loop in `io_group` constructor.

This patch currently lacks a test because one will be much easier to add once https://github.com/scylladb/seastar/pull/2825 lands. We can either wait for that to land and add it after or do it as a followup.

Fixes #2817