### PR TITLE
reactor: Remove unused try_sleep() method

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -648,8 +648,6 @@ public:
     /// \returns Returns the `smp` instance which owns this reactor.
     const seastar::smp& smp() const noexcept;
 
-    void try_sleep();
-
     steady_clock_type::duration total_idle_time();
     steady_clock_type::duration total_busy_time();
     steady_clock_type::duration total_awake_time() const;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3384,15 +3384,6 @@ reactor::wait_and_process_events() {
     _backend->wait_and_process_events(&_active_sigmask);
 }
 
-void
-reactor::try_sleep() {
-    if (!pollers_enter_interrupt_mode()) {
-        return;
-    }
-    wait_and_process_events();
-    pollers_exit_interrupt_mode();
-}
-
 bool
 reactor::poll_once() {
     bool work = false;


### PR DESCRIPTION
It was partially open-coded by faa171e30c and became unused since then.