### PR TITLE
task: Move task::get_backtrace() definition in its class

### DIFF
--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -54,22 +54,14 @@ public:
     /// Returns the next task which is waiting for this task to complete execution, or nullptr.
     virtual task* waiting_task() noexcept = 0;
     scheduling_group group() const { return _sg; }
-    shared_backtrace get_backtrace() const;
 #ifdef SEASTAR_TASK_BACKTRACE
     void make_backtrace() noexcept;
+    shared_backtrace get_backtrace() const { return _bt; }
 #else
     void make_backtrace() noexcept {}
+    shared_backtrace get_backtrace() const { return {}; }
 #endif
 };
-
-inline
-shared_backtrace task::get_backtrace() const {
-#ifdef SEASTAR_TASK_BACKTRACE
-    return _bt;
-#else
-    return {};
-#endif
-}
 
 SEASTAR_MODULE_EXPORT_BEGIN
 


### PR DESCRIPTION
Much shorter this way. All the more so the corresponding ifdef also controls the peer make_backtrace() declaration and definition.