### PR TITLE
net: tcp: change unsent queue from packets to temporary_buffer:s

### DIFF
--- a/demos/tcp_demo.cc
+++ b/demos/tcp_demo.cc
@@ -45,7 +45,8 @@ struct tcp_test {
                     return;
                 }
                 fmt::print("read {:d} bytes\n", p.len());
-                (void)tcp_conn.send(std::move(p));
+                auto v = std::move(p).release();
+                (void)tcp_conn.send(std::span(v));
                 run();
             });
         }


### PR DESCRIPTION
The unsent queue is currently a queue of packets. This is awkward because the packets queued don't correspond to packets to be sent; they have to be cut and pasted to fit the send window or maximum packet size, whichever is greater.

The recent change to data_sink to work in terms of temporary_buffer:s rather than packets provides an additional incentive to fix this.

The fix is simple: change the queue type to hold temporary buffers. The compatibility code to construct a packet out of the data_sink temporary_buffer:s is no longer needed.

The code to reshape the unsent packets to a packet to be sent is simplified: we append buffers to the packet until a complete buffer will overflow the maximum send size, then split the last buffer (if available and needed) to complete the packet.

Tested with httpd on a tap device, seems to work.