### PR TITLE
Fix incorrect defaults for io queue iops/bandwidth

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -181,8 +181,8 @@ public:
 
     struct config {
         unsigned id;
-        unsigned long req_count_rate = std::numeric_limits<int>::max();
-        unsigned long blocks_count_rate = std::numeric_limits<int>::max();
+        unsigned long req_count_rate = std::numeric_limits<unsigned long>::max();
+        unsigned long blocks_count_rate = std::numeric_limits<unsigned long>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;
         unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -510,3 +510,15 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_unconfigured_io_queue) {
+    io_queue_for_tests tio;
+
+    for (uint64_t reqsize = 512; reqsize < 128 << 10; reqsize <<= 1) {
+        auto cost_read = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, reqsize));
+        auto cost_write = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, reqsize));
+
+        SEASTAR_ASSERT(cost_read == 0);
+        SEASTAR_ASSERT(cost_write == 0);
+    }
+}


### PR DESCRIPTION
This patch switches de default values of `req_count_rate` and `blocks_count_rate` from io_queue to `unsigned long` max value.

This fixes an issue we've been chasing for quite a while, iotune would report maximum bandwidth values of aprox. 8.1GB/s which is much less than what should be reported for i7i instances. This issue was also reproducible with the `ioinfo` tool, the io scheduler would render too high request costs when running unconfigured, now the resulting request cost for unconfigured io scheduler is 0, which makes the token bucket not grab any tokens, giving us unbounded output for iotune to enjoy.

I doubled checked usages of these iops/bandwidth uint64_max variables and the costs which now might become 0 and I didn't spot any problematic cases of overflows or division by 0.

Fixes #2819