### PR TITLE
Fix handle_exception_type for lvalues

### DIFF
--- a/include/seastar/core/function_traits.hh
+++ b/include/seastar/core/function_traits.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <tuple>
+#include <functional>
 
 namespace seastar {
 
@@ -75,6 +76,10 @@ struct function_traits : public function_traits<decltype(&T::operator())>
 
 template<typename T>
 struct function_traits<T&> : public function_traits<std::remove_reference_t<T>>
+{};
+
+template<typename T>
+struct function_traits<std::reference_wrapper<T>> : public function_traits<T>
 {};
 
 }


### PR DESCRIPTION
Fixes `handle_exception_type` for lvalues by accepting `std::reference_wrapper` in `function_traits`. Fixes #3154.

Enhancements to `function_traits`:

* Added support for `std::reference_wrapper<T>` in `function_traits`, allowing traits to be correctly deduced for wrapped callables. [[1]](diffhunk://#diff-24f4e345ded9cc6f513c67558cb4c545ecc98abca533f661ad3b83d2b09dae0aR25) [[2]](diffhunk://#diff-24f4e345ded9cc6f513c67558cb4c545ecc98abca533f661ad3b83d2b09dae0aR81-R84)
* Included `<functional>` in `function_traits.hh` to enable use of `std::reference_wrapper`.

Testing improvements:

* Added a new `compile_tests` function in `futures_test.cc` containing extensive `static_assert` checks for `function_traits` with various callable types, including function pointers, lambdas, member functions, and reference wrappers, ensuring correctness at compile time.
* Added missing include of `<seastar/core/future.hh>` in the test file to support the new tests.