### PR TITLE
build: don't recover from sanitizer failures

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -80,6 +80,8 @@ if (Sanitizers_FOUND)
           INTERFACE_LINK_LIBRARIES "${Sanitizers_${COMPONENT}_COMPILE_OPTIONS}")
     endif ()
   endforeach ()
+  target_compile_options(${library} INTERFACE "-fno-sanitize-recover=all")
+  target_link_libraries(${library} INTERFACE "-fno-sanitize-recover=all")
 endif ()
 
 cmake_policy (POP)


### PR DESCRIPTION
The sanitizer is able to recover from some errors, but we want to fail early so we can fix those bugs.

Set -fno-sanitize-recover=all to accomplish that.