### PR TITLE
reactor: Mark some sched-stats getters const

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -355,10 +355,10 @@ private:
 
     // Last measured accumulated steal time, i.e., the simple difference of accumulated
     // awake time and consumed thread CPU time.
-    sched_clock::duration _last_true_steal{0};
+    mutable sched_clock::duration _last_true_steal{0};
     // Accumulated steal time forced to be monotinic by rejecting any updates that would
     // decrease it. See total_steal_time() for details.
-    sched_clock::duration _last_mono_steal{0};
+    mutable sched_clock::duration _last_mono_steal{0};
     sched_clock::duration _total_idle{0};
     sched_clock::duration _total_sleep{0};
     sched_clock::time_point _start_time = now();
@@ -655,11 +655,11 @@ public:
     /// \returns Returns the `smp` instance which owns this reactor.
     const seastar::smp& smp() const noexcept;
 
-    steady_clock_type::duration total_idle_time();
-    steady_clock_type::duration total_busy_time();
+    steady_clock_type::duration total_idle_time() const;
+    steady_clock_type::duration total_busy_time() const;
     steady_clock_type::duration total_awake_time() const;
     std::chrono::nanoseconds total_cpu_time() const;
-    std::chrono::nanoseconds total_steal_time();
+    std::chrono::nanoseconds total_steal_time() const;
 
     const io_stats& get_io_stats() const { return _io_stats; }
     /// Returns statistics related to scheduling. The statistics are

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4851,11 +4851,11 @@ future<> later() noexcept {
     return check_for_io_immediately();
 }
 
-steady_clock_type::duration reactor::total_idle_time() {
+steady_clock_type::duration reactor::total_idle_time() const {
     return _total_idle;
 }
 
-steady_clock_type::duration reactor::total_busy_time() {
+steady_clock_type::duration reactor::total_busy_time() const {
     return now() - _start_time - _total_idle;
 }
 
@@ -4867,7 +4867,7 @@ std::chrono::nanoseconds reactor::total_cpu_time() const {
     return thread_cputime_clock::now().time_since_epoch();
 }
 
-std::chrono::nanoseconds reactor::total_steal_time() {
+std::chrono::nanoseconds reactor::total_steal_time() const {
     // Steal time: this mimics the concept some Hypervisors have about Steal time.
     // That is the time in which a VM has something to run, but is not running because some other
     // process (another VM or the hypervisor itself) is in control.


### PR DESCRIPTION
The methods that return idle, busy and steal time are naturally const The last one, however, "caches" the result of prevuous evaluation, so the cache members perfectly deserve being marked mutable.