### PR TITLE
file: Configure DMA alignment from block size

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -621,7 +621,11 @@ static bool blockdev_nowait_works(dev_t device_id) {
 
 blockdev_file_impl::blockdev_file_impl(int fd, open_flags f, file_open_options options, dev_t device_id, size_t block_size)
         : posix_file_impl(fd, f, options, device_id, blockdev_nowait_works(device_id)) {
-    // FIXME -- configure file_impl::_..._dma_alignment's from block_size
+    // Configure DMA alignment requirements based on block device block size
+    _memory_dma_alignment = block_size;
+    _disk_read_dma_alignment = block_size;
+    _disk_write_dma_alignment = block_size;
+    _disk_overwrite_dma_alignment = block_size;
 }
 
 future<>


### PR DESCRIPTION
Replace FIXME comment with actual implementation that sets all DMA alignment fields (_memory_dma_alignment, _disk_read_dma_alignment, _disk_write_dma_alignment, _disk_overwrite_dma_alignment) based on the block device block size.

Instead of mirroring XFS's separate settings for read and write ops, we use the same alignment for both operations. The alignment is typically 4096 bytes under most circumstances, but the system could report a greater number if, for instance, the user overrides it or the device is a RAID device. In those cases, we respect the reported size for optimal performance and to avoid the request being rejected by the kernel.