### PR TITLE
memory: inline disable_abort_on_alloc_failure_temporarily

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -171,10 +171,20 @@ void configure_minimal();
 [[deprecated("use set_abort_on_allocation_failure(true) instead")]]
 void enable_abort_on_allocation_failure();
 
+namespace internal {
+
+extern thread_local constinit int abort_on_alloc_failure_suppressed;
+
+}
+
 class disable_abort_on_alloc_failure_temporarily {
 public:
-    disable_abort_on_alloc_failure_temporarily();
-    ~disable_abort_on_alloc_failure_temporarily() noexcept;
+    disable_abort_on_alloc_failure_temporarily() {
+        ++internal::abort_on_alloc_failure_suppressed;
+    }
+    ~disable_abort_on_alloc_failure_temporarily() noexcept {
+        --internal::abort_on_alloc_failure_suppressed;
+    }
 };
 
 // Disables heap profiling as long as this object is alive.

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -157,14 +157,10 @@ namespace memory {
 // seastar allocator is enabled.
 seastar::logger seastar_memory_logger("seastar_memory");
 
-static thread_local int abort_on_alloc_failure_suppressed = 0;
+namespace internal {
 
-disable_abort_on_alloc_failure_temporarily::disable_abort_on_alloc_failure_temporarily() {
-    ++abort_on_alloc_failure_suppressed;
-}
+thread_local constinit int abort_on_alloc_failure_suppressed = 0;
 
-disable_abort_on_alloc_failure_temporarily::~disable_abort_on_alloc_failure_temporarily() noexcept {
-    --abort_on_alloc_failure_suppressed;
 }
 
 void enable_abort_on_allocation_failure() {
@@ -2168,7 +2164,7 @@ void maybe_dump_memory_diagnostics(size_t size, bool is_aborting) {
 void on_allocation_failure(size_t size) {
     alloc_stats::increment(alloc_stats::types::failed_allocs);
 
-    bool will_abort = !abort_on_alloc_failure_suppressed
+    bool will_abort = !internal::abort_on_alloc_failure_suppressed
             && abort_on_allocation_failure.load(std::memory_order_relaxed);
 
     maybe_dump_memory_diagnostics(size, will_abort);


### PR DESCRIPTION
disable_abort_on_alloc_failure_temporarily is used to disable aborting on allocation failures, strangely enough. It is used in somewhat hot paths, but is not inlined, which is a pity because the constructor and destructor compile to single instructions.

Inline it; place the referenced variable in an internal namespace to avoid abuse and mark it constinit to avoid thread local storage initialization guards from killing the optimization.