### PR TITLE
websocket: Avoid sending scattered_message to output_stream

### DIFF
--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -161,7 +161,7 @@ protected:
     /*!
      * \brief Packs buff in websocket frame and sends it to the client.
      */
-    future<> send_data(opcodes opcode, temporary_buffer<char>&& buff);
+    future<> send_data(opcodes opcode, temporary_buffer<char> buff);
 };
 
 std::string sha1_base64(std::string_view source);


### PR DESCRIPTION
There's a helper that sends a simple header and a temporary_buffer payload to the output_stream. Modern output_stream-s allow mixing buffered prefixes (the header) and zero-copy payloads (temp. buffer).

This change will allow to deprecate and remove net::packet from output_stream API eventually.