### PR TITLE
http: Add support of multiple key repetitions for the request

### DIFF
--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -66,7 +66,7 @@ void set_routes(routes& r) {
         demo_json::my_object obj;
         obj.var1 = req.param.at("var1");
         obj.var2 = req.param.at("var2");
-        demo_json::ns_hello_world::query_enum v = demo_json::ns_hello_world::str2query_enum(req.query_parameters.at("query_enum"));
+        demo_json::ns_hello_world::query_enum v = demo_json::ns_hello_world::str2query_enum(req.get_query_param("query_enum"));
         // This demonstrate enum conversion
         obj.enum_var = v;
         return obj;

--- a/include/seastar/util/string_utils.hh
+++ b/include/seastar/util/string_utils.hh
@@ -47,6 +47,19 @@ SEASTAR_MODULE_EXPORT_BEGIN
 // Collection of utilities for working with strings .
 //
 
+struct string_view_hash {
+    using is_transparent = void;
+    size_t operator()(const char *txt) const {
+        return std::hash<std::string_view>{}(txt);
+    }
+    size_t operator()(std::string_view txt) const {
+        return std::hash<std::string_view>{}(txt);
+    }
+    size_t operator()(const sstring &txt) const {
+        return std::hash<sstring>()(txt);
+    }
+};
+
 struct case_insensitive_cmp {
     bool operator()(const sstring& s1, const sstring& s2) const {
         return std::equal(s1.begin(), s1.end(), s2.begin(), s2.end(),

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -900,9 +900,9 @@ class metrics_handler : public httpd::handler_base  {
     std::function<bool(const mi::labels_type&)> make_filter(const http::request& req) {
         std::unordered_map<sstring, std::regex> matcher;
         auto labels = mi::get_local_impl()->get_labels();
-        for (auto&& qp : req.query_parameters) {
+        for (auto&& qp : req.get_query_params()) {
             if (labels.find(qp.first) != labels.end()) {
-                matcher.emplace(qp.first, std::regex(qp.second.c_str()));
+                matcher.emplace(qp.first, std::regex(qp.second.back().c_str()));
             }
         }
         return (matcher.empty()) ? _true_function : [matcher](const mi::labels_type& labels) {

--- a/tests/unit/rest_api_httpd.cc
+++ b/tests/unit/rest_api_httpd.cc
@@ -47,7 +47,7 @@ void set_routes(routes& r) {
         api_json::my_object obj;
         obj.var1 = req.param.at("var1");
         obj.var2 = req.param.at("var2");
-        query_enum v = str2query_enum(req.query_parameters.at("query_enum"));
+        query_enum v = str2query_enum(req.get_query_param("query_enum"));
         // This demonstrate enum conversion
         obj.enum_var = v;
 
@@ -55,7 +55,7 @@ void set_routes(routes& r) {
         obj.array_var = vec123;
         obj.chunked_array_var = vec123;
 
-        auto use_streaming = req.query_parameters.at("use_streaming");
+        auto use_streaming = req.get_query_param("use_streaming");
 
         if (use_streaming != "false" && use_streaming != "true") {
             throw bad_param_exception("param use_streaming must be true or false");


### PR DESCRIPTION
This change improves the handling of HTTP request query parameters
by properly supporting multiple occurrences of the same parameter key.

To maintain backward compatibility, the existing get_query_param() method
and query_parameters field are preserved.
The query_parameters field, which stores the last value for each
query parameter key, is deprecated and will be removed in the future.

New functionality has been introduced that require
handling multiple values per parameter key:
- get_query_param_array()
- get_query_params()
- set_query_params()
- set_query_param()


Fixes #693