### PR TITLE
include: Keep linux-aio.hh deeper in internal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,7 +528,6 @@ add_library (seastar
   include/seastar/core/iostream.hh
   include/seastar/util/later.hh
   include/seastar/core/layered_file.hh
-  include/seastar/core/linux-aio.hh
   include/seastar/core/loop.hh
   include/seastar/core/lowres_clock.hh
   include/seastar/core/manual_clock.hh

--- a/include/seastar/core/internal/linux-aio.hh
+++ b/include/seastar/core/internal/linux-aio.hh
@@ -112,10 +112,6 @@ int io_pgetevents(linux_abi::aio_context_t io_context, long min_nr, long nr, lin
 
 void setup_aio_context(size_t nr, linux_abi::aio_context_t* io_context);
 
-}
-
-namespace internal {
-
 inline
 linux_abi::iocb
 make_read_iocb(int fd, uint64_t offset, void* buffer, size_t len) {
@@ -224,8 +220,7 @@ set_nowait(linux_abi::iocb& iocb, bool nowait) {
 #endif
 }
 
-}
+} // internal namespace
 
-
-}
+} // seastar namespace
 

--- a/src/core/fsqual.cc
+++ b/src/core/fsqual.cc
@@ -22,7 +22,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/util/assert.hh>
 #include <seastar/util/defer.hh>
-#include <seastar/core/linux-aio.hh>
+#include <seastar/core/internal/linux-aio.hh>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <fcntl.h>

--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -36,7 +36,7 @@ module;
 #ifdef SEASTAR_MODULE
 module seastar;
 #else
-#include <seastar/core/linux-aio.hh>
+#include <seastar/core/internal/linux-aio.hh>
 #include <seastar/core/print.hh>
 #include <seastar/util/read_first_line.hh>
 #endif

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -26,7 +26,7 @@
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/core/internal/poll.hh>
-#include <seastar/core/linux-aio.hh>
+#include <seastar/core/internal/linux-aio.hh>
 #include <seastar/core/cacheline.hh>
 #include <seastar/util/modules.hh>
 


### PR DESCRIPTION
All this file contents is now in internal namespace. On top of that, this patch

- removes the pointless namespace breakage in the middle
- adds comments to terminating curly braces
- moves the file into internal/ sub-directory
- ... and updates the includes from .cc (quite a few)