### PR TITLE
tls: Add helper to skip waiting for EOF on shutdown

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -495,6 +495,14 @@ namespace tls {
     future<> force_rehandshake(connected_socket& socket);
 
     /**
+     * Clear the "wait for EOF on shutdown" bit.
+     * Useful if the caller is willing to close the connection immediately
+     * Must be called before socket is shutdown or closed, otherwise it
+     * has no effect
+     */
+    void skip_wait_for_eof_on_shutdown(connected_socket& socket);
+
+    /**
      * Subject alt name types.
     */
     enum class subject_alt_name_type {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1334,6 +1334,9 @@ public:
         }
         return do_handshake_sync(&session::do_force_rehandshake);
     }
+    void skip_wait_for_eof_on_shutdown() {
+        _options.wait_for_eof_on_shutdown = false;
+    }
 
     future<> handshake() {
         // maybe load system certificates before handshake, in case we
@@ -2078,6 +2081,9 @@ public:
     future<> force_rehandshake() {
         return _session->force_rehandshake();
     }
+    void skip_wait_for_eof_on_shutdown() {
+        _session->skip_wait_for_eof_on_shutdown();
+    }
 };
 
 
@@ -2291,6 +2297,9 @@ future<> tls::force_rehandshake(connected_socket& socket) {
     return s->force_rehandshake();
 }
 
+void tls::skip_wait_for_eof_on_shutdown(connected_socket& socket) {
+    get_tls_socket(socket)->skip_wait_for_eof_on_shutdown();
+}
 
 std::string_view tls::format_as(subject_alt_name_type type) {
     switch (type) {


### PR DESCRIPTION
When TLS socket is closed or shutdown, it spawns a background fiber that waits for the EOF on a socket (and kills it after 10 seconds). That behavior is not always welcome, sometimes client want to close the socket instantly.

In S3 client, there's a function that downloads a file. For that, it sends a GET request with large Range header asking for big portion of data in advance. Sometimes, however, the on-going GET request should be closed by the client before all the arriving data is consumed. In that case client calls connected_socket::close() which immediately launches the aforementioned background EOF wait. As a result, the unwanted data arrives on a node, given NIC speed of 100MB/s, up to 1GB can arrive.

At the same time, this early termination is exceptional situlation, normally the socket data is read and if it gets closed, it gets closed cleanly with no data to be waited, so turning this option off by default is probably bad idea to.

This patch proposes the helper that turns the waiting OFF on a live socket. The intented usage are those emerency cases when the socket has to be closed instantly.