### PR TITLE
demos: Simplify udp_zero_copy_demo's way of preparing the packet

### DIFF
--- a/demos/udp_zero_copy_demo.cc
+++ b/demos/udp_zero_copy_demo.cc
@@ -21,8 +21,6 @@
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/app-template.hh>
-#include <seastar/core/scattered_message.hh>
-#include <seastar/core/vector-data-sink.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/units.hh>
 #include <seastar/core/timer.hh>
@@ -49,8 +47,6 @@ private:
     uint64_t _n_sent {};
     size_t _chunk_size;
     bool _copy;
-    std::vector<packet> _packets;
-    std::unique_ptr<output_stream<char>> _out;
     steady_clock_type::time_point _last;
     sstring _key;
     size_t _packet_size = 8*KB;
@@ -94,9 +90,6 @@ public:
         _copy = copy;
         _key = sstring(new char[64], 64);
 
-        _out = std::make_unique<output_stream<char>>(
-            data_sink(std::make_unique<vector_data_sink>(_packets)), _packet_size);
-
         _mem = new char[mem_size];
         _mem_size = mem_size;
 
@@ -108,27 +101,17 @@ public:
         (void)keep_doing([this] {
             return _chan.receive().then([this] (datagram dgram) {
                 auto chunk = next_chunk();
-                lw_shared_ptr<sstring> item;
-                if (_copy) {
-                    _packets.clear();
-                    // FIXME: future is discarded
-                    (void)_out->write(chunk, _chunk_size);
+                std::vector<temporary_buffer<char>> bufs;
+                bufs.reserve(3);
+                for (unsigned int i = 0; i < bufs.size(); i++) {
+                    if (_copy) {
+                        bufs.emplace_back(temporary_buffer<char>(chunk, _chunk_size));
+                    } else {
+                        bufs.emplace_back(temporary_buffer<char>(chunk, _chunk_size, deleter()));
+                    }
                     chunk += _chunk_size;
-                    (void)_out->write(chunk, _chunk_size);
-                    chunk += _chunk_size;
-                    (void)_out->write(chunk, _chunk_size);
-                    (void)_out->flush();
-                    SEASTAR_ASSERT(_packets.size() == 1);
-                    return send(dgram.get_src(), std::move(_packets[0]));
-                } else {
-                    auto chunk = next_chunk();
-                    scattered_message<char> msg;
-                    msg.reserve(3);
-                    msg.append_static(chunk, _chunk_size);
-                    msg.append_static(chunk, _chunk_size);
-                    msg.append_static(chunk, _chunk_size);
-                    return send(dgram.get_src(), std::move(msg).release());
                 }
+                return send(dgram.get_src(), net::packet(std::span(bufs)));
             });
         });
     }


### PR DESCRIPTION
There are two modes in it, actually -- zero-copy and not. In each, the response packet is prepared using pre-allocated array of chars. A portion of bytes is appended three times to the response data, either with the help of scattered_message::append_static (zero-copy) or with the help of output_stream + vector_data_sink (copying mode). In either case, it's much simpler to just prepare three temp buffers in a vector and then send them as net::packet into datagram channel.

This is pre-requisite patch for removing net::packet from UDP posix channels implemntation and to deprecate the vector_data_sink itself.