### PR TITLE
socket: Return unspecified socket_address for unconnected socket

### DIFF
--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -111,7 +111,14 @@ public:
         return _fd.get_address();
     }
     virtual socket_address remote_address(file_desc& _fd) const {
-        return _fd.get_remote_address();
+        try {
+            return _fd.get_remote_address();
+        } catch (const std::system_error& e) {
+            if (e.code().value() != ENOTCONN) {
+                throw;
+            }
+            return socket_address();
+        }
     }
 };
 


### PR DESCRIPTION
When calling connected_socket::remote_address() it may happen that the kernel-level socket is really unconnected, e.g. because it was connected before and then was forcibly disconnected.

For posix_connected_socket_impl this leads to app termination, because its remote_address() method is noexcept, it calls file_desc wrapper of get_peer_address() libc function which, in turn, returns ENOTCON error and the file_desc throws system_error with it.

Fix by catching exceptions from file_desc and returning default-initialized socket_address instead.

To test it there must appear foribly disconnected socket. For TCP it can be done by closing a socket with unread data in it. The attached test does it, it crashes before the fix and passes after it.

fixes #2379