### PR TITLE
futurize::invoke: use std::invoke and forwarding

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1994,14 +1994,14 @@ template<typename T>
 template<typename Func, typename... FuncArgs>
 typename futurize<T>::type futurize<T>::invoke(Func&& func, FuncArgs&&... args) noexcept {
     try {
-        using ret_t = decltype(std::forward<Func>(func)(std::forward<FuncArgs>(args)...));
+        using ret_t = std::invoke_result_t<Func, FuncArgs&&...>;
         if constexpr (std::is_void_v<ret_t>) {
-            std::forward<Func>(func)(std::forward<FuncArgs>(args)...);
+            std::invoke(std::forward<Func>(func), std::forward<FuncArgs>(args)...);
             return make_ready_future<>();
         } else if constexpr (is_future<ret_t>::value) {
-            return std::forward<Func>(func)(std::forward<FuncArgs>(args)...);
+            return std::invoke(std::forward<Func>(func), std::forward<FuncArgs>(args)...);
         } else {
-            return convert(std::forward<Func>(func)(std::forward<FuncArgs>(args)...));
+            return convert(std::invoke(std::forward<Func>(func), std::forward<FuncArgs>(args)...));
         }
     } catch (...) {
         return current_exception_as_future();


### PR DESCRIPTION
 - Use std::invoke to call the passed function, rather than a direct call. This allows member function pointers and other callable types to be used. This is already the case in other calls like future_invoke.
 - Forward the function itself, not just the arguments. This allows an rvalue-qualified operator() to be called if present.

This is good for a 0.06% reduction in the .text section of the release redpanda binary, so I guess we do have some && call operators?

The real reason for this though is the std::invoke part. Later I build on this.