### PR TITLE
test: Remove no-op dispatch from fair_queue ticker

### DIFF
--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -110,17 +110,6 @@ public:
                 _results[req.index]++;
                 _fq.notify_request_finished(req.fqent.capacity());
             }
-
-            while (dispatched < n) {
-                auto* req = _fq.top();
-                if (req == nullptr) {
-                    break;
-                }
-
-                dispatched++;
-                _fq.pop_front();
-                boost::intrusive::get_parent_from_member(req, &request::fqent)->submit();
-            }
         }
         return processed;
     }


### PR DESCRIPTION
The fair_queue tests all look the same -- they put some amount of requests into a fair queue, then try to process some other amount of requests from it with the help of a tick(int n) method, and then check that the per-class processed counters are in expected ratio.

The tick() method used to contain two dispatch loop, since the processing code was "time-based" due to outgoing throttler code. Recently (scylladb/seastar#2820) the throttler code was moved to the io-queue and the fair-queue dispatch loop was re-implemented to be very precise in terms of amount of requests dispatched by the test. With that, the 2nd dispatch loop in the test ticker becomes dead code and can be removed.