### PR TITLE
github: disable AVX instruction set when building dpdk

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,8 @@ jobs:
       standard: 23
       mode: release
       enables: --enable-dpdk
-      options: --cook dpdk
+      options: --cook dpdk --dpdk-machine corei7-avx
+
   build_with_cxx_modules:
     name: "Test with C++20 modules enabled"
     uses: ./.github/workflows/test.yaml


### PR DESCRIPTION
by default, we build dpdk with "meson setup
-Dcpu_instruction_set=native". in which, "cpu_instruction_set=native" option tells the building system to configures "-march", "-mcpu" and "-mtune" to "native". this might instruct the compiler to emit target code using advanced instruction set like AVX-512, while the the CPU might not be able to execute it, because the hypervisor might not expose all CPU features in a virtualization environment.

in this change, instead of using "generic" which is mapped to "corei7", we use a conservative but performant alternative -- "corei7-avx" where SSE4.2 and AVX is enabled, but AVX2 is disabled.

Fixes #3083