### PR TITLE
http/reply: introduce set_cookie()

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -279,7 +279,7 @@ struct reply {
     }
 
 private:
-    future<> write_reply_to_connection(output_stream<char>& out);
+    future<> write_reply(output_stream<char>& out);
     future<> write_reply_headers(output_stream<char>& out);
 
     http::body_writer_type _body_writer;

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -149,6 +149,8 @@ struct reply {
      */
     std::unordered_map<sstring, sstring, seastar::internal::case_insensitive_hash, seastar::internal::case_insensitive_cmp> _headers;
 
+    std::unordered_map<sstring, sstring> _cookies;
+
     sstring _version;
     /**
      * The content to be sent in the reply.
@@ -213,6 +215,14 @@ struct reply {
      */
     reply& set_content_type(const sstring& content_type = "html") {
         set_mime_type(http::mime_types::extension_to_type(content_type));
+        return *this;
+    }
+
+    /**
+     * Set the cookie with the given name and value.
+     */
+    reply& set_cookie(const sstring& name, const sstring& value) {
+        _cookies[name] = value;
         return *this;
     }
 

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -279,8 +279,8 @@ struct reply {
     }
 
 private:
-    future<> write_reply_to_connection(httpd::connection& con);
-    future<> write_reply_headers(httpd::connection& connection);
+    future<> write_reply_to_connection(output_stream<char>& out);
+    future<> write_reply_headers(output_stream<char>& out);
 
     http::body_writer_type _body_writer;
     friend class httpd::routes;

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -278,13 +278,12 @@ struct reply {
         _skip_body = true;
     }
 
-private:
     future<> write_reply(output_stream<char>& out);
     future<> write_reply_headers(output_stream<char>& out);
 
+private:
     http::body_writer_type _body_writer;
     friend class httpd::routes;
-    friend class httpd::connection;
 };
 
 std::ostream& operator<<(std::ostream& os, reply::status_type st);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -99,7 +99,7 @@ future<> connection::do_response_loop() {
 
 future<> connection::start_response() {
     if (_resp->_body_writer) {
-        return _resp->write_reply_to_connection(out()).then_wrapped([this] (auto f) {
+        return _resp->write_reply(out()).then_wrapped([this] (auto f) {
             if (f.failed()) {
                 // In case of an error during the write close the connection
                 _server._respond_errors++;

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -99,7 +99,7 @@ future<> connection::do_response_loop() {
 
 future<> connection::start_response() {
     if (_resp->_body_writer) {
-        return _resp->write_reply_to_connection(*this).then_wrapped([this] (auto f) {
+        return _resp->write_reply_to_connection(out()).then_wrapped([this] (auto f) {
             if (f.failed()) {
                 // In case of an error during the write close the connection
                 _server._respond_errors++;
@@ -139,7 +139,7 @@ future<> connection::start_response() {
             _resp->_content.size());
     return _write_buf.write(_resp->_response_line.data(),
             _resp->_response_line.size()).then([this] {
-        return _resp->write_reply_headers(*this);
+        return _resp->write_reply_headers(out());
     }).then([this] {
         return _write_buf.write("\r\n", 2);
     }).then([this] {

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -132,7 +132,7 @@ void reply::write_body(const sstring& content_type, sstring content) {
     done(content_type);
 }
 
-future<> reply::write_reply_to_connection(output_stream<char>& out) {
+future<> reply::write_reply(output_stream<char>& out) {
     add_header("Transfer-Encoding", "chunked");
     return out.write(response_line()).then([this, &out] () mutable {
         return write_reply_headers(out);

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -160,6 +160,10 @@ future<> reply::write_reply(output_stream<char>& out) {
 future<> reply::write_reply_headers(output_stream<char>& out) {
     return do_for_each(_headers, [&out](auto& h) {
         return out.write(h.first + ": " + h.second + "\r\n");
+    }).then([this, &out] {
+        return do_for_each(_cookies, [&out] (auto& c) {
+            return out.write("Set-Cookie: " + c.first + "=" + c.second + "\r\n");
+        });
     });
 }
 


### PR DESCRIPTION
Cookies are problematic to use with existing set_header() and friends, as multiple cookies are expected to be set with multiple Set-Cookie header lines, which is a problem for the current header related infrastructure which assumes one value for one header key. Introduce separate mechanism for setting cookies, allowing for multiple cookies to be set. Set-Cookie headers are written separately after the normal headers are written.