### PR TITLE
net/dns: fixed socket concurrent access

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -1442,17 +1442,15 @@ dns_resolver::impl::do_sendv(ares_socket_t fd, const iovec * vec, int len) {
 
 
             // check if we're already writing.
-            if (e.typ == type::tcp) {
-                if (!(e.avail & POLLOUT)) {
-                    dns_log.trace("Send already pending {}", fd);
-                    errno = EWOULDBLOCK;
-                    return -1;
-                }
+            if (!(e.avail & POLLOUT)) {
+                dns_log.trace("Send already pending {}", fd);
+                errno = EWOULDBLOCK;
+                return -1;
+            }
 
-                if (!e.tcp.socket) {
-                    errno = ENOTCONN;
-                    return -1;
-                }
+            if (e.typ == type::tcp && !e.tcp.socket) {
+                errno = ENOTCONN;
+                return -1;
             }
 
 #if ARES_VERSION >= 0x012200


### PR DESCRIPTION
The problem with DNS queries is caused by the fact that the UDP socket is used concurrently i.e. write is scheduled while the other one is pending.

DNS queries are based on c-ares library. The library is initialized with a set of functions (callbacks) that are called whenever there is a need to send, receive, create socket, connect or close.

Fixed processing of send requests leading to assertion being triggered in reactor.

The fix involves checking if send is already pending and if so returning an error. The error returned from send callback will instruct c-ares library to retry the query.


(cherry picked from commit 74d5e9cc02ce9e75be01e4985df6b28a9bac750e)