### PR TITLE
file: Finally override dma_read_bulk() in posix_file_impl

### DIFF
--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -110,7 +110,7 @@ public:
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override = 0;
     virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) noexcept override = 0;
     virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override = 0;
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept override = 0;
+    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept final override;
 
     open_flags flags() const {
         return _open_flags;
@@ -153,7 +153,6 @@ protected:
     future<size_t> do_write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept;
     future<size_t> do_read_dma(uint64_t pos, void* buffer, size_t len, io_intent* intent) noexcept;
     future<size_t> do_read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept;
-    future<temporary_buffer<uint8_t>> do_dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept;
 };
 
 class posix_file_real_impl final : public posix_file_impl {
@@ -167,7 +166,6 @@ public:
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept override;
 };
 
 namespace testing {
@@ -259,7 +257,6 @@ public:
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept override;
 
     future<> flush() noexcept override;
     future<struct stat> stat() noexcept override;
@@ -288,7 +285,6 @@ public:
     virtual future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) noexcept override;
     virtual future<size_t> write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept override;
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept override;
 };
 
 }

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -531,12 +531,7 @@ posix_file_real_impl::read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* 
 }
 
 future<temporary_buffer<uint8_t>>
-posix_file_real_impl::dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept {
-    return posix_file_impl::do_dma_read_bulk(offset, range_size, intent);
-}
-
-future<temporary_buffer<uint8_t>>
-posix_file_impl::do_dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept {
+posix_file_impl::dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept {
     auto front = offset & (_disk_read_dma_alignment - 1);
     offset -= front;
     range_size += front;
@@ -679,11 +674,6 @@ blockdev_file_impl::read_dma(uint64_t pos, void* buffer, size_t len, io_intent* 
 future<size_t>
 blockdev_file_impl::read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* intent) noexcept {
     return posix_file_impl::do_read_dma(pos, std::move(iov), intent);
-}
-
-future<temporary_buffer<uint8_t>>
-blockdev_file_impl::dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept {
-    return posix_file_impl::do_dma_read_bulk(offset, range_size, intent);
 }
 
 append_challenged_posix_file_impl::append_challenged_posix_file_impl(int fd, open_flags f, file_open_options options, const internal::fs_info& fsi, dev_t device_id)
@@ -921,11 +911,6 @@ append_challenged_posix_file_impl::write_dma(uint64_t pos, std::vector<iovec> io
             });
         }
     );
-}
-
-future<temporary_buffer<uint8_t>>
-append_challenged_posix_file_impl::dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) noexcept {
-    return posix_file_impl::do_dma_read_bulk(offset, range_size, intent);
 }
 
 future<>

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -1120,9 +1120,7 @@ public:
         std::memcpy(buffer, _data.get() + pos, rlen);
         return make_ready_future<size_t>(rlen);
     }
-    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* i) noexcept override {
-        return posix_file_impl::do_dma_read_bulk(offset, range_size, i);
-    }
+
     test_posix_file_impl(const temporary_buffer<char>& d)
         : posix_file_impl(0, {}, nullptr, 0, block_size, block_size, block_size, block_size, true)
         , _data(d)


### PR DESCRIPTION
There are three files that inherit from posix_file_impl -- the blockdev file, append-challenged file and posix file per-se. All three override the bulk reading method by calling their base class implementation.

This method was implemented like this for append-challenged file, which runs its IO via internal queue. However, for bulk reading method this queue is avoided, because "real" IO happens inside do_dma_read_bulk() -- it allocates properly aligned buffers and calls read_dma() on it.

Said that, there's no need in re-overriding the dma_read_bulk() for all those sub-classes, the base posix_file_impl final override is enough.