### PR TITLE
disable exception interception when ASAN enabled

### DIFF
--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -168,7 +168,10 @@ int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, voi
     return r;
 }
 
-#ifndef NO_EXCEPTION_INTERCEPT
+// We disable interception of _Unwind_RaiseException when ASAN is enabled
+// since it can produce a large number of stack-related false positives when
+// it is enabled and exceptions are thrown.
+#if !defined(NO_EXCEPTION_INTERCEPT) && !defined(SEASTAR_ASAN_ENABLED)
 extern "C"
 [[gnu::visibility("default")]]
 [[gnu::used]]


### PR DESCRIPTION
We disable interception of _Unwind_RaiseException when ASAN is enabled since it can produce a large number of stack-related false positives when it is enabled and exceptions are thrown.

Some notes:

 - ASAN also intercepts `_Unwind_RaiseException` and perfoms stack-related bookeeping work in there relating to the unwinding that is about to occur.
 - In the reproducers I looked at, both seastar and ASAN URE functions are called, ASAN first, sesatar second. 
 - The problem seems to be with the logging call we do in the seastar: if that is commented out, the problem is not observed. One could speculate the problem arises with anything that uses the stack in non-trivial ways and the rest of the stuff in there is trivial.
 - The problem occurs at -O1 and -O2, but not at -O0, and one can speculate this is related to whether (part of) the logging code gets inlined into URE. 
 - The problem is much less evident with `detect_stack_use_after_return=1` (the default) but occurs on the majority of tests with `detect_stack_use_after_return=0`. One can imagine this is because `detect_stack_use_after_return=1` enables the "fake stack" of ASAN, which allocates most stack frames on the "fake stack" (a type of heap) instead of the real stack, which hides the problems. This is supported by observation that increasing min/max_uar_stack_size_log reduces the failures by a lot and if put high enough (unreasonably high like 30, meaning 11*2^30 MB of memory used per fake stack) failures stop entirely: this is because all frames can be allocated from the fake stack, whereas with the default values the fake stack becomes exhausted. This is further supported by the observation that failures often occur in long running tests, or tests which have many test cases (but if the failing case is run by itself, it does not fail) as these are the ones that are able to exhaust the fake stack.

So a working theory is that during it's URW intercept, ASAN unpoisons the stack in the unwound region, but then in seastar's own intercept it then calls into the logger which results in some stack using code poisoning a bit more stack, then we do the actual unwind, leaving an incorrectly poisoned landmine up the stack. Later on when the stack grows up there you'll get a random stack buffer overflow/etc when ASAN detects the poisoned access.

Fixes scylladb/seastar#2892.