### PR TITLE
test: Add unit test for append_challenged_posix_file

### DIFF
--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -166,6 +166,10 @@ public:
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept override;
 };
 
+namespace testing {
+class append_challenged_posix_file_test;
+}
+
 // The Linux XFS implementation is challenged wrt. append: a write that changes
 // eof will be blocked by any other concurrent AIO operation to the same file, whether
 // it changes file size or not. Furthermore, ftruncate() will also block and be blocked
@@ -259,7 +263,15 @@ public:
     future<uint64_t> size() noexcept override;
     virtual future<> allocate(uint64_t position, uint64_t length) noexcept override;
     future<> close() noexcept override;
+
+    friend class testing::append_challenged_posix_file_test;
 };
+
+class file_desc;
+namespace testing {
+shared_ptr<append_challenged_posix_file_impl>
+make_append_challenged_posix_file(file_desc& fd, unsigned concurrency, bool fsync_is_exclusive, std::optional<size_t> sloppy_size);
+}
 
 class blockdev_file_impl final : public posix_file_impl {
 public:

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1368,4 +1368,24 @@ future<file> open_directory(std::string_view name) noexcept {
     return engine().open_directory(name);
 }
 
+namespace testing {
+
+shared_ptr<append_challenged_posix_file_impl>
+make_append_challenged_posix_file(file_desc& fd, unsigned concurrency, bool fsync_is_exclusive, std::optional<size_t> sloppy_size) {
+    internal::fs_info fsi {
+        .block_size = 4096,
+        .append_challenged = true,
+        .append_concurrency = concurrency,
+        .fsync_is_exclusive = fsync_is_exclusive,
+        .nowait_works = true,
+        .dioinfo = std::nullopt,
+    };
+    // device number can be any value, reactor would just pick "fallback" queue
+    // that will be unused anyway, because no real IO is supposed to happen
+    constexpr dev_t dev = 0;
+    return make_shared<append_challenged_posix_file_impl>(fd.get(), open_flags::rw, file_open_options{}, fsi, dev);
+}
+
+}
+
 }


### PR DESCRIPTION
The test validates several things:
- the maximum number of writes-above-file-size doesn't exceed the limit
- the number of writes-above-file-size actually reaches it
- no parallel fsyncs are run if disabled

In fact, the 2nd test fails for concurrency above 1, but for XFS it's not currently configured, so OK for now.

To work, the test creates an "real" temporary file, but doesn't do real IO, instead, it runs counting-only operations. Truncations, however, happen for real, because this file impl uses raw ftruncate systemcall for it.