### PR TITLE
Improve io_tester's seqwrite and append workloads

### DIFF
--- a/apps/io_tester/conf.yaml
+++ b/apps/io_tester/conf.yaml
@@ -1,6 +1,6 @@
 - name: big_writes
   shards: all
-  type: seqwrite
+  type: overwrite
   shard_info:
     parallelism: 10
     reqsize: 256kB

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -611,7 +611,7 @@ private:
         }
         file_open_options options;
         options.extent_allocation_size_hint = _config.extent_allocation_size_hint.value_or(_config.file_size);
-        options.append_is_unlikely = true;
+        options.append_is_unlikely = (req_type() != request_type::append);
 
         return create_and_fill_file(fname, _config.file_size, flags, options, req_type() != request_type::append).then([this](file f) {
             _file = std::move(f);

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -72,7 +72,7 @@ static auto random_seed = std::chrono::duration_cast<std::chrono::microseconds>(
 static thread_local std::default_random_engine random_generator(random_seed);
 
 class context;
-enum class request_type { seqread, seqwrite, randread, randwrite, append, cpu, unlink };
+enum class request_type { seqread, overwrite, randread, randwrite, append, cpu, unlink };
 
 namespace std {
 
@@ -414,7 +414,7 @@ public:
     // unlink them. So every job (a class in a shard) will have its own file(s) and will operate differently depending on the type:
     //
     // sequential reads  : will read the file from pos = 0 onwards, back to 0 on EOF
-    // sequential writes : will write the file from pos = 0 onwards, back to 0 on EOF
+    // overwrites        : will write the file from pos = 0 onwards, back to 0 on EOF
     // random reads      : will read the file at random positions, between 0 and EOF
     // random writes     : will overwrite the file at a random position, between 0 and EOF
     // append            : will write to the file from pos = EOF onwards, always appending to the end.
@@ -444,7 +444,7 @@ protected:
     sstring type_str() const {
         return std::unordered_map<request_type, sstring>{
             { request_type::seqread, "SEQ READ" },
-            { request_type::seqwrite, "SEQ WRITE" },
+            { request_type::overwrite, "OVERWRITE" },
             { request_type::randread, "RAND READ" },
             { request_type::randwrite, "RAND WRITE" },
             { request_type::append , "APPEND" },
@@ -518,7 +518,7 @@ protected:
     }
 
     bool is_sequential() const {
-        return (req_type() == request_type::seqread) || (req_type() == request_type::seqwrite);
+        return (req_type() == request_type::seqread) || (req_type() == request_type::overwrite);
     }
     bool is_random() const {
         return (req_type() == request_type::randread) || (req_type() == request_type::randwrite);
@@ -935,7 +935,7 @@ struct convert<request_type> {
     static bool decode(const Node& node, request_type& rt) {
         static std::unordered_map<std::string, request_type> mappings = {
             { "seqread", request_type::seqread },
-            { "seqwrite", request_type::seqwrite},
+            { "overwrite", request_type::overwrite},
             { "randread", request_type::randread },
             { "randwrite", request_type::randwrite },
             { "append", request_type::append},

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -545,9 +545,6 @@ protected:
         });
     }
 
-    bool is_sequential() const {
-        return (req_type() == request_type::seqread) || (req_type() == request_type::overwrite);
-    }
     bool is_random() const {
         return (req_type() == request_type::randread) || (req_type() == request_type::randwrite);
     }
@@ -558,8 +555,10 @@ protected:
             pos = _pos_distribution(random_generator) * req_size();
         } else {
             pos = _last_pos + req_size();
-            if (is_sequential() && (pos >= _config.file_size)) {
-                pos = 0;
+            if (pos >= _config.file_size) {
+                if (req_type() != request_type::append) {
+                    pos = 0;
+                }
             }
         }
         _last_pos = pos;

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -529,6 +529,7 @@ public:
 class io_class_data : public class_data {
     uint64_t _last_pos = 0;
     uint64_t _offset = 0;
+    unsigned _overflows = 0;
     std::uniform_int_distribution<uint32_t> _pos_distribution;
 protected:
     bool _is_dev_null = false;
@@ -556,6 +557,7 @@ protected:
         } else {
             pos = _last_pos + req_size();
             if (pos >= _config.file_size) {
+                _overflows++;
                 if (req_type() != request_type::append) {
                     pos = 0;
                 }
@@ -707,6 +709,7 @@ public:
         }
         out << YAML::Key << "max" << YAML::Value << (unsigned)max(_disk_queue_lengths);
         out << YAML::EndMap;
+        out << YAML::Key << "file_size_overflows" << YAML::Value << _overflows;
         out << YAML::EndMap;
     }
 };


### PR DESCRIPTION
The PR does several things with the aforementioned workload types.

First, it fixes the way APPEND interacts with file-size parameter. Nowadays the append fills a file and then starts appending data to it, which is weird -- pre-filling data is thus pretty pointless. After this PR append will start from position of zero all the time and not fill the file beforehand. The configured file size will only be used to truncate the file to that size. Note, that append workload is _not_ O_APPEND and it will write into file from start to end regardless of its size.

Also the PR renames "seqwrite" workload into "overwrite", because strictly speaking "append" is also sequential write. So this new "overwrite" name better explains what the workload type is about.

And, while at it, coroutinizes some code and tosses fields and methods between class_data and io_class_data.