### PR TITLE
iostream: Update "used stream" check for output_stream::detach()

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -515,7 +515,7 @@ output_stream<CharType>::close() noexcept {
 template <typename CharType>
 data_sink
 output_stream<CharType>::detach() && {
-    if (_buf) {
+    if (_buf || _zc_bufs) {
         throw std::logic_error("detach() called on a used output_stream");
     }
 


### PR DESCRIPTION
The method imples that the stream is not used (or at best flushed). The check is incomplete, used stream may have empty _buf, but non-empty zc buffers, which also need to be checked.