### PR TITLE
timer: Enable highres timer based on next timeout value

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3207,8 +3207,8 @@ void reactor::sched_entity::wakeup() {
 
 void reactor::service_highres_timer() noexcept {
     _timers.complete(_expired_timers, [this] () noexcept {
-        if (!_timers.empty()) {
-            enable_timer(_timers.get_next_timeout());
+        if (auto next = _timers.get_next_timeout(); next != decltype(next)::time_point::max()) {
+            enable_timer(next);
         }
     });
 }


### PR DESCRIPTION
When highres timers are completed, the post-completion callback checks if there are any timers queued to decide whether or not to set up the timerfd notification. The check is wrong, timer list can be empty at that point if a timer is (was) canceled while being run. At the same time, since "next timeout" value is set, timer-set thinks that the timerfd is active and may decide not to re-activate it when another timer appears.

The fix is to engage timerfd based on "next timeout" value.

Test that reproduced the issue is included, it fails before the fix.

fixes #3013