### PR TITLE
foreign_ptr: add unwrap_on_owner_shard method

### DIFF
--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -25,6 +25,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/internal/run_in_background.hh>
+#include <seastar/core/on_internal_error.hh>
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/core/do_with.hh>
@@ -977,6 +978,14 @@ private:
         }
         return make_ready_future<>();
     }
+
+    void check_shard() const {
+#ifdef SEASTAR_DEBUG_SHARED_PTR
+        if (_cpu != this_shard_id()) [[unlikely]] {
+            on_fatal_internal_error(seastar_logger, "foreign_ptr accessed on non-owner cpu");
+        }
+#endif
+    }
 public:
     using element_type = typename std::pointer_traits<PtrType>::element_type;
     using pointer = element_type*;
@@ -1035,6 +1044,7 @@ public:
     /// pointer on its owner shard. This method is best called on the
     /// owner shard to avoid accidents.
     PtrType release() noexcept(std::is_nothrow_default_constructible_v<PtrType>) {
+        check_shard();
         return std::exchange(_value, {});
     }
     /// Replace the managed pointer with new_ptr.

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -1038,6 +1038,18 @@ public:
         _cpu = other._cpu;
         return *this;
     }
+    /// Return a reference to the wrapped pointer.
+    ///
+    /// Warning: This method must be called on the
+    /// owner shard to avoid accidents.
+    const PtrType& unwrap_on_owner_shard() const noexcept {
+        check_shard();
+        return _value;
+    }
+    PtrType& unwrap_on_owner_shard() noexcept {
+        check_shard();
+        return _value;
+    }
     /// Releases the owned pointer
     ///
     /// Warning: the caller is now responsible for destroying the

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -173,3 +173,28 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
     BOOST_REQUIRE_EQUAL(done[1].get_future().get(), true);
     BOOST_REQUIRE_EQUAL(done[0].get_future().get(), false);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_foreign_ptr_use_count) {
+    shard_id shard = (this_shard_id() + 1) % smp::count;
+    auto p0 = smp::submit_to(shard, [] {
+        return make_foreign(make_lw_shared<sstring>("foo"));
+    }).get();
+    smp::submit_to(shard, [&] {
+        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 1);
+    }).get();
+    auto p1 = p0.copy().get();
+    smp::submit_to(shard, [&] {
+        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 2);
+    }).get();
+    smp::submit_to(shard, [&] {
+        auto ptr = p0.release();
+        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
+        BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 2);
+        ptr = {};
+        BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 1);
+    }).get();
+    p1.reset();
+    smp::submit_to(shard, [&] {
+        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
+    }).get();
+}


### PR DESCRIPTION
The motivation for this new method as to allow
the user to check the wrapped pointer use_count
on the owner shard before e.g. clearing it,
if the use_count equals 1.

Refs scylladb/scylladb#25026
