### PR TITLE
dns: Use TCP connection data_sink directly

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -208,7 +208,7 @@ private:
         ;
         connected_socket socket;
         std::optional<input_stream<char>> in;
-        std::optional<output_stream<char>> out;
+        std::optional<data_sink> out;
         temporary_buffer<char> indata;
     };
     struct udp_entry {
@@ -1111,9 +1111,9 @@ dns_resolver::impl::do_sendv(ares_socket_t fd, const iovec * vec, int len) {
             switch (e.typ) {
             case type::tcp:
                 if (!e.tcp.out) {
-                    e.tcp.out = e.tcp.socket.output(0);
+                    e.tcp.out = e.tcp.socket.output(0).detach();
                 }
-                f = e.tcp.out->write(std::move(p));
+                f = e.tcp.out->put(std::move(p));
                 break;
             case type::udp:
                 // always chain UDP sends


### PR DESCRIPTION
In order to send requests, the dns fiber calls
connected_socket::output() to get the output_stream for the socket. However, the stream itself is not really needed -- the buffer size is set to zero and the only sent message is the zero-copy packet.

For that use-case the detached data_sink fits much better.

This will allow to deprecate and eventually remove the net::packet from the output_stream API.