### PR TITLE
io: Count and export number of AIO retries

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -1145,6 +1145,10 @@ public:
                 cl->emit_results(out);
                 out << YAML::EndMap;
             }
+            out << YAML::Key << "statistics";
+            out << YAML::BeginMap;
+            out << YAML::Key << "aio_retries" << YAML::Value << engine().get_io_stats().aio_retries;
+            out << YAML::EndMap;
             return make_ready_future<>();
         });
     }

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -194,6 +194,7 @@ public:
         uint64_t aio_write_bytes = 0;
         uint64_t aio_outsizes = 0;
         uint64_t aio_errors = 0;
+        uint64_t aio_retries = 0;
         uint64_t fstream_reads = 0;
         uint64_t fstream_read_bytes = 0;
         uint64_t fstream_reads_blocked = 0;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2530,6 +2530,7 @@ void reactor::register_metrics() {
             sm::make_histogram("stalls", sm::description("A histogram of reactor stall durations"), [this] {return _stalls_histogram.to_metrics_histogram();}).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
             // total_operations value:DERIVE:0:U
             sm::make_counter("fsyncs", _fsyncs, sm::description("Total number of fsync operations")),
+            sm::make_counter("aio_retries", _io_stats.aio_retries, sm::description("Total number of IOCB-s re-submitted via thread-pool")),
             // total_operations value:DERIVE:0:U
             io_fallback_counter("aio_fallback", internal::thread_pool_submit_reason::aio_fallback),
             // total_operations value:DERIVE:0:U

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -306,6 +306,7 @@ bool aio_storage_context::reap_completions(bool allow_retry)
         auto iocb = get_iocb(_ev_buffer[i]);
         if (_ev_buffer[i].res == -EAGAIN && allow_retry) {
             set_nowait(*iocb, false);
+            _r._io_stats.aio_retries++;
             _pending_aio_retry.push_back(iocb);
             continue;
         }


### PR DESCRIPTION
The AIO requests may come via two places -- the reactor itself polling
for IO and thread-pool that retries requests that had been rejected by
the kernel on the first try.

This patch counts the latter events and exports them as metrics. The
former can be calculated using existing aio-reads and aio-writes.
