### PR TITLE
websocket: Remove unused scattered_message.hh inclusion

### DIFF
--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -24,7 +24,6 @@
 #include <seastar/core/loop.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
-#include <seastar/core/scattered_message.hh>
 #include <seastar/http/request.hh>
 
 namespace seastar::experimental::websocket {


### PR DESCRIPTION
That helper is not used by server.cc file that includes it