### PR TITLE
file: Shorten then-chain for file creation

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1799,9 +1799,9 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
             return wrap_syscall(fd, st);
         }).then([&options, name = std::move(name), &open_flags] (syscall_result_extra<struct stat> sr) {
             sr.throw_fs_exception_if_error("open failed", name);
-            return make_file_impl(sr.result, options, open_flags, sr.extra);
-        }).then([] (shared_ptr<file_impl> impl) {
-            return make_ready_future<file>(std::move(impl));
+            return make_file_impl(sr.result, options, open_flags, sr.extra).then([] (shared_ptr<file_impl> impl) {
+                return make_ready_future<file>(std::move(impl));
+            });
         });
     });
 }
@@ -2331,9 +2331,9 @@ reactor::open_directory(std::string_view name) noexcept {
             return wrap_syscall(fd, st);
         }).then([name = sstring(name), oflags] (syscall_result_extra<struct stat> sr) {
             sr.throw_fs_exception_if_error("open failed", name);
-            return make_file_impl(sr.result, file_open_options(), oflags, sr.extra);
-        }).then([] (shared_ptr<file_impl> file_impl) {
-            return make_ready_future<file>(std::move(file_impl));
+            return make_file_impl(sr.result, file_open_options(), oflags, sr.extra).then([] (shared_ptr<file_impl> impl) {
+                return make_ready_future<file>(std::move(impl));
+            });
         });
     });
 }


### PR DESCRIPTION
The open_file_dma() (as well as open_directory()) both use 3-steps chain:

return thread_pool->submit([] {
    fd = ::open();
    and_some_other_stuff();
}).then([] {
    return make_file_impl(fd, ...);
}).then([] (shared_ptr<file_impl> impl) {
    return make_ready_future<file>(impl);
});

The first entry in the chain is never instantly ready, so both subsequent then()-s allocate continuations. However, the second entry, namely the make_file_impl() is almost always instantly ready future, so attaching the third continuation to it likely saves allocation.

The make_file_impl() returns future<> at all, because it may want to call ::fstatfs() via thread-pool in case the filesystem info is missing in local cache, which happens only once per filesystem.