### PR TITLE
Improve loads evaluation by reactor

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -353,6 +353,7 @@ private:
     lowres_clock::time_point _lowres_next_timeout = lowres_clock::time_point::max();
     std::optional<pollable_fd> _aio_eventfd;
     static constexpr unsigned loads_size = 5;
+    timer<lowres_clock> _load_timer;
     circular_buffer<double> _loads;
     double _load = 0;
     // Next two fields are required to enforce the monotonicity of total_steal_time()

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3294,10 +3294,9 @@ int reactor::do_run() {
     poller sig_poller(std::make_unique<signal_pollfn>(*this));
 
     using namespace std::chrono_literals;
-    timer<lowres_clock> load_timer;
     auto last_idle = _total_idle;
     auto idle_start = now(), idle_end = idle_start;
-    load_timer.set_callback([this, &last_idle, &idle_start, &idle_end] () mutable {
+    _load_timer.set_callback([this, &last_idle, &idle_start, &idle_end] () mutable {
         _total_idle += idle_end - idle_start;
         auto load = double((_total_idle - last_idle).count()) / double(std::chrono::duration_cast<sched_clock::duration>(1s).count());
         last_idle = _total_idle;
@@ -3308,7 +3307,7 @@ int reactor::do_run() {
         _loads.push_front(load);
         _load += (load / loads_size);
     });
-    load_timer.arm_periodic(1s);
+    _load_timer.arm_periodic(1s);
 
     itimerspec its = seastar::posix::to_relative_itimerspec(_cfg.task_quota, _cfg.task_quota);
     _task_quota_timer.timerfd_settime(0, its);
@@ -3385,7 +3384,7 @@ int reactor::do_run() {
         }
     }
 
-    load_timer.cancel();
+    _load_timer.cancel();
     // Final tasks may include sending the last response to cpu 0, so run them
     while (have_more_tasks()) {
         _cpu_sched.run_some_tasks();


### PR DESCRIPTION
The evaluation in question is a 1s periodic timer that calculates the average value of the idling time fraction over pas 5 seconds. The evaluation loop uses more memory and cpu cycles that it could. Also the load timer is kept on stack which complicates the debugging on [lowres-timer re-arm]( https://github.com/scylladb/seastar/pull/3092#issuecomment-3528389847)