### PR TITLE
reactor: Equip make_task() and lambda_task with concepts

### DIFF
--- a/include/seastar/core/make_task.hh
+++ b/include/seastar/core/make_task.hh
@@ -32,6 +32,7 @@ namespace seastar {
 SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename Func>
+requires std::invocable<Func>
 class lambda_task final : public task {
     Func _func;
     using futurator = futurize<std::invoke_result_t<Func>>;
@@ -50,6 +51,7 @@ public:
 };
 
 template <typename Func>
+requires std::invocable<Func>
 inline
 lambda_task<Func>*
 make_task(Func&& func) noexcept {
@@ -57,6 +59,7 @@ make_task(Func&& func) noexcept {
 }
 
 template <typename Func>
+requires std::invocable<Func>
 inline
 lambda_task<Func>*
 make_task(scheduling_group sg, Func&& func) noexcept {


### PR DESCRIPTION
The latter is in fact a wrapper over fn(void) functions, and the former just inherits that. Adding a concept makes this requirement explicit.