### PR TITLE
core: restore seastar_logger namespace in try_systemwide_memory_barrier

### DIFF
--- a/src/core/systemwide_memory_barrier.cc
+++ b/src/core/systemwide_memory_barrier.cc
@@ -44,6 +44,9 @@ module seastar;
 #include <seastar/util/assert.hh>
 
 namespace seastar {
+
+extern logger seastar_logger;
+
 namespace internal {
 
 
@@ -146,7 +149,6 @@ bool try_systemwide_memory_barrier() {
     // Some (not all) ARM processors can broadcast TLB invalidations using the
     // TLBI instruction. On those, the mprotect trick won't work.
     static std::once_flag warn_once;
-    extern logger seastar_logger;
     std::call_once(warn_once, [] {
         seastar_logger.warn("membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED) is not available, reactor will not sleep when idle. Upgrade to Linux 4.14 or later");
     });


### PR DESCRIPTION
`try_systemwide_memory_barrier` was recently moved to the `seastar::internal` namespace in cf933e7abdbb444143a1c13942dd4ff7e134f800. However, the function contained an `extern logger seastar_logger` declaration for `__aarch64__`. As a result, the logger symbol was treated as if it were declared inside `seastar::internal`, which led to a link error on ARM.

Fixes: https://github.com/scylladb/seastar/issues/3021