### PR TITLE
Fix incorrect defaults for io queue iops/bandwidth

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -181,8 +181,8 @@ public:
 
     struct config {
         unsigned id;
-        unsigned long req_count_rate = std::numeric_limits<int>::max();
-        unsigned long blocks_count_rate = std::numeric_limits<int>::max();
+        unsigned long req_count_rate = std::numeric_limits<unsigned long>::max();
+        unsigned long blocks_count_rate = std::numeric_limits<unsigned long>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;
         unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();
@@ -416,6 +416,10 @@ private:
 
     static io_throttler::config configure_throttler(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);
+
+    inline size_t max_request_length(int dnl_idx) const noexcept {
+        return _max_request_length[dnl_idx];
+    }
 };
 
 inline const io_queue::config& io_queue::get_config() const noexcept {


### PR DESCRIPTION
This patch switches de default values of `req_count_rate` and `blocks_count_rate` from io_queue to `unsigned long` max value.

This fixes an issue we've been chasing for quite a while, iotune would report maximum bandwidth values of aprox. 8.1GB/s which is much less than what should be reported for i7i instances. This issue was also reproducible with the `ioinfo` tool, the io scheduler would render too high request costs when running unconfigured, now the resulting request cost for unconfigured io scheduler is 0, which makes the token bucket not grab any tokens, giving us unbounded output for iotune to enjoy.

Fixes #2819

Notes:
- Identical with the initial PR which was merged and reverted: https://github.com/scylladb/seastar/pull/2857 (#2854 is needed first so that seastar stays stable, this PR fixes the issue, but only due to another lucky overflow, #2854 addresses that).
- This needs to be merged only after https://github.com/scylladb/seastar/pull/2854