### PR TITLE
test,perf: Measure time it takes to traverse a runqueue

### DIFF
--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -253,6 +253,10 @@ inline void stop_measuring_time()
     internal::time_measurement_stop_iteration();
 }
 
+namespace internal { std::string get_parameter(std::string); }
+inline std::string get_parameter(std::string name) {
+    return internal::get_parameter(std::move(name));
+}
 
 template<typename T>
 void do_not_optimize(const T& v)

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -266,6 +266,13 @@ void time_measurement_stop_iteration() {
     measure_time->stop_iteration();
 }
 
+std::map<std::string, std::string> parameters;
+
+std::string get_parameter(std::string name) {
+    auto it = parameters.find(name);
+    return it == parameters.end() ? "" : it->second;
+}
+
 struct config;
 struct result;
 
@@ -910,6 +917,11 @@ void run_all(const std::vector<std::string>& test_patterns, config& conf) {
         fmt::print(stderr, "\n");
         throw std::runtime_error("no tests matched the given pattern(s)");
     }
+
+    for (auto p : parameters) {
+        fmt::print("parameter {}: {}\n", p.first, p.second);
+    }
+
     for (auto& rp : conf.printers) {
         rp->update_name_column_length(max_name_column_length);
         rp->print_configuration(conf);
@@ -956,6 +968,7 @@ int main(int ac, char** av)
             "warn if overhead exceeds this ratio (default: 0.1 = 10%)")
         ("fail-on-high-overhead", "fail the test run if any test exceeds the overhead threshold")
         ("no-perf-counters", "disable hardware perf counters (inst/cycles)")
+        ("parameter", bpo::value<std::vector<std::string>>(), "specify test-specific parameters")
         ;
 
     return app.run(ac, av, [&] {
@@ -977,6 +990,18 @@ int main(int ac, char** av)
             std::vector<std::string> tests_to_run;
             if (app.configuration().count("test")) {
                 tests_to_run = app.configuration()["test"].as<std::vector<std::string>>();
+            }
+
+            if (app.configuration().count("parameter")) {
+                auto param = app.configuration()["parameter"].as<std::vector<std::string>>();
+                for (auto& p : param) {
+                    size_t split = p.find('=');
+                    if (split == std::string::npos) {
+                        parameters.emplace(std::make_pair(p, ""));
+                    } else {
+                        parameters.emplace(std::make_pair(p.substr(0, split), p.substr(split+1, p.size())));
+                    }
+                }
             }
 
             if (app.configuration().count("list")) {


### PR DESCRIPTION
Add a test that populates run-queue and measures the time it takes for the scheduler to process one.
Useful to measure the effect the runqueue implementation has.