### PR TITLE
Fix and tune http::request setup by client

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -127,8 +127,7 @@ public:
     future<> close();
 
 private:
-    future<reply_ptr> do_make_request(request& rq);
-    void setup_request(request& rq);
+    future<reply_ptr> do_make_request(const request& rq);
     future<> send_request_head(const request& rq);
     future<reply_ptr> maybe_wait_for_continue(const request& req);
     future<> write_body(const request& rq);
@@ -182,7 +181,7 @@ private:
     requires std::invocable<Fn, connection&>
     auto with_new_connection(Fn&& fn, abort_source*);
 
-    future<> do_make_request(connection& con, request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
+    future<> do_make_request(connection& con, const request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
 
 public:
     /**

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -274,7 +274,7 @@ public:
      * `request and the `handle`, it caller's responsibility the make sure they
      * are referencing valid instances
      */
-    future<> make_request(request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
+    future<> make_request(const request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Updates the maximum number of connections a client may have

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -115,11 +115,8 @@ static void setup_request(request& req) {
     if (req._version.empty()) {
         throw std::runtime_error("HTTP version not set");
     }
-    if (req.content_length != 0) {
-        if (!req.body_writer && req.content.empty()) {
-            throw std::runtime_error("Request body writer not set and content is empty");
-        }
-        req._headers["Content-Length"] = to_sstring(req.content_length);
+    if (req.content_length != 0 && !req.body_writer && req.content.empty()) {
+        throw std::runtime_error("Request body writer not set and content is empty");
     }
 }
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -354,7 +354,7 @@ static bool is_retryable_exception(std::exception_ptr ex) {
     return false;
 }
 
-future<> client::make_request(request& req, reply_handler& handle, std::optional<reply::status_type> expected, abort_source* as) {
+future<> client::make_request(const request& req, reply_handler& handle, std::optional<reply::status_type> expected, abort_source* as) {
     try {
         validate_request(req);
     } catch (...) {

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -113,7 +113,7 @@ future<connection::reply_ptr> connection::maybe_wait_for_continue(const request&
 
 static void setup_request(request& req) {
     if (req._version.empty()) {
-        req._version = "1.1";
+        throw std::runtime_error("HTTP version not set");
     }
     if (req.content_length != 0) {
         if (!req.body_writer && req.content.empty()) {

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -126,6 +126,7 @@ void request::set_expects_continue() {
 
 request request::make(sstring method, sstring host, sstring path) {
     request rq;
+    rq._version = "1.1";
     rq._method = std::move(method);
     rq._url = std::move(path);
     rq._headers["Host"] = std::move(host);

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -101,6 +101,7 @@ sstring request::parse_query_param() {
 void request::write_body(const sstring& content_type, sstring content) {
     set_content_type(content_type);
     content_length = content.size();
+    _headers["Content-Length"] = to_sstring(content_length);
     this->content = std::move(content);
 }
 
@@ -113,6 +114,7 @@ void request::write_body(const sstring& content_type, body_writer_type&& body_wr
 void request::write_body(const sstring& content_type, size_t len, body_writer_type&& body_writer) {
     set_content_type(content_type);
     content_length = len;
+    _headers["Content-Length"] = to_sstring(content_length);
     if (len > 0) {
         // At the time of this writing, connection::write_body()
         // assumes that `body_writer` is unset if `content_length` is 0.

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2099,7 +2099,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_with_broken_wire) {
 
     http::experimental::client c(addr, creds);
     http::request req;
-
+    req._version = "1.1";
     req.write_body("html", std::string(5134, 'a'));
 
     auto sa = server.accept();


### PR DESCRIPTION
Currently, if a request passed into client::make_request() fails validation (missing version and inconsistent body content vs headers) the method throws, while it's a furure<>-returning method and should return exceptional future instead. This PR turns exception into a future.

Other than that, request validation is moved, so that it happens once per make_request(). Nowadays it happens on every retry.

And finally, placing defaults on request is moved from connection::make_request() into request::make(), so that client request making API accepts const request reference (finalizes the #1848 effort)