### PR TITLE
include: Move array_map.hh to util/internal/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,7 +496,6 @@ add_library (seastar
   include/seastar/core/align.hh
   include/seastar/core/aligned_buffer.hh
   include/seastar/core/app-template.hh
-  include/seastar/core/array_map.hh
   include/seastar/core/bitops.hh
   include/seastar/core/bitset-iter.hh
   include/seastar/core/byteorder.hh

--- a/include/seastar/net/ip.hh
+++ b/include/seastar/net/ip.hh
@@ -33,7 +33,7 @@
 #include <chrono>
 #endif
 
-#include <seastar/core/array_map.hh>
+#include <seastar/util/internal/array_map.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/byteorder.hh>
 #include <seastar/net/arp.hh>
@@ -292,7 +292,7 @@ private:
     ipv4_tcp _tcp;
     ipv4_icmp _icmp;
     ipv4_udp _udp;
-    array_map<ip_protocol*, 256> _l4;
+    internal::array_map<ip_protocol*, 256> _l4;
     ip_packet_filter * _packet_filter = nullptr;
     struct frag {
         packet header;

--- a/include/seastar/util/internal/array_map.hh
+++ b/include/seastar/util/internal/array_map.hh
@@ -31,6 +31,7 @@
 #endif
 
 namespace seastar {
+namespace internal {
 
 // unordered_map implemented as a simple array
 
@@ -55,4 +56,5 @@ public:
     }
 };
 
-}
+} // internal namespace
+} // seastar namespace

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -166,7 +166,6 @@ export module seastar;
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>
 #include <seastar/core/app-template.hh>
-#include <seastar/core/array_map.hh>
 #include <seastar/core/bitops.hh>
 #include <seastar/core/bitset-iter.hh>
 #include <seastar/core/byteorder.hh>

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -52,7 +52,7 @@ module seastar;
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
 
-#include <seastar/core/array_map.hh>
+#include <seastar/util/internal/array_map.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/print.hh>
@@ -87,7 +87,7 @@ template <> struct formatter<wrapped_log_level> {
 
     template <typename FormatContext>
     auto format(wrapped_log_level wll, FormatContext& ctx) const {
-        static seastar::array_map<seastar::sstring, nr_levels> text = {
+        static seastar::internal::array_map<seastar::sstring, nr_levels> text = {
             { int(log_level::debug), "DEBUG" },
             { int(log_level::info),  "INFO " },
             { int(log_level::trace), "TRACE" },
@@ -96,7 +96,7 @@ template <> struct formatter<wrapped_log_level> {
         };
         int index = static_cast<int>(wll.level);
         std::string_view name = text[index];
-        static seastar::array_map<text_style, nr_levels> style = {
+        static seastar::internal::array_map<text_style, nr_levels> style = {
             { int(log_level::debug), fg(terminal_color::green)  },
             { int(log_level::info),  fg(terminal_color::white)  },
             { int(log_level::trace), fg(terminal_color::blue)   },
@@ -364,7 +364,7 @@ logger::do_log(log_level level, log_writer& writer) {
         auto it = buf.back_insert_begin();
         it = print_once(it);
         *it = '\0';
-        static array_map<int, 20> level_map = {
+        static internal::array_map<int, 20> level_map = {
                 { int(log_level::debug), LOG_DEBUG },
                 { int(log_level::info), LOG_INFO },
                 { int(log_level::trace), LOG_DEBUG },  // no LOG_TRACE


### PR DESCRIPTION
And to internal namespace either. And adjust the callers.

Callers could use the std::array<> directly, but they need C99-style designated initializers for convenience.