### PR TITLE
memory: Call finish_allocation() at the end of allocate_aligned()

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1732,15 +1732,7 @@ void* allocate_aligned(size_t align, size_t size) {
     } else {
         ptr = allocate_large_aligned(align, size, should_sample);
     }
-    if (!ptr) {
-        on_allocation_failure(size);
-    } else {
-#ifdef SEASTAR_DEBUG_ALLOCATIONS
-        std::memset(ptr, debug_allocation_pattern, size);
-#endif
-    }
-    alloc_stats::increment_local(alloc_stats::types::allocs);
-    return ptr;
+    return finish_allocation(ptr, size);
 }
 
 


### PR DESCRIPTION
The helper in questionb does the very same sequence of steps and is already used in other allocating functions.