### PR TITLE
rpc: Add a new constructor in closed_error to accept string argument

### DIFF
--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -142,6 +142,7 @@ public:
 class closed_error : public error {
 public:
     closed_error() : error("connection is closed") {}
+    closed_error(const std::string& msg) : error(msg) {}
 };
 
 class timeout_error : public error {


### PR DESCRIPTION
In the scylladb codebase, it has been observed that the presence of certain context
details in the error messages can ease debugging in case of error throws. For such 
scenarios, its helpful to have an interface in the error class itself that accepts those
information and passes them along to enrich the context.

This pr adds a new constructor in the `rpc::closed_error` which accepts a string as 
argument, where the caller can pass relevant context useful for debugging.

Since this is not a bug fix, backport is not needed

ref: https://github.com/scylladb/scylladb/issues/16923