### PR TITLE
reactor: Narrow down io_completion::complete_with() friendship

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -204,6 +204,7 @@ public:
 
     private:
         friend class file_data_source_impl;
+        friend void io_completion::complete_with(ssize_t);
         static io_stats& local() noexcept;
     };
     /// Scheduling statistics.
@@ -213,7 +214,6 @@ public:
         /// entire task quota.
         uint64_t tasks_processed = 0;
     };
-    friend void io_completion::complete_with(ssize_t);
 
     /// Obtains an alien::instance object that can be used to send messages
     /// to Seastar shards from non-Seastar threads.
@@ -724,6 +724,9 @@ inline int hrtimer_signal() {
     return SIGRTMIN;
 }
 
+inline auto reactor::io_stats::local() noexcept -> io_stats& {
+    return engine()._io_stats;
+}
 
 extern logger seastar_logger;
 

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -77,10 +77,6 @@ inline internal::maybe_priority_class_ref get_io_priority(const Options& opts) {
     return internal::maybe_priority_class_ref{};
 }
 
-inline auto reactor::io_stats::local() noexcept -> io_stats& {
-    return engine()._io_stats;
-}
-
 class file_data_source_impl : public data_source_impl {
     struct issued_read {
         uint64_t _pos;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1676,7 +1676,7 @@ void io_completion::complete_with(ssize_t res) {
         return;
     }
 
-    ++engine()._io_stats.aio_errors;
+    reactor::io_stats::local().aio_errors++;
     try {
         throw_kernel_error(res);
     } catch (...) {


### PR DESCRIPTION
The method in question only needs to increment some io_stats counter. For that, there's io_stats::local() helper and io_stats friendship introduced earlier in ac1733a21f, no need for bigger hammer.