### PR TITLE
Update perf_test text output, make columns selectable

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -19,16 +19,19 @@
  * Copyright (C) 2018 ScyllaDB Ltd.
  */
 
+#include <algorithm>
+#include <boost/program_options/value_semantic.hpp>
+#include <cmath>
+#include <ranges>
 #include <seastar/testing/perf_tests.hh>
 
 #include <cstdio>
 #include <fstream>
 #include <regex>
 #include <type_traits>
-
-#include <boost/range.hpp>
-#include <boost/range/adaptors.hpp>
-#include <boost/range/algorithm.hpp>
+#include <utility>
+#include <string_view>
+#include <array>
 
 #include <fmt/ostream.h>
 
@@ -165,44 +168,224 @@ struct config {
     unsigned random_seed = 0;
 };
 
+// absorbs a single metric across all runs and calculates summary statistics
+// on it
+template <typename Wrapper = double>
+struct float_stats {
+    std::vector<double> results_;
+
+    float_stats(size_t runs) {
+        results_.reserve(runs);
+    }
+
+    // wrap a double value in the Wrapper type, e.g. to distinguish durations
+    // from plain doubles
+    static Wrapper wrap(double value) {
+        return Wrapper{value};
+    }
+
+    // add a given value (over all iterations) and a number of iterations
+    // the recorded value will be value / iterations
+    void add(double value, double iterations) {
+        results_.push_back(value / iterations);
+    }
+
+    // summary stats
+    struct summary {
+        double avg, med, min, max, mad;
+    };
+
+    summary stats() const {
+        auto results = results_;                 // work on a copy
+        const size_t count = results.size();
+        assert(count);
+        const size_t mid = count / 2;
+        std::sort(results.begin(), results.end());
+        const double median = results[mid];
+        std::vector<double> diffs(results.begin(), results.end());
+        for (auto& d : diffs) { d = std::fabs(d - median); }
+        std::sort(diffs.begin(), diffs.end());
+        const double sum = std::accumulate(results.begin(), results.end(), 0.0);
+        return { sum / count, median, results.front(), results.back(), diffs[mid] };
+    }
+};
+
 struct result {
+    result(size_t run_count) :
+        runtime{run_count},
+        allocs{run_count},
+        tasks{run_count},
+        inst{run_count},
+        cycles{run_count}
+        {}
+
     sstring test_name = "";
 
     uint64_t total_iterations = 0;
     unsigned runs = 0;
 
-    double median = 0.;
-    double mad = 0.;
-    double min = 0.;
-    double max = 0.;
+    float_stats<duration> runtime;
 
-    double allocs = 0.;
-    double tasks = 0.;
-    double inst = 0.;
-    double cycles = 0.;
+    float_stats<> allocs;
+    float_stats<> tasks;
+    float_stats<> inst;
+    float_stats<> cycles;
 };
-
 
 struct duration {
     double value;
 };
 
-static inline std::ostream& operator<<(std::ostream& os, duration d)
-{
-    auto value = d.value;
-    if (value < 1'000) {
-        os << fmt::format("{:.3f}ns", value);
-    } else if (value < 1'000'000) {
-        // fmt hasn't discovered unicode yet so we are stuck with uicroseconds
-        // See: https://github.com/fmtlib/fmt/issues/628
-        os << fmt::format("{:.3f}us", value / 1'000);
-    } else if (value < 1'000'000'000) {
-        os << fmt::format("{:.3f}ms", value / 1'000'000);
-    } else {
-        os << fmt::format("{:.3f}s", value / 1'000'000'000);
+struct scaled_duration {
+    double scaled;
+    std::string_view unit; // one of ns, us, ms, s
+};
+
+struct text_options {
+    std::FILE *file = nullptr;
+    std::set<sstring> mad_columns;
+};
+
+struct format_options {
+    size_t width = 0;      // 0 means 'unspecified/disabled'
+    int precision = -1;    // -1 triggers adaptive reduction logic
+};
+
+// compute the apparent width of a utf-8 string, taking into account
+// that some characters (e.g. CJK ideographs) are wider than one column
+// and some (e.g. combining accents) are zero-width. Use a concept so we
+// accept either std::string_view directly or any type exposing data()/size()
+// (e.g. seastar::sstring) without creating multiple overloads.
+size_t apparent_width(std::convertible_to<std::string_view> auto sv) {
+    return fmt::detail::compute_width(std::string_view{sv});
+}
+
+// Definition of adaptive formatter (see forward declaration above).
+static sstring format_double_fit(double value, size_t width, size_t default_precision) {
+    if (!width || default_precision < 0) {
+        return sstring("");
     }
+
+    auto fits = [width](const sstring& s) {
+        return apparent_width(s) <= width;
+    };
+
+    auto make_hash_fallback = [width]() {
+        sstring r(sstring::initialized_later{}, width);
+        for (size_t i = 0; i < width; ++i) {
+            r.data()[i] = '#';
+        }
+        return r;
+    };
+
+    if (default_precision > 18) { // more than ~18 digits rarely useful for double
+        default_precision = 18;
+    }
+
+    // 1 & 2: fixed format with decreasing precision.
+    for (int p = default_precision; p >= 0; --p) {
+        // Build a runtime format specification for fixed format.
+        auto fmt_spec = fmt::format("{{:>{}.{}f}}", width, p);
+        auto s = fmt::format(fmt::runtime(fmt_spec), value);
+        if (fits(s)) {
+            return sstring(s);
+        }
+    }
+
+    // 3: scientific notation with decreasing precision.
+    // Note: scientific adds characters like e+NN which may help for very large/small values.
+    for (int p = default_precision; p >= 0; --p) {
+        auto fmt_spec = fmt::format("{{:>{}.{}e}}", width, p);
+        auto s = fmt::format(fmt::runtime(fmt_spec), value);
+        if (fits(s)) {
+            return sstring(s);
+        }
+    }
+
+    // 4: last resort.
+    return make_hash_fallback();
+}
+
+
+// Given a value in nanoseconds, scale to the first unit whose value is < 1000.
+// Progression: ns -> us -> ms -> s. 
+static inline scaled_duration calculate_units_and_scale(double nanoseconds) {
+    static const std::array units = {
+        "ns", "µs", "ms"
+    };
+
+    double scaled = nanoseconds;
+    for (auto unit : units) {
+        if (scaled < 1000.) {
+            return {scaled, unit};
+        }
+        scaled /= 1000.0;
+    }
+    return {scaled, "s"};
+}
+
+inline std::ostream& operator<<(std::ostream& os, duration d) {
+    auto sd = calculate_units_and_scale(d.value);
+    // fmt hasn't discovered unicode yet so we are stuck with 'us' not 'µs'
+    os << fmt::format("{:.3f}{}", sd.scaled, sd.unit);
     return os;
 }
+
+
+// Format a raw duration value expressed in nanoseconds, scaling to the most
+// suitable unit (ns, µs, ms, s) and fitting the numeric portion into the
+// provided width minus the unit suffix length using the same adaptive logic
+// as format_double_fit.
+static sstring format_duration_fit(double nanoseconds, size_t width, int precision) {
+    auto sd = calculate_units_and_scale(nanoseconds);
+    size_t unit_len = apparent_width(sd.unit);
+    size_t avail_width = (width > unit_len) ? (width - unit_len) : size_t(1);
+    auto num_part = format_double_fit(sd.scaled, avail_width, precision);
+    assert(apparent_width(num_part) == avail_width);
+    return fmt::format("{}{}", num_part, sd.unit);
+}
+
+struct printer {
+    format_options fopts{};
+    bool include_mad = false;
+
+    sstring operator()(duration t) const {
+        return format_duration_fit(t.value, fopts.width, fopts.precision);
+    }
+    sstring operator()(double d) const {
+        return format_double_fit(d, fopts.width, fopts.precision);
+    }
+    template <typename T>
+    sstring operator()(const float_stats<T>& t) const {
+        auto st = t.stats();
+        sstring ret = (*this)(T{st.med});
+        if (include_mad) {
+            double rel_med = st.mad / st.med * 100.;
+            if (rel_med != rel_med) { rel_med = 0; }
+            ret += fmt::format(" \u00B1{:5.2f}%", rel_med);
+        }
+        return ret;
+    }
+};
+
+template <typename T>
+struct value_traits {
+    static constexpr T sample_value{};
+};
+
+
+template <typename T>
+struct value_traits<float_stats<T>> {
+    static const float_stats<T> sample_value;
+};
+
+template<typename T>
+const float_stats<T> value_traits<float_stats<T>>::sample_value = [] {
+    float_stats<T> f{1};
+    f.add(1., 1.);
+    return f;
+}();
+
 
 /**
  * A column object encapsulates the logic needed to print one
@@ -212,45 +395,59 @@ static inline std::ostream& operator<<(std::ostream& os, duration d)
  * columns.
  */
 struct column {
-    static constexpr int default_width = 11;
+    static constexpr int default_width = 9;
 
-    using print_fn = std::function<void(const column&, std::FILE *file, const result& r)>;
+    using print_fn = std::function<void(const text_options&, const result&)>;
+    using header_fn = std::function<size_t(const text_options&)>;
 
     template <typename F>
-    column(sstring header, int prec, F fn) : header{header}, prec{prec} {
-        using result_t = std::invoke_result_t<F,const result&>;
-        constexpr auto is_integral = std::is_integral_v<result_t>;
-        constexpr auto is_double = std::is_same_v<result_t, double>;
-        constexpr auto is_duration = std::is_same_v<result_t, duration>;
-        static_assert(is_integral || is_double || is_duration, "unsupported return type");
-        static constexpr std::string_view fmt_str = is_double ? "{:>{}.{}f}": "{:>{}}";
-        print_text = [=](const column& c, std::FILE *file, const result& r) {
-            fmt::print(file, fmt_str, fn(r), c.width, c.prec);
+    column(sstring header, int prec, F fn) : header{header}, fopts{default_width, prec} {
+        using result_t = std::invoke_result_t<F, const result&>;
+        using result_traits = value_traits<result_t>;
+        
+        print_text = [=, fopts = fopts](const text_options& opts, const result& r) {
+            printer p{fopts, opts.mad_columns.contains(header)};
+            fmt::print(opts.file, "{}", p(fn(r)));
         };
+
+        header_size = [=, fopts = fopts](const text_options& opts) {
+            printer p{fopts, opts.mad_columns.contains(header)};
+            auto v = p(result_traits::sample_value);
+            return fmt::detail::compute_width(std::string_view(v));
+        };
+
         to_double = [fn](const result& r) {
-            if constexpr (is_duration) {
-                return fn(r).value;
-            } else {
-                return static_cast<double>(fn(r));
-            }
+            return column::convert_to_double(fn(r));
         };
     }
 
-    void print_header(std::FILE *file, const char* str = nullptr) const {
-        fmt::print(file, "{:>{}}", str ? str : header, width);
+    static double convert_to_double(duration d) {
+        return d.value;
+    }
+
+    static double convert_to_double(double d) {
+        return d;
+    }
+
+    template <typename T>
+    static double convert_to_double(float_stats<T> s) {
+        return s.stats().med;
+    }
+
+    void print_header(text_options topts, const char* str = nullptr) const {
+        size_t width = header_size(topts); // calculate header size by actually formatting a representative value
+        fmt::print(topts.file, "{:>{}}", str ? str : header, width);
     }
 
     // column header
     sstring header;
 
-    // width for the column in text output
-    int width = 11;
-
-    // precision in case of double
-    int prec = 3;
+    format_options fopts;
 
     // used by stdout and md formats to print as text
     print_fn print_text;
+
+    header_fn header_size;
 
     // used by json format to extract double result
     std::function<double(const result&)> to_double;
@@ -258,66 +455,94 @@ struct column {
 
 using columns = std::vector<column>;
 
-static void print_result_columns(std::FILE* out,
-    const columns& cols,
-    int name_length,
-    const result& r,
-    const char* start_delim = "",
-    const char* middle_delim = " ",
-    const char* end_delim = ""
-    ) {
-
-    fmt::print(out, "{}{:<{}}", start_delim, r.test_name, name_length);
-    for (auto& c : cols) {
-        fmt::print(out, "{}", middle_delim);
-        c.print_text(c, out, r);
-    }
-    fmt::print(out, "{}\n", end_delim);
-}
-
-// columns for json ouput
-static const std::vector<column> json_columns{
-    {"median", 0, [](const result& r) { return duration { r.median }; }},
-    {"mad"   , 0, [](const result& r) { return duration { r.mad };    }},
-    {"min"   , 0, [](const result& r) { return duration { r.min };    }},
-    {"max"   , 0, [](const result& r) { return duration { r.max };    }},
+static const std::vector<column> common_columns{
     {"allocs", 3, [](const result& r) { return r.allocs;              }},
     {"tasks" , 3, [](const result& r) { return r.tasks;               }},
-    {"inst"  , 1, [](const result& r) { return r.inst;                }},
+    {"inst"  , 2, [](const result& r) { return r.inst;                }},
     {"cycles", 1, [](const result& r) { return r.cycles;              }},
 };
-
-// columns for text output
-const std::vector<column> text_columns = [] { 
-    std::vector<column> ret{
-        {"iterations" , 0, [](const result& r) { return r.total_iterations / r.runs; }}
+// json columns
+static const std::vector<column> json_columns = [] {
+    columns v{
+        {"median", 0, [](const result& r) { return duration { r.runtime.stats().med }; }},
+        {"mad"   , 0, [](const result& r) { return duration { r.runtime.stats().mad }; }},
+        {"min"   , 0, [](const result& r) { return duration { r.runtime.stats().min }; }},
+        {"max"   , 0, [](const result& r) { return duration { r.runtime.stats().max }; }},
     };
-    ret.insert(ret.end(), json_columns.begin(), json_columns.end());
-    return ret;
+    v.insert(v.end(), common_columns.begin(), common_columns.end());
+    return v;
 }();
 
-struct stdout_printer final : result_printer {
-  virtual void print_configuration(const config& c) override {
-    fmt::print("{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n\n",
-               "single run iterations:", c.single_run_iterations,
-               "single run duration:", duration { double(c.single_run_duration.count()) },
-               "number of runs:", c.number_of_runs,
-               "number of cores:", smp::count,
-               "random seed:", c.random_seed);
+// text columns
+static const columns text_columns = [] {
+    columns v{
+        {"iters"   , 0, [](const result& r) { return 1. * r.total_iterations / r.runs; }},
+        {"runtime" , 2, [](const result& r) { return r.runtime; }}
+    };
+    v.insert(v.end(), common_columns.begin(), common_columns.end());
+    return v;
+}();
 
-    fmt::print("{:<{}}", "test", name_column_length());
-    for (auto& c : text_columns) {
-        // a middle delimiter between each column
-        fmt::print(" ");
-        c.print_header(stdout);
+struct delimiters {
+    const char* start_delim = "";
+    const char* middle_delim = "  ";
+    const char* end_delim = "";
+};
+
+struct text_printer : public result_printer {
+    text_printer(const columns& columns, const text_options& opts, delimiters delims = {}) :
+        columns_{columns},
+        opts{opts},
+        delims{delims}
+    {
+        assert(opts.file && delims.start_delim && delims.middle_delim && delims.end_delim);
     }
-    // end of line
-    fmt::print("\n");
-  }
 
-  virtual void print_result(const result& r) override {
-    print_result_columns(stdout, text_columns, name_column_length(), r);
-  }
+    void print_header_row(const char* first_col = "test", const char* header_override = nullptr) {
+        // start delimeter, and the top-left cell
+        fmt::print(opts.file, "{}{:<{}}", delims.start_delim, first_col, name_column_length());
+        // the header cells
+        for (auto& c : columns_) {
+            // middle delimeter
+            fmt::print(opts.file, "{}", delims.middle_delim);
+            // right align the text in result cells
+            c.print_header(opts, header_override);
+        }
+        // end delimeter
+        fmt::print(opts.file, "{}\n", delims.end_delim);
+    }
+
+    virtual void print_result(const result& r) override {
+        fmt::print(opts.file, "{}{:<{}}", delims.start_delim, r.test_name, name_column_length());
+        for (auto& c : columns_) {
+            fmt::print(opts.file, "{}", delims.middle_delim);
+            c.print_text(opts, r);
+        }
+        fmt::print(opts.file, "{}\n", delims.end_delim);
+    }
+
+    columns columns_;
+    text_options opts;
+    delimiters delims;
+};
+
+
+
+struct stdout_printer : text_printer {
+
+    stdout_printer(const columns& columns, text_options options)
+        : text_printer(columns, options) {}
+
+    virtual void print_configuration(const config& c) override {
+        fmt::print("{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n\n",
+                "single run iterations:", c.single_run_iterations,
+                "single run duration:", duration { double(c.single_run_duration.count()) },
+                "number of runs:", c.number_of_runs,
+                "number of cores:", smp::count,
+                "random seed:", c.random_seed);
+
+        print_header_row();
+    }
 };
 
 class json_printer final : public result_printer {
@@ -346,37 +571,15 @@ public:
     }
 };
 
-class markdown_printer final : public result_printer {
-    std::FILE* _output = nullptr;
+struct markdown_printer final : public text_printer {
+    constexpr static delimiters md_delims{"| ", " | ", " |"};
 
-    void print_header_row(const char* head_text, const char* body_text) {
-        // start delimeter, and the top-left cell
-        fmt::print(_output, "| {:<{}}", head_text, name_column_length());
-        // the header cells
-        for (auto& c : text_columns) {
-            // middle delimeter
-            fmt::print(_output, " | ");
-            // right align the text in result cells
-            c.print_header(_output, body_text);
-        }
-        // end delimeter
-        fmt::print(_output, " |\n");
-    }
+    explicit markdown_printer(const columns& columns, text_options options)
+        : text_printer(columns, options, md_delims) {}
 
-public:
-    explicit markdown_printer(const std::string& filename) {
-        if (filename == "-") {
-            _output = stdout;
-        } else {
-            _output = std::fopen(filename.c_str(), "w");
-        }
-        if (!_output) {
-            throw std::invalid_argument(fmt::format("unable to write to {}", filename));
-        }
-    }
     ~markdown_printer() {
-        if (_output != stdout) {
-            std::fclose(_output);
+        if (opts.file != stdout) {
+            std::fclose(opts.file);
         }
     }
 
@@ -386,11 +589,6 @@ public:
         // then the divider row of all -
         print_header_row("-", "-:");
     }
-
-    void print_result(const result& r) override {
-        print_result_columns(_output, text_columns, name_column_length(), r, "| ", " | ", " |");
-    }
-
 };
 
 static std::vector<pre_run_hook> pre_run_hooks;
@@ -404,6 +602,14 @@ void performance_test::run_hooks() {
     for (auto& hook : pre_run_hooks) {
         hook(test_group(), test_case());
     }
+}
+
+static std::FILE* maybe_open(const sstring& filename) {
+    FILE *ret = filename == "-" ? stdout : std::fopen(filename.c_str(), "w");
+    if (!ret) {
+        throw std::invalid_argument(fmt::format("unable to write to {}", filename));
+    }
+    return ret;
 }
 
 void performance_test::do_run(const config& conf)
@@ -429,9 +635,8 @@ void performance_test::do_run(const config& conf)
         }).get();
     }
 
-    result r{};
+    result r{conf.number_of_runs};
 
-    auto results = std::vector<double>(conf.number_of_runs);
     uint64_t total_iterations = 0;
     for (auto i = 0u; i < conf.number_of_runs; i++) {
         // switch out of seastar thread
@@ -440,14 +645,19 @@ void performance_test::do_run(const config& conf)
             return do_single_run().then([&] (run_result rr) {
                 clock_type::duration dt = rr.duration;
                 double ns = std::chrono::duration_cast<std::chrono::nanoseconds>(dt).count();
-                results[i] = ns / _single_run_iterations;
+
+                auto add = [this](auto& m, double value) {
+                    m.add(value, _single_run_iterations);
+                };
+                
+                add(r.runtime, ns);
 
                 total_iterations += _single_run_iterations;
 
-                r.allocs += double(rr.stats.allocations) / _single_run_iterations;
-                r.tasks += double(rr.stats.tasks_executed) / _single_run_iterations;
-                r.inst += double(rr.stats.instructions_retired) / _single_run_iterations;
-                r.cycles += double(rr.stats.cpu_cycles_retired) / _single_run_iterations;
+                add(r.allocs, rr.stats.allocations);
+                add(r.tasks, rr.stats.tasks_executed);
+                add(r.inst, rr.stats.instructions_retired);
+                add(r.cycles, rr.stats.cpu_cycles_retired);
             });
         }).get();
     }
@@ -455,25 +665,6 @@ void performance_test::do_run(const config& conf)
     r.test_name = name();
     r.total_iterations = total_iterations;
     r.runs = conf.number_of_runs;
-
-    auto mid = conf.number_of_runs / 2;
-
-    boost::range::sort(results);
-    r.median = results[mid];
-
-    auto diffs = boost::copy_range<std::vector<double>>(
-        results | boost::adaptors::transformed([&] (double x) { return fabs(x - r.median); })
-    );
-    boost::range::sort(diffs);
-    r.mad = diffs[mid];
-
-    r.min = results[0];
-    r.max = results[results.size() - 1];
-
-    r.allocs /= conf.number_of_runs;
-    r.tasks /= conf.number_of_runs;
-    r.inst /= conf.number_of_runs;
-    r.cycles /= conf.number_of_runs;
 
     for (auto& rp : conf.printers) {
         rp->print_result(r);
@@ -503,26 +694,31 @@ void performance_test::register_test(std::unique_ptr<performance_test> test)
     all_tests().emplace_back(std::move(test));
 }
 
-void run_all(const std::vector<std::string>& tests, config& conf)
-{
-    auto can_run = [tests = boost::copy_range<std::vector<std::regex>>(tests)] (auto&& test) {
-        auto it = boost::range::find_if(tests, [&test] (const std::regex& regex) {
-            return std::regex_match(test->name(), regex);
-        });
-        return tests.empty() || it != tests.end();
-    };
-
-    size_t max_name_column_length = 0;
-    for (auto&& test : all_tests() | boost::adaptors::filtered(can_run)) {
-        max_name_column_length = std::max(max_name_column_length, test->name().size());
+void run_all(const std::vector<std::string>& test_patterns, config& conf) {
+    std::vector<std::regex> regexes;
+    regexes.reserve(test_patterns.size());
+    for (auto& pat : test_patterns) {
+        regexes.emplace_back(pat);
     }
-
+    auto match = [&regexes](const performance_test* t) {
+        if (regexes.empty()) { return true; }
+        for (auto& rgx : regexes) {
+            if (std::regex_match(t->name(), rgx)) { return true; }
+        }
+        return false;
+    };
+    size_t max_name_column_length = 0;
+    for (auto& t : all_tests()) {
+        if (match(t.get())) {
+            max_name_column_length = std::max(max_name_column_length, t->name().size());
+        }
+    }
     for (auto& rp : conf.printers) {
         rp->update_name_column_length(max_name_column_length);
         rp->print_configuration(conf);
     }
-    for (auto&& test : all_tests() | boost::adaptors::filtered(std::move(can_run))) {
-        test->run(conf);
+    for (auto& t : all_tests()) {
+        if (match(t.get())) { t->run(conf); }
     }
 }
 
@@ -547,6 +743,10 @@ int main(int ac, char** av)
         ("no-stdout", "do not print to stdout")
         ("json-output", bpo::value<std::string>(), "output json file")
         ("md-output", bpo::value<std::string>(), "output markdown file")
+        ("mad-columns", bpo::value<std::string>()->default_value("runtime"),
+            "Either 'all' or comma-separated list of columns for which to show MAD as a percentage of median")
+        ("columns", bpo::value<std::string>()->default_value("all"),
+            "comma separated list of column (by name) to include in text/md output, or 'all'")
         ("list", "list available tests")
         ;
 
@@ -574,8 +774,44 @@ int main(int ac, char** av)
                 return;
             }
 
+            // local helper to split comma-separated strings
+            auto split = [](const std::string& str) {
+                auto view = str | std::views::split(',') | std::views::transform([](const auto& sub) {
+                    return std::string(sub.begin(), sub.end());
+                });
+
+                return std::vector<std::string>{view.begin(), view.end()};
+            };
+
+            // calculate the effective column set
+            auto selected_cols_str = split(app.configuration()["columns"].as<std::string>());
+            std::set<std::string> selected_set(selected_cols_str.begin(), selected_cols_str.end());
+            
+            columns selected_columns;
+            for (const column& col : text_columns) {
+                if (selected_set.contains("all") || selected_set.contains(col.header)) {
+                    selected_columns.emplace_back(col);
+                }
+            }
+            
+            auto selected_mad_str = split(app.configuration()["mad-columns"].as<std::string>());
+            if (std::ranges::find(selected_mad_str, "all") != selected_mad_str.end()) {
+                selected_mad_str.clear();
+                // add all column names
+                for (const column& col : selected_columns) {
+                    selected_mad_str.emplace_back(col.header);
+                }
+            }
+
+            text_options base_topts{
+                .file = nullptr,
+                .mad_columns{selected_mad_str.begin(), selected_mad_str.end()},
+            };
+
             if (!app.configuration().count("no-stdout")) {
-                conf.printers.emplace_back(std::make_unique<stdout_printer>());
+                auto topts = base_topts;
+                topts.file = stdout;
+                conf.printers.emplace_back(std::make_unique<stdout_printer>(selected_columns, topts));
             }
 
             if (app.configuration().count("json-output")) {
@@ -585,8 +821,10 @@ int main(int ac, char** av)
             }
 
             if (app.configuration().count("md-output")) {
-                conf.printers.emplace_back(std::make_unique<markdown_printer>(
-                    app.configuration()["md-output"].as<std::string>()
+                auto topts = base_topts;
+                topts.file = maybe_open(app.configuration()["md-output"].as<std::string>());
+                conf.printers.emplace_back(
+                    std::make_unique<markdown_printer>(selected_columns, topts
                 ));
             }
 


### PR DESCRIPTION
This is a follow up for an earlier series where we made the columns
more generic. Now we add the ability to choose exactly which columns
are output, and also show the "variance" (in the form of MAD / median)
for any numeric column.

Configurable MAD display, selectable columns, tighter numeric packing

- Add --mad-columns option allowing 'all' or comma-separated list so any
  stats column (runtime, allocs, tasks, inst, cycles, etc.) can show
  relative MAD (±pct of median) instead of being fixed
- Add --columns option to restrict which columns appear in text/markdown
  output (or 'all' to keep previous behavior)
- Improve width fitting: adaptive formatting packs large values and
  scaled durations (ns/µs/ms/s) more tightly while preserving
  significant digits
- Derive header widths from representative sample values for more
  consistent alignment and reduced horizontal space
- Unified duration scaling path reused for both raw durations and
  aggregated statistics



This shouldn't affect json output at all.

Also in this series we add a few which benchmarks stress the textual output with large/small amounts
of iterations, allocs, runtime. Useful to check that the table formatting works. The output from these 
benchmarks are shown below (the new output is run with `--mad-columns=runtime,inst`):

---
**text output**

**before**

```
test                                  iterations      median         mad         min         max      allocs       tasks        inst      cycles
output_check.high_iters              396696730000     0.000ns     0.000ns     0.000ns     0.000ns       0.000       0.000         0.0         0.0
output_check.no_runtime                 71041741     0.141ns     0.000ns     0.141ns     0.142ns       0.000       0.000         4.0         0.6
output_check.low_runtime                  382523    26.094ns     0.005ns    26.049ns    26.099ns       0.000       0.000       307.0       103.5
output_check.high_runtime                     79   126.607us    97.873ns   126.509us   126.865us       0.000       0.000   3000012.1    502851.1
output_check.high_runtime_allocs               1   582.727ms   108.715us   582.619ms   587.716ms 100000000.000       0.000 9600000987.3 2325084710.7
output_check.highly_variable_runtime           1    20.089ms    14.525ms     1.404us    34.614ms 3130404.333       0.000 300519388.3  72540181.0
```

**after**

```
test                                      iters            runtime     allocs      tasks               inst     cycles
output_check.high_iters                   4e+11     0.00ns ± 0.05%      0.000      0.000       0.00 ± 0.00%        0.0
output_check.no_runtime                70937442     0.14ns ± 0.44%      0.000      0.000       4.00 ± 0.00%        0.6
output_check.low_runtime                 382914    26.07ns ± 0.03%      0.000      0.000     307.00 ± 0.00%      103.4
output_check.high_runtime                    79   126.72µs ± 0.18%      0.000      0.000  3000012.1 ± 0.00%   502621.3
output_check.high_runtime_allocs              1   582.97ms ± 0.06%  100000000      0.000   9.60e+09 ± 0.00%    2.3e+09
output_check.highly_variable_runtime          3    18.43ms ± 4.35%  3155514.0      0.000  302929658 ± 4.51%   73260844
```

---
**md output**

**before**

| test                                 |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |      cycles |
| -                                    |          -: |          -: |          -: |          -: |          -: |          -: |          -: |          -: |          -: |
| output_check.high_iters              | 396696730000 |     0.000ns |     0.000ns |     0.000ns |     0.000ns |       0.000 |       0.000 |         0.0 |         0.0 |
| output_check.no_runtime              |    71041741 |     0.141ns |     0.000ns |     0.141ns |     0.142ns |       0.000 |       0.000 |         4.0 |         0.6 |
| output_check.low_runtime             |      382523 |    26.094ns |     0.005ns |    26.049ns |    26.099ns |       0.000 |       0.000 |       307.0 |       103.5 |
| output_check.high_runtime            |          79 |   126.607us |    97.873ns |   126.509us |   126.865us |       0.000 |       0.000 |   3000012.1 |    502851.1 |
| output_check.high_runtime_allocs     |           1 |   582.727ms |   108.715us |   582.619ms |   587.716ms | 100000000.000 |       0.000 | 9600000987.3 | 2325084710.7 |
| output_check.highly_variable_runtime |           1 |    20.089ms |    14.525ms |     1.404us |    34.614ms | 3130404.333 |       0.000 | 300519388.3 |  72540181.0 |

**after**

| test                                 |     iters |           runtime |    allocs |     tasks |              inst |    cycles |
| -                                    |        -: |                -: |        -: |        -: |                -: |        -: |
| output_check.high_iters              |     4e+11 |    0.00ns ± 0.05% |     0.000 |     0.000 |      0.00 ± 0.00% |       0.0 |
| output_check.no_runtime              |  70937442 |    0.14ns ± 0.44% |     0.000 |     0.000 |      4.00 ± 0.00% |       0.6 |
| output_check.low_runtime             |    382914 |   26.07ns ± 0.03% |     0.000 |     0.000 |    307.00 ± 0.00% |     103.4 |
| output_check.high_runtime            |        79 |  126.72µs ± 0.18% |     0.000 |     0.000 | 3000012.1 ± 0.00% |  502621.3 |
| output_check.high_runtime_allocs     |         1 |  582.97ms ± 0.06% | 100000000 |     0.000 |  9.60e+09 ± 0.00% |   2.3e+09 |
| output_check.highly_variable_runtime |         3 |   18.43ms ± 4.35% | 3155514.0 |     0.000 | 302929658 ± 4.51% |  73260844 |