### PR TITLE
io_queue: Destroy priority class data with scheduling group

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -222,6 +222,7 @@ public:
     void update_shares_for_class_group(unsigned index, size_t new_shares);
     future<> update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth);
     void rename_priority_class(internal::priority_class pc, sstring new_name);
+    void destroy_priority_class(internal::priority_class pc) noexcept;
     void throttle_priority_class(const priority_class_data& pc) noexcept;
     void unthrottle_priority_class(const priority_class_data& pc) noexcept;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4988,6 +4988,9 @@ reactor::destroy_scheduling_group(scheduling_group sg) noexcept {
     }).then( [this, sg] () {
         get_sg_data(sg).queue_is_initialized = false;
         _task_queues[sg._id].reset();
+        for (auto&& queue : _io_queues) {
+            queue.second->destroy_priority_class(internal::priority_class(sg));
+        }
     });
 
 }


### PR DESCRIPTION
When a scheduling group is destroyed, the IO queue's priority_class_data that corresponds to it stays intact. It's not actually a leak, as when the reactor is destroyed all class data objects are collected.

However, if another scheduling group under the same ID is created, the IO queue will re-use the dangling priority class for the newly created group, but its name and shares won't match the new group until rename or shares update. And it's not nice that IO class remains alive anyway.

Since scheduling group destruction must happen after all tasks from it are completed and picked up, the class destruction code may also assume that no queued or in-flight requests exist.

Test included.