### PR TITLE
memory: Remove deprecated enable_abort_on_allocation_failure()

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -167,10 +167,6 @@ internal::numa_layout configure(std::vector<resource::memory> m, bool mbind,
 
 void configure_minimal();
 
-// A deprecated alias for set_abort_on_allocation_failure(true).
-[[deprecated("use set_abort_on_allocation_failure(true) instead")]]
-void enable_abort_on_allocation_failure();
-
 namespace internal {
 
 extern thread_local constinit int abort_on_alloc_failure_suppressed;

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -163,10 +163,6 @@ thread_local constinit int abort_on_alloc_failure_suppressed = 0;
 
 }
 
-void enable_abort_on_allocation_failure() {
-    set_abort_on_allocation_failure(true);
-}
-
 static std::pmr::polymorphic_allocator<char> static_malloc_allocator{std::pmr::get_default_resource()};;
 std::pmr::polymorphic_allocator<char>* malloc_allocator{&static_malloc_allocator};
 


### PR DESCRIPTION
The method was deprecated in favor of set_abort_on_allocation_failure more than 2 years ago (19285ca35f) and can be safely removed now.