### PR TITLE
io_tester: Add support for scheduling supergroups

### DIFF
--- a/apps/io_tester/sched.yaml
+++ b/apps/io_tester/sched.yaml
@@ -1,0 +1,13 @@
+- name: statement
+  shares: 1000
+
+- name: maintenance
+  shares: 100
+
+- name: compaction
+  shares: 200
+  parent: maintenance
+
+- name: backup
+  shares: 100
+  parent: maintenance


### PR DESCRIPTION
The nested IO classes support is coming, so the io_tester should be patched to create nested layouts too. However, nesting of sched groups is standalone API, that's aready in, so io_tester can be patched right now (without visible effect on the IO part).

The support is to introduce the --sched-groups option that provides a YAML file with sched groups listed in it. The job config already supports assigning individual jobs to sched groups by the sched group names, so no other actions are needed.