### PR TITLE
Add fixture support for seastar::testing

### DIFF
--- a/include/seastar/testing/test_fixture.hh
+++ b/include/seastar/testing/test_fixture.hh
@@ -1,0 +1,184 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <functional>
+
+#include <seastar/core/future.hh> // IWYU pragma: keep
+#include <seastar/core/thread.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/testing/seastar_test.hh>
+#include <seastar/testing/test_runner.hh>
+
+namespace seastar::testing {
+namespace detail {
+
+    template<typename T>
+future<> conditional_invoke_setup(T& t) {
+    if constexpr (boost::unit_test::impl_fixture::has_setup<T>::value) {
+        return futurize_invoke(std::mem_fn(&T::setup), t);
+    }
+    return make_ready_future<>();
+}
+
+template<typename T>
+future<> conditional_invoke_teardown(T& t) {
+    if constexpr (boost::unit_test::impl_fixture::has_teardown<T>::value) {
+        return futurize_invoke(std::mem_fn(&T::teardown), t);
+    }
+    return make_ready_future<>();
+}
+void warn_teardown_exception(const sstring&, std::exception_ptr);
+
+template<typename Func, typename T>
+requires std::is_invocable_v<Func, T>
+future<> do_fixture_test(Func&& f, T& t, const sstring& name) {
+    return conditional_invoke_setup(t).then([f = std::forward<Func>(f), &t]() mutable {
+        return futurize_invoke(std::forward<Func>(f), t);
+    }).finally([&]() {
+        return conditional_invoke_teardown(t).handle_exception([&](auto ep) {
+            warn_teardown_exception(name, ep);
+        });
+    });
+}
+} // detail
+
+// holder for decorator based fixture using class
+template<typename F>
+class async_class_based_fixture : public boost::unit_test::test_unit_fixture {
+public:
+    template<typename... Args>
+    requires std::is_constructible_v<F, const Args&...>
+    async_class_based_fixture(Args&& ...args)
+        : _create([args = std::make_tuple(std::forward<Args>(args)...)] { 
+            return std::apply([](auto&& ...args) {
+                return std::make_unique<F>(args...); 
+            }, args);
+        })
+    {}
+private:
+    // Fixture interface
+    void setup() override { 
+        // create and possibly init the fixture object in reactor, on the
+        // test thread.
+        global_test_runner().run_sync([this] {
+            _inst = _create();
+            return detail::conditional_invoke_setup(*_inst);
+        });
+    }
+    void teardown() override { 
+        // possibly de-init and destroy the fixture object in reactor, on the
+        // test thread.
+        global_test_runner().run_sync([this] {
+            auto inst = std::exchange(_inst, {});
+            return detail::conditional_invoke_teardown(*inst).finally([inst = std::move(inst)] {});
+        });
+    }
+    // Data members
+    std::unique_ptr<F> _inst;
+    std::function<std::unique_ptr<F>()> _create;
+};
+
+using fixture_function = std::function<future<>()>;
+
+// holder for decorator based fixture using functions
+class async_function_based_fixture : public boost::unit_test::test_unit_fixture {
+public:
+    async_function_based_fixture(fixture_function setup, fixture_function teardown)
+        : _setup(std::move(setup))
+        , _teardown(std::move(teardown))
+    {}
+private:
+    // Fixture interface
+    void setup() override { 
+        if (_setup) {
+            // run in reactor thread
+            global_test_runner().run_sync([this] {
+                return _setup();
+            });
+        }
+    }
+    void teardown() override {
+        if (_teardown) {
+            // run in reactor thread
+            global_test_runner().run_sync([this] {
+                return _teardown();
+            });
+        }
+    }
+    fixture_function _setup, _teardown;
+};
+
+// our versions of "fixture" in boost. only differs in decorator used
+template<typename F, typename... Args>
+requires std::is_constructible_v<F, const Args&...>
+inline boost::unit_test::decorator::fixture_t async_fixture(Args&& ...args) {
+    return boost::unit_test::decorator::fixture_t(
+        boost::unit_test::test_unit_fixture_ptr(new async_class_based_fixture<F>(std::forward<Args>(args)...))
+    );
+}
+inline boost::unit_test::decorator::fixture_t async_fixture(fixture_function setup, fixture_function teardown) {
+    return boost::unit_test::decorator::fixture_t(
+        boost::unit_test::test_unit_fixture_ptr(new async_function_based_fixture(std::move(setup), std::move(teardown)))
+    );
+}
+template<typename F1, typename F2>
+requires (std::is_invocable_v<F1> && std::is_invocable_v<F2>)
+inline boost::unit_test::decorator::fixture_t async_func_fixture(F1 setup, F2 teardown) {
+    return boost::unit_test::decorator::fixture_t(
+        boost::unit_test::test_unit_fixture_ptr(new async_function_based_fixture(std::move(setup), std::move(teardown)))
+    );
+}
+}
+
+// macro for using a base-class type fixture with async setup/teardown
+// this just piggy-backs on normal seastar test case.
+#define SEASTAR_FIXTURE_TEST_CASE(name, F, ...)                     \
+    struct name ## _fxt : public F {                                \
+        seastar::future<> run_test_case() const;                    \
+    };                                                              \
+    SEASTAR_TEST_CASE(name, ##__VA_ARGS__) {                        \
+        namespace td =  seastar::testing::detail;                   \
+        using type = name ## _fxt;                                  \
+        auto t = std::make_unique<type>();                          \
+        return td::do_fixture_test(                                 \
+                std::mem_fn(&type::run_test_case), *t, #F           \
+            ).finally([t = std::move(t)] {});                       \
+    }                                                               \
+    seastar::future<> name ## _fxt::run_test_case() const
+
+#define SEASTAR_FIXTURE_THREAD_TEST_CASE(name, F, ...)              \
+    struct name ## _fxt : public F {                                \
+        void run_test_case() const;                                 \
+    };                                                              \
+    SEASTAR_TEST_CASE(name, ##__VA_ARGS__) {                        \
+        return seastar::async([] {                                  \
+            namespace td =  seastar::testing::detail;               \
+            using type = name ## _fxt;                              \
+            type t;                                                 \
+            td::do_fixture_test(                                    \
+                std::mem_fn(&type::run_test_case), t, #F            \
+                ).get();                                            \
+        });                                                         \
+    }                                                               \
+    void name ## _fxt::run_test_case() const

--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -25,6 +25,7 @@
 
 #include <seastar/testing/entry_point.hh>
 #include <seastar/testing/seastar_test.hh>
+#include <seastar/testing/test_fixture.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/on_internal_error.hh>
@@ -104,6 +105,10 @@ scoped_no_abort_on_internal_error::scoped_no_abort_on_internal_error() noexcept
 
 scoped_no_abort_on_internal_error::~scoped_no_abort_on_internal_error() {
     set_abort_on_internal_error(_prev);
+}
+
+void detail::warn_teardown_exception(const sstring& name, std::exception_ptr e) {
+    std::cerr << "Warning! Exception in fixture " << name << "::teardown. " << e << std::endl;
 }
 
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -808,3 +808,7 @@ set_tests_properties (Seastar.unit.prometheus
 seastar_add_test (gate
   SOURCES
     gate_test.cc)
+
+seastar_add_test (test_fixture
+  SOURCES
+    test_fixture_test.cc)

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -1,0 +1,126 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB Ltd.
+ */
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/test_fixture.hh>
+
+using namespace seastar;
+using namespace seastar::testing;
+
+struct AsyncTestFixture {
+    bool inited = false;
+    bool destroyed = false;
+
+    ~AsyncTestFixture() {
+        BOOST_REQUIRE(destroyed);
+    }
+    future<> setup() {
+        inited = true;
+        return make_ready_future<>();
+    }
+    future<> teardown() {
+        destroyed = true;
+        return make_ready_future<>();
+    }
+};
+
+SEASTAR_FIXTURE_TEST_CASE(test_single_test_fixture, AsyncTestFixture) {
+    BOOST_REQUIRE(inited);
+    return make_ready_future<>();
+}
+
+struct SyncTestFixture {
+    bool inited = false;
+    bool destroyed = false;
+
+    ~SyncTestFixture() {
+        BOOST_REQUIRE(destroyed);
+    }
+    void setup() {
+        inited = true;
+    }
+    void teardown() {
+        destroyed = true;
+    }
+};
+
+SEASTAR_FIXTURE_TEST_CASE(test_single_test_fixture_void_ret, SyncTestFixture) {
+    BOOST_REQUIRE(inited);
+    return make_ready_future<>();
+}
+
+SEASTAR_FIXTURE_THREAD_TEST_CASE(test_single_thread_test_fixture_void_ret, SyncTestFixture) {
+    BOOST_REQUIRE(inited);
+}
+
+// having these thread local subtly verifies that the fixture 
+// is run on the proper shard.
+static thread_local int num_shared_test_fixts_setup = 0;
+static thread_local int num_shared_test_fixts_teardown = 0;
+static thread_local std::string shared_test_fixts_string;
+
+struct SharedTestFixture { 
+    SharedTestFixture()
+    {}
+    SharedTestFixture(const std::string& s)
+    {
+        shared_test_fixts_string = s;
+    }
+    future<> setup() {
+        ++num_shared_test_fixts_setup;
+        return make_ready_future<>();
+    }
+    future<> teardown() {
+        ++num_shared_test_fixts_teardown;
+        shared_test_fixts_string = {};
+        return make_ready_future<>();
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(shared_fixtures, 
+    *async_fixture<SharedTestFixture>()
+    *async_fixture<SharedTestFixture>("los lobos")
+    *async_fixture(
+        [] { ++num_shared_test_fixts_setup; return make_ready_future<>(); },
+        [] { ++num_shared_test_fixts_teardown; return make_ready_future<>(); }
+    )
+)
+
+SEASTAR_TEST_CASE(test_shared_fixture1) {
+    BOOST_REQUIRE(num_shared_test_fixts_setup == 3);
+    BOOST_REQUIRE(num_shared_test_fixts_teardown == 0);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_shared_fixture2) {
+    BOOST_REQUIRE(num_shared_test_fixts_setup == 3);
+    BOOST_REQUIRE(num_shared_test_fixts_teardown == 0);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_shared_fixture_init_value) {
+    BOOST_REQUIRE(shared_test_fixts_string != "");
+    BOOST_TEST_MESSAGE(shared_test_fixts_string);
+    return make_ready_future<>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #2947

Adds decorator level fixture handlers that delegate creation and setup/teardown of the objects to test thread. Also allows for async setup/teardown, thus using seastar API:s in them works.

Also adds new test case macro for mix-in fixture (inherited type), also supporting optional async setup/teardown.