### PR TITLE
coroutines: simplify execute_involving_handle_destruction_in_await_suspend()

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -39,18 +39,22 @@ inline
 void
 execute_involving_handle_destruction_in_await_suspend(std::invocable<> auto&& func) noexcept {
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 15 || (__GNUC__ == 15 && __GNUC_MINOR__ >= 2))
-    // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121961
-    if constexpr (std::is_base_of_v<seastar::task, std::remove_cvref_t<decltype(func)>>) {
-        schedule(&func);
-    } else {
-        memory::scoped_critical_alloc_section _;
-        schedule(new lambda_task(current_scheduling_group(), std::forward<decltype(func)>(func)));
-    }
+    memory::scoped_critical_alloc_section _;
+    schedule(new lambda_task(current_scheduling_group(), std::forward<decltype(func)>(func)));
 #else
     std::invoke(std::forward<decltype(func)>(func));
 #endif
 }
 
+inline
+void
+execute_involving_handle_destruction_in_await_suspend(task* tsk) noexcept {
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 15 || (__GNUC__ == 15 && __GNUC_MINOR__ >= 2))
+    schedule(tsk);
+#else
+    tsk->run_and_dispose();
+#endif
+}
 
 template <typename T = void>
 class coroutine_traits_base {

--- a/include/seastar/coroutine/try_future.hh
+++ b/include/seastar/coroutine/try_future.hh
@@ -63,7 +63,7 @@ public:
         _waiting_task = hndl.promise().waiting_task();
 
         if (_future.available()) {
-            execute_involving_handle_destruction_in_await_suspend(*this);
+            execute_involving_handle_destruction_in_await_suspend(this);
         } else {
             _future.set_coroutine(*this);
         }
@@ -77,11 +77,7 @@ public:
         }
     }
 
-    void operator()() noexcept {
-        run_and_dispose();
-    }
-
-    virtual void run_and_dispose() noexcept override {
+    virtual void run_and_dispose() noexcept final override {
         _resume_or_destroy(_future, *_coroutine_task);
     }
 


### PR DESCRIPTION

execute_involving_handle_destruction_in_await_suspend() auto-recognizes if a task is passed to it, so it can avoid allocating a new task, but that causes the caller to have to create an artificial operator().

Simplify by having a separate overload for task*.

The artificial operator()() in try_future is removed, and run_and_dispose() is marked final to reduce call overhead.