### PR TITLE
build: explicitly enable vptr sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,7 +883,8 @@ if (condition)
   target_link_libraries (seastar
     PUBLIC
       $<${condition}:Sanitizers::address>
-      $<${condition}:Sanitizers::undefined_behavior>)
+      $<${condition}:Sanitizers::undefined_behavior>
+      $<${condition}:Sanitizers::vptr>)
 endif ()
 
 # We only need valgrind to find uninitialized memory uses, so disable

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -26,7 +26,8 @@ cmake_policy (SET CMP0057 NEW)
 if(NOT Sanitizers_FIND_COMPONENTS)
   set(Sanitizers_FIND_COMPONENTS
     address
-    undefined_behavior)
+    undefined_behavior
+    vptr)
 endif()
 
 foreach (component ${Sanitizers_FIND_COMPONENTS})
@@ -36,6 +37,10 @@ foreach (component ${Sanitizers_FIND_COMPONENTS})
     list (APPEND ${compile_options} -fsanitize=address)
   elseif (component STREQUAL "undefined_behavior")
     list (APPEND ${compile_options} -fsanitize=undefined)
+  elseif (component STREQUAL "vptr")
+    # since Clang version 21, -fsanitize=undefined no longer implies vptr,
+    # so we enable it explicitly
+    list (APPEND ${compile_options} -fsanitize=vptr)
   else ()
     message (FATAL_ERROR "Unsupported sanitizer: ${component}")
   endif ()


### PR DESCRIPTION
The vptr sanitizer is split off from ubsan as from Clang version 21. In this commit we explicitly enable the vptr sanitizer.

Fixes https://github.com/scylladb/seastar/issues/3028