### PR TITLE
packet: Mark constructor from temporary_buffer explicit

### DIFF
--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -225,7 +225,7 @@ public:
     // append temporary_buffer (zero-copy)
     packet(packet&& x, temporary_buffer<char> buf);
     // create from temporary_buffer (zero-copy)
-    packet(temporary_buffer<char> buf);
+    explicit packet(temporary_buffer<char> buf);
     // append deleter
     packet(packet&& x, deleter d);
 


### PR DESCRIPTION
Otherwise attempt to put temporary_buffer into output_stream::write() implicitly converts the buffer into packet and calls the write(packet) overload. Effectively, the write(temporary_buffer) is unused.

Marking the aforementioned constuctor explicit makes complier pick the write(temporary_buffer) overload. Althoug it does the very same buffer to packet conversion, pointing the compiler at it will allow to deprecate the write(packet) one in the future.