### PR TITLE
tls: Rework session termination

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -366,8 +366,21 @@ namespace tls {
 
     /// TLS configuration options
     struct tls_options {
+    private:
+        struct deprecated_wait_for_eof_on_shutdown {
+            bool _value = true;
+            deprecated_wait_for_eof_on_shutdown() noexcept : _value(true) {}
+            [[deprecated("Use tls::options::bye_timeout instead")]]
+            deprecated_wait_for_eof_on_shutdown(bool value) noexcept : _value(value) {}
+            [[deprecated("Use tls::options::bye_timeout instead")]]
+            void operator=(bool value) noexcept { _value = value; }
+            [[deprecated("Use tls::options::bye_timeout instead")]]
+            operator bool() const noexcept { return _value; }
+        };
+
+    public:
         /// \brief whether to wait for EOF from server on session termination
-        bool wait_for_eof_on_shutdown = true;
+        deprecated_wait_for_eof_on_shutdown wait_for_eof_on_shutdown;
         /// \brief server name to be used for the SNI TLS extension
         sstring server_name = {};
 
@@ -382,6 +395,16 @@ namespace tls {
         /// \brief Optional list of ALPN protocols to offer to the server,
         /// in order of preference.
         std::vector<sstring> alpn_protocols;
+
+        // \brief Time to wait for correct session wrap-up
+        // If set to zero, the TLS-level closing is not performed, the
+        // connection is just aborted
+        std::chrono::seconds bye_timeout = std::chrono::seconds(10);
+
+        // \brief Whether or not to pick up any unread data during shutdown
+        // When false and any data arrives at the socket, the connection is
+        // immediately aborted without waiting for graceful wrap-up
+        bool wait_for_data_on_shutdown = false;
     };
 
     /**


### PR DESCRIPTION
First things first, when a TLS socket is shutdown or closed, it leaves a background fiber that sends GNUTLS_BYE message, wires a timer for 10 seconds and waits until EOF appears on the socket. If the timer fires earlier, the underlying socket is closed (thus implicitly causing the EOF to appear).

Whether or not to wait for the EOF is controlled by the tls_options bit called wait_for_eof_on_shutdown, and it's "true" by default.

This patch includes several interconnected enhancements to that process.

First, the aforementioned bool value is replaced with with the timeout value in seconds (default is 10). The related change: if the configured timeout is zero, the BYE message is not sent at all, the socket is just closed. This is not compatible with existing wait_for_eof_on_shutdown which does sends BYE message, but since the socket is closed instantly without letting TLS wrap the session correctly, the incompatibility seems to be OK.

Next, here's the second option called wait_for_data_on_shutdown. After BYE message is sent, if the option is false (which it is by default), the session waits for any value resolved from the do_get() method's future. The value can be a buffer with data or an empty buffer indicating an EOF.  In any case, after an event the transport socket is closed.

That option plays well with clients that read all data from server before closing the socket. In that case, the only "event" that would appear from do_get() is the EOF one -- despite BYE message implies data transfer between client and server, session data doesn't resolve into buffer from do_get(), so only after successful session termination the EOF would appear. In case client shuts down the connection without reading all the data from the server, some unread data would be read, the underlying socket will be closed thus aborting the proper TLS termintation. If that's not called for, the wait_for_data_on_shutdown can be set to true.

Finally, the existing wait_for_eof_on_shutdown is deprecated in favor of setting the bye_timeout to zero.

Fixes: #2983