### PR TITLE
posix_data_sink_impl: Assert to guard put UB

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -144,7 +144,7 @@ class posix_data_sink_impl : public data_sink_impl {
 #if SEASTAR_API_LEVEL >= 9
     internal::wrapped_iovecs _vecs;
 #else
-    packet _p;
+    packet _p{net::packet::make_null_packet()};
 #endif
 public:
     explicit posix_data_sink_impl(pollable_fd fd) : _fd(std::move(fd)) {}

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -891,10 +891,11 @@ posix_data_sink_impl::put(temporary_buffer<char> buf) {
 
 future<>
 posix_data_sink_impl::put(packet p) {
+    SEASTAR_ASSERT(!_p);
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();
-    return _fd.write_all(_p).then([this] { _p.reset(); });
+    return _fd.write_all(_p).finally([this] { _p.reset(); });
 }
 #endif
 


### PR DESCRIPTION
Posix stack's data_sink implementation stores a net packet locally and passes it by reference to the file descriptor.

If put is called concurrently, UB can occur.
With two invocations, one faster and one slower the faster invocation will reset the packet on completion of its write_all invocation, and the slower may dereference a nullptr in using the referenced packet

This commit changes three things:
1. it initializes the net::packet in posix_data_sink_impl to a null packet
2. reset of posix_data_sink_impl's net::packet will now occur in a finally s.t. the contained packet will also be reset on exceptions
3. invocation of posix_data_sink_impl::put will now assert that the contained packet is null before overwriting.

Any concurrent usages should now fail on an assert.