### PR TITLE
resource: Tune up some allocate_io_queues() arguments

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -390,8 +390,7 @@ struct distribute_objects {
 };
 
 static io_queue_topology
-allocate_io_queues(hwloc_topology_t topology, std::vector<cpu> cpus, std::unordered_map<unsigned, hwloc_obj_t>& cpu_to_node,
-        unsigned num_io_groups, unsigned& last_node_idx) {
+allocate_io_queues(hwloc_topology_t topology, const std::vector<cpu>& cpus, const std::unordered_map<unsigned, hwloc_obj_t>& cpu_to_node, unsigned num_io_groups, unsigned& last_node_idx) {
     auto node_of_shard = [&cpus, &cpu_to_node] (unsigned shard) {
         auto node = cpu_to_node.at(cpus[shard].cpu_id);
         return hwloc_bitmap_first(node->nodeset);


### PR DESCRIPTION
The vector of CPUs can be made const reference instead of value to avoid its copying (although the method is called for each IO queue and there are typically two of them)

The cpu-to-node map is a reference already, but keeping it const ref is safer.