### PR TITLE
ci: Disable ccache for DPDK job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,7 @@ jobs:
       mode: release
       enables: --enable-dpdk
       options: --cook dpdk
+      enable-ccache: false
   build_with_cxx_modules:
     name: "Test with C++20 modules enabled"
     uses: ./.github/workflows/test.yaml


### PR DESCRIPTION
Somehow ccache and recent generator rework interfered with each other. When validating a PR, all tests in the DPDK job abort early with SIGILL. Branch validation on push passes.

fixes #3083
refs #2218