### PR TITLE
httpd: Add API to set tcp keepalive params

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -135,6 +135,7 @@ class http_server {
     size_t _content_length_limit = std::numeric_limits<size_t>::max();
     bool _content_streaming = false;
     gate _task_gate;
+    std::optional<net::keepalive_params> _keepalive_params;
 public:
     routes _routes;
     using connection = seastar::httpd::connection;
@@ -170,6 +171,10 @@ public:
      */
     [[deprecated("use listen(socket_address addr, server_credentials_ptr credentials)")]]
     void set_tls_credentials(server_credentials_ptr credentials);
+
+    void set_keepalive_parameters(std::optional<net::keepalive_params> params) {
+        _keepalive_params = std::move(params);
+    }
 
     size_t get_content_length_limit() const;
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -440,6 +440,10 @@ future<> http_server::do_accepts(int which){
 
 future<> http_server::do_accept_one(int which, bool tls) {
     return _listeners[which].accept().then([this, tls] (accept_result ar) mutable {
+        if (_keepalive_params) {
+            ar.connection.set_keepalive(true);
+            ar.connection.set_keepalive_parameters(_keepalive_params.value());
+        }
         auto local_address = ar.connection.local_address();
         auto conn = std::make_unique<connection>(*this, std::move(ar.connection),
                 std::move(ar.remote_address), std::move(local_address), tls);


### PR DESCRIPTION
Allow setting TCP keepalive settings on the httpd connections.