### PR TITLE
treewide: fix build with `SEASTAR_SSTRING` undefined

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -658,7 +658,7 @@ template<>
 struct formatter<seastar::metrics::impl::escaped_string> : public fmt::formatter<seastar::sstring> {
     template <typename FormatContext>
     auto format(const seastar::metrics::impl::escaped_string& s, FormatContext& ctx) const {
-        return fmt::formatter<seastar::sstring>::format(s, ctx);
+        return fmt::formatter<seastar::sstring>::format(s.value(), ctx);
     }
 };
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -897,7 +897,7 @@ static sstring shorten_name(const sstring& name, size_t length) {
     using split_iter_t = ba::split_iterator<sstring::const_iterator>;
     static constexpr auto delimiter = "_";
 
-    sstring shortname(typename sstring::initialized_later{}, length);
+    auto shortname = uninitialized_string(length);
     auto output = shortname.begin();
     auto last = shortname.end();
     if (name.find(delimiter) == name.npos) {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -197,7 +197,7 @@ static auto get_gtls_string = [](auto func, auto... args) noexcept {
         return std::make_pair(ret, sstring{});
     }
     SEASTAR_ASSERT(size != 0);
-    sstring res(sstring::initialized_later{}, size - 1);
+    auto res = uninitialized_string(size - 1);
     ret = func(args..., res.data(), &size);
     return std::make_pair(ret, res);
 };

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -24,7 +24,7 @@ namespace seastar {
 namespace rpc {
 
 void logger::operator()(const client_info& info, id_type msg_id, const sstring& str) const {
-    log(format("client {} msg_id {}:  {}", info.addr, msg_id, str));
+    log(fmt::format("client {} msg_id {}:  {}", info.addr, msg_id, str));
 }
 
 void logger::operator()(const client_info& info, id_type msg_id, log_level level, std::string_view str) const {
@@ -40,7 +40,7 @@ void logger::operator()(const client_info& info, log_level level, std::string_vi
 }
 
 void logger::operator()(const socket_address& addr, const sstring& str) const {
-    log(format("client {}: {}", addr, str));
+    log(fmt::format("client {}: {}", addr, str));
 }
 
 void logger::operator()(const socket_address& addr, log_level level, std::string_view str) const {

--- a/src/util/short_streams.cc
+++ b/src/util/short_streams.cc
@@ -56,7 +56,7 @@ future<sstring> read_entire_stream_contiguous(input_stream<char>& inp) {
         for (auto&& buf : bufs) {
             total_size += buf.size();
         }
-        sstring ret(sstring::initialized_later(), total_size);
+        auto ret = uninitialized_string(total_size);
         size_t pos = 0;
         for (auto&& buf : bufs) {
             std::copy(buf.begin(), buf.end(), ret.data() + pos);

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -294,7 +294,7 @@ static sstring format_double_fit(double value, size_t width, size_t default_prec
     };
 
     auto make_hash_fallback = [width]() {
-        sstring r(sstring::initialized_later{}, width);
+        auto r = uninitialized_string(width);
         for (size_t i = 0; i < width; ++i) {
             r.data()[i] = '#';
         }


### PR DESCRIPTION
The build was failing with `SEASTAR_SSTRING` undefined.

* Use `uninitialized_string` helper function instead of constructing `sstring` with `initialized_later`.
* Replace `format` with `fmt::format` in `rpc.cc`. It was already included in the file.
* Call `value()` to get the underlying `sstring` in the formatter for `seastar::metrics::impl::escaped_string`.