### PR TITLE
io_queue: Narrow down friendship with reactor

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -179,7 +179,6 @@ private:
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;
     friend class reactor_backend_selector;
-    friend class io_queue; // for aio statistics
     friend struct reactor_options;
     friend class aio_storage_context;
 public:
@@ -205,6 +204,7 @@ public:
     private:
         friend class file_data_source_impl;
         friend void io_completion::complete_with(ssize_t);
+        friend class io_queue;
         static io_stats& local() noexcept;
     };
     /// Scheduling statistics.

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -954,7 +954,7 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
         p = make_lw_shared<std::vector<future<size_t>>>();
         p->reserve(parts.size());
         find_or_create_class(pc).on_split(dnl);
-        engine()._io_stats.aio_outsizes++;
+        reactor::io_stats::local().aio_outsizes++;
     } catch (...) {
         return current_exception_as_future<size_t>();
     }
@@ -999,16 +999,16 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
 }
 
 future<size_t> io_queue::submit_io_read(internal::priority_class pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-    auto& r = engine();
-    ++r._io_stats.aio_reads;
-    r._io_stats.aio_read_bytes += len;
+    auto& io_stats = reactor::io_stats::local();
+    ++io_stats.aio_reads;
+    io_stats.aio_read_bytes += len;
     return queue_request(std::move(pc), io_direction_and_length(io_direction_read, len), std::move(req), intent, std::move(iovs));
 }
 
 future<size_t> io_queue::submit_io_write(internal::priority_class pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-    auto& r = engine();
-    ++r._io_stats.aio_writes;
-    r._io_stats.aio_write_bytes += len;
+    auto& io_stats = reactor::io_stats::local();
+    ++io_stats.aio_writes;
+    io_stats.aio_write_bytes += len;
     return queue_request(std::move(pc), io_direction_and_length(io_direction_write, len), std::move(req), intent, std::move(iovs));
 }
 


### PR DESCRIPTION
The io_queue is reactor friend to update io_stats member. For such cases there's reactor::io_stats::local() helper, so this friendship can be more fine-grained.