### PR TITLE
util: adapt to fmt 12.0.0 API changes

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -266,7 +266,11 @@ static internal::log_buf::inserter_iterator print_real_timestamp(internal::log_b
     if (this_second.t != t) {
         this_second.t = t;
         this_second.buf.clear();
-        fmt::format_to(this_second.buf.back_insert_begin(), "{:%Y-%m-%d %T}", fmt::localtime(t));
+        std::tm tm_local;
+        if (!localtime_r(&t, &tm_local)) {
+            throw fmt::format_error("time_t value out of range");
+        }
+        fmt::format_to(this_second.buf.back_insert_begin(), "{:%F %T}", tm_local);
     }
     auto ms = (n - clock::from_time_t(t)) / 1ms;
     return fmt::format_to(it, "{},{:03d}", this_second.buf.view(), ms);


### PR DESCRIPTION
Replace deprecated fmt::localtime() with direct localtime_r() call to accommodate fmt 12.0.0 which removed several deprecated APIs.

The new implementation maintains identical behavior by throwing a fmt::format_error exception when localtime_r() fails, matching the original fmt::localtime() behavior.

See: https://github.com/fmtlib/fmt/releases/tag/12.0.0