### PR TITLE
foreign_ptr: add get_wrapped_ptr method

### DIFF
--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -1038,6 +1038,18 @@ public:
         _cpu = other._cpu;
         return *this;
     }
+    /// Return a reference to the wrapped pointer.
+    ///
+    /// Warning: This method must be called on the
+    /// owner shard to avoid accidents.
+    const PtrType& get_wrapped_ptr() const noexcept {
+        check_shard();
+        return _value;
+    }
+    PtrType& get_wrapped_ptr() noexcept {
+        check_shard();
+        return _value;
+    }
     /// Releases the owned pointer
     ///
     /// Warning: the caller is now responsible for destroying the


### PR DESCRIPTION
The motivation for this new method as to allow
the user to check the wrapped pointer use_count
on the owner shard before e.g. clearing it,
if the use_count equals 1.

Refs scylladb/scylladb#25026