### PR TITLE
file, io_queue: Drop maybe_priority_class_ref{} from internal calls

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -283,7 +283,7 @@ public:
     template <typename CharType>
     future<size_t>
     dma_read(uint64_t aligned_pos, CharType* aligned_buffer, size_t aligned_len, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(aligned_pos, reinterpret_cast<uint8_t*>(aligned_buffer), aligned_len, internal::maybe_priority_class_ref(), intent);
+        return dma_read_impl(aligned_pos, reinterpret_cast<uint8_t*>(aligned_buffer), aligned_len, intent);
     }
 
     /**
@@ -303,7 +303,7 @@ public:
      */
     template <typename CharType>
     future<temporary_buffer<CharType>> dma_read(uint64_t pos, size_t len, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(pos, len, internal::maybe_priority_class_ref(), intent).then([] (temporary_buffer<uint8_t> t) {
+        return dma_read_impl(pos, len, intent).then([] (temporary_buffer<uint8_t> t) {
             return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
         });
     }
@@ -327,7 +327,7 @@ public:
     template <typename CharType>
     future<temporary_buffer<CharType>>
     dma_read_exactly(uint64_t pos, size_t len, io_intent* intent = nullptr) noexcept {
-        return dma_read_exactly_impl(pos, len, internal::maybe_priority_class_ref(), intent).then([] (temporary_buffer<uint8_t> t) {
+        return dma_read_exactly_impl(pos, len, intent).then([] (temporary_buffer<uint8_t> t) {
             return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
         });
     }
@@ -345,7 +345,7 @@ public:
     /// Note that for this overload, \ref disk_read_max_length corresponds to the sum of
     /// the iovec sizes.
     future<size_t> dma_read(uint64_t pos, std::vector<iovec> iov, io_intent* intent = nullptr) noexcept {
-        return dma_read_impl(pos, std::move(iov), internal::maybe_priority_class_ref(), intent);
+        return dma_read_impl(pos, std::move(iov), intent);
     }
 
     /// Performs a DMA write from the specified buffer.
@@ -360,7 +360,7 @@ public:
     ///         write may happen due to an I/O error.
     template <typename CharType>
     future<size_t> dma_write(uint64_t pos, const CharType* buffer, size_t len, io_intent* intent = nullptr) noexcept {
-        return dma_write_impl(pos, reinterpret_cast<const uint8_t*>(buffer), len, internal::maybe_priority_class_ref(), intent);
+        return dma_write_impl(pos, reinterpret_cast<const uint8_t*>(buffer), len, intent);
     }
 
     /// Performs a DMA write to the specified iovec.
@@ -376,7 +376,7 @@ public:
     /// Note that for this overload, \ref disk_write_max_length corresponds to the sum of
     /// the iovec sizes.
     future<size_t> dma_write(uint64_t pos, std::vector<iovec> iov, io_intent* intent = nullptr) noexcept {
-        return dma_write_impl(pos, std::move(iov), internal::maybe_priority_class_ref(), intent);
+        return dma_write_impl(pos, std::move(iov), intent);
     }
 
     /// Causes any previously written data to be made stable on persistent storage.
@@ -535,7 +535,7 @@ public:
     template <typename CharType>
     future<temporary_buffer<CharType>>
     dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent = nullptr) noexcept {
-        return dma_read_bulk_impl(offset, range_size, internal::maybe_priority_class_ref(), intent).then([] (temporary_buffer<uint8_t> t) {
+        return dma_read_bulk_impl(offset, range_size, intent).then([] (temporary_buffer<uint8_t> t) {
             return temporary_buffer<CharType>(reinterpret_cast<CharType*>(t.get_write()), t.size(), t.release());
         });
     }
@@ -551,25 +551,25 @@ public:
     file_handle dup();
 private:
     future<temporary_buffer<uint8_t>>
-    dma_read_bulk_impl(uint64_t offset, size_t range_size, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_read_bulk_impl(uint64_t offset, size_t range_size, io_intent* intent) noexcept;
 
     future<size_t>
-    dma_write_impl(uint64_t pos, const uint8_t* buffer, size_t len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_write_impl(uint64_t pos, const uint8_t* buffer, size_t len, io_intent* intent) noexcept;
 
     future<size_t>
-    dma_write_impl(uint64_t pos, std::vector<iovec> iov, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_write_impl(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept;
 
     future<temporary_buffer<uint8_t>>
-    dma_read_impl(uint64_t pos, size_t len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_read_impl(uint64_t pos, size_t len, io_intent* intent) noexcept;
 
     future<size_t>
-    dma_read_impl(uint64_t aligned_pos, uint8_t* aligned_buffer, size_t aligned_len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_read_impl(uint64_t aligned_pos, uint8_t* aligned_buffer, size_t aligned_len, io_intent* intent) noexcept;
 
     future<size_t>
-    dma_read_impl(uint64_t pos, std::vector<iovec> iov, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_read_impl(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept;
 
     future<temporary_buffer<uint8_t>>
-    dma_read_exactly_impl(uint64_t pos, size_t len, internal::maybe_priority_class_ref pc, io_intent* intent) noexcept;
+    dma_read_exactly_impl(uint64_t pos, size_t len, io_intent* intent) noexcept;
 
     future<uint64_t> get_lifetime_hint_impl(int op) noexcept;
     future<> set_lifetime_hint_impl(int op, uint64_t hint) noexcept;

--- a/include/seastar/core/io_priority_class.hh
+++ b/include/seastar/core/io_priority_class.hh
@@ -38,9 +38,4 @@ using io_priority_class_id = unsigned;
 
 SEASTAR_MODULE_EXPORT_END
 
-namespace internal {
-struct maybe_priority_class_ref {
-};
-}
-
 } // namespace seastar

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -67,12 +67,10 @@ using io_group_ptr = std::shared_ptr<io_group>;
 using iovec_keeper = std::vector<::iovec>;
 
 namespace internal {
-struct maybe_priority_class_ref;
 class priority_class {
     unsigned _id;
 public:
     explicit priority_class(const scheduling_group& sg) noexcept;
-    explicit priority_class(internal::maybe_priority_class_ref pc) noexcept;
     unsigned id() const noexcept { return _id; }
 };
 }
@@ -203,10 +201,8 @@ public:
 
     stream_id request_stream(internal::io_direction_and_length dnl) const noexcept;
 
-    future<size_t> submit_io_read(internal::priority_class priority_class,
-            size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
-    future<size_t> submit_io_write(internal::priority_class priority_class,
-            size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
+    future<size_t> submit_io_read(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
+    future<size_t> submit_io_write(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs = {}) noexcept;
 
     void submit_request(io_desc_read_write* desc, internal::io_request req) noexcept;
     void cancel_request(queued_io_request& req) noexcept;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -374,9 +374,6 @@ namespace internal {
 priority_class::priority_class(const scheduling_group& sg) noexcept : _id(internal::scheduling_group_index(sg))
 { }
 
-priority_class::priority_class(internal::maybe_priority_class_ref pc) noexcept : priority_class(current_scheduling_group())
-{ }
-
 cancellable_queue::cancellable_queue(cancellable_queue&& o) noexcept
         : _first(std::exchange(o._first, nullptr))
         , _rest(std::move(o._rest)) {
@@ -998,14 +995,16 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
     });
 }
 
-future<size_t> io_queue::submit_io_read(internal::priority_class pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+future<size_t> io_queue::submit_io_read(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+    internal::priority_class pc = internal::priority_class(current_scheduling_group());
     auto& io_stats = reactor::io_stats::local();
     ++io_stats.aio_reads;
     io_stats.aio_read_bytes += len;
     return queue_request(std::move(pc), io_direction_and_length(io_direction_read, len), std::move(req), intent, std::move(iovs));
 }
 
-future<size_t> io_queue::submit_io_write(internal::priority_class pc, size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+future<size_t> io_queue::submit_io_write(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+    internal::priority_class pc = internal::priority_class(current_scheduling_group());
     auto& io_stats = reactor::io_stats::local();
     ++io_stats.aio_writes;
     io_stats.aio_write_bytes += len;

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -82,7 +82,7 @@ public:
     future<> put(temporary_buffer<char> buf) override {
         size_t buf_size = buf.size();
         auto req = internal::io_request::make_write(_fd.get(), 0, buf.get(), buf_size, false);
-        return _io_queue.submit_io_write(internal::priority_class(internal::maybe_priority_class_ref()), buf_size, std::move(req), nullptr).then(
+        return _io_queue.submit_io_write(buf_size, std::move(req), nullptr).then(
             [this, buf = std::move(buf), buf_size] (size_t written) mutable {
                 if (written < buf_size) {
                     buf.trim_front(written);


### PR DESCRIPTION
In the old days priority class to do IO in was passed as explicit argument to file API methods. Later the new API level was introduced that made IO code pick current_scheduling_group as the priority class to do IO in.

To make both levels co-exist in the same code there appeared that maybe_priority_class_ref marker that instructed io_queue methods where to pick priority class from -- current sched group or the explicit argument.

Recently the older API level was removed [1], so the marker is not needed any longer. In the end of the day, io_queue code can just pick current_scheduling_group() for its internal::priority_class and that's it.

[1] 3e07190e3d (file, scheduling: remove non-unified I/O and CPU scheduling)