### PR TITLE
sharded: Deprecate distributed alias

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -19,7 +19,7 @@
  * Copyright (C) 2017 ScyllaDB
  */
 #include <seastar/core/app-template.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -1133,7 +1133,7 @@ public:
     }
 };
 
-static void show_results(distributed<context>& ctx) {
+static void show_results(sharded<context>& ctx) {
     YAML::Emitter out;
     out << YAML::BeginDoc;
     out << YAML::BeginSeq;
@@ -1163,7 +1163,7 @@ int main(int ac, char** av) {
         ("sched-groups", bpo::value<sstring>(), "YAML file containing scheduling groups configuration")
     ;
 
-    distributed<context> ctx;
+    sharded<context> ctx;
     return app.run(ac, av, [&] {
         return seastar::async([&] {
             auto& opts = app.configuration();

--- a/apps/seawreck/seawreck.cc
+++ b/apps/seawreck/seawreck.cc
@@ -24,7 +24,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/app-template.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/semaphore.hh>
 #include <chrono>
 
@@ -194,7 +194,7 @@ int main(int ac, char** av) {
             return make_ready_future<int>(-1);
         }
 
-        auto http_clients = new distributed<http_client>;
+        auto http_clients = new sharded<http_client>;
 
         // Start http requests on all the cores
         auto started = steady_clock_type::now();

--- a/demos/tcp_sctp_client_demo.cc
+++ b/demos/tcp_sctp_client_demo.cc
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/units.hh>
 
@@ -37,7 +37,7 @@ static int tx_msg_nr = tx_msg_total_size / tx_msg_size;
 static std::string str_txbuf(tx_msg_size, 'X');
 
 class client;
-distributed<client> clients;
+sharded<client> clients;
 
 transport protocol = transport::TCP;
 

--- a/demos/tcp_sctp_server_demo.cc
+++ b/demos/tcp_sctp_server_demo.cc
@@ -22,7 +22,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/temporary_buffer.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
@@ -210,7 +210,7 @@ int main(int ac, char** av) {
                 fmt::print(std::cerr, "Error: no protocols enabled. Use \"--tcp yes\" and/or \"--sctp yes\" to enable\n");
                 return 1;
             }
-            distributed<tcp_server> server;
+            sharded<tcp_server> server;
             server.start().get();
             auto stop_server = deferred_stop(server);
             // Start listening in the background.

--- a/include/seastar/core/distributed.hh
+++ b/include/seastar/core/distributed.hh
@@ -31,7 +31,7 @@ namespace seastar {
 SEASTAR_MODULE_EXPORT_BEGIN
 
 template <typename Service>
-using distributed = sharded<Service>;
+using distributed [[deprecated("Use sharded<T> from sharded.hh instead")]] = sharded<Service>;
 
 SEASTAR_MODULE_EXPORT_END
 

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -51,7 +51,7 @@ future<> start(httpd::http_server_control& http_server, config ctx);
 /// \defgroup add_prometheus_routes adds a /metrics endpoint that returns prometheus metrics
 ///    both in txt format and in protobuf according to the prometheus spec
 /// @{
-future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx);
+future<> add_prometheus_routes(sharded<httpd::http_server>& server, config ctx);
 future<> add_prometheus_routes(httpd::http_server& server, config ctx);
 /// @}
 SEASTAR_MODULE_EXPORT_END

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -31,7 +31,7 @@
 #include <seastar/http/request.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -157,7 +157,7 @@ public:
      *
      * Use case example using seastar threads for clarity:
 
-        distributed<http_server> server; // typical server
+        sharded<http_server> server; // typical server
 
         seastar::shared_ptr<seastar::tls::credentials_builder> creds = seastar::make_shared<seastar::tls::credentials_builder>();
         sstring ms_cert = "MyCertificate.crt";
@@ -231,11 +231,11 @@ public:
  *              });
  */
 class http_server_control {
-    std::unique_ptr<distributed<http_server>> _server_dist;
+    std::unique_ptr<sharded<http_server>> _server_dist;
 private:
     static sstring generate_server_name();
 public:
-    http_server_control() : _server_dist(new distributed<http_server>) {
+    http_server_control() : _server_dist(new sharded<http_server>) {
     }
 
     future<> start(const sstring& name = generate_server_name());
@@ -245,7 +245,7 @@ public:
     future<> listen(socket_address addr, http_server::server_credentials_ptr credentials);
     future<> listen(socket_address addr, listen_options lo);
     future<> listen(socket_address addr, listen_options lo, http_server::server_credentials_ptr credentials);
-    distributed<http_server>& server();
+    sharded<http_server>& server();
 };
 SEASTAR_MODULE_EXPORT_END
 }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -954,7 +954,7 @@ future<> add_prometheus_routes(httpd::http_server& server, config ctx) {
     return make_ready_future<>();
 }
 
-future<> add_prometheus_routes(distributed<httpd::http_server>& server, config ctx) {
+future<> add_prometheus_routes(sharded<httpd::http_server>& server, config ctx) {
     return server.invoke_on_all([ctx](httpd::http_server& s) {
         return add_prometheus_routes(s, ctx);
     });

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -42,7 +42,7 @@ module seastar;
 #include <seastar/core/sstring.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/circular_buffer.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/metrics.hh>
@@ -516,7 +516,7 @@ future<> http_server_control::listen(socket_address addr, listen_options lo, htt
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, http_server::server_credentials_ptr)>(&http_server::listen, addr, lo, credentials);
 }
 
-distributed<http_server>& http_server_control::server() {
+sharded<http_server>& http_server_control::server() {
     return *_server_dist;
 }
 

--- a/src/seastar.cc
+++ b/src/seastar.cc
@@ -178,7 +178,6 @@ export module seastar;
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/deleter.hh>
 #include <seastar/core/disk_params.hh>
-#include <seastar/core/distributed.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/enum.hh>
 #include <seastar/core/exception_hacks.hh>

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -22,8 +22,8 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
-#include <seastar/core/distributed.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/sleep.hh>
 #include <iostream>

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -33,7 +33,6 @@
 #include <seastar/testing/test_runner.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/core/distributed.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/util/assert.hh>

--- a/tests/unit/thread_context_switch_test.cc
+++ b/tests/unit/thread_context_switch_test.cc
@@ -24,7 +24,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/do_with.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sleep.hh>
 #include <fmt/printf.h>
 
@@ -75,7 +75,7 @@ public:
 int main(int ac, char** av) {
     static const auto test_time = 5s;
     return app_template().run_deprecated(ac, av, [] {
-        auto dcstp = std::make_unique<distributed<context_switch_tester>>();
+        auto dcstp = std::make_unique<sharded<context_switch_tester>>();
         auto& dcst = *dcstp;
         return dcst.start().then([&dcst] {
             return dcst.invoke_on_all(&context_switch_tester::begin_measurement);


### PR DESCRIPTION
The distributed<T> was renamed to be sharded<T> long ago (ab7be2890) Encourage people to use the latter name more actively