### PR TITLE
posix-stack: Initialize unique_ptr-s with new result directly

### DIFF
--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -454,8 +454,7 @@ class posix_socket_impl final : public socket_impl {
         return engine().posix_connect(_fd, sa, local).then(
             [fd = _fd, allocator = _allocator](){
                 // a problem with 'private' interaction with 'unique_ptr'
-                std::unique_ptr<connected_socket_impl> csi;
-                csi.reset(new posix_connected_socket_impl{AF_UNIX, 0, std::move(fd), allocator});
+                std::unique_ptr<connected_socket_impl> csi(new posix_connected_socket_impl{AF_UNIX, 0, std::move(fd), allocator});
                 return make_ready_future<connected_socket>(connected_socket(std::move(csi)));
             }
         );
@@ -469,8 +468,7 @@ public:
             return connect_unix_domain(sa, local);
         }
         return find_port_and_connect(sa, local, proto).then([this, sa, proto, allocator = _allocator] () mutable {
-            std::unique_ptr<connected_socket_impl> csi;
-            csi.reset(new posix_connected_socket_impl(sa.family(), static_cast<int>(proto), _fd, allocator));
+            std::unique_ptr<connected_socket_impl> csi(new posix_connected_socket_impl(sa.family(), static_cast<int>(proto), _fd, allocator));
             return make_ready_future<connected_socket>(connected_socket(std::move(csi)));
         });
     }


### PR DESCRIPTION
When making unique_ptr for posix_connected_socket_impl one cannot use the make_unique directory, as the _impl's constructor is private, so the ptr is created default-initialized and then reset() with the result of new invocation. Initializing the ptr with new result is simply shorter.