### PR TITLE
util: Genralize memory_data_sink

### DIFF
--- a/include/seastar/core/vector-data-sink.hh
+++ b/include/seastar/core/vector-data-sink.hh
@@ -25,7 +25,11 @@
 
 namespace seastar {
 
-class vector_data_sink final : public data_sink_impl {
+class
+#if SEASTAR_API_LEVEL >= 9
+[[deprecated("Use util::memory_data_sink")]]
+#endif
+vector_data_sink final : public data_sink_impl {
 public:
     using vector_type = std::vector<net::packet>;
 private:

--- a/include/seastar/util/memory-data-sink.hh
+++ b/include/seastar/util/memory-data-sink.hh
@@ -1,0 +1,78 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2025 ScyllaDB
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <seastar/core/iostream.hh>
+
+namespace seastar {
+namespace util {
+
+#if SEASTAR_API_LEVEL >= 9
+
+template <template <typename T> class Container>
+requires requires (Container<temporary_buffer<char>>& col, size_t s) {
+    typename std::back_insert_iterator<Container<temporary_buffer<char>>>;
+}
+inline void append_buffers(Container<temporary_buffer<char>>& c, std::span<temporary_buffer<char>> bufs) {
+    std::ranges::move(bufs, std::back_inserter(c));
+}
+
+template <typename Container, size_t DefaultBufferSize = 1024>
+requires requires (Container& ct, std::span<temporary_buffer<char>> bufs) {
+    { append_buffers(ct, bufs) };
+}
+class basic_memory_data_sink final : public data_sink_impl {
+    Container& _container;
+    const size_t _buffer_size;
+
+public:
+    basic_memory_data_sink(Container& ct, size_t buffer_size = DefaultBufferSize)
+        : _container(ct)
+        , _buffer_size(buffer_size)
+    {
+    }
+
+    virtual future<> put(std::span<temporary_buffer<char>> bufs) override {
+        append_buffers(this->_container, bufs);
+        return make_ready_future<>();
+    }
+
+    virtual future<> flush() override {
+        return make_ready_future<>();
+    }
+
+    virtual future<> close() override {
+        return make_ready_future<>();
+    }
+
+    virtual size_t buffer_size() const noexcept override {
+        return _buffer_size;
+    }
+};
+
+using memory_data_sink = basic_memory_data_sink<std::vector<temporary_buffer<char>>>;
+
+#endif
+
+}
+}

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -165,6 +165,7 @@ module;
 #include <seastar/util/read_first_line.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/memory-data-source.hh>
+#include <seastar/util/memory-data-sink.hh>
 
 #include <seastar/net/arp.hh>
 #include <seastar/net/packet.hh>
@@ -342,6 +343,7 @@ export namespace seastar::util {
 
 using seastar::util::basic_memory_data_source;
 using seastar::util::temporary_buffer_data_source;
+using seastar::util::basic_memory_data_sink;
 
 }
 

--- a/tests/unit/memory-data-sink.hh
+++ b/tests/unit/memory-data-sink.hh
@@ -20,51 +20,23 @@
  */
 
 #pragma once
+#include <seastar/util/memory-data-sink.hh>
 
 namespace seastar {
+
+inline void append_buffers(std::stringstream& ss, std::span<seastar::temporary_buffer<char>> bufs) {
+    for (auto& buf : bufs) {
+        ss.write(buf.get(), buf.size());
+    }
+}
+
 namespace testing {
+
+using memory_data_sink_impl = util::basic_memory_data_sink<std::stringstream>;
 
 /*!
  * \brief a helper data sink that stores everything it gets in a stringstream
  */
-class memory_data_sink_impl : public data_sink_impl {
-    std::stringstream& _ss;
-    const size_t _buffer_size;
-public:
-    static constexpr size_t default_buffer_size = 1024;
-    memory_data_sink_impl(std::stringstream& ss, size_t buffer_size = default_buffer_size)
-        : _ss(ss)
-        , _buffer_size(buffer_size)
-    {
-    }
-#if SEASTAR_API_LEVEL >= 9
-    future<> put(std::span<temporary_buffer<char>> bufs) override {
-        for (auto& buf : bufs) {
-            _ss.write(buf.get(), buf.size());
-        }
-        return make_ready_future<>();
-    }
-#else
-    virtual future<> put(net::packet data)  override {
-        return data_sink_impl::fallback_put(std::move(data));
-    }
-    virtual future<> put(temporary_buffer<char> buf) override {
-        _ss.write(buf.get(), buf.size());
-        return make_ready_future<>();
-    }
-#endif
-    virtual future<> flush() override {
-        return make_ready_future<>();
-    }
-
-    virtual future<> close() override {
-        return make_ready_future<>();
-    }
-
-    virtual size_t buffer_size() const noexcept override {
-        return _buffer_size;
-    }
-};
 
 class memory_data_sink : public data_sink {
 public:


### PR DESCRIPTION
The sink that stores temporary buffers put into it into some external collection is useful on its own. It's used in tests, that store buffers in stringstream, it's used by memcache, that stores buffers into a vector of vectors of buffers, and it's used in Scylla, which accumulates buffers in a vector decorated with some axuliary data.

This patch introduces basic_memory_data_sink template with Container parameter. The append_buffers(Container&, span<temporary_buffer>) function is a requirement for Container type.

The new sink is available for API level 9 (and above) only, not to implement legacy put() methods. It suits the needs of tests, memcached and Scylla.

The vector_data_sink, that forwards temporary_buffers into net::packet is deprecated in favor of basic_memory_data_sink<vector> for newer API levels.