### PR TITLE
headers: Remove smp.hh from app-template.hh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,6 +554,7 @@ add_library (seastar
   include/seastar/core/scollectd.hh
   include/seastar/core/scollectd_api.hh
   include/seastar/core/seastar.hh
+  include/seastar/core/smp.hh
   include/seastar/core/semaphore.hh
   include/seastar/core/shard_id.hh
   include/seastar/core/sharded.hh

--- a/include/seastar/core/app-template.hh
+++ b/include/seastar/core/app-template.hh
@@ -26,7 +26,6 @@
 #include <chrono>
 #endif
 #include <seastar/core/future.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/core/smp_options.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/program-options.hh>
@@ -36,6 +35,8 @@
 #include <seastar/util/modules.hh>
 
 namespace seastar {
+
+class smp;
 
 namespace alien {
 

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -21,8 +21,9 @@
 
 #pragma once
 
-#ifndef SEASTAR_MODULE
+#include <seastar/core/resource.hh>
 #include <seastar/util/program-options.hh>
+#ifndef SEASTAR_MODULE
 #include <seastar/util/modules.hh>
 #include <string>
 #endif

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -27,6 +27,7 @@ module;
 #include <memory>
 #include <utility>
 #include <numeric>
+#include <span>
 
 #ifdef SEASTAR_MODULE
 module seastar;


### PR DESCRIPTION
It needs it for std::shared_ptr<smp> field, but can just go with forward declaration. The smp_options.hh carried the resource::cpuset indirectly via this inclusion, no it needs to include resource.hh explicitly.