### PR TITLE
test: Make fair_queue_test validation code use BOOST_CHECK_...-s

### DIFF
--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -180,9 +180,9 @@ public:
         for (auto i = 0ul; i < ratios.size(); ++i) {
             int min_expected = ratios[i] * (_results[0] - expected_error);
             int max_expected = ratios[i] * (_results[0] + expected_error);
-            BOOST_REQUIRE(_results[i] >= min_expected);
-            BOOST_REQUIRE(_results[i] <= max_expected);
-            BOOST_REQUIRE(_exceptions[i].size() == 0);
+            BOOST_CHECK_GE(_results[i], min_expected);
+            BOOST_CHECK_LE(_results[i], max_expected);
+            BOOST_CHECK_EQUAL(_exceptions[i].size(), 0);
         }
     }
 };


### PR DESCRIPTION
The validation code uses BOOST_REQUIRE(condition) which is OK, but in case of failures prints too little info about the failure.