### PR TITLE
coroutine: exception: workaround broken destroy coroutine handle in a…

### DIFF
--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -43,8 +43,10 @@ struct exception_awaiter {
 
     template<typename U>
     void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+      execute_involving_handle_destruction_in_await_suspend([hndl, eptr = std::move(eptr)] () mutable {
         hndl.promise().set_exception(std::move(eptr));
         hndl.destroy();
+      });
     }
 
     void await_resume() noexcept {}


### PR DESCRIPTION
gcc 15.2 and above crash if a coroutine handle is destroyed when await_suspend for that coroutine is called [1]. An internal reference counter is accessed after the coroutine is destroyed.

Work around this by scheduling the work to a task. This is slower, but doesn't crash, and exceptions are supposed to be somewhat rare.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121961