### PR TITLE
httpd: add timeout on requests

### DIFF
--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -98,6 +98,12 @@ future<> connection::do_response_loop() {
 }
 
 future<> connection::start_response() {
+    // While writing the response, disable the read timeout even though
+    // the server might already be reading the next request. If the connection
+    // dies we'll notice this when failing to write the response, and don't
+    // need to notice this via a read timeout. we'll re-arm the read timeout
+    // timer below - when we finish writing the response.
+    _request_timeout_timer.cancel();
     return _resp->write_reply(out()).then_wrapped([this] (auto f) {
         if (f.failed()) {
             // In case of an error during the write close the connection
@@ -130,6 +136,10 @@ future<> connection::start_response() {
             f.ignore_ready_future();
         }
         _resp.reset();
+        if (_server._request_timeout.count() > 0) {
+            _request_timeout_timer.cancel();
+            _request_timeout_timer.arm(_server._request_timeout);
+        }
         return make_ready_future<>();
     });
 }
@@ -208,7 +218,12 @@ void connection::generate_error_reply_and_close(std::unique_ptr<http::request> r
 
 future<> connection::read_one() {
     _parser.init();
+    if (_server._request_timeout.count() > 0) {
+        _request_timeout_timer.cancel();
+        _request_timeout_timer.arm(_server._request_timeout);
+    }
     return _read_buf.consume(_parser).then([this] () mutable {
+        _request_timeout_timer.cancel();
         if (_parser.eof()) {
             _done = true;
             return make_ready_future<>();


### PR DESCRIPTION
This patch adds to http_server a set_request_timeout() method which enables a time limit on reading a request from a connection. When this timeout is reached before a request is read, the connection is closed.

The primary goal for this feature is to clean up persistent connections (HTTP keep-alive) from clients that have died, or were "forgotten" by a proxy or load balancer which created them. Such dead connections can accumulate over time and consume server resources, and the new request timeout feature will remove them.

The request timeout can drop not only idle connections, but also connections where a client died in the middle of sending a request, and will never continue. This situation isn't common, but again if we don't clean up these connections, they can accumulate over time.

Finally, the request timeout can also help defend against slowloris DoS attacks - where an attacker deliberately sends a request extremely slowly. The request timeout can drop these connections even though they are not completely idle.

The set_keepalive_parameters() feature added recently can also solve some of these problems, but not all of them, and needs to work harder to verify a connection is really dead - whereas set_request_timeout() just assumes that a connection can be closed immediately if a request wasn't received for a long time.

The request timeout continues to default to 0, meaning it is disabled, so this patch doesn't change the http server's behavior for applications unless they choose to use the new feature.

Fixes #3130