### PR TITLE
Add `touch` command to `rl` file processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,8 @@ function (seastar_generate_ragel)
     OUTPUT ${args_OUT_FILE}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${out_dir}
     COMMAND ${ragel_RAGEL_EXECUTABLE} -G2 -o ${args_OUT_FILE} ${args_IN_FILE}
-    COMMAND sed -i -e "'1h;2,$$H;$$!d;g'" -re "'s/static const char _nfa[^;]*;//g'" ${args_OUT_FILE})
+    COMMAND sed -i -e "'1h;2,$$H;$$!d;g'" -re "'s/static const char _nfa[^;]*;//g'" ${args_OUT_FILE}
+    COMMAND touch ${args_OUT_FILE} -r ${args_IN_FILE})
 
   add_custom_target (${args_TARGET}
     DEPENDS ${args_OUT_FILE})


### PR DESCRIPTION
Files processed by `ragel` and `sed` produce files with time modification set to "now". As a result produced precompiled header is different every time ragel files are rebuild (most often after removing `build` directory), which will cause full rebuild of the whole project, when precompiled header is used (because it's different binary wise). After this patch rebuild precompiled header will have the same binary content, which will allow `ccache` alike tools to detect it and reuse previously built content.
This patch adds a `touch` command, which sets output file time modification to the same as input file time modification (since output is just mechanically processed from input). This will make time modification the same after full rebuild, precompiled header will be binary identical and we will avoid full rebuild in precompiled header enabled build mode.