### PR TITLE
Relax large allocation error originating from json_list_template

### DIFF
--- a/include/seastar/json/json_elements.hh
+++ b/include/seastar/json/json_elements.hh
@@ -198,6 +198,15 @@ public:
         }
         return *this;
     }
+
+    template<class C>
+    json_list_template& operator=(json_list_template<T, Container>&& list) noexcept {
+        if (this != &list) {
+            _elements = std::move(list._elements);
+        }
+        return *this;
+    }
+
     virtual future<> write(output_stream<char>& s) const override {
         return formatter::write(s, _elements);
     }


### PR DESCRIPTION
This PR relaxes the cause of a large allocation errors like the one reported in https://github.com/scylladb/scylladb/issues/26736
The PR adds 2 patches, one that reserves the capacity of the container upfront within the copy assignment operator, and another that adds a move assignment operator for `json_list_template`.

Fixes #3110 