### PR TITLE
BUILD FIX: memory max constant in allocator

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1873,7 +1873,7 @@ static long mbind(void *addr,
 static
 unsigned
 cpu_id_bits(unsigned nr_shards) {
-    auto w = std::bit_width(nr_shards - 1);
+    int w = std::bit_width(nr_shards - 1);
     // Preserve at least 8 bits for CPU ID to have a traditional memory map
     return std::max(w, 8);
 }


### PR DESCRIPTION
After recent changes to memory.cc, it fails to compile as standard
libraries vary in their return value for std::bit_width. Initial C++20
behavior was to return an integer of the same signeness as the input,
but later standards specify an `int` return type.

This patch changes the variable `w` to be an `int` from auto so it
works everywhere.