### PR TITLE
stop_signal: stop including reactor.hh

### DIFF
--- a/apps/lib/stop_signal.hh
+++ b/apps/lib/stop_signal.hh
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include <seastar/core/reactor.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/signal.hh>
 


### PR DESCRIPTION
stop_signal now (c3e826ad1197) imports handle_signal via core/signal.hh, but still includes the heavyweight reactor.hh. Remove the unnecessary include.