### PR TITLE
prometheus: remove hostname and metric_help config

### DIFF
--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -100,7 +100,6 @@ int main(int ac, char** av) {
                 prometheus::config pctx;
                 net::inet_address prom_addr(config["prometheus_address"].as<sstring>());
 
-                pctx.metric_help = "seastar::httpd server statistics";
                 pctx.prefix = config["prometheus_prefix"].as<sstring>();
 
                 std::cout << "starting prometheus API server" << std::endl;

--- a/include/seastar/core/internal/api-level.hh
+++ b/include/seastar/core/internal/api-level.hh
@@ -39,3 +39,12 @@ namespace seastar {
         }
     }
 }
+
+// Helpers for ignoring deprecation warnings in code that has to deal with
+// deprecated APIs, e.g., constructors/etc for structs with deprecated fields.
+#define SEASTAR_INTERNAL_BEGIN_IGNORE_DEPRECATIONS \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define SEASTAR_INTERNAL_END_IGNORE_DEPRECATIONS \
+    _Pragma("GCC diagnostic pop")

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -40,8 +40,19 @@ SEASTAR_MODULE_EXPORT_BEGIN
  * Holds prometheus related configuration
  */
 struct config {
-    sstring metric_help; //!< Default help message for the returned metrics
-    sstring hostname; //!< hostname is deprecated, use label instead
+
+    [[deprecated("metric_help is deprecated and no longer used, to be removed in 2027")]]
+    sstring metric_help;
+
+    [[deprecated("hostname is deprecated and unused, use label instead, to be removed in 2027")]]
+    sstring hostname;
+
+    SEASTAR_INTERNAL_BEGIN_IGNORE_DEPRECATIONS // prevent warnings about deprecated fields in implicitly-defined special member functions
+    config() = default;
+    config(const config&) = default;
+    config(config&&) = default;
+    SEASTAR_INTERNAL_END_IGNORE_DEPRECATIONS
+
     std::optional<metrics::label_instance> label; //!< A label that will be added to all metrics, we advice not to use it and set it on the prometheus server
     sstring prefix = "seastar"; //!< a prefix that will be added to metric names
     bool allow_protobuf = false; // protobuf support is experimental and off by default


### PR DESCRIPTION
Neither are used (they are never read). metric_help is set in one place and hostname is never set. They are vestigial.

Officially deprecated them and remove them at API_LEVEL 9 and above.

Use some macros to suppress warnings about their use in implicitly generated constructors.