### PR TITLE
http: Introduce retry strategy machinery for http client (take two)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -720,6 +720,7 @@ add_library (seastar
   src/http/url.cc
   src/http/client.cc
   src/http/request.cc
+  src/http/retry_strategy.cc
   src/json/formatter.cc
   src/json/json_elements.cc
   src/net/arp.cc

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -278,6 +278,24 @@ public:
     future<> make_request(request&& req, reply_handler&& handle, std::optional<reply::status_type>&& expected = std::nullopt, abort_source* as = nullptr);
 
     /**
+     * \brief Send the request and handle the response with retry strategy
+     *
+     * Same as \ref make_request()
+     * The retry strategy defines how the client should behave in case of transient failures.
+     *
+     * \param req -- request to be sent
+     * \param handle -- the response handler
+     * \param strategy -- retry strategy to apply on transient failures
+     * \param expected -- the optional expected reply status code, default is std::nullopt
+     * \param as -- abort source that aborts the request
+     *
+     * Note that the handle callback should be prepared to be called more than once, because
+     * client may restart the whole request processing in case server closes the connection
+     * in the middle of operation
+     */
+    future<> make_request(request&& req, reply_handler&& handle, const retry_strategy& strategy, std::optional<reply::status_type>&& expected = std::nullopt, abort_source* as = nullptr);
+
+    /**
      * \brief Send the request and handle the response (abortable), same as \ref make_request()
      *
      *  @attention Note that the method does not take the ownership of the
@@ -285,6 +303,24 @@ public:
      * are referencing valid instances
      */
     future<> make_request(const request& req, reply_handler& handle, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
+
+    /**
+     * \brief Send the request and handle the response with retry strategy (abortable), same as \ref make_request()
+     *
+     * Same as \ref make_request()
+     * The retry strategy defines how the client should behave in case of transient failures.
+     *
+     * \param req -- request to be sent (non-owning reference)
+     * \param handle -- the response handler (non-owning reference)
+     * \param strategy -- retry strategy to apply on transient failures
+     * \param expected -- the optional expected reply status code, default is std::nullopt
+     * \param as -- abort source that aborts the request
+     *
+     * @attention Note that the method does not take the ownership of the
+     * `request` and the `handle`, it is the caller's responsibility to ensure they
+     * are referencing valid instances
+     */
+    future<> make_request(const request& req, reply_handler& handle, const retry_strategy& strategy, std::optional<reply::status_type> expected = std::nullopt, abort_source* as = nullptr);
 
     /**
      * \brief Updates the maximum number of connections a client may have

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -27,6 +27,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/http/connection_factory.hh>
 #include <seastar/http/reply.hh>
+#include <seastar/http/retry_strategy.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/modules.hh>
@@ -163,7 +164,7 @@ private:
     unsigned _max_connections;
     size_t _max_bytes_to_drain;
     unsigned long _total_new_connections = 0;
-    const retry_requests _retry;
+    std::unique_ptr<retry_strategy> _retry_strategy;
     condition_variable _wait_con;
     connections_list_t _pool;
 
@@ -180,6 +181,14 @@ private:
     template <typename Fn>
     requires std::invocable<Fn, connection&>
     auto with_new_connection(Fn&& fn, abort_source*);
+
+    future<> maybe_retry_request(std::exception_ptr ex,
+                                 unsigned retry_count,
+                                 const request& req,
+                                 reply_handler& handle,
+                                 const retry_strategy& strategy,
+                                 std::optional<reply::status_type> expected,
+                                 abort_source* as);
 
     future<> do_make_request(connection& con, const request& req, reply_handler& handle, abort_source*, std::optional<reply::status_type> expected);
 
@@ -218,7 +227,7 @@ public:
      * \param f -- the factory pointer
      * \param max_connections -- maximum number of connection a client is allowed to maintain
      * (both active and cached in pool)
-     * \param retry -- whether or not to retry requests on connection IO errors
+     * \param retry_strategy -- optional custom logic for retrying failed requests
      *
      * The client uses connections provided by factory to send requests over and receive responses
      * back. Once request-response cycle is over the connection used for that is kept by a client
@@ -247,6 +256,7 @@ public:
      * second attempt fails, this error is reported back to user.
      */
     explicit client(std::unique_ptr<connection_factory> f, unsigned max_connections = default_max_connections, retry_requests retry = retry_requests::no, size_t max_bytes_to_drain = default_max_bytes_to_drain);
+    client(std::unique_ptr<connection_factory> f, unsigned max_connections, size_t max_bytes_to_drain, std::unique_ptr<retry_strategy>&& retry_strategy);
 
     /**
      * \brief Send the request and handle the response

--- a/include/seastar/http/retry_strategy.hh
+++ b/include/seastar/http/retry_strategy.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+#include <seastar/core/future.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/util/modules.hh>
+
+namespace seastar {
+SEASTAR_MODULE_EXPORT_BEGIN
+
+namespace http::experimental {
+
+class retry_strategy {
+public:
+    virtual ~retry_strategy() = default;
+    // Returns true if the error can be retried given the error and the number of times already tried.
+    virtual future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const = 0;
+};
+
+class default_retry_strategy final : public retry_strategy {
+    unsigned _max_retries;
+
+public:
+    default_retry_strategy();
+    explicit default_retry_strategy(unsigned max_retries);
+
+    future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+};
+
+class no_retry_strategy final : public retry_strategy {
+public:
+    future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+};
+} // namespace http::experimental
+
+SEASTAR_MODULE_EXPORT_END
+} // namespace seastar

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources (seastar-module
     http/mime_types.cc
     http/reply.cc
     http/request.cc
+    http/retry_strategy.cc
     http/routes.cc
     http/transformers.cc
     http/url.cc

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -23,6 +23,7 @@
 module;
 #endif
 
+#include <cassert>
 #include <concepts>
 #include <gnutls/gnutls.h>
 #include <memory>
@@ -41,6 +42,7 @@ module seastar;
 #include <seastar/http/reply.hh>
 #include <seastar/http/response_parser.hh>
 #include <seastar/http/internal/content_source.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/string_utils.hh>
 #endif
@@ -217,12 +219,27 @@ client::client(socket_address addr, shared_ptr<tls::certificate_credentials> cre
 {
 }
 
-client::client(std::unique_ptr<connection_factory> f, unsigned max_connections, retry_requests retry, size_t max_bytes_to_drain)
+static std::unique_ptr<retry_strategy> get_strategy(client::retry_requests retry) {
+    if (retry == client::retry_requests::no) {
+        return std::make_unique<no_retry_strategy>();
+    }
+    return std::make_unique<default_retry_strategy>();
+}
+
+client::client(std::unique_ptr<connection_factory> f, unsigned max_connections, retry_requests retry, size_t max_bytes_to_drain) : client(
+    std::move(f),
+    max_connections,
+    max_bytes_to_drain,
+    get_strategy(retry)) {
+}
+
+client::client(std::unique_ptr<connection_factory> f, unsigned max_connections, size_t max_bytes_to_drain, std::unique_ptr<retry_strategy>&& retry_strategy)
         : _new_connections(std::move(f))
         , _max_connections(max_connections)
         , _max_bytes_to_drain(max_bytes_to_drain)
-        , _retry(retry)
+        , _retry_strategy(std::move(retry_strategy))
 {
+    assert(_retry_strategy);
 }
 
 future<client::connection_ptr> client::get_connection(abort_source* as) {
@@ -321,39 +338,6 @@ future<> client::make_request(request&& req, reply_handler&& handle, std::option
     });
 }
 
-static bool is_retryable_exception(std::exception_ptr ex) {
-    while (ex) {
-        try {
-            std::rethrow_exception(ex);
-        } catch (const std::system_error& sys_err) {
-            auto code = sys_err.code().value();
-            if (code == EPIPE || code == ECONNABORTED || code == ECONNRESET || code == GNUTLS_E_PREMATURE_TERMINATION) {
-                return true;
-            }
-            try {
-                std::rethrow_if_nested(sys_err);
-            } catch (...) {
-                ex = std::current_exception();
-                continue;
-            }
-            return false;
-        } catch (const httpd::response_parsing_exception&) {
-            return true;
-        } catch (const std::exception& e) {
-            try {
-                std::rethrow_if_nested(e);
-            } catch (...) {
-                ex = std::current_exception();
-                continue;
-            }
-            return false;
-        } catch (...) {
-            return false;
-        }
-    }
-    return false;
-}
-
 future<> client::make_request(const request& req, reply_handler& handle, std::optional<reply::status_type> expected, abort_source* as) {
     try {
         validate_request(req);
@@ -366,17 +350,27 @@ future<> client::make_request(const request& req, reply_handler& handle, std::op
         if (as && as->abort_requested()) {
             return make_exception_future<>(as->abort_requested_exception_ptr());
         }
+        return maybe_retry_request(std::move(ex), 0, req, handle, *_retry_strategy, expected, as);
+    });
+}
 
-        if (!_retry || !is_retryable_exception(ex)) {
-            return make_exception_future<>(ex);
+future<> client::maybe_retry_request(std::exception_ptr ex,
+        unsigned retry_count,
+        const request& req,
+        reply_handler& handle,
+        const retry_strategy& strategy,
+        std::optional<reply::status_type> expected,
+        abort_source* as) {
+    return strategy.should_retry(ex, retry_count).then([this, ex = std::move(ex), retry_count, &req, &handle, &strategy, as, expected](bool retry) mutable {
+        if (!retry) {
+            return make_exception_future<>(std::move(ex));
         }
-
-        // The 'con' connection may not yet be freed, so the total connection
-        // count still account for it and with_new_connection() may temporarily
-        // break the limit. That's OK, the 'con' will be closed really soon
-        return with_new_connection([this, &req, &handle, as, expected] (connection& con) {
-            return do_make_request(con, req, handle, as, expected);
-        }, as);
+        return with_new_connection([this, &req, &handle, as, expected](connection& con) {
+                    return do_make_request(con, req, handle, as, expected);
+                },
+                as).handle_exception([this, retry_count, &req, &handle, &strategy, as, expected](std::exception_ptr ex) {
+            return maybe_retry_request(std::move(ex), retry_count + 1, req, handle, strategy, expected, as);
+        });
     });
 }
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -348,22 +348,6 @@ future<> client::make_request(const request& req, reply_handler& handle, std::op
     return make_request(req, handle, *_retry_strategy, expected, as);
 }
 
-future<> client::make_request(const request& req, reply_handler& handle, const retry_strategy& strategy, std::optional<reply::status_type> expected, abort_source* as) {
-    try {
-        validate_request(req);
-    } catch (...) {
-        return current_exception_as_future();
-    }
-    return with_connection([this, &req, &handle, as, expected] (connection& con) {
-        return do_make_request(con, req, handle, as, expected);
-    }, as).handle_exception([this, &req, &handle, &strategy, as, expected] (std::exception_ptr ex) {
-        if (as && as->abort_requested()) {
-            return make_exception_future<>(as->abort_requested_exception_ptr());
-        }
-        return maybe_retry_request(std::move(ex), 0, req, handle, strategy, expected, as);
-    });
-}
-
 future<> client::maybe_retry_request(std::exception_ptr ex,
                                      unsigned retry_count,
                                      const request& req,
@@ -381,6 +365,25 @@ future<> client::maybe_retry_request(std::exception_ptr ex,
                                    as).handle_exception([this, retry_count, &req, &handle, &strategy, as, expected](std::exception_ptr ex) {
             return maybe_retry_request(std::move(ex), retry_count + 1, req, handle, strategy, expected, as);
         });
+    });
+}
+
+future<> client::make_request(const request& req, reply_handler& handle, const retry_strategy& strategy, std::optional<reply::status_type> expected, abort_source* as) {
+    if (as && as->abort_requested()) {
+        return make_exception_future(as->abort_requested_exception_ptr());
+    }
+    try {
+        validate_request(req);
+    } catch (...) {
+        return current_exception_as_future();
+    }
+    return with_connection([this, &req, &handle, as, expected] (connection& con) {
+        return do_make_request(con, req, handle, as, expected);
+    }, as).handle_exception([this, &req, &handle, &strategy, as, expected] (std::exception_ptr ex) {
+        if (as && as->abort_requested()) {
+            return make_exception_future<>(as->abort_requested_exception_ptr());
+        }
+        return maybe_retry_request(std::move(ex), 0, req, handle, strategy, expected, as);
     });
 }
 

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#ifdef SEASTAR_MODULE
+module;
+#endif
+
+#include <chrono>
+#include <coroutine>
+#include <gnutls/gnutls.h>
+
+#ifdef SEASTAR_MODULE
+module seastar;
+#else
+#include <seastar/http/exception.hh>
+#include <seastar/http/retry_strategy.hh>
+#include <seastar/util/short_streams.hh>
+
+#endif
+
+using namespace std::chrono_literals;
+
+namespace seastar {
+extern logger http_log;
+
+namespace http::experimental {
+logger rs_logger("default_http_retry_strategy");
+
+extern bool is_retryable_exception(std::exception_ptr ex);
+
+default_retry_strategy::default_retry_strategy(unsigned max_retries)
+    : _max_retries(max_retries) {
+}
+
+default_retry_strategy::default_retry_strategy()
+    : default_retry_strategy(1) {
+}
+
+future<bool> default_retry_strategy::should_retry(std::exception_ptr error, unsigned attempted_retries) const {
+    if (attempted_retries >= _max_retries) {
+        rs_logger.debug("Retries exhausted. Retry# {}", attempted_retries);
+        co_return false;
+    }
+
+    co_return is_retryable_exception(error);
+}
+
+future<bool> no_retry_strategy::should_retry(std::exception_ptr error, unsigned) const {
+    co_return false;
+}
+
+}
+}


### PR DESCRIPTION
Introduce extensible retry strategy machinery for the HTTP client to simplify adding new retry conditions. Rather than modifying seastar code to support additional error types, users can now provide their own custom implementations of the retry strategy—offering flexibility without repeated code changes.

Fixes: https://github.com/scylladb/seastar/issues/2803

Scylladb based on these changes: https://github.com/scylladb/scylladb/pull/25801