### PR TITLE
co_return to accept same expressions and types as return

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -158,8 +158,8 @@ arg_parser.add_argument('--ldflags', action='store', dest='user_ldflags', defaul
                         help='Extra flags for the linker')
 arg_parser.add_argument('--optflags', action='store', dest='user_optflags', default='',
                         help='Extra optimization flags for the release mode')
-arg_parser.add_argument('--api-level', action='store', dest='api_level', default='9',
-                        help='Compatibility API level (9=latest)')
+arg_parser.add_argument('--api-level', action='store', dest='api_level', default='10',
+                        help='Compatibility API level (10=latest)')
 arg_parser.add_argument('--compiler', action='store', dest='cxx', default='g++',
                         help='C++ compiler path')
 arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc',

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -78,6 +78,10 @@ versions of the API. For example.
      and become a move-only type
    - Seastar_API_LEVEL=9 defines the data_sink_impl::put(span<temporary_buffer>)
      as the new and only method to be implemented
+   - Seastar_API_LEVEL=10 makes co_return and promise.set_value() semantics
+     closer to those of plain C++ return regarding how they convert
+     expressions used as their arguments to the declared type.
+
 
 Applications can use an old API_LEVEL during a transition
 period, fix their code, and move to the new API_LEVEL.
@@ -112,15 +116,15 @@ API Level History
 
 |Level|Introduced |Mandatory|Description                                   |
 |:---:|:---------:|:-------:| -------------------------------------------- |
-| 2   |  2019-07  | 2020-04 | Non-variadic futures in socket::accept()     |
-| 3   |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
-| 4   |  2020-06  | 2023-03 | Non-variadic futures in when_all_succeed()   |
-| 5   |  2020-08  | 2023-03 | future::get() returns std::monostate() instead of void |
-| 6   |  2020-09  | 2023-03 | future<T> instead of future<T...>            |
-| 7   |  2023-05  | 2024-09 | unified CPU/IO scheduling groups             |
-| 8   |  2025-08  |         | noncopyable function in json_return_type     |
-| 9   |  2025-08  |         | data_sink_impl new API                       |
-
+|  2  |  2019-07  | 2020-04 | Non-variadic futures in socket::accept()     |
+|  3  |  2020-05  | 2023-03 | make_file_data_sink() closes file and returns a future<>  |
+|  4  |  2020-06  | 2023-03 | Non-variadic futures in when_all_succeed()   |
+|  5  |  2020-08  | 2023-03 | future::get() returns std::monostate() instead of void |
+|  6  |  2020-09  | 2023-03 | future<T> instead of future<T...>            |
+|  7  |  2023-05  | 2024-09 | unified CPU/IO scheduling groups             |
+|  8  |  2025-08  |         | noncopyable function in json_return_type     |
+|  9  |  2025-08  |         | data_sink_impl new API                       |
+| 10  |  2026-04  |         | co_return and set_value strict type semantics |
 
 Note: The "mandatory" column indicates when backwards compatibility
 support for the API preceding the new level was removed.

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -95,9 +95,14 @@ public:
         promise_type(promise_type&&) = delete;
         promise_type(const promise_type&) = delete;
 
-        template<typename... U>
-        void return_value(U&&... value) {
-            _promise.set_value(std::forward<U>(value)...);
+        template<typename U>
+        void return_value(U&& value) {
+            _promise.set_value(std::forward<U>(value));
+        }
+
+        [[deprecated("Forwarding coroutine returns are deprecated as too dangerous. Use 'co_return co_await ...' until explicit syntax is available.")]]
+        void return_value(future<T>&& fut) noexcept {
+            fut.forward_to(std::move(_promise));
         }
 
         void return_value(coroutine::exception ce) noexcept {
@@ -106,11 +111,6 @@ public:
 
         void set_exception(std::exception_ptr&& eptr) noexcept {
             _promise.set_exception(std::move(eptr));
-        }
-
-        [[deprecated("Forwarding coroutine returns are deprecated as too dangerous. Use 'co_return co_await ...' until explicit syntax is available.")]]
-        void return_value(future<T>&& fut) noexcept {
-            fut.forward_to(std::move(_promise));
         }
 
         void unhandled_exception() noexcept {

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -95,6 +95,7 @@ public:
         promise_type(promise_type&&) = delete;
         promise_type(const promise_type&) = delete;
 
+#if SEASTAR_API_LEVEL < 10
         template<typename U>
         void return_value(U&& value) {
             _promise.set_value(std::forward<U>(value));
@@ -104,6 +105,18 @@ public:
         void return_value(future<T>&& fut) noexcept {
             fut.forward_to(std::move(_promise));
         }
+#else
+        // this non-templated version only exists to support co_returning a braced-init-list
+        void return_value(T&& value) noexcept {
+            _promise.set_value(std::forward<T>(value));
+        }
+
+        template<typename U>
+        requires std::is_convertible_v<U&&, T>
+        void return_value(U&& value) noexcept {
+            _promise.set_value(std::forward<U>(value));
+        }
+#endif
 
         void return_value(coroutine::exception ce) noexcept {
             _promise.set_exception(std::move(ce.eptr));

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -336,7 +336,7 @@ public:
     void uninitialized_set_loose_type_conversion(tuple_type&& v) {
         uninitialized_set(std::move(std::get<0>(v)));
     }
-    void uninitialized_set_legacy(const tuple_type& v) {
+    void uninitialized_set_loose_type_conversion(const tuple_type& v) {
         uninitialized_set(std::get<0>(v));
     }
     maybe_wrap_ref<T>& uninitialized_get() {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -273,6 +273,13 @@ struct get0_return_type {
 template<typename T>
 using maybe_wrap_ref = std::conditional_t<std::is_reference_v<T>, std::reference_wrapper<std::remove_reference_t<T>>, T>;
 
+/// Convert U to T using copy-initialization (implicit conversions only).
+/// C++17 mandatory copy elision ensures no extra moves or copies.
+template<typename T, typename U>
+T implicit_convert(U&& u) {
+    return std::forward<U>(u);
+}
+
 /// \brief Wrapper for keeping uninitialized values of non default constructible types.
 ///
 /// This is similar to a std::optional<T>, but it doesn't know if it is holding a value or not, so the user is
@@ -290,16 +297,33 @@ struct uninitialized_wrapper {
 
 public:
     uninitialized_wrapper() noexcept = default;
+    template<typename U>
+    requires std::is_convertible_v<U&&, T>
+    void uninitialized_set(U&& u) {
+        // Despite the `requires` condition above, the line below may still fail compilation if T is a reference type.
+        // E.g. when T is a const lvalue reference and U is an rvalue reference to a non-const type.
+        // These kind of conversions make little sense both here and with plain `return`.
+        new(&_v.value) auto(implicit_convert<maybe_wrap_ref<T>>(std::forward<U>(u)));
+    }
     template<typename... U>
-    requires (!std::same_as<std::tuple<std::remove_cv_t<U>...>, std::tuple<tuple_type>>)
-    void
-    uninitialized_set(U&&... vs) {
+    void uninitialized_emplace(U&&... vs) {
         new (&_v.value) maybe_wrap_ref<T>(T(std::forward<U>(vs)...));
     }
-    void uninitialized_set(tuple_type&& v) {
+    void uninitialized_set_from_tuple(tuple_type&& v) {
+        uninitialized_set_loose_type_conversion(std::move(std::get<0>(v)));
+    }
+    void uninitialized_set_from_tuple(const tuple_type& v) {
+        uninitialized_set_loose_type_conversion(std::get<0>(v));
+    }
+    template<typename... U>
+    requires (!std::same_as<std::tuple<std::remove_cv_t<U>...>, std::tuple<tuple_type>>)
+    void uninitialized_set_loose_type_conversion(U&&... vs) {
+        new (&_v.value) maybe_wrap_ref<T>(T(std::forward<U>(vs)...));
+    }
+    void uninitialized_set_loose_type_conversion(tuple_type&& v) {
         uninitialized_set(std::move(std::get<0>(v)));
     }
-    void uninitialized_set(const tuple_type& v) {
+    void uninitialized_set_legacy(const tuple_type& v) {
         uninitialized_set(std::get<0>(v));
     }
     maybe_wrap_ref<T>& uninitialized_get() {
@@ -315,13 +339,23 @@ struct uninitialized_wrapper<internal::monostate> {
     [[no_unique_address]] internal::monostate _v;
 public:
     uninitialized_wrapper() noexcept = default;
-    void uninitialized_set() {
-    }
     void uninitialized_set(internal::monostate) {
     }
-    void uninitialized_set(std::tuple<>&& v) {
+    void uninitialized_emplace(internal::monostate) {
     }
-    void uninitialized_set(const std::tuple<>& v) {
+    void uninitialized_emplace() {
+    }
+    void uninitialized_set_from_tuple(std::tuple<>&& v) {
+    }
+    void uninitialized_set_from_tuple(const std::tuple<>& v) {
+    }
+    void uninitialized_set_loose_type_conversion() {
+    }
+    void uninitialized_set_loose_type_conversion(internal::monostate) {
+    }
+    void uninitialized_set_loose_type_conversion(std::tuple<>&& v) {
+    }
+    void uninitialized_set_loose_type_conversion(const std::tuple<>& v) {
     }
     internal::monostate& uninitialized_get() {
         return _v;
@@ -556,7 +590,11 @@ inline void future_state_base::any::check_failure() noexcept {
     }
 }
 
-struct ready_future_marker {};
+struct loose_type_conversion_ready_future_marker {};
+struct set_ready_future_marker {};
+struct set_from_tuple_ready_future_marker {};
+struct emplace_ready_future_marker {};
+
 struct exception_future_marker {};
 struct future_for_get_promise_marker {};
 
@@ -612,18 +650,59 @@ struct future_state :  public future_state_base, private internal::uninitialized
         move_it(std::move(x));
         return *this;
     }
-    template <typename... A>
-    future_state(ready_future_marker, A&&... a) noexcept : future_state_base(state::result) {
-      try {
-        this->uninitialized_set(std::forward<A>(a)...);
-      } catch (...) {
-        new (this) future_state(current_exception_future_marker());
-      }
+    template<typename U>
+    requires std::is_convertible_v<U&&, T>
+    future_state(set_ready_future_marker, U&& v) noexcept : future_state_base(state::result) {
+        try {
+            this->uninitialized_set(std::forward<U>(v));
+        } catch (...) {
+            new (this) future_state(current_exception_future_marker());
+        }
+    }
+    template <typename Tup>
+    future_state(set_from_tuple_ready_future_marker, Tup&& v) noexcept : future_state_base(state::result) {
+        try {
+            this->uninitialized_set_from_tuple(std::forward<Tup>(v));
+        } catch (...) {
+            new (this) future_state(current_exception_future_marker());
+        }
     }
     template <typename... A>
-    void set(A&&... a) noexcept {
+    future_state(emplace_ready_future_marker, A&&... a) noexcept : future_state_base(state::result) {
+        try {
+            this->uninitialized_emplace(std::forward<A>(a)...);
+        } catch (...) {
+            new (this) future_state(current_exception_future_marker());
+        }
+    }
+    template <typename... A>
+    future_state(loose_type_conversion_ready_future_marker, A&&... a) noexcept : future_state_base(state::result) {
+        try {
+            this->uninitialized_set_loose_type_conversion(std::forward<A>(a)...);
+        } catch (...) {
+            new (this) future_state(current_exception_future_marker());
+        }
+    }
+    template<typename U>
+    requires std::is_convertible_v<U&&, T>
+    void set(U&& v) {
         assert(_u.st == state::future);
-        new (this) future_state(ready_future_marker(), std::forward<A>(a)...);
+        new (this) future_state(set_ready_future_marker(), std::forward<U>(v));
+    }
+    template <typename Tup>
+    void set_from_tuple(Tup&& tup) noexcept {
+        assert(_u.st == state::future);
+        new (this) future_state(set_from_tuple_ready_future_marker(), std::forward<Tup>(tup));
+    }
+    template <typename... A>
+    void emplace(A&&... a) noexcept {
+        assert(_u.st == state::future);
+        new (this) future_state(emplace_ready_future_marker(), std::forward<A>(a)...);
+    }
+    template <typename... A>
+    void set_loose_type_conversion(A&&... a) noexcept {
+        assert(_u.st == state::future);
+        new (this) future_state(loose_type_conversion_ready_future_marker(), std::forward<A>(a)...);
     }
     future_state(exception_future_marker, std::exception_ptr&& ex) noexcept : future_state_base(std::move(ex)) { }
     future_state(exception_future_marker, future_state_base&& state) noexcept : future_state_base(std::move(state)) { }
@@ -863,7 +942,8 @@ public:
 template <typename T>
 class promise_base_with_type : protected internal::promise_base {
 protected:
-    using future_state = seastar::future_state<future_stored_type_t<T>>;
+    using stored_type = future_stored_type_t<T>;
+    using future_state = seastar::future_state<stored_type>;
     future_state* get_state() noexcept {
         return static_cast<future_state*>(_state);
     }
@@ -887,10 +967,27 @@ public:
         }
     }
 
-    template <typename... A>
-    void set_value(A&&... a) noexcept {
+    template<typename U>
+    requires std::is_convertible_v<U&&, stored_type>
+    void set_value(U&& v) noexcept {
         if (auto *s = get_state()) {
-            s->set(std::forward<A>(a)...);
+            s->set(std::forward<U>(v));
+            make_ready<urgent::no>();
+        }
+    }
+
+    template <typename... A>
+    void emplace_value(A&&... a) noexcept {
+        if (auto *s = get_state()) {
+            s->emplace(std::forward<A>(a)...);
+            make_ready<urgent::no>();
+        }
+    }
+
+    template <typename... A>
+    void set_value_loose_type_conversion(A&&... a) noexcept {
+        if (auto *s = get_state()) {
+            s->set_loose_type_conversion(std::forward<A>(a)...);
             make_ready<urgent::no>();
         }
     }
@@ -921,6 +1018,7 @@ private:
 /// \tparam T A type to be carried as the result of the associated future. Use void (default) for no result.
 template <typename T>
 class promise : private internal::promise_base_with_type<T> {
+    using accepted_type = typename internal::promise_base_with_type<T>::stored_type;
     using future_state = typename internal::promise_base_with_type<T>::future_state;
     future_state _local_state;
 
@@ -964,6 +1062,14 @@ public:
     /// was attached to the future, it will run.
     future<T> get_future() noexcept;
 
+
+    /// \brief Sets the promises value for T=void
+    ///
+    /// pr.set_value();
+    void set_value() noexcept requires std::is_void_v<T> {
+        set_value(internal::monostate{});
+    }
+
     /// \brief Sets the promises value
     ///
     /// Forwards the arguments and makes them available to the associated
@@ -979,7 +1085,24 @@ public:
     /// pr.set_value(std::tuple<int, double>(42, 43.0))
     template <typename... A>
     void set_value(A&&... a) noexcept {
-        internal::promise_base_with_type<T>::set_value(std::forward<A>(a)...);
+        internal::promise_base_with_type<T>::set_value_loose_type_conversion(std::forward<A>(a)...);
+    }
+
+    /// \brief Sets the promises value by constructing it in place
+    ///
+    /// Forwards the arguments and uses them to create the value available to
+    /// the associated future.  May be called either before or after
+    /// \c get_future().
+    ///
+    /// The arguments can have either the types the promise is
+    /// templated with, or a corresponding std::tuple. That is, given
+    /// a promise<int, double>, both calls are valid:
+    ///
+    /// pr.emplace_value(42, 43.0);
+    /// pr.emplace_value(std::tuple<int, double>(42, 43.0))
+    template <typename... A>
+    void emplace_value(A&&... a) noexcept {
+        internal::promise_base_with_type<T>::emplace_value(std::forward<A>(a)...);
     }
 
     /// \brief Marks the promise as failed
@@ -1232,8 +1355,15 @@ private:
     future(future_for_get_promise_marker) noexcept { }
 
     future(promise<T>* pr) noexcept : future_base(pr, &_state), _state(std::move(pr->_local_state)) { }
+
     template <typename... A>
-    future(ready_future_marker m, A&&... a) noexcept : _state(m, std::forward<A>(a)...) { }
+    future(loose_type_conversion_ready_future_marker m, A&&... a) noexcept : _state(m, std::forward<A>(a)...) { }
+    template <typename A>
+    future(set_ready_future_marker m, A&& a) noexcept : _state(m, std::forward<A>(a)) { }
+    template <typename A>
+    future(set_from_tuple_ready_future_marker m, A&& a) noexcept : _state(m, std::forward<A>(a)) { }
+    template <typename... A>
+    future(emplace_ready_future_marker m, A&&... a) noexcept : _state(m, std::forward<A>(a)...) { }
     future(future_state_base::current_exception_future_marker m) noexcept : _state(m) {}
     future(future_state_base::nested_exception_marker m, future_state_base&& old) noexcept : _state(m, std::move(old)) {}
     future(future_state_base::nested_exception_marker m, future_state_base&& n, future_state_base&& old) noexcept : _state(m, std::move(n), std::move(old)) {}
@@ -1804,6 +1934,11 @@ private:
     friend struct futurize;
     template <typename U>
     friend class internal::promise_base_with_type;
+    #if SEASTAR_API_LEVEL >= 10
+    template <typename U>
+    friend future<U> make_ready_future(U&& value) noexcept;
+    #endif
+    // for SEASTAR_API_LEVEL >= 10 it's only needed for U=void
     template <typename U, typename... A>
     friend future<U> make_ready_future(A&&... value) noexcept;
     template <typename U>
@@ -1891,20 +2026,20 @@ struct futurize : public internal::futurize_base<T> {
 
     /// Convert the tuple representation into a future
     static type from_tuple(tuple_type&& value) {
-        return type(ready_future_marker(), std::move(value));
+        return type(set_from_tuple_ready_future_marker(), std::move(value));
     }
     /// Convert the tuple representation into a future
     static type from_tuple(const tuple_type& value) {
-        return type(ready_future_marker(), value);
+        return type(set_from_tuple_ready_future_marker(), value);
     }
 
     /// Convert the tuple representation into a future
     static type from_tuple(value_type&& value) {
-        return type(ready_future_marker(), std::move(value));
+        return type(set_ready_future_marker(), std::move(value));
     }
     /// Convert the tuple representation into a future
     static type from_tuple(const value_type& value) {
-        return type(ready_future_marker(), value);
+        return type(set_ready_future_marker(), value);
     }
 private:
     /// Forwards the result of, or exception thrown by, func() to the
@@ -1942,7 +2077,7 @@ void promise<T>::move_it(promise&& x) noexcept {
 template <typename T, typename... A>
 inline
 future<T> make_ready_future(A&&... value) noexcept {
-    return future<T>(ready_future_marker(), std::forward<A>(value)...);
+    return future<T>(loose_type_conversion_ready_future_marker(), std::forward<A>(value)...);
 }
 
 template <typename T>
@@ -2010,7 +2145,7 @@ void futurize<T>::satisfy_with_result_of(promise_base_with_type&& pr, Func&& fun
     using ret_t = decltype(func());
     if constexpr (std::is_void_v<ret_t>) {
         func();
-        pr.set_value();
+        pr.set_value(internal::monostate{});
     } else if constexpr (is_future<ret_t>::value) {
         func().forward_to(std::move(pr));
     } else {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -156,6 +156,19 @@ class shared_future;
 
 struct future_state_base;
 
+#if SEASTAR_API_LEVEL >= 10
+
+/// \brief Creates a \ref future in an available, value state.
+///
+/// Creates a \ref future object that is already resolved.  This
+/// is useful when it is determined that no I/O needs to be performed
+/// to perform a computation (for example, because the data is cached
+/// in some buffer).
+template <typename T>
+future<T> make_ready_future(T&& value) noexcept;
+
+#endif
+
 /// \brief Creates a \ref future in an available, value state.
 ///
 /// Creates a \ref future object that is already resolved.  This
@@ -1070,6 +1083,7 @@ public:
         set_value(internal::monostate{});
     }
 
+#if SEASTAR_API_LEVEL < 10
     /// \brief Sets the promises value
     ///
     /// Forwards the arguments and makes them available to the associated
@@ -1087,6 +1101,34 @@ public:
     void set_value(A&&... a) noexcept {
         internal::promise_base_with_type<T>::set_value_loose_type_conversion(std::forward<A>(a)...);
     }
+#else
+    /// \brief Sets the promises value
+    ///
+    /// Forwards the argument and makes them available to the associated
+    /// future. May be called either before or after \c get_future().
+    /// Must be called at most once, setting value on a promise with a value
+    /// is undefined behavior. Must not be called after \c set_exception().
+    ///
+    /// This non-templated overried only exists to support co_returning
+    /// a braced-init-list.
+    ///
+    /// pr.set_value({1, 2, 3});
+    void set_value(accepted_type&& value) noexcept {
+        internal::promise_base_with_type<T>::set_value(std::forward<accepted_type>(value));
+    }
+
+    /// \brief Sets the promises value using the declared type rvalue reference
+    ///
+    /// Forwards the argument and makes them available to the associated
+    /// future. May be called either before or after \c get_future().
+    /// Must be called at most once, setting value on a promise with a value
+    /// is undefined behavior. Must not be called after \c set_exception().
+    ///
+    /// pr.set_value(42);
+    /// pr.set_value(std::move(my_value));
+    /// pr.set_value(var); // invokes copy constructor
+    using internal::promise_base_with_type<T>::set_value;
+#endif
 
     /// \brief Sets the promises value by constructing it in place
     ///
@@ -2074,11 +2116,29 @@ void promise<T>::move_it(promise&& x) noexcept {
     }
 }
 
+#if SEASTAR_API_LEVEL < 10
+
 template <typename T, typename... A>
 inline
 future<T> make_ready_future(A&&... value) noexcept {
     return future<T>(loose_type_conversion_ready_future_marker(), std::forward<A>(value)...);
 }
+
+#else
+
+template <typename T>
+inline
+future<T> make_ready_future(T&& value) noexcept {
+    return future<T>(set_ready_future_marker(), std::forward<T>(value));
+}
+
+template <typename T, typename... A>
+inline
+future<T> make_ready_future(A&&... value) noexcept {
+    return future<T>(emplace_ready_future_marker(), std::forward<A>(value)...);
+}
+
+#endif
 
 template <typename T>
 inline

--- a/include/seastar/core/shared_future.hh
+++ b/include/seastar/core/shared_future.hh
@@ -201,7 +201,7 @@ private:
             } else if (_original_future.failed()) {
                 return future_type(exception_future_marker(), std::exception_ptr(_original_future._state.get_exception()));
             } else {
-                return future_type(ready_future_marker(), _original_future._state.get_value());
+                return future_type(set_ready_future_marker(), _original_future._state.get_value());
             }
         }
 
@@ -227,7 +227,7 @@ private:
             } else if (_original_future.failed()) {
                 return future_type(exception_future_marker(), std::exception_ptr(_original_future._state.get_exception()));
             } else {
-                return future_type(ready_future_marker(), _original_future._state.get_value());
+                return future_type(set_ready_future_marker(), _original_future._state.get_value());
             }
         }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1559,7 +1559,7 @@ public:
             void complete(size_t fd) noexcept final {
                 _listenfd.speculate_epoll(EPOLLIN);
                 pollable_fd pfd(file_desc::from_fd(fd), pollable_fd::speculation(EPOLLOUT));
-                _result.set_value(std::move(pfd), std::move(_sa));
+                _result.emplace_value(std::move(pfd), std::move(_sa));
                 delete this;
             }
             void set_exception(std::exception_ptr eptr) noexcept final {

--- a/tests/unit/conversion_test_types.hh
+++ b/tests/unit/conversion_test_types.hh
@@ -1,0 +1,97 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2026-present ScyllaDB
+ */
+
+#pragma once
+
+#include <seastar/core/shared_ptr.hh>
+
+namespace seastar::tests {
+
+// Mutual-conversion probe: used to check that only implicit conversions /
+// implicit constructors are selected on a value path (e.g. co_return,
+// promise::set_value). If an explicit ctor/operator were selected instead, the
+// conversion would throw.
+struct explisyt;
+struct implicit {
+    implicit() = default;
+    implicit(explisyt &&) {}
+    operator explisyt();
+};
+struct explisyt {
+    explisyt() = default;
+    explicit operator implicit() {
+        throw 42;
+    }
+    explicit explisyt(implicit &&) {
+        throw 42;
+    }
+};
+inline implicit::operator explisyt() { return {}; }
+
+// Throws if copied. Use to assert that a value path never copies the returned
+// value (only moves or constructs in place).
+struct thrower_on_copy {
+    thrower_on_copy() = default;
+    thrower_on_copy(const thrower_on_copy&) { throw 42; }
+    thrower_on_copy(thrower_on_copy&&) = default;
+    ~thrower_on_copy() = default;
+};
+
+// Counts copies and moves into a shared state, so all instances spawned from
+// the original (by copy or move) report into the same counters. Default-
+// constructed instances get a fresh shared state; construct multiple related
+// ones by copying/moving an original.
+struct copy_move_counter {
+    struct counts { int copies = 0; int moves = 0; };
+    lw_shared_ptr<counts> shared = make_lw_shared<counts>();
+
+    copy_move_counter() = default;
+    copy_move_counter(const copy_move_counter& o) noexcept : shared(o.shared) {
+        ++shared->copies;
+    }
+    copy_move_counter(copy_move_counter&& o) noexcept : shared(o.shared) {
+        ++shared->moves;
+    }
+    copy_move_counter& operator=(const copy_move_counter& o) noexcept {
+        shared = o.shared;
+        ++shared->copies;
+        return *this;
+    }
+    copy_move_counter& operator=(copy_move_counter&& o) noexcept {
+        shared = o.shared;
+        ++shared->moves;
+        return *this;
+    }
+    ~copy_move_counter() = default;
+
+    // Extra moves introduced by the co_await round-trip
+    constexpr static auto co_await_moves = 2;
+};
+
+struct move_counter : copy_move_counter {
+    using copy_move_counter::copy_move_counter;
+    move_counter(const move_counter&) = delete;
+    move_counter(move_counter&&) noexcept = default;
+    move_counter& operator=(const move_counter&) = delete;
+    move_counter& operator=(move_counter&&) noexcept = default;
+};
+
+} // namespace seastar::tests

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -23,11 +23,13 @@
 #include <numeric>
 #include <ranges>
 #include <any>
+#include <expected>
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/coroutine/all.hh>
@@ -42,6 +44,8 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
+#include "conversion_test_types.hh"
+
 using seastar::broken_promise;
 using seastar::circular_buffer;
 using seastar::create_scheduling_group;
@@ -55,11 +59,14 @@ using seastar::promise;
 using seastar::scheduling_group;
 using seastar::semaphore;
 using seastar::semaphore_timed_out;
+using seastar::sstring;
 using seastar::sleep;
 using seastar::yield;
 
 namespace coroutine = seastar::coroutine;
 namespace testing = seastar::testing;
+
+using namespace seastar::tests;
 
 using namespace std::chrono_literals;
 
@@ -945,4 +952,129 @@ SEASTAR_TEST_CASE(test_try_future) {
     co_await run_try_future_test<false>(return_int, 128);
     co_await run_try_future_test<true>(return_ex_int, std::nullopt);
     co_await run_try_future_test<false>(return_ex_int, std::nullopt);
+}
+
+#if SEASTAR_API_LEVEL < 10
+future<int> co_return_tup_int_rv() {
+    co_return std::tuple(42);
+}
+
+future<int> co_return_tup_int_clv() {
+    const std::tuple t(42);
+    co_return t;
+}
+
+SEASTAR_TEST_CASE(test_std_expected_void_specialization) {
+    BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_rv(), 42);
+    BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_clv(), 42);
+}
+
+#else
+#ifdef __cpp_lib_expected
+
+future<std::expected<void, std::string>> void_return_expected() {
+    co_return {};
+}
+
+SEASTAR_TEST_CASE(test_std_expected_void_specialization) {
+    auto result = co_await void_return_expected();
+    BOOST_REQUIRE(result.has_value());
+}
+
+#endif
+
+// implicit conversion used, explicit ctor ruled out
+future<explisyt> i2e() {
+    co_return implicit();
+};
+
+// implicit ctor used, explicit conversion ruled out
+future<implicit> e2i() {
+    co_return explisyt();
+};
+
+future<std::vector<std::string>> co_return_vector(int cnt) {
+    switch (cnt) {
+    case 0:
+        co_return {};
+    case 2:
+        co_return {"foo", "foo"};
+    case 3:
+        co_return {3, "foo"};
+    default:
+        throw std::runtime_error("bad option");
+    }
+}
+
+static std::vector<int> static_vector;
+
+future<std::vector<int> &> co_return_reference() {
+    co_return static_vector;
+}
+
+SEASTAR_TEST_CASE(test_co_return_conversions) {
+    std::ignore = co_await i2e();
+    std::ignore = co_await e2i();
+    BOOST_REQUIRE_EQUAL(co_await co_return_vector(0), (std::vector<std::string>{}));
+    // gcc 13.3 will ICE if we inline the expected values here
+    std::vector<std::string> foo_x2{"foo", "foo"};
+    BOOST_REQUIRE_EQUAL(co_await co_return_vector(2), foo_x2);
+    std::vector<std::string> foo_x3{"foo", "foo", "foo"};
+    BOOST_REQUIRE_EQUAL(co_await co_return_vector(3), foo_x3);
+    BOOST_REQUIRE_EQUAL(&co_await co_return_reference(), &static_vector);
+}
+
+future<thrower_on_copy> co_return_thrower_on_copy() {
+    co_return {};
+}
+
+SEASTAR_TEST_CASE(test_co_return_thrower_on_copy) {
+    std::ignore = co_await co_return_thrower_on_copy();
+}
+
+#endif
+
+future<copy_move_counter> co_return_copy_counter_const_lv(const copy_move_counter& cc) {
+    co_return cc;
+}
+
+SEASTAR_TEST_CASE(test_co_return_copy_counter) {
+    {
+        copy_move_counter cc;
+        std::ignore = co_return_copy_counter_const_lv(cc);
+        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+    }
+    {
+        copy_move_counter cc;
+        std::ignore = co_await co_return_copy_counter_const_lv(cc);
+        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        BOOST_CHECK_EQUAL(cc.shared->moves, copy_move_counter::co_await_moves);
+    }
+}
+
+// mc is an rvalue-reference parameter — per [class.copy.elision], an implicitly
+// movable entity — so `co_return mc;` performs an implicit move, exercising the
+// strict-co_return lvalue-treated-as-rvalue path for move-only types.
+future<move_counter> co_return_move_counter_lv(move_counter&& mc) {
+    co_return mc;
+}
+
+future<move_counter> co_return_move_counter_rv(move_counter&& mc) {
+    co_return std::move(mc);
+}
+
+SEASTAR_TEST_CASE(test_co_return_move_counter) {
+    for (const auto fnptr: {co_return_move_counter_lv, co_return_move_counter_rv}) {
+        {
+            move_counter mc;
+            std::ignore = (*fnptr)(std::move(mc));
+            BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+        }
+        {
+            move_counter mc;
+            std::ignore = co_await (*fnptr)(std::move(mc));
+            BOOST_CHECK_EQUAL(mc.shared->moves, 1 + copy_move_counter::co_await_moves);
+        }
+    }
 }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -21,10 +21,12 @@
 
 #include <boost/test/tools/old/interface.hpp>
 #include <cstddef>
+#include <expected>
 #include <forward_list>
 #include <iterator>
 #include <ranges>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <vector>
 #include <seastar/testing/test_case.hh>
@@ -58,6 +60,7 @@
 #include <seastar/core/internal/api-level.hh>
 #include <unistd.h>
 
+#include "conversion_test_types.hh"
 #include "expected_exception.hh"
 
 using namespace seastar;
@@ -180,7 +183,198 @@ SEASTAR_TEST_CASE(test_set_future_state_with_tuple) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_make_ready_future_tuple) {
+    // Under v<10, make_ready_future<T>(std::tuple<T>(...)) unpacks the tuple
+    // into T. The tuple special-case is removed in v10 — the emplace path used
+    // there direct-initializes T from the args, which rejects a tuple arg.
+    auto f = make_ready_future<int>(std::tuple(42));
+    BOOST_REQUIRE_EQUAL(f.get(), 42);
+    return make_ready_future<>();
+}
 #endif
+
+#if SEASTAR_API_LEVEL >= 10
+
+namespace {
+std::vector<int> conversion_test_static_vector;
+}
+
+SEASTAR_TEST_CASE(test_set_value_conversions) {
+    // implicit conversion used, explicit ctor ruled out
+    {
+        promise<tests::explisyt> p;
+        auto f = p.get_future();
+        p.set_value(tests::implicit{});
+        std::ignore = f.get();
+    }
+    // implicit ctor used, explicit conversion ruled out
+    {
+        promise<tests::implicit> p;
+        auto f = p.get_future();
+        p.set_value(tests::explisyt{});
+        std::ignore = f.get();
+    }
+    // brace-init-list: empty vector
+    {
+        promise<std::vector<std::string>> p;
+        auto f = p.get_future();
+        p.set_value({});
+        BOOST_REQUIRE_EQUAL(f.get(), (std::vector<std::string>{}));
+    }
+    // brace-init-list: initializer_list<string> ctor
+    {
+        promise<std::vector<std::string>> p;
+        auto f = p.get_future();
+        p.set_value({"foo", "foo"});
+        std::vector<std::string> foo_x2{"foo", "foo"};
+        BOOST_REQUIRE_EQUAL(f.get(), foo_x2);
+    }
+    // brace-init-list: (count, value) ctor
+    {
+        promise<std::vector<std::string>> p;
+        auto f = p.get_future();
+        p.set_value({3, "foo"});
+        std::vector<std::string> foo_x3{"foo", "foo", "foo"};
+        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+    }
+    // reference preserved
+    {
+        promise<std::vector<int>&> p;
+        auto f = p.get_future();
+        p.set_value(conversion_test_static_vector);
+        BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
+    }
+    return make_ready_future<>();
+}
+
+#ifdef __cpp_lib_expected
+SEASTAR_TEST_CASE(test_set_value_brace_init_expected_void) {
+    promise<std::expected<void, std::string>> p;
+    auto f = p.get_future();
+    p.set_value({});
+    BOOST_REQUIRE(f.get().has_value());
+    return make_ready_future<>();
+}
+#endif
+
+SEASTAR_TEST_CASE(test_set_value_thrower_on_copy) {
+    promise<tests::thrower_on_copy> p;
+    auto f = p.get_future();
+    p.set_value(tests::thrower_on_copy{});
+    std::ignore = f.get();
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_set_value_copy_counter) {
+    // const lvalue → 1 copy
+    {
+        promise<tests::copy_move_counter> p;
+        auto f = p.get_future();
+        const tests::copy_move_counter cc;
+        p.set_value(cc);
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+    }
+    // non-const lvalue → 1 copy
+    {
+        promise<tests::copy_move_counter> p;
+        auto f = p.get_future();
+        tests::copy_move_counter cc;
+        p.set_value(cc);
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+    }
+    // rvalue (equivalent to prvalue — same category) → 1 move
+    {
+        promise<tests::copy_move_counter> p;
+        auto f = p.get_future();
+        tests::copy_move_counter cc;
+        p.set_value(std::move(cc));
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(cc.shared->copies, 0);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 1);
+    }
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_set_value_move_counter) {
+    // rvalue (only possibility for move-only) → 1 move
+    promise<tests::move_counter> p;
+    auto f = p.get_future();
+    tests::move_counter mc;
+    p.set_value(std::move(mc));
+    std::ignore = f.get();
+    BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_make_ready_future_conversions) {
+    // emplace path: (count, value) ctor
+    {
+        auto f = make_ready_future<std::vector<std::string>>(3, "foo");
+        std::vector<std::string> foo_x3{"foo", "foo", "foo"};
+        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+    }
+    // reference preserved
+    {
+        auto f = make_ready_future<std::vector<int>&>(conversion_test_static_vector);
+        BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
+    }
+    // Emplace uses direct-initialization, so explicit converting ctors are
+    // accepted — differs from co_return and promise::set_value, which gate on
+    // std::is_convertible. explisyt(implicit&&) throws.
+    {
+        auto f = make_ready_future<tests::explisyt>(tests::implicit{});
+        BOOST_REQUIRE_THROW(f.get(), int);
+    }
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_make_ready_future_copy_counter) {
+    // type-deduced form with rvalue → 1 move (single-arg overload wins)
+    {
+        tests::copy_move_counter cc;
+        auto f = make_ready_future(std::move(cc));
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(cc.shared->copies, 0);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 1);
+    }
+    // explicit-T emplace form with const lvalue → 1 copy (single-arg
+    // overload's T&& cannot bind to const lvalue, so emplace overload wins)
+    {
+        const tests::copy_move_counter cc;
+        auto f = make_ready_future<tests::copy_move_counter>(cc);
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+    }
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_make_ready_future_move_counter) {
+    // type-deduced form with rvalue → 1 move (single-arg overload wins)
+    {
+        tests::move_counter mc;
+        auto f = make_ready_future(std::move(mc));
+        std::ignore = f.get();
+        BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+    }
+    // no-arg emplace: the single-arg T&& overload needs one argument, so the
+    // variadic overload wins and default-constructs move_counter in place
+    // (0 moves). f.get() then extracts via exactly 1 move, so the total count
+    // observable via the extracted value is 1.
+    {
+        auto f = make_ready_future<tests::move_counter>();
+        auto mc = f.get();
+        BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+    }
+    return make_ready_future<>();
+}
+
+#endif  // SEASTAR_API_LEVEL >= 10
 
 SEASTAR_THREAD_TEST_CASE(test_set_value_make_exception_in_copy) {
     struct throw_in_copy {

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -170,6 +170,7 @@ SEASTAR_TEST_CASE(test_reference) {
     return make_ready_future<>();
 }
 
+#if SEASTAR_API_LEVEL < 10
 SEASTAR_TEST_CASE(test_set_future_state_with_tuple) {
     future_state<std::tuple<int>> s1;
     promise<int> p1;
@@ -179,6 +180,7 @@ SEASTAR_TEST_CASE(test_set_future_state_with_tuple) {
 
     return make_ready_future<>();
 }
+#endif
 
 SEASTAR_THREAD_TEST_CASE(test_set_value_make_exception_in_copy) {
     struct throw_in_copy {


### PR DESCRIPTION
Current implementation of `co_return` behaves differently from plain
`return` when interpreting the expression returned. This includes both
- `co_return` accepting expressions `return` would reject;
- `co_return` rejecting expressions `return` would accept.

Unexpectedly accepted expressions allow bugs from accidental misuse:
- a value of a strongly-defined type may be implicitly instantiated from
its underlying type thus defeating the purpose, e.g. a coroutine
declared to return `future<std::chrono::seconds>`, may `co_return 42;`
- instead of a value of an enum type used in the future, a value of an
unrelated enum type may be used if it uses the same underlying type;
- obscure convertions, such as a number to `std::vector`, may be applied
implicitly.

Unexpectedly rejected expressions include:
- those rejected due to false ambiguity, where compiler cannot decide
between a reasonable interpretation and one of the situtaions described
above;
- brace-enclosed initializer list without type specified.

This happens because we save the `co_return`'ed value in a state by:
- calling a chain of unnecessarily templated functions;
- implicitly calling the type ctor even if it is marked explicit.

The fix is to avoid the above.

One of the test cases was shamelessly stolen from https://github.com/scylladb/seastar/pull/2971 as my change fixes their use case.