### PR TITLE
Add lib info to one line backtrace

### DIFF
--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -62,6 +62,13 @@ def get_command_line_parser():
 class Node:
     def __init__(self, addr: str):
         self.addr = addr
+        x = addr.find('+')
+        if x >= 0:
+            self.addr_only = addr[x + 1:]
+            self.module = addr[:x]
+        else:
+            self.addr_only = addr
+            self.module = None
         self.callers = {}
         self.callees = {}
         self.printed = False
@@ -232,7 +239,7 @@ Use --direction={'bottom-up' if top_down else 'top-down'} to print {'callees' if
                 l = f"{prefix}{p}{l} addr={n.addr}{stats}"
                 p = "| "
                 if self.resolver:
-                    lines = self.resolver.resolve_address(n.addr).splitlines()
+                    lines = self.resolver.resolve_address(n.addr_only, module=n.module).splitlines()
                     if len(lines) == 1:
                         li = lines[0]
                         if li.startswith("??"):

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -793,8 +793,13 @@ public:
 
     void append_backtrace_oneline() noexcept {
         backtrace([this] (frame f) noexcept {
-            reserve(3 + sizeof(f.addr) * 2);
-            append(" 0x");
+            reserve(3 + sizeof(f.addr) * 2 + (f.so->name.empty() ? 0 : f.so->name.size() + 1));
+            append(" ");
+            if (!f.so->name.empty()) {
+                append(f.so->name.c_str(), f.so->name.size());
+                append("+");
+            }
+            append("0x");
             append_hex(f.addr);
         }, _immediate);
     }


### PR DESCRIPTION
Previously oneline backtrace would consist only of raw offsets, interpreted as offsets into scylla binary. This prevents backtrace decoding on cases, where portion of it ends in external libraries.

This patch adds library path to the backtrace output, in format `<libpath>+0xAABB....`, where `libpath` is absolute path to the library. This format is handled by both `stall-analyser.py` and `addr2line`, although the latter one requires a minor fix for invalid addresses case.