### PR TITLE
queue: Remove duplicating static assertion

### DIFF
--- a/include/seastar/core/queue.hh
+++ b/include/seastar/core/queue.hh
@@ -221,14 +221,11 @@ T queue<T>::pop() noexcept {
 }
 
 template <typename T>
+// seastar allows only nothrow_move_constructible types
+// to be returned as future<T>
 requires std::is_nothrow_move_constructible_v<T>
 inline
 future<T> queue<T>::pop_eventually() noexcept {
-    // seastar allows only nothrow_move_constructible types
-    // to be returned as future<T>
-    static_assert(std::is_nothrow_move_constructible_v<T>,
-                  "Queue element type must be no-throw move constructible");
-
     if (_ex) {
         return make_exception_future<T>(_ex);
     }


### PR DESCRIPTION
The queue<T> requires T to be nothrow-move-constructible and this requirement is all around in queue.hh. There's a duplicating check in one of the methods which can be safely removed.