### PR TITLE
reactor: Move read_directory() to posix_file_impl

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -549,6 +549,7 @@ public:
     future<> link_file(std::string_view oldpath, std::string_view newpath) noexcept;
     future<> chmod(std::string_view name, file_permissions permissions) noexcept;
 
+    [[deprecated("Use file::list_directory API instead")]]
     future<size_t> read_directory(int fd, char* buffer, size_t buffer_size);
 
     future<int> inotify_add_watch(int fd, std::string_view path, uint32_t flags);

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -115,6 +115,10 @@ public:
     open_flags flags() const {
         return _open_flags;
     }
+
+    // can be moved to private once reactor::read_directory is removed
+    static future<size_t> read_directory(int fd, char* buffer, size_t buffer_size);
+
 private:
     void configure_dma_alignment(const internal::fs_info& fsi);
     void configure_io_lengths() noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -68,7 +68,6 @@ module;
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/clamp.hpp>
 #include <boost/version.hpp>
-#include <dirent.h>
 #define __user /* empty */  // for xfs includes, below
 #include <linux/types.h> // for xfs, below
 #include <sys/ioctl.h>
@@ -1909,16 +1908,6 @@ timespec_to_time_point(const timespec& ts) {
     auto d = std::chrono::duration_cast<std::chrono::system_clock::duration>(
             ts.tv_sec * 1s + ts.tv_nsec * 1ns);
     return std::chrono::system_clock::time_point(d);
-}
-
-future<size_t> reactor::read_directory(int fd, char* buffer, size_t buffer_size) {
-    syscall_result<long> ret = co_await _thread_pool->submit<syscall_result<long>>(
-            internal::thread_pool_submit_reason::file_operation, [fd, buffer, buffer_size] () {
-        auto ret = ::syscall(__NR_getdents64, fd, reinterpret_cast<linux_dirent64*>(buffer), buffer_size);
-        return wrap_syscall(ret);
-    });
-    ret.throw_if_error();
-    co_return ret.result;
 }
 
 future<int>


### PR DESCRIPTION
This method is a thread-pool wrapper over raw readdir64 syscall. It's used only by posix_file_impl's list_directory() API, but this file impl can talk to thread-pool on its own (all the more so it already does so in many other ways).