### PR TITLE
aio: Squash aio_nowait_supported into fs_info::nowait_works

### DIFF
--- a/include/seastar/core/linux-aio.hh
+++ b/include/seastar/core/linux-aio.hh
@@ -96,7 +96,6 @@ linux_abi::iocb make_writev_iocb(int fd, uint64_t offset, const ::iovec* iov, si
 linux_abi::iocb make_poll_iocb(int fd, uint32_t events);
 
 void set_user_data(linux_abi::iocb& iocb, void* data);
-void set_nowait(linux_abi::iocb& iocb, bool nowait);
 
 void set_eventfd_notification(linux_abi::iocb& iocb, int eventfd);
 
@@ -114,8 +113,6 @@ int io_pgetevents(linux_abi::aio_context_t io_context, long min_nr, long nr, lin
 void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context);
 
 }
-
-extern bool aio_nowait_supported;
 
 namespace internal {
 
@@ -219,13 +216,11 @@ inline
 void
 set_nowait(linux_abi::iocb& iocb, bool nowait) {
 #ifdef RWF_NOWAIT
-    if (aio_nowait_supported) {
         if (nowait) {
             iocb.aio_rw_flags |= RWF_NOWAIT;
         } else {
             iocb.aio_rw_flags &= ~RWF_NOWAIT;
         }
-    }
 #endif
 }
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -753,6 +753,7 @@ public:
         /// resets the supression state.
         static void set_stall_detector_report_function(std::function<void ()> report);
         static std::function<void ()> get_stall_detector_report_function();
+        static bool linux_aio_nowait();
     };
 };
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -42,6 +42,7 @@ struct reactor_config {
     bool strict_o_direct = true;
     bool bypass_fsync = false;
     bool no_poll_aio = false;
+    bool aio_nowait_works = false;
 };
 /// \endcond
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1121,6 +1121,7 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
                 fsi.fsync_is_exclusive = true;
                 fsi.nowait_works = false;
             }
+            fsi.nowait_works &= engine()._cfg.aio_nowait_works;
             s_fstype.insert(std::make_pair(st.st_dev, std::move(fsi)));
             return make_file_impl(fd, std::move(options), flags, std::move(st));
         });

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -567,10 +567,6 @@ using namespace internal::linux_abi;
 
 std::atomic<manual_clock::rep> manual_clock::_now;
 
-// Base version where this works; some filesystems were only fixed later, so
-// this value is mixed in with filesystem-provided values later.
-bool aio_nowait_supported = internal::kernel_uname().whitelisted({"4.13"});
-
 static std::atomic<bool> abort_on_ebadf = { false };
 
 void set_abort_on_ebadf(bool do_abort) {
@@ -1482,6 +1478,10 @@ reactor::test::set_stall_detector_report_function(std::function<void ()> report)
 std::function<void ()>
 reactor::test::get_stall_detector_report_function() {
     return engine()._cpu_stall_detector->get_config().report;
+}
+
+bool reactor::test::linux_aio_nowait() {
+    return engine()._cfg.aio_nowait_works;
 }
 
 void
@@ -3869,7 +3869,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
     , blocked_reactor_reports_per_minute(*this, "blocked-reactor-reports-per-minute", 5, "Maximum number of backtraces reported by stall detector per minute")
     , blocked_reactor_report_format_oneline(*this, "blocked-reactor-report-format-oneline", true, "Print a simplified backtrace on a single line")
     , relaxed_dma(*this, "relaxed-dma", "allow using buffered I/O if DMA is not available (reduces performance)")
-    , linux_aio_nowait(*this, "linux-aio-nowait", aio_nowait_supported,
+    , linux_aio_nowait(*this, "linux-aio-nowait", internal::kernel_uname().whitelisted({"4.13"}), // base version where this works
                 "use the Linux NOWAIT AIO feature, which reduces reactor stalls due to aio (autodetected)")
     , unsafe_bypass_fsync(*this, "unsafe-bypass-fsync", false, "Bypass fsync(), may result in data loss. Use for testing on consumer drives")
     , kernel_page_cache(*this, "kernel-page-cache", false,
@@ -4411,6 +4411,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .strict_o_direct = !reactor_opts.relaxed_dma,
         .bypass_fsync = reactor_opts.unsafe_bypass_fsync.get_value(),
         .no_poll_aio = !reactor_opts.poll_aio.get_value() || (reactor_opts.poll_aio.defaulted() && reactor_opts.overprovisioned),
+        .aio_nowait_works = reactor_opts.linux_aio_nowait.get_value(), // Mixed in with filesystem-provided values later
     };
 
     // Disable hot polling if sched wakeup granularity is too high
@@ -4429,7 +4430,6 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         }
     }
 
-    aio_nowait_supported = reactor_opts.linux_aio_nowait.get_value();
     std::mutex mtx;
 
 #ifdef SEASTAR_HEAPPROF

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -197,8 +197,6 @@ aio_storage_context::handle_aio_error(linux_abi::iocb* iocb, int ec) {
     }
 }
 
-extern bool aio_nowait_supported;
-
 bool
 aio_storage_context::submit_work() {
     bool did_work = false;

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -730,10 +730,6 @@ SEASTAR_TEST_CASE(test_with_file_close_on_failure) {
     });
 }
 
-namespace seastar {
-    extern bool aio_nowait_supported;
-}
-
 SEASTAR_TEST_CASE(test_nowait_flag_correctness) {
     return tmp_dir::do_with_thread([] (tmp_dir& t) {
         auto oflags = open_flags::rw | open_flags::create;
@@ -749,7 +745,7 @@ SEASTAR_TEST_CASE(test_nowait_flag_correctness) {
             return buf.f_type == internal::fs_magic::tmpfs;
         };
 
-        if (!seastar::aio_nowait_supported) {
+        if (!seastar::reactor::test::linux_aio_nowait()) {
             BOOST_TEST_WARN(0, "Skipping this test because RWF_NOWAIT is not supported by the system");
             return;
         }


### PR DESCRIPTION
When setting up aiocb, the set_nowait() helper checks two bits:
- global aio_nowait_supported, which comes from CLI option whose default value depends on the kernel uname
- per-request nowait_works, which is inherited from file that gets it from fs_info object filled based on filesystem type and, again, kernel uname value

This patch removes the global bit, keeps the respective CLI option on reactor config and then updates the per-filesystem fs_info nowait_works with it.

"While at it" drop few unneeded forward declaration.