### PR TITLE
.clangd: tell the LSP about seastar's header style

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+Style:
+  AngledHeaders:
+    # public headers (under include/seastar) use angle brackets
+    - "seastar/.*"

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ tags
 .idea/
 .vscode/
 compile_commands.json
-.clangd
 .cache


### PR DESCRIPTION
.clangd: tell the LSP about seastar's header style

Seastar includes all public using angle brackets.

Tell clangd about it so that it gets it right (available since clangd 20).

Also removes .clangd from .gitignore. This was added in:

https://github.com/scylladb/seastar/pull/1640

with the assertion that clangd stores its index there (and .cache), but
that is not correct: it uses only .cache and possibly some other
directories outside the project, but .clangd itself has always been
a configuration file (that should be checked in).
