### PR TITLE
operator co_await: use rvalue reference

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -185,7 +185,7 @@ public:
 SEASTAR_MODULE_EXPORT_BEGIN
 
 template<typename T>
-auto operator co_await(future<T> f) noexcept {
+auto operator co_await(future<T>&& f) noexcept {
     return internal::awaiter<true, T>(std::move(f));
 }
 


### PR DESCRIPTION
Use an rvalue reference for the future argument to operator co_await, to avoid an unnecessary move when co_awaiting an lvalue future.

This saves one move in these cases, which is 10 instructions for a trivially ready future<void> like this:

    future<> f = make_ready_future<>();
    co_await f;

or 13 instructions if the `make_ready_future<>` function is not inlined.

The savings goes up if the future has a non-trivial type, or carries an exception.

In Redpanda, this saves slightly more than 0.5% of .text and .debug_info, and I expect a similar savings in CPU.

I think this is a source compatible change, at least all of Redpanda and seastar compile without complaint.