### PR TITLE
addr2line, scripts/stall-analyser: change the default tool to llvm-addr2line

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -64,7 +64,7 @@ class Addr2Line:
         parent: 'BacktraceResolver',
         binary: str,
         concise: bool = False,
-        cmd_path: str = "addr2line",
+        cmd_path: str = "llvm-addr2line",
     ):
         self._parent = parent
         self._binary = binary

--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -49,6 +49,9 @@ def get_command_line_parser():
                         help='Drop branches responsible for less than this threshold relative to the previous level, not global. (default 3%%)')
     parser.add_argument('--format', choices=['graph', 'trace'], default='graph',
                         help='The output format, default is %(default)s. `trace` is suitable as input for flamegraph.pl')
+    parser.add_argument('-a', '--addr2line', default='llvm-addr2line',
+                        help='The path or name of the addr2line command, which should behave as and '
+                            'accept the same options as binutils addr2line or llvm-addr2line (the default).')
     parser.add_argument('file', nargs='?',
                         type=argparse.FileType('r'),
                         default=sys.stdin,
@@ -401,7 +404,8 @@ def main():
     resolver = None
     if args.executable:
         resolver = addr2line.BacktraceResolver(executable=args.executable,
-                                               concise=not args.full_function_names)
+                                               concise=not args.full_function_names,
+                                               cmd_path=args.addr2line)
     if args.format == 'graph':
         render = Graph(resolver)
     else:


### PR DESCRIPTION
As a follow-up to 4bd3d123, change the default addr2line tool to llvm-addr2line also for scripts/stall-analyser and the BacktraceResolver class.