### PR TITLE
cleanup: Missing pragma and licence

### DIFF
--- a/include/seastar/util/read_first_line.hh
+++ b/include/seastar/util/read_first_line.hh
@@ -1,3 +1,6 @@
+
+#pragma once
+
 #include <filesystem>
 #include <seastar/core/sstring.hh>
 #ifndef SEASTAR_MODULE

--- a/include/seastar/util/read_first_line.hh
+++ b/include/seastar/util/read_first_line.hh
@@ -1,3 +1,23 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2018 ScyllaDB Ltd.
+ */
 
 #pragma once
 


### PR DESCRIPTION
Add missing `#pragma once` and the license boilerplate to the `read_first_line.hh` header