### PR TITLE
Convert timer test into seastar test (and a bit more)

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -454,7 +454,7 @@ seastar_add_test (scheduling_group_nesting
 seastar_add_app_test (thread_context_switch
   SOURCES thread_context_switch_test.cc)
 
-seastar_add_app_test (timer
+seastar_add_test (timer
   SOURCES timer_test.cc)
 
 seastar_add_test (uname

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -33,10 +33,6 @@
 using namespace seastar;
 using namespace std::chrono_literals;
 
-#define OK() do { \
-        std::cerr << "OK @ " << __FILE__ << ":" << __LINE__ << std::endl; \
-    } while (0)
-
 template <typename Clock>
 void test_timer_basic() {
     timer<Clock> t1;
@@ -47,16 +43,15 @@ void test_timer_basic() {
     promise<> pr1;
 
     t1.set_callback([&] {
-        OK();
         fmt::print(" 500ms timer expired\n");
         BOOST_REQUIRE(t4.cancel());
         BOOST_REQUIRE(t5.cancel());
         t5.arm(1100ms);
     });
-    t2.set_callback([] { OK(); fmt::print(" 900ms timer expired\n"); });
-    t3.set_callback([] { OK(); fmt::print("1000ms timer expired\n"); });
+    t2.set_callback([] { fmt::print(" 900ms timer expired\n"); });
+    t3.set_callback([] { fmt::print("1000ms timer expired\n"); });
     t4.set_callback([] { BOOST_FAIL("cancelled timer expired\n"); });
-    t5.set_callback([&pr1] { OK(); fmt::print("1600ms rearmed timer expired\n"); pr1.set_value(); });
+    t5.set_callback([&pr1] { fmt::print("1600ms rearmed timer expired\n"); pr1.set_value(); });
 
     t1.arm(500ms);
     t2.arm(900ms);
@@ -87,7 +82,7 @@ void test_timer_cancelling() {
     t1.arm(100ms);
     t1.cancel();
 
-    t1.set_callback([&pr2] { OK(); pr2.set_value(); });
+    t1.set_callback([&pr2] { pr2.set_value(); });
     t1.arm(100ms);
 
     pr2.get_future().get();
@@ -121,7 +116,6 @@ void test_timer_with_scheduling_groups() {
         t2.arm(10ms);
         sleep(500ms).get();
         BOOST_REQUIRE_EQUAL(expirations, 2);
-        OK();
     }).get();
     destroy_scheduling_group(sg1).get();
     destroy_scheduling_group(sg2).get();

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -19,7 +19,9 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#include <seastar/core/app-template.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
 #include <seastar/core/timer.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/print.hh>
@@ -41,17 +43,15 @@ using namespace std::chrono_literals;
     } while (0)
 
 template <typename Clock>
-struct timer_test {
+void test_timer_basic() {
     timer<Clock> t1;
     timer<Clock> t2;
     timer<Clock> t3;
     timer<Clock> t4;
     timer<Clock> t5;
     promise<> pr1;
-    promise<> pr2;
 
-    future<> run() {
-        t1.set_callback([this] {
+        t1.set_callback([&] {
             OK();
             fmt::print(" 500ms timer expired\n");
             if (!t4.cancel()) {
@@ -65,7 +65,7 @@ struct timer_test {
         t2.set_callback([] { OK(); fmt::print(" 900ms timer expired\n"); });
         t3.set_callback([] { OK(); fmt::print("1000ms timer expired\n"); });
         t4.set_callback([] { OK(); fmt::print("  BAD cancelled timer expired\n"); });
-        t5.set_callback([this] { OK(); fmt::print("1600ms rearmed timer expired\n"); pr1.set_value(); });
+        t5.set_callback([&pr1] { OK(); fmt::print("1600ms rearmed timer expired\n"); pr1.set_value(); });
 
         t1.arm(500ms);
         t2.arm(900ms);
@@ -73,13 +73,22 @@ struct timer_test {
         t4.arm(700ms);
         t5.arm(800ms);
 
-        return pr1.get_future().then([this] { return test_timer_cancelling(); }).then([this] {
-            return test_timer_with_scheduling_groups();
-        });
-    }
+    pr1.get_future().get();
+}
 
-    future<> test_timer_cancelling() {
-        timer<Clock>& t1 = *new timer<Clock>();
+SEASTAR_THREAD_TEST_CASE(test_timer_basic_steady) {
+    test_timer_basic<steady_clock_type>();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timer_basic_lowres) {
+    test_timer_basic<lowres_clock>();
+}
+
+template <typename Clock>
+void test_timer_cancelling() {
+    promise<> pr2;
+
+        timer<Clock> t1;
         t1.set_callback([] { BUG(); });
         t1.arm(100ms);
         t1.cancel();
@@ -87,13 +96,22 @@ struct timer_test {
         t1.arm(100ms);
         t1.cancel();
 
-        t1.set_callback([this] { OK(); pr2.set_value(); });
+        t1.set_callback([&pr2] { OK(); pr2.set_value(); });
         t1.arm(100ms);
-        return pr2.get_future().then([&t1] { delete &t1; });
-    }
 
-    future<> test_timer_with_scheduling_groups() {
-        return async([] {
+    pr2.get_future().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timer_cancelling_steady) {
+    test_timer_cancelling<steady_clock_type>();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timer_cancelling_lowres) {
+    test_timer_cancelling<lowres_clock>();
+}
+
+template <typename Clock>
+void test_timer_with_scheduling_groups() {
             auto sg1 = create_scheduling_group("sg1", 100).get();
             auto sg2 = create_scheduling_group("sg2", 100).get();
             thread_attributes t1attr;
@@ -120,22 +138,12 @@ struct timer_test {
             }).get();
             destroy_scheduling_group(sg1).get();
             destroy_scheduling_group(sg2).get();
-        });
-    }
-};
+}
 
-int main(int ac, char** av) {
-    app_template app;
-    timer_test<steady_clock_type> t1;
-    timer_test<lowres_clock> t2;
-    return app.run_deprecated(ac, av, [&t1, &t2] {
-        fmt::print("=== Start High res clock test\n");
-        return t1.run().then([&t2] {
-            fmt::print("=== Start Low  res clock test\n");
-            return t2.run();
-        }).then([] {
-            fmt::print("Done\n");
-            engine().exit(0);
-        });
-    });
+SEASTAR_THREAD_TEST_CASE(test_timer_with_scheduling_groups_steady) {
+    test_timer_with_scheduling_groups<steady_clock_type>();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timer_with_scheduling_groups_lowres) {
+    test_timer_with_scheduling_groups<lowres_clock>();
 }

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -55,7 +55,7 @@ void test_timer_basic() {
     });
     t2.set_callback([] { OK(); fmt::print(" 900ms timer expired\n"); });
     t3.set_callback([] { OK(); fmt::print("1000ms timer expired\n"); });
-    t4.set_callback([] { OK(); fmt::print("  BAD cancelled timer expired\n"); });
+    t4.set_callback([] { BOOST_FAIL("cancelled timer expired\n"); });
     t5.set_callback([&pr1] { OK(); fmt::print("1600ms rearmed timer expired\n"); pr1.set_value(); });
 
     t1.arm(500ms);


### PR DESCRIPTION
It currently has several sub-test-cases, it's easier to maintain them using standard seastar test framework.
Also there's homebrew BUG and OK macros. It's better to use BOOST_REQUIRE/_CHECK instead of the former. The latter is just dropped.