### PR TITLE
configure.py: fix --api-level help

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -75,7 +75,7 @@ arg_parser.add_argument('--ldflags', action='store', dest='user_ldflags', defaul
 arg_parser.add_argument('--optflags', action='store', dest='user_optflags', default='',
                         help='Extra optimization flags for the release mode')
 arg_parser.add_argument('--api-level', action='store', dest='api_level', default='9',
-                        help='Compatibility API level (8=latest)')
+                        help='Compatibility API level (9=latest)')
 arg_parser.add_argument('--compiler', action='store', dest='cxx', default='g++',
                         help='C++ compiler path')
 arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc',


### PR DESCRIPTION
Fixes the help text to match the updated default value