### PR TITLE
exceptions: log thrown and propagated exception with distinct log levels

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -43,6 +43,7 @@
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
+#include <seastar/util/log-level.hh>
 
 namespace seastar {
 
@@ -1890,7 +1891,7 @@ future<T> current_exception_as_future() noexcept {
     return future<T>(future_state_base::current_exception_future_marker());
 }
 
-void log_exception_trace() noexcept;
+void log_exception_trace(log_level level) noexcept;
 
 /// \brief Creates a \ref future in an available, failed state.
 ///
@@ -1901,7 +1902,7 @@ void log_exception_trace() noexcept;
 template <typename T, typename Exception>
 inline
 future<T> make_exception_future(Exception&& ex) noexcept {
-    log_exception_trace();
+    log_exception_trace(log_level::trace);
     return make_exception_future<T>(std::make_exception_ptr(std::forward<Exception>(ex)));
 }
 

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -98,7 +98,7 @@ template<typename T>
 [[deprecated("Use co_await coroutine::return_exception_ptr or co_return coroutine::exception instead")]]
 [[nodiscard]]
 exception make_exception(T&& t) noexcept {
-    log_exception_trace();
+    log_exception_trace(log_level::trace);
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 
@@ -148,7 +148,7 @@ inline exception return_exception(std::exception_ptr ex) noexcept {
 template<typename T>
 [[nodiscard]]
 exception return_exception(T&& t) noexcept {
-    log_exception_trace();
+    log_exception_trace(log_level::trace);
     return exception(std::make_exception_ptr(std::forward<T>(t)));
 }
 

--- a/include/seastar/util/log-level.hh
+++ b/include/seastar/util/log-level.hh
@@ -1,0 +1,62 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2025 Cloudius Systems, Ltd.
+ */
+#pragma once
+
+#include <seastar/util/modules.hh>
+
+#ifndef SEASTAR_MODULE
+#include <iosfwd>
+#include <fmt/core.h>
+#endif
+
+/// \addtogroup logging
+/// @{
+
+namespace seastar {
+
+SEASTAR_MODULE_EXPORT_BEGIN
+
+/// \brief log level used with \see {logger}
+/// used with the logger.do_log method.
+/// Levels are in increasing order. That is if you want to see debug(3) logs you
+/// will also see error(0), warn(1), info(2).
+///
+enum class log_level {
+    error,
+    warn,
+    info,
+    debug,
+    trace,
+};
+
+std::ostream& operator<<(std::ostream& out, log_level level);
+std::istream& operator>>(std::istream& in, log_level& level);
+
+SEASTAR_MODULE_EXPORT_END
+}
+
+template <>
+struct fmt::formatter<seastar::log_level> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(seastar::log_level level, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+/// @}

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log-impl.hh>
+#include <seastar/util/log-level.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
@@ -42,34 +43,6 @@
 /// \addtogroup logging
 /// @{
 
-namespace seastar {
-
-SEASTAR_MODULE_EXPORT_BEGIN
-
-/// \brief log level used with \see {logger}
-/// used with the logger.do_log method.
-/// Levels are in increasing order. That is if you want to see debug(3) logs you
-/// will also see error(0), warn(1), info(2).
-///
-enum class log_level {
-    error,
-    warn,
-    info,
-    debug,
-    trace,
-};
-
-std::ostream& operator<<(std::ostream& out, log_level level);
-std::istream& operator>>(std::istream& in, log_level& level);
-
-SEASTAR_MODULE_EXPORT_END
-}
-
-template <>
-struct fmt::formatter<seastar::log_level> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    auto format(seastar::log_level level, fmt::format_context& ctx) const -> decltype(ctx.out());
-};
 
 namespace seastar {
 SEASTAR_MODULE_EXPORT_BEGIN

--- a/src/core/exception_hacks.cc
+++ b/src/core/exception_hacks.cc
@@ -131,16 +131,16 @@ void internal::increase_thrown_exceptions_counter() noexcept {
 #ifndef NO_EXCEPTION_INTERCEPT
 seastar::logger exception_logger("exception");
 
-void log_exception_trace() noexcept {
+void log_exception_trace(seastar::log_level level) noexcept {
     static thread_local bool nested = false;
-    if (!nested && exception_logger.is_enabled(log_level::trace)) {
+    if (!nested && exception_logger.is_enabled(level)) {
         nested = true;
-        exception_logger.trace("Throw exception at:\n{}", current_backtrace());
+        exception_logger.log(level, "Throw exception at:\n{}", current_backtrace());
         nested = false;
     }
 }
 #else
-void log_exception_trace() noexcept {}
+void log_exception_trace(seastar::log_level) noexcept {}
 #endif
 
 }
@@ -184,7 +184,7 @@ int _Unwind_RaiseException(struct ::_Unwind_Exception *h) {
     }
     if (seastar::local_engine) {
         seastar::internal::increase_thrown_exceptions_counter();
-        seastar::log_exception_trace();
+        seastar::log_exception_trace(seastar::log_level::debug);
     }
     return org(h);
 }


### PR DESCRIPTION
Log thrown exceptions with debug and propagated (via future) exceptions with trace levels. Allows seprately logging just thrown exceptions, which are the actual bad ones, hurting performance.