### PR TITLE
Update compilers in GH actions scripts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,11 @@ jobs:
         run: |
           sudo apt-get -y install clang-tools-20
 
+      - name: Install g++
+        if: ${{ inputs.compiler == 'g++' }}
+        run: |
+          sudo apt-get -y install gcc-14 g++-14
+
       - name: Install ccache
         if: ${{ inputs.enable-ccache }}
         run: |
@@ -77,8 +82,8 @@ jobs:
             CC=clang-20
             CPP=clang++-20
           else
-            CC=gcc
-            CPP=g++
+            CC=gcc-14
+            CPP=g++-14
           fi
           if ${{ inputs.enable-ccache }}; then
             MAYBE_CCACHE_OPT="--ccache"


### PR DESCRIPTION
Actions run in native gihub ubuntu-24.04 containers, which is the newest available one. Default compliers versions in it are pretty old, but fortunately newer versions are also available from built-in repositories.