### PR TITLE
rpc: Tune up connection methods visibility

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -307,6 +307,7 @@ protected:
     future<> stream_close();
     future<> stream_process_incoming(rcv_buf&&);
     future<> handle_stream_frame();
+    future<> send_negotiation_frame(feature_map features);
 
 public:
     connection(connected_socket&& fd, const logger& l, void* s, connection_id id = invalid_connection_id) : connection(l, s, id) {
@@ -319,10 +320,11 @@ public:
     }
 
     void set_socket(connected_socket&& fd);
-    future<> send_negotiation_frame(feature_map features);
     bool error() const noexcept { return _error; }
     void abort();
     future<> stop() noexcept;
+
+private:
     future<> stream_receive(circular_buffer<foreign_ptr<std::unique_ptr<rcv_buf>>>& bufs);
     future<> close_sink() {
         _sink_closed = true;
@@ -341,6 +343,8 @@ public:
         }
         return make_ready_future();
     }
+
+public:
     connection_id get_connection_id() const noexcept {
         return _id;
     }


### PR DESCRIPTION
The send_negotiation_frame() is used internally and by child server::connection class, so move it to protected.

The sink/source closing methods as well as stream_receive() one are only uised by sink/source impls, which are friends of connection, so move them to private.