### PR TITLE
future: invoke continuation function as temporary when type-erasing too

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1371,7 +1371,7 @@ public:
         {
             memory::scoped_critical_alloc_section _;
             ncf = noncopyable_function<func_type>([func = std::forward<Func>(func)](auto&&... args) mutable {
-                return futurize_invoke(func, std::forward<decltype(args)>(args)...);
+                return futurize_invoke(std::move(func), std::forward<decltype(args)>(args)...);
             });
         }
         return then_impl(std::move(ncf));


### PR DESCRIPTION
In 950b54ef3d ("future: invoke continuation functions as temporaries"), we changed the value category of the function being invoked to be an rvalue. This is so that lambdas that pass the capture group to the lambda body by value (using the `this auto` trick, `[captures] (this auto) {}`), can move the captures to the body rather than copy it, which is not possible for move-only types.

However, we forgot (at least) on case: when the lambda is type-erased in order to save compilation time.

We fix this case here by moving the function when invoking it.

Fixes #3024.