### PR TITLE
Internalize reactor::posix_... API methods

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -136,6 +136,7 @@ void at_exit(noncopyable_function<future<> ()> func);
 void set_current_task(task* t);
 
 pollable_fd posix_listen(socket_address sa, listen_options opts = {});
+future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local);
 
 }
 
@@ -519,7 +520,10 @@ public:
 
     pollable_fd make_pollable_fd(socket_address sa, int proto);
 
-    future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local);
+    [[deprecated("Internal reactor function, consider using seastar::connect)")]]
+    future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local) {
+        return internal::posix_connect(std::move(pfd), sa, local);
+    }
 
     future<> send_all(pollable_fd_state& fd, const void* buffer, size_t size);
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1629,8 +1629,9 @@ reactor::make_pollable_fd(socket_address sa, int proto) {
     return pollable_fd(std::move(fd));
 }
 
-future<>
-reactor::posix_connect(pollable_fd pfd, socket_address sa, socket_address local) {
+namespace internal {
+
+future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local) {
 #ifdef IP_BIND_ADDRESS_NO_PORT
     if (!sa.is_af_unix()) {
         try {
@@ -1652,6 +1653,8 @@ reactor::posix_connect(pollable_fd pfd, socket_address sa, socket_address local)
     }
     return pfd.connect(sa).finally([pfd] {});
 }
+
+} // internal namespace
 
 server_socket
 reactor::listen(socket_address sa, listen_options opt) {


### PR DESCRIPTION
There are two of those -- posix_connect() and posix_listen(). Both have nothing to do with reactor and are only called by posix_stack.cc. Despite both just deserve being in posix_stack.cc, they are public methods, and need to be deprecated first, for safety.