### PR TITLE
file: recursive_remove_directory(): use a list instead of a deque

### DIFF
--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -25,7 +25,7 @@ module;
 #endif
 
 #include <cstdint>
-#include <deque>
+#include <list>
 #include <optional>
 #include <filesystem>
 #include <iostream>
@@ -177,7 +177,7 @@ static future<> do_recursive_remove_directory(const fs::path path) noexcept {
         }
     };
 
-    return do_with(std::deque<work_entry>(), [path = std::move(path)] (auto& work_queue) mutable {
+    return do_with(std::list<work_entry>(), [path = std::move(path)] (auto& work_queue) mutable {
         work_queue.emplace_back(std::move(path), false);
         return do_until([&work_queue] { return work_queue.empty(); }, [&work_queue] () mutable {
             auto ent = work_queue.back();


### PR DESCRIPTION
recursive_remove_directory() stores a list of pending files in a dequeue. This can lead to large allocations with large directories.

Switch to std::list. This is less memory and cpu efficient, but doesn't have large allocations.

Performance will be dominated by the OS anyway.

Ref https://github.com/scylladb/scylladb/issues/26925