### PR TITLE
reactor: Use writeable_eventfd for reactor::_notify_eventfd

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -237,6 +237,7 @@ public:
     writeable_eventfd(writeable_eventfd&&) = default;
     readable_eventfd read_side();
     void signal(size_t nr);
+    std::optional<size_t> consume();
     int get_read_fd() { return _fd.get(); }
 private:
     explicit writeable_eventfd(file_desc&& fd) : _fd(std::move(fd)) {}

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -223,7 +223,7 @@ private:
     std::shared_ptr<seastar::smp> _smp;
     alien::instance& _alien;
     reactor_config _cfg;
-    file_desc _notify_eventfd;
+    writeable_eventfd _notify;
     file_desc _task_quota_timer;
     std::unique_ptr<reactor_backend> _backend;
     sigset_t _active_sigmask; // holds sigmask while sleeping with sig disabled

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1026,12 +1026,11 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     : _smp(std::move(smp))
     , _alien(alien)
     , _cfg(std::move(cfg))
-    , _notify_eventfd(file_desc::eventfd(0, EFD_CLOEXEC))
     , _task_quota_timer(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC))
     , _id(id)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
     , _cpu_sched(nullptr, 0)
-    , _thread_pool(std::make_unique<thread_pool>(seastar::format("syscall-{}", id), _notify_eventfd)) {
+    , _thread_pool(std::make_unique<thread_pool>(seastar::format("syscall-{}", id), _notify)) {
     /*
      * The _backend assignment is here, not on the initialization list as
      * the chosen backend constructor may want to handle signals and thus
@@ -2953,10 +2952,7 @@ reactor::wakeup() {
 
     // We are free to clear it, because we're sending a signal now
     _sleeping.store(false, std::memory_order_relaxed);
-
-    uint64_t one = 1;
-    auto res = ::write(_notify_eventfd.get(), &one, sizeof(one));
-    SEASTAR_ASSERT(res == sizeof(one) && "write(2) failed on _reactor._notify_eventfd");
+    _notify.signal(1);
 }
 
 void reactor::start_aio_eventfd_loop() {
@@ -3746,6 +3742,11 @@ void writeable_eventfd::signal(size_t count) {
     uint64_t c = count;
     auto r = _fd.write(&c, sizeof(c));
     SEASTAR_ASSERT(r == sizeof(c));
+}
+
+std::optional<size_t> writeable_eventfd::consume() {
+    uint64_t c;
+    return _fd.read(&c, sizeof(c));
 }
 
 writeable_eventfd readable_eventfd::write_side() {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -140,9 +140,12 @@ struct task_quota_aio_completion : public fd_kernel_completion,
     virtual void complete_with(ssize_t value) override;
 };
 
-struct smp_wakeup_aio_completion : public fd_kernel_completion,
+struct smp_wakeup_aio_completion final : public kernel_completion,
                                    public completion_with_iocb {
-    smp_wakeup_aio_completion(file_desc& fd);
+private:
+    writeable_eventfd& _efd;
+public:
+    smp_wakeup_aio_completion(writeable_eventfd& fd);
     virtual void complete_with(ssize_t value) override;
 };
 

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -53,14 +53,14 @@ public:
 } // namespace internal
 
 class thread_pool {
-    file_desc& _notify_eventfd;
+    writeable_eventfd& _notify;
     internal::submit_metrics metrics;
     syscall_work_queue inter_thread_wq;
     posix_thread _worker_thread;
     std::atomic<bool> _stopped = { false };
     std::atomic<bool> _main_thread_idle = { false };
 public:
-    explicit thread_pool(sstring thread_name, file_desc& notify);
+    explicit thread_pool(sstring thread_name, writeable_eventfd& notify);
     ~thread_pool();
     template <typename T, typename Func>
     future<T> submit(internal::thread_pool_submit_reason reason, Func func) noexcept {


### PR DESCRIPTION
The member in question is initialized with eventfd descriptor and is then used by reactor to wakeup backend from sleep. The writeable_eventfd class provides "compatible" signalling facility that can be re-used.

The reading part of writeable_eventfd is readable_eventfd, which is too much for the backend usage, so the writeable_eventfd::consume() helper is added. Next, the read-side of the eventfd nowdays works via fd_kernel_completion-s inheritants, that are patched to call the newly introduced method.

In the end of the day, the patch generalizes the "protocol" that notify eventfd peers use to kick each other -- the 8 bytes dummy tranfer.