### PR TITLE
cmake: Mark hwloc headers as system includes to suppress warnings

### DIFF
--- a/cmake/Findhwloc.cmake
+++ b/cmake/Findhwloc.cmake
@@ -57,6 +57,7 @@ if (hwloc_FOUND)
     set_target_properties (hwloc::hwloc
       PROPERTIES
         IMPORTED_LOCATION ${hwloc_LIBRARY}
-        INTERFACE_INCLUDE_DIRECTORIES ${hwloc_INCLUDE_DIRS})
+        INTERFACE_INCLUDE_DIRECTORIES ${hwloc_INCLUDE_DIRS}
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${hwloc_INCLUDE_DIRS})
   endif ()
 endif ()


### PR DESCRIPTION
Fix GCC 15 array-bounds warning when compiling on Alpine Linux by marking hwloc headers as system includes in CMake configuration.

The warning manifested as:
```
  warning: array subscript -1 is outside array bounds of
  'hwloc_bitmap_s* [4294967295]' [-Warray-bounds=]
  at /usr/include/hwloc/helper.h:1007:24
```

Root cause:
The hwloc library's hwloc_distrib() inline function uses negative array indexing (cpusetp[-1]) which is safe in its intended context but triggers GCC 15's stricter bounds checking when inlined into seastar code.

Solution:
Set `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` on the `hwloc::hwloc` imported target in `cmake/Findhwloc.cmake`. This causes CMake to include hwloc headers with `-isystem` instead of `-I`, which suppresses warnings from external library code per standard practice.

This is cleaner than using #pragma directives in source files and follows CMake best practices for handling third-party libraries.