### PR TITLE
Fix incorrect union access in dns resolver

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -1350,15 +1350,17 @@ dns_resolver::impl::do_sendv(ares_socket_t fd, const iovec * vec, int len) {
 
         for (;;) {
             // check if we're already writing.
-            if (e.typ == type::tcp && !(e.avail & POLLOUT)) {
-                dns_log.trace("Send already pending {}", fd);
-                errno = EWOULDBLOCK;
-                return -1;
-            }
+            if (e.typ == type::tcp) {
+                if (!(e.avail & POLLOUT)) {
+                    dns_log.trace("Send already pending {}", fd);
+                    errno = EWOULDBLOCK;
+                    return -1;
+                }
 
-            if (e.type == type::tcp && !e.tcp.socket) {
-                errno = ENOTCONN;
-                return -1;
+                if (!e.tcp.socket) {
+                    errno = ENOTCONN;
+                    return -1;
+                }
             }
 
             packet p;


### PR DESCRIPTION
The resolver maintains a map of sock_entry's each containing union of tcp_entry and udp_entry and its type. There's (at least) one place that accesses the union without checking if it contains the expected object.