### PR TITLE
code: Move pollable_fd_state::write_all(const char*) from API level 9

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -97,14 +97,14 @@ public:
     future<size_t> read_some(uint8_t* buffer, size_t size);
     future<size_t> read_some(const std::vector<iovec>& iov);
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba);
-    future<> write_all(const char* buffer, size_t size);
-    future<> write_all(const uint8_t* buffer, size_t size);
 #if SEASTAR_API_LEVEL >= 9
     future<size_t> write_some(std::span<iovec> iovs);
     future<> write_all(std::span<iovec> iovs);
 #else
     future<size_t> write_some(net::packet& p);
     future<> write_all(net::packet& p);
+    future<> write_all(const char* buffer, size_t size);
+    future<> write_all(const uint8_t* buffer, size_t size);
 #endif
     future<> readable();
     future<> writeable();
@@ -151,12 +151,6 @@ public:
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba) {
         return _s->read_some(ba);
     }
-    future<> write_all(const char* buffer, size_t size) {
-        return _s->write_all(buffer, size);
-    }
-    future<> write_all(const uint8_t* buffer, size_t size) {
-        return _s->write_all(buffer, size);
-    }
 #if SEASTAR_API_LEVEL >= 9
     future<size_t> write_some(std::span<iovec> iov) {
         return _s->write_some(iov);
@@ -170,6 +164,12 @@ public:
     }
     future<> write_all(net::packet& p) {
         return _s->write_all(p);
+    }
+    future<> write_all(const char* buffer, size_t size) {
+        return _s->write_all(buffer, size);
+    }
+    future<> write_all(const uint8_t* buffer, size_t size) {
+        return _s->write_all(buffer, size);
     }
 #endif
     future<> readable() {

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -459,8 +459,11 @@ private:
     future<temporary_buffer<char>>
     do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 
+#if SEASTAR_API_LEVEL < 9
     future<size_t>
     do_send(pollable_fd_state& fd, const void* buffer, size_t size);
+#endif
+
     future<size_t>
     do_sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len);
 
@@ -522,7 +525,9 @@ public:
         return internal::posix_connect(std::move(pfd), sa, local);
     }
 
+#if SEASTAR_API_LEVEL < 9
     future<> send_all(pollable_fd_state& fd, const void* buffer, size_t size);
+#endif
 
     future<file> open_file_dma(std::string_view name, open_flags flags, file_open_options options = {}) noexcept;
     future<file> open_directory(std::string_view name) noexcept;
@@ -683,7 +688,10 @@ private:
     void unregister_poller(pollfn* p);
     void replace_poller(pollfn* old, pollfn* neww);
     void register_metrics();
+
+#if SEASTAR_API_LEVEL < 9
     future<> send_all_part(pollable_fd_state& fd, const void* buffer, size_t size, size_t completed);
+#endif
 
     future<> fdatasync(int fd) noexcept;
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -672,10 +672,12 @@ reactor_backend_aio::read_some(pollable_fd_state& fd, internal::buffer_allocator
     return _r.do_read_some(fd, ba);
 }
 
+#if SEASTAR_API_LEVEL < 9
 future<size_t>
 reactor_backend_aio::send(pollable_fd_state& fd, const void* buffer, size_t len) {
     return _r.do_send(fd, buffer, len);
 }
+#endif
 
 future<size_t>
 reactor_backend_aio::sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) {
@@ -1056,10 +1058,12 @@ reactor_backend_epoll::read_some(pollable_fd_state& fd, internal::buffer_allocat
     return _r.do_read_some(fd, ba);
 }
 
+#if SEASTAR_API_LEVEL < 9
 future<size_t>
 reactor_backend_epoll::send(pollable_fd_state& fd, const void* buffer, size_t len) {
     return _r.do_send(fd, buffer, len);
 }
+#endif
 
 future<size_t>
 reactor_backend_epoll::sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) {
@@ -1742,6 +1746,8 @@ public:
         auto req = internal::io_request::make_sendmsg(fd.fd.get(), desc->msghdr(), MSG_NOSIGNAL);
         return submit_request(std::move(desc), std::move(req));
     }
+
+#if SEASTAR_API_LEVEL < 9
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override {
         if (fd.take_speculation(EPOLLOUT)) {
             try {
@@ -1782,6 +1788,7 @@ public:
         auto req = internal::io_request::make_send(fd.fd.get(), buffer, len, MSG_NOSIGNAL);
         return submit_request(std::move(desc), std::move(req));
     }
+#endif
 
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override {
         if (fd.take_speculation(POLLIN)) {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -202,7 +202,9 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) = 0;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) = 0;
+#if SEASTAR_API_LEVEL < 9
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) = 0;
+#endif
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
 
     virtual bool do_blocking_io() const {
@@ -268,7 +270,9 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) override;
+#if SEASTAR_API_LEVEL < 9
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
+#endif
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override;
@@ -316,7 +320,9 @@ public:
     virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override;
     virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
     virtual future<size_t> sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) override;
+#if SEASTAR_API_LEVEL < 9
     virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override;
+#endif
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override;
 
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override;


### PR DESCRIPTION
The pair of methods sending plain buffer into fd are not used in the 9th API level, because the only caller of it are data_sink::put()-s overloads that send single temporary_buffer and they were left in older API levels in favor of span-nized put()-s.

Together with this method, reactor::send() bunch. All those methods but the send_all() one are private. The send_all, however, needs internal pollable_fd_state& argument, so is likely not the part of the public API either.