### PR TITLE
io_queue costs shouldn't be zero for large bandwidth/iops

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -176,15 +176,15 @@ public:
     // (read_request_base_count * 130) / 100.
     // It is also technically possible for reads to be the expensive ones, in which case
     // writes will have an integer value lower than read_request_base_count.
-    static constexpr unsigned read_request_base_count = 128;
+    static constexpr double read_request_base_count = 128.0;
     static constexpr unsigned block_size_shift = 9;
 
     struct config {
         unsigned id;
         unsigned long req_count_rate = std::numeric_limits<int>::max();
         unsigned long blocks_count_rate = std::numeric_limits<int>::max();
-        unsigned disk_req_write_to_read_multiplier = read_request_base_count;
-        unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
+        double disk_req_write_to_read_multiplier = read_request_base_count;
+        double disk_blocks_write_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();
         size_t disk_write_saturation_length = std::numeric_limits<size_t>::max();
         sstring mountpoint = "undefined";

--- a/src/core/disk_params.cc
+++ b/src/core/disk_params.cc
@@ -178,7 +178,7 @@ struct io_queue::config disk_config_params::generate_config(const disk_params& p
     cfg.id = q;
 
     if (p.read_bytes_rate != std::numeric_limits<uint64_t>::max()) {
-        cfg.blocks_count_rate = (io_queue::read_request_base_count * (unsigned long)per_io_group(p.read_bytes_rate, nr_groups)) >> io_queue::block_size_shift;
+        cfg.blocks_count_rate = static_cast<unsigned long>(io_queue::read_request_base_count * per_io_group(p.read_bytes_rate, nr_groups)) >> io_queue::block_size_shift;
         cfg.disk_blocks_write_to_read_multiplier = (io_queue::read_request_base_count * p.read_bytes_rate) / p.write_bytes_rate;
     }
     if (p.read_req_rate != std::numeric_limits<uint64_t>::max()) {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -880,8 +880,8 @@ stream_id io_queue::request_stream(io_direction_and_length dnl) const noexcept {
 
 double internal::request_tokens(io_direction_and_length dnl, const io_queue::config& cfg) noexcept {
     struct {
-        unsigned weight;
-        unsigned size;
+        double weight;
+        double size;
     } mult[2];
 
     mult[io_direction_write] = {


### PR DESCRIPTION
This patch fixes a case in which given large enough iops/bandwitdh configured in io-properties, the requests costs would show up 0.

The bug is in internal::request_tokens, for bigger configured iops and bandwidth, disk_req_write_to_read_multiplier and
disk_blocks_write_to_read_multiplier end up < 1, so casting them to unsigned would make them 0, so in the end costs end up 0. They should end up 0 anyway the closer you get to uint64_t max, but not that soon.

This PR depends on https://github.com/scylladb/seastar/pull/2825 getting some test glue code in.

Fixes #2816