### PR TITLE
http::reply::status_type: Promote to namespace and make extensible struct

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -94,6 +94,12 @@ struct status_type {
         }
     };
 
+    // The following list of status codes is part of the HTTP standard,
+    // and are defined in RFC 9110, and in a few case in older RFCs as
+    // listed in IANA's "HTTP Status Code Registry". Please do not add
+    // to this list non-standard error codes. Seastar applications should
+    // be able to use non-standard error codes, but shouldn't expect
+    // Seastar to give them official names.
     static constexpr status_init continue_{100}; //!< continue
     static constexpr status_init switching_protocols{101}; //!< switching_protocols
     static constexpr status_init ok{200}; //!< ok
@@ -106,6 +112,7 @@ struct status_type {
     static constexpr status_init multiple_choices{300}; //!< multiple_choices
     static constexpr status_init moved_permanently{301}; //!< moved_permanently
     static constexpr status_init moved_temporarily{302}; //!< moved_temporarily
+    static constexpr status_init found{moved_temporarily}; //!< found is modern name for moved_temporarily
     static constexpr status_init see_other{303}; //!< see_other
     static constexpr status_init not_modified{304}; //!< not_modified
     static constexpr status_init use_proxy{305}; //!< use_proxy
@@ -118,15 +125,19 @@ struct status_type {
     static constexpr status_init not_found{404}; //!< not_found
     static constexpr status_init method_not_allowed{405}; //!< method_not_allowed
     static constexpr status_init not_acceptable{406}; //!< not_acceptable
+    static constexpr status_init proxy_authentication_required{407}; //<! proxy_authentication_required
     static constexpr status_init request_timeout{408}; //!< request_timeout
     static constexpr status_init conflict{409}; //!< conflict
     static constexpr status_init gone{410}; //!< gone
     static constexpr status_init length_required{411}; //!< length_required
+    static constexpr status_init precondition_failed{412}; //!< precondition_failed
     static constexpr status_init payload_too_large{413}; //!< payload_too_large
     static constexpr status_init uri_too_long{414}; //!< uri_too_long
     static constexpr status_init unsupported_media_type{415}; //!< unsupported_media_type
+    static constexpr status_init range_not_satisfiable{416}; //!< range_not_satisfiable
     static constexpr status_init expectation_failed{417}; //!< expectation_failed
     static constexpr status_init page_expired{419}; //!< page_expired
+    static constexpr status_init misdirected_request{421}; //!< misdirected_request
     static constexpr status_init unprocessable_entity{422}; //!< unprocessable_entity
     static constexpr status_init upgrade_required{426}; //!< upgrade_required
     static constexpr status_init too_many_requests{429}; //!< too_many_requests

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -68,7 +68,7 @@ static auto& status_strings() {
         {reply::status_type::partial_content, "Partial Content"},
         {reply::status_type::multiple_choices, "Multiple Choices"},
         {reply::status_type::moved_permanently, "Moved Permanently"},
-        {reply::status_type::moved_temporarily, "Moved Temporarily"},
+        {reply::status_type::moved_temporarily, "Found"},
         {reply::status_type::see_other, "See Other"},
         {reply::status_type::not_modified, "Not Modified"},
         {reply::status_type::use_proxy, "Use Proxy"},
@@ -81,16 +81,20 @@ static auto& status_strings() {
         {reply::status_type::not_found, "Not Found"},
         {reply::status_type::method_not_allowed, "Method Not Allowed"},
         {reply::status_type::not_acceptable, "Not Acceptable"},
+        {reply::status_type::proxy_authentication_required, "Proxy Authentication Required"},
         {reply::status_type::request_timeout, "Request Timeout"},
         {reply::status_type::conflict, "Conflict"},
         {reply::status_type::gone, "Gone"},
         {reply::status_type::length_required, "Length Required"},
-        {reply::status_type::payload_too_large, "Payload Too Large"},
+        {reply::status_type::precondition_failed, "Precondition Failed"},
+        {reply::status_type::payload_too_large, "Content Too Large"},
         {reply::status_type::uri_too_long, "URI Too Long"},
         {reply::status_type::unsupported_media_type, "Unsupported Media Type"},
+        {reply::status_type::range_not_satisfiable, "Range Not Satisfiable"},
         {reply::status_type::expectation_failed, "Expectation Failed"},
         {reply::status_type::page_expired, "Page Expired"},
-        {reply::status_type::unprocessable_entity, "Unprocessable Entity"},
+        {reply::status_type::misdirected_request, "Misdirected Request"},
+        {reply::status_type::unprocessable_entity, "Unprocessable Content"},
         {reply::status_type::upgrade_required, "Upgrade Required"},
         {reply::status_type::too_many_requests, "Too Many Requests"},
         {reply::status_type::login_timeout, "Login Timeout"},
@@ -103,7 +107,9 @@ static auto& status_strings() {
         {reply::status_type::insufficient_storage, "Insufficient Storage"},
         {reply::status_type::bandwidth_limit_exceeded, "Bandwidth Limit Exceeded"},
         {reply::status_type::network_read_timeout, "Network Read Timeout"},
-        {reply::status_type::network_connect_timeout, "Network Connect Timeout"}};
+        {reply::status_type::network_connect_timeout, "Network Connect Timeout"},
+        {reply::status_type::insufficient_storage, "Insufficient Storage"}
+    };
 
     return status_strings;
 }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -856,7 +856,7 @@ SEASTAR_TEST_CASE(content_length_limit) {
             output.flush().get();
             resp = input.read().get();
             BOOST_REQUIRE_EQUAL(std::string(resp.get(), resp.size()).find("200 OK"), std::string::npos);
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Payload Too Large"), std::string::npos);
+            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Content Too Large"), std::string::npos);
 
             input.close().get();
             output.close().get();
@@ -1333,7 +1333,7 @@ SEASTAR_TEST_CASE(test_100_continue) {
             output.flush().get();
             auto resp = input.read().get();
             BOOST_REQUIRE_EQUAL(std::string(resp.get(), resp.size()).find("100 Continue"), std::string::npos);
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Payload Too Large"), std::string::npos);
+            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Content Too Large"), std::string::npos);
 
             input.close().get();
             output.close().get();


### PR DESCRIPTION
Refs #884

Moves HTTP status codes to top-level type "status_type", and changes it from enum to struct.
The former to be able to forward declare the type.
The latter to be able to type-safely extend the type (i.e. define a typed constant in a different compilation unit, without having to modify a seastar enum).

"Extending" is done by simply constexpr-declaring your custom status in a code unit, then adding a dllink-time constant for static init registration, i.e:

```
.hh:

constexpr seastar::http::status_type MY_STATUS = <number>;

.cc

static const auto my_status_label = seastar::http::bind_status_name(MY_STATUS, "Some textual name");
```

Only valid in static init time.

Motivation:
1.) Using custom values for an enum type is oxymoronic. While it is workable to just cast int:s back and forth into the enum-values fields for status_type, it smells of bad practice. While replacing this with an admittedly weakly aliasing wrapper type is not much more type-safe, at least it is consistent.
2.) Some aspects of seastar level code relies (for some definition thereof) on translating status codes to strings, mainly pretty-printing a received reply (less important) and sending such a reply (see write_reply_to_connection). While a stringized value for the status is not mandatory, it is nice to be consistent, and get all info at all time without reinventing wheels.

Note: contains some haxxor to make the compile-time API as compatible as possible, i.e. include constexpr constants for all existing codes, as well as ensuring old code compiles (doing underlying_type_t stuff etc).
