### PR TITLE
metrics: Add default ~config()

### DIFF
--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -51,6 +51,7 @@ struct config {
     config() = default;
     config(const config&) = default;
     config(config&&) = default;
+    ~config() = default;
     SEASTAR_INTERNAL_END_IGNORE_DEPRECATIONS
 
     std::optional<metrics::label_instance> label; //!< A label that will be added to all metrics, we advice not to use it and set it on the prometheus server


### PR DESCRIPTION
After 7a08db98b0 (prometheus: remove hostname and metric_help config) some clang versions (20.1.8 in particular) started to generate warning in generated destructor about some members being deprecated. This patch puts the default destructor explicitly into "ignore deprecation warning" section.