### PR TITLE
reactor: replace boost::barrier with std::barrier<>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,7 +833,6 @@ target_link_libraries (seastar
   PUBLIC
     Boost::boost
     Boost::program_options
-    Boost::thread
     c-ares::cares
     fmt::fmt
     lz4::lz4

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -33,12 +33,12 @@
 
 #ifndef SEASTAR_MODULE
 #include <boost/lockfree/spsc_queue.hpp>
-#include <boost/thread/barrier.hpp>
 #include <deque>
 #include <optional>
 #include <thread>
 #include <ranges>
 #include <span>
+#include <barrier>
 #endif
 
 /// \file
@@ -316,7 +316,7 @@ class smp : public std::enable_shared_from_this<smp> {
     alien::instance& _alien;
     std::vector<posix_thread> _threads;
     std::vector<std::function<void ()>> _thread_loops; // for dpdk
-    std::optional<boost::barrier> _all_event_loops_done;
+    std::optional<std::barrier<>> _all_event_loops_done;
     std::unique_ptr<internal::memory_prefaulter> _prefaulter;
     struct qs_deleter {
       void operator()(smp_message_queue** qs) const;

--- a/include/seastar/net/net.hh
+++ b/include/seastar/net/net.hh
@@ -31,6 +31,7 @@
 #include <seastar/net/packet.hh>
 #include <seastar/net/const.hh>
 #include <seastar/util/assert.hh>
+#include <map>
 #include <unordered_map>
 
 namespace seastar {

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <list>

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -19,7 +19,6 @@ boost_system_libs=@Boost_SYSTEM_LIBRARY@
 # Dependencies.
 boost_cflags=-I$<JOIN:@Boost_INCLUDE_DIRS@, -I>
 boost_program_options_libs=$<TARGET_PROPERTY:Boost::program_options,LOCATION>
-boost_thread_libs=${boost_system_libs} $<TARGET_PROPERTY:Boost::thread,LOCATION>
 c_ares_cflags=-I$<JOIN:@c-ares_INCLUDE_DIRS@, -I>
 c_ares_libs=$<JOIN:@c-ares_LIBRARIES@, >
 fmt_cflags=-I$<JOIN:$<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>, -I>
@@ -37,5 +36,5 @@ Requires: liblz4 >= 1.7.3
 Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
 Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags}
-Libs: ${seastar_libs} ${boost_program_options_libs} ${boost_thread_libs} ${c_ares_libs} ${fmt_libs}
-Libs.private: ${dl_libs} ${rt_libs} ${boost_thread_libs} ${lksctp_tools_libs} ${liburing_libs} ${stdatomic_libs} ${dpdk_libs}
+Libs: ${seastar_libs} ${boost_program_options_libs} ${c_ares_libs} ${fmt_libs}
+Libs.private: ${dl_libs} ${rt_libs} ${lksctp_tools_libs} ${liburing_libs} ${stdatomic_libs} ${dpdk_libs}

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -48,6 +48,7 @@ module;
 #include <array>
 #include <algorithm>
 #include <atomic>
+#include <barrier>
 #include <bitset>
 #include <cassert>
 #include <chrono>
@@ -115,7 +116,6 @@ module;
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/irange.hpp>
-#include <boost/thread/barrier.hpp>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>


### PR DESCRIPTION
This allows dropping the boost.thread dependency, so do that too.

Some dependencies on std::map were lost as a result, so restore them.