### PR TITLE
`util/variant_utils`: correct type deduction for `seastar::visit`

### DIFF
--- a/include/seastar/util/variant_utils.hh
+++ b/include/seastar/util/variant_utils.hh
@@ -65,7 +65,7 @@ auto make_visitor(Args&&... args)
 /// \param args lambda objects each accepting one or some types stored in the variant as input
 /// \return
 template <typename Variant, typename... Args>
-inline auto visit(Variant&& variant, Args&&... args)
+inline decltype(auto) visit(Variant&& variant, Args&&... args)
 {
     static_assert(sizeof...(Args) > 0, "At least one lambda must be provided for visitation");
     return std::visit(

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -771,6 +771,9 @@ seastar_add_test (pipe
 seastar_add_test (spawn
   SOURCES spawn_test.cc)
 
+seastar_add_test (variant_utils
+  SOURCES variant_utils_test.cc)
+
 seastar_generate_swagger (
   TARGET rest_api_httpd_swagger
   VAR rest_api_httpd_swagger_files

--- a/tests/unit/variant_utils_test.cc
+++ b/tests/unit/variant_utils_test.cc
@@ -1,0 +1,65 @@
+#define BOOST_TEST_MODULE core
+
+#include <seastar/util/variant_utils.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <variant>
+
+struct noncopyable_type {
+    noncopyable_type() = default;
+    ~noncopyable_type() = default;
+    noncopyable_type(const noncopyable_type&) = delete;
+    noncopyable_type& operator=(const noncopyable_type&) = delete;
+    noncopyable_type(noncopyable_type&&) noexcept = default;
+    noncopyable_type& operator=(noncopyable_type&&) noexcept = default;
+};
+
+using variant_t = std::variant<int, bool>;
+static noncopyable_type t{};
+
+static_assert(
+  std::is_same_v<
+    decltype(seastar::visit(
+      variant_t{true},
+      [](const int& i) -> noncopyable_type { return noncopyable_type{}; },
+      [](const bool& b) -> noncopyable_type { return noncopyable_type{}; })),
+    noncopyable_type>);
+
+static_assert(std::is_same_v<
+              decltype(seastar::visit(
+                variant_t{true},
+                [](const int& i) -> noncopyable_type& { return t; },
+                [](const bool& b) -> noncopyable_type& { return t; })),
+              noncopyable_type&>);
+
+static_assert(
+  std::is_same_v<
+    decltype(std::visit(
+      [](auto&& v) -> noncopyable_type& { return t; }, variant_t{true})),
+    decltype(seastar::visit(
+      variant_t{true},
+      [](const int& i) -> noncopyable_type& { return t; },
+      [](const bool& b) -> noncopyable_type& { return t; }))>);
+
+static_assert(
+  std::is_same_v<
+    decltype(std::visit(
+      [](auto&& v) -> noncopyable_type { return noncopyable_type{}; },
+      variant_t{true})),
+    decltype(seastar::visit(
+      variant_t{true},
+      [](const int& i) -> noncopyable_type { return noncopyable_type{}; },
+      [](const bool& b) -> noncopyable_type { return noncopyable_type{}; }))>);
+
+BOOST_AUTO_TEST_CASE(test_visit_can_return_reference) {
+    auto& std_visit_ref = std::visit(
+      [](auto&& v) -> noncopyable_type& { return t; }, variant_t{true});
+    auto& ss_visit_ref = seastar::visit(
+      variant_t{true},
+      [](const int& i) -> noncopyable_type& { return t; },
+      [](const bool& b) -> noncopyable_type& { return t; });
+    BOOST_REQUIRE_EQUAL(
+      std::addressof(std_visit_ref), std::addressof(ss_visit_ref));
+    BOOST_REQUIRE_EQUAL(std::addressof(t), std::addressof(std_visit_ref));
+}


### PR DESCRIPTION
`auto` decays reference, and therefore `seastar::visit` cannot at present return l-value references.

Through use of `decltype(auto)` instead, we can preserve the exact type, including references.

Previously, code like this:

```cpp
auto& r = seastar::visit(std::variant<int, bool>{true},
                         [&t](const int& i) -> noncopyable_type& { return t; },
                         [&t](const bool& b) -> noncopyable_type& { return t; });
```

would be a compilation error:

```
error: cannot bind non-const lvalue reference of type ‘noncopyable_type&’ to an rvalue of type ‘noncopyable_type’
```

 It is now made valid.