### PR TITLE
Add label values to the duplicate metrics exception

### DIFF
--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -31,6 +31,7 @@ module;
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
+#include <fmt/ranges.h>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -485,7 +486,7 @@ register_ref impl::add_registration(const metric_id& id, const metric_type& type
     if (_value_map.find(name) != _value_map.end()) {
         auto& metric = _value_map[name];
         if (metric.find(rm->info().id.labels()) != metric.end()) {
-            throw double_registration("registering metrics twice for metrics: " + name);
+            throw double_registration(fmt::format("registering metrics twice for metrics: {} with labels {}", name, rm->info().id.labels()));
         }
         if (metric.info().type != type.base_type) {
             throw std::runtime_error("registering metrics " + name + " registered with different type.");


### PR DESCRIPTION
A metric must be unique. Trying to register two metrics with the same name and the same labels will throw an exception and, in many cases, terminate the process.

This patch adds the label values to the exception message to make it easier to understand which metric caused the exception.

An example
```
registering metrics twice for metrics: scylladb_current_version {"__level": "basic", "shard": "", "version": "2025.4.0~dev-0.20250709.69b5289a0e54"}
```