### PR TITLE
Handle nowait support for reads and writes independently

### DIFF
--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -41,7 +41,7 @@ struct reactor_config {
     bool strict_o_direct = true;
     bool bypass_fsync = false;
     bool no_poll_aio = false;
-    bool aio_nowait_works = false;
+    std::optional<bool> aio_nowait_works = false;
     bool abort_on_too_long_task_queue = false;
 };
 /// \endcond

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -40,7 +40,8 @@ class io_sink;
 
 }
 
-enum class nowait_mode { yes, no };
+enum class nowait_mode { yes, no, read_only };
+
 template <typename FileImpl>
 class posix_file_handle_impl : public seastar::file_handle_impl {
     int _fd;

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -40,6 +40,7 @@ class io_sink;
 
 }
 
+enum class nowait_mode { yes, no };
 template <typename FileImpl>
 class posix_file_handle_impl : public seastar::file_handle_impl {
     int _fd;
@@ -50,7 +51,7 @@ class posix_file_handle_impl : public seastar::file_handle_impl {
     uint32_t _disk_read_dma_alignment;
     uint32_t _disk_write_dma_alignment;
     uint32_t _disk_overwrite_dma_alignment;
-    bool _nowait_works;
+    const nowait_mode _nowait_works;
     bool _durable;
     bool _aio_fdatasync;
 public:
@@ -59,7 +60,7 @@ public:
             uint32_t disk_read_dma_alignment,
             uint32_t disk_write_dma_alignment,
             uint32_t disk_overwrite_dma_alignment,
-            bool nowait_works, bool durable, bool aio_fdatasync)
+            nowait_mode nowait_works, bool durable, bool aio_fdatasync)
             : _fd(fd), _refcount(refcount), _device_id(device_id), _open_flags(f)
             , _memory_dma_alignment(memory_dma_alignment)
             , _disk_read_dma_alignment(disk_read_dma_alignment)
@@ -79,7 +80,7 @@ public:
 
 class posix_file_impl : public file_impl {
     std::atomic<unsigned>* _refcount = nullptr;
-    const bool _nowait_works;
+    const nowait_mode _nowait_works;
     const bool _durable;
     const bool _aio_fdatasync;
     const dev_t _device_id;
@@ -94,7 +95,7 @@ protected:
             uint32_t disk_read_dma_alignment,
             uint32_t disk_write_dma_alignment,
             uint32_t disk_overwrite_dma_alignment,
-            bool nowait_works, bool durable, bool aio_fdatasync);
+            nowait_mode nowait_works, bool durable, bool aio_fdatasync);
 public:
     virtual ~posix_file_impl() override;
     future<> flush() noexcept override;
@@ -173,7 +174,7 @@ public:
     posix_file_real_impl(int fd, open_flags of, file_open_options options, const internal::fs_info& fsi, dev_t device_id)
         : posix_file_impl(fd, of, std::move(options), device_id, fsi) {}
     posix_file_real_impl(int fd, open_flags of, std::atomic<unsigned>* refcount, dev_t device_id,
-            uint32_t memory_dma_alignment, uint32_t disk_read_dma_alignment, uint32_t disk_write_dma_alignment, uint32_t disk_overwrite_dma_alignment, bool nowait_works, bool durable, bool aio_fdatasync)
+            uint32_t memory_dma_alignment, uint32_t disk_read_dma_alignment, uint32_t disk_write_dma_alignment, uint32_t disk_overwrite_dma_alignment, nowait_mode nowait_works, bool durable, bool aio_fdatasync)
         : posix_file_impl(fd, of, refcount, device_id, memory_dma_alignment, disk_read_dma_alignment, disk_write_dma_alignment, disk_overwrite_dma_alignment, nowait_works, durable, aio_fdatasync) {}
     virtual future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept override;
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
@@ -294,7 +295,7 @@ public:
     blockdev_file_impl(int fd, open_flags f, file_open_options options, const internal::fs_info& fsi, dev_t device_id)
         : posix_file_impl(fd, f, options, device_id, fsi) {}
     blockdev_file_impl(int fd, open_flags of, std::atomic<unsigned>* refcount, dev_t device_id,
-            uint32_t memory_dma_alignment, uint32_t disk_read_dma_alignment, uint32_t disk_write_dma_alignment, uint32_t disk_overwrite_dma_alignment, bool nowait_works, bool durable, bool aio_fdatasync)
+            uint32_t memory_dma_alignment, uint32_t disk_read_dma_alignment, uint32_t disk_write_dma_alignment, uint32_t disk_overwrite_dma_alignment, nowait_mode nowait_works, bool durable, bool aio_fdatasync)
         : posix_file_impl(fd, of, refcount, device_id, memory_dma_alignment, disk_read_dma_alignment, disk_write_dma_alignment, disk_overwrite_dma_alignment, nowait_works, durable, aio_fdatasync) {}
 
     future<> truncate(uint64_t length) noexcept override;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -133,7 +133,7 @@ file_handle::to_file() && {
 }
 
 posix_file_impl::posix_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, const internal::fs_info& fsi)
-        : _nowait_works(fsi.nowait_works)
+        : _nowait_works(fsi.nowait_works ? nowait_mode::yes : nowait_mode::no)
         , _durable(options.durable)
         , _aio_fdatasync(engine().have_aio_fdatasync())
         , _device_id(device_id)
@@ -189,7 +189,7 @@ posix_file_impl::posix_file_impl(int fd, open_flags f, std::atomic<unsigned>* re
         uint32_t disk_read_dma_alignment,
         uint32_t disk_write_dma_alignment,
         uint32_t disk_overwrite_dma_alignment,
-        bool nowait_works, bool durable, bool aio_fdatasync)
+        nowait_mode nowait_works, bool durable, bool aio_fdatasync)
         : _refcount(refcount)
         , _nowait_works(nowait_works)
         , _durable(durable)
@@ -566,27 +566,27 @@ posix_file_impl::list_directory(std::function<future<> (directory_entry de)> nex
 
 future<size_t>
 posix_file_impl::do_write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) noexcept {
-    auto req = internal::io_request::make_write(_fd, pos, buffer, len, _nowait_works);
+    auto req = internal::io_request::make_write(_fd, pos, buffer, len, _nowait_works == nowait_mode::yes);
     return _io_queue.submit_io_write(len, std::move(req), intent);
 }
 
 future<size_t>
 posix_file_impl::do_write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept {
     auto len = internal::sanitize_iovecs(iov, _disk_write_dma_alignment);
-    auto req = internal::io_request::make_writev(_fd, pos, iov, _nowait_works);
+    auto req = internal::io_request::make_writev(_fd, pos, iov, _nowait_works == nowait_mode::yes);
     return _io_queue.submit_io_write(len, std::move(req), intent, std::move(iov));
 }
 
 future<size_t>
 posix_file_impl::do_read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept {
-    auto req = internal::io_request::make_read(_fd, pos, buffer, len, _nowait_works);
+    auto req = internal::io_request::make_read(_fd, pos, buffer, len, _nowait_works == nowait_mode::yes);
     return _io_queue.submit_io_read(len, std::move(req), intent);
 }
 
 future<size_t>
 posix_file_impl::do_read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept {
     auto len = internal::sanitize_iovecs(iov, _disk_read_dma_alignment);
-    auto req = internal::io_request::make_readv(_fd, pos, iov, _nowait_works);
+    auto req = internal::io_request::make_readv(_fd, pos, iov, _nowait_works == nowait_mode::yes);
     return _io_queue.submit_io_read(len, std::move(req), intent, std::move(iov));
 }
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -579,14 +579,14 @@ posix_file_impl::do_write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* i
 
 future<size_t>
 posix_file_impl::do_read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept {
-    auto req = internal::io_request::make_read(_fd, pos, buffer, len, _nowait_works == nowait_mode::yes);
+    auto req = internal::io_request::make_read(_fd, pos, buffer, len, _nowait_works == nowait_mode::yes || _nowait_works == nowait_mode::read_only);
     return _io_queue.submit_io_read(len, std::move(req), intent);
 }
 
 future<size_t>
 posix_file_impl::do_read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept {
     auto len = internal::sanitize_iovecs(iov, _disk_read_dma_alignment);
-    auto req = internal::io_request::make_readv(_fd, pos, iov, _nowait_works == nowait_mode::yes);
+    auto req = internal::io_request::make_readv(_fd, pos, iov, _nowait_works == nowait_mode::yes || _nowait_works == nowait_mode::read_only);
     return _io_queue.submit_io_read(len, std::move(req), intent, std::move(iov));
 }
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -711,6 +711,37 @@ static bool blockdev_nowait_works(dev_t device_id) {
     return blockdev_gen_nowait_works;
 }
 
+static nowait_mode filesystem_nowait_mode(bool fs_capable, std::optional<bool> cfg_override) {
+    if (!fs_capable) {
+        return nowait_mode::no;
+    }
+    if (cfg_override.has_value()) {
+        return *cfg_override ? nowait_mode::yes : nowait_mode::no;
+    }
+
+    // First, the nowait became useable in 4.13, see
+    // https://lore.kernel.org/linux-xfs/20210117213401.GB78941@dread.disaster.area/
+    // and seastar commit 487d04ee (file, reactor: reinstate RWF_NOWAIT support)
+    //
+    // Then it was (un)intentionally broken by Linux-6.0 commit 66fa3ced (fs: Add
+    // async write file modification handling) so that lots of writes hit the need
+    // to update cmtimes for an inode and returned EAGAIN seeing the nowait flag.
+    // The change effectively allowed only read-only nowait AIO
+    //
+    // In Linux-7.0 lazytime mode cmtime update was patched to work nicely with the
+    // nowait flag, see 77ef2c3f (re-enable IOCB_NOWAIT writes to files v6)
+
+    if (internal::kernel_uname().whitelisted({"7.0"})) {
+        return nowait_mode::yes;
+    } else if (internal::kernel_uname().whitelisted({"6.0"})) {
+        return nowait_mode::read_only; // seastar issue #2974
+    } else if (internal::kernel_uname().whitelisted({"4.13"})) {
+        return nowait_mode::yes;
+    } else {
+        return nowait_mode::no;
+    }
+}
+
 future<>
 blockdev_file_impl::truncate(uint64_t length) noexcept {
     return make_ready_future<>();
@@ -1351,11 +1382,8 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
                 fsi.append_concurrency = 0;
                 fsi.fsync_is_exclusive = true;
             }
-            if (fs_nowait_works && engine()._cfg.aio_nowait_works) {
-                fsi.nowait_works = nowait_mode::yes;
-            } else {
-                fsi.nowait_works = nowait_mode::no;
-            }
+
+            fsi.nowait_works = filesystem_nowait_mode(fs_nowait_works, engine()._cfg.aio_nowait_works);
             fsi.align = filesystem_alignments(fd, st.st_dev, fsi.block_size, sfs.f_type);
             s_fstype.insert(std::make_pair(st.st_dev, std::move(fsi)));
             return make_file_impl(fd, std::move(options), flags, std::move(st));

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -100,7 +100,7 @@ struct fs_info {
     bool append_challenged;
     unsigned append_concurrency;
     bool fsync_is_exclusive;
-    bool nowait_works;
+    nowait_mode nowait_works;
     std::optional<alignments> align;
 };
 
@@ -133,7 +133,7 @@ file_handle::to_file() && {
 }
 
 posix_file_impl::posix_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, const internal::fs_info& fsi)
-        : _nowait_works(fsi.nowait_works ? nowait_mode::yes : nowait_mode::no)
+        : _nowait_works(fsi.nowait_works)
         , _durable(options.durable)
         , _aio_fdatasync(engine().have_aio_fdatasync())
         , _device_id(device_id)
@@ -1287,7 +1287,7 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
             auto align = blkdev_alignments(fd, st.st_rdev);
             internal::fs_info fsi;
             fsi.block_size = align.disk_read; // use logical_block_size for block_size
-            fsi.nowait_works = blockdev_nowait_works(st.st_rdev);
+            fsi.nowait_works = blockdev_nowait_works(st.st_rdev) ? nowait_mode::yes : nowait_mode::no;
             fsi.align = align;
             return make_ready_future<shared_ptr<file_impl>>(make_shared<blockdev_file_impl>(fd, open_flags(flags), options, fsi, st.st_rdev));
         } catch (...) {
@@ -1300,7 +1300,7 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
         // query it here. Just provide something reasonable.
         internal::fs_info fsi;
         fsi.block_size = 4096;
-        fsi.nowait_works = false;
+        fsi.nowait_works = nowait_mode::no;
         return make_ready_future<shared_ptr<file_impl>>(make_shared<posix_file_real_impl>(fd, open_flags(flags), options, fsi, st.st_dev));
     }
 
@@ -1312,31 +1312,32 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
         return engine().fstatfs(fd).then([fd, options = std::move(options), flags, st = std::move(st)] (struct statfs sfs) {
             internal::fs_info fsi;
             fsi.block_size = sfs.f_bsize;
+            bool fs_nowait_works = false;
             switch (sfs.f_type) {
             case internal::fs_magic::xfs:
                 fsi.append_challenged = true;
                 static auto xc = xfs_concurrency_from_kernel_version();
                 fsi.append_concurrency = xc;
                 fsi.fsync_is_exclusive = true;
-                fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
+                fs_nowait_works = internal::kernel_uname().whitelisted({"4.13"});
                 break;
             case internal::fs_magic::nfs:
                 fsi.append_challenged = false;
                 fsi.append_concurrency = 0;
                 fsi.fsync_is_exclusive = false;
-                fsi.nowait_works = internal::kernel_uname().whitelisted({"4.13"});
+                fs_nowait_works = internal::kernel_uname().whitelisted({"4.13"});
                 break;
             case internal::fs_magic::ext4:
                 fsi.append_challenged = true;
                 fsi.append_concurrency = 0;
                 fsi.fsync_is_exclusive = false;
-                fsi.nowait_works = internal::kernel_uname().whitelisted({"5.5"});
+                fs_nowait_works = internal::kernel_uname().whitelisted({"5.5"});
                 break;
             case internal::fs_magic::btrfs:
                 fsi.append_challenged = true;
                 fsi.append_concurrency = 0;
                 fsi.fsync_is_exclusive = true;
-                fsi.nowait_works = internal::kernel_uname().whitelisted({"5.9"});
+                fs_nowait_works = internal::kernel_uname().whitelisted({"5.9"});
                 break;
             case internal::fs_magic::tmpfs:
             case internal::fs_magic::fuse:
@@ -1344,15 +1345,17 @@ make_file_impl(int fd, file_open_options options, int flags, struct stat st) noe
                 fsi.append_challenged = false;
                 fsi.append_concurrency = 999;
                 fsi.fsync_is_exclusive = false;
-                fsi.nowait_works = false;
                 break;
             default:
                 fsi.append_challenged = true;
                 fsi.append_concurrency = 0;
                 fsi.fsync_is_exclusive = true;
-                fsi.nowait_works = false;
             }
-            fsi.nowait_works &= engine()._cfg.aio_nowait_works;
+            if (fs_nowait_works && engine()._cfg.aio_nowait_works) {
+                fsi.nowait_works = nowait_mode::yes;
+            } else {
+                fsi.nowait_works = nowait_mode::no;
+            }
             fsi.align = filesystem_alignments(fd, st.st_dev, fsi.block_size, sfs.f_type);
             s_fstype.insert(std::make_pair(st.st_dev, std::move(fsi)));
             return make_file_impl(fd, std::move(options), flags, std::move(st));
@@ -1643,7 +1646,7 @@ make_append_challenged_posix_file(file_desc& fd, unsigned concurrency, bool fsyn
         .append_challenged = true,
         .append_concurrency = concurrency,
         .fsync_is_exclusive = fsync_is_exclusive,
-        .nowait_works = true,
+        .nowait_works = nowait_mode::yes,
         .align = std::nullopt,
     };
     // device number can be any value, reactor would just pick "fallback" queue

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1583,7 +1583,7 @@ reactor::test::get_stall_detector_report_function() {
 }
 
 bool reactor::test::linux_aio_nowait() {
-    return engine()._cfg.aio_nowait_works;
+    return engine()._cfg.aio_nowait_works.value_or(true);
 }
 
 reactor::test::long_task_queue_state
@@ -3995,7 +3995,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
     , blocked_reactor_reports_per_minute(*this, "blocked-reactor-reports-per-minute", 5, "Maximum number of backtraces reported by stall detector per minute")
     , blocked_reactor_report_format_oneline(*this, "blocked-reactor-report-format-oneline", true, "Print a simplified backtrace on a single line")
     , relaxed_dma(*this, "relaxed-dma", "allow using buffered I/O if DMA is not available (reduces performance)")
-    , linux_aio_nowait(*this, "linux-aio-nowait", internal::kernel_uname().whitelisted({"4.13"}), // base version where this works
+    , linux_aio_nowait(*this, "linux-aio-nowait", {},
                 "use the Linux NOWAIT AIO feature, which reduces reactor stalls due to aio (autodetected)")
     , unsafe_bypass_fsync(*this, "unsafe-bypass-fsync", false, "Bypass fsync(), may result in data loss. Use for testing on consumer drives")
     , kernel_page_cache(*this, "kernel-page-cache", false,
@@ -4559,7 +4559,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         .strict_o_direct = !reactor_opts.relaxed_dma,
         .bypass_fsync = reactor_opts.unsafe_bypass_fsync.get_value(),
         .no_poll_aio = !reactor_opts.poll_aio.get_value() || (reactor_opts.poll_aio.defaulted() && reactor_opts.overprovisioned),
-        .aio_nowait_works = reactor_opts.linux_aio_nowait.get_value(), // Mixed in with filesystem-provided values later
+        .aio_nowait_works = reactor_opts.linux_aio_nowait.defaulted() ? std::optional<bool>(std::nullopt) : std::optional<bool>(reactor_opts.linux_aio_nowait.get_value()), // Mixed in with filesystem-provided values later
         .abort_on_too_long_task_queue = reactor_opts.abort_on_too_long_task_queue.get_value(),
     };
 

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -1237,7 +1237,7 @@ public:
     }
 
     test_posix_file_impl(const temporary_buffer<char>& d)
-        : posix_file_impl(0, {}, nullptr, 0, block_size, block_size, block_size, block_size, true, true, true)
+        : posix_file_impl(0, {}, nullptr, 0, block_size, block_size, block_size, block_size, nowait_mode::yes, true, true)
         , _data(d)
     {}
 };


### PR DESCRIPTION
Whether or not to set RWF_NOWAIT flag for iocb is controlled by the nowait_works bit that travels a long journey from reactor option via fs_info, then file, then struct request (or more exactly -- one of its united sub-structures). Nowadays this bit is boolean, but we've seen that it might be ultimately broken for writes and work for reads. This PR turns the nowait_works bit on file and fs_info to be a tri-state enum. The request struct still carries it as bit (because they are independent for reads and writes) as well as reactor option remains boolean.

"By default" (i.e. -- on modern kernels with no --linux-aio-nowait option) the mode activates to read_only for XFS. As a result, reads are submitted with the flag and writes are submitted without it. With that we trade guaranteed write-retry for potential delay in the kernel submitting it. Hopefully, chances for the latter are low enough.

refs: #2974 