### PR TITLE
add missing headers

### DIFF
--- a/include/seastar/core/circular_buffer_fixed_capacity.hh
+++ b/include/seastar/core/circular_buffer_fixed_capacity.hh
@@ -28,6 +28,7 @@
 // Similar to libstdc++'s std::deque, except that it uses a single level
 // store, and so is more efficient for simple stored items.
 
+#include <algorithm>
 #include <type_traits>
 #include <cstddef>
 #include <iterator>

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -26,6 +26,7 @@
 #include <seastar/util/bool_class.hh>
 #include <boost/intrusive_ptr.hpp>
 #include <cstdint>
+#include <span>
 #include <vector>
 #include <tuple>
 #include <sys/uio.h>

--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -25,6 +25,7 @@
 #include <exception>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <seastar/core/future.hh>


### PR DESCRIPTION
span and optional were missing from two files which used std::span and std::optional, respectively. This fails to compile unless those happen to be included indirectly via other headers (in practice, it fails to compile for me on Ubuntu 22.04 and distro libstc++).