### PR TITLE
treewide: avoid `static sstring` in favor of `constexpr string_view`

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -350,7 +350,7 @@ namespace tls {
     private:
         friend class reloadable_credentials_base;
 
-        std::multimap<sstring, std::any> _blobs;
+        std::multimap<std::string_view, std::any> _blobs;
         client_auth _client_auth = client_auth::NONE;
         session_resume_mode _session_resume_mode = session_resume_mode::NONE;
         sstring _priority;

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -30,8 +30,6 @@
 
 namespace seastar::experimental::websocket {
 
-extern sstring magic_key_suffix;
-
 using handler_t = std::function<future<>(input_stream<char>&, output_stream<char>&)>;
 
 class server;

--- a/src/websocket/common.cc
+++ b/src/websocket/common.cc
@@ -29,7 +29,6 @@
 
 namespace seastar::experimental::websocket {
 
-sstring magic_key_suffix = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 logger websocket_logger("websocket");
 
 future<> connection::handle_ping() {


### PR DESCRIPTION
I had problems with fuzzer+address sanitizer `-fsanitize=fuzzer,address`. It worked fine with `SEASTAR_SSTRING` undefined. Enabling `SEASTAR_ASAN_ENABLED` didn't help.

What I gathered is that it was static sstring destructors being called at exit.

IIUC, there is no reason to use `sstring` for static constants, except to avoid copies like in `tls.cc`.
Luckily, it doesn't seem like the `_blobs` map stores any keys that are external to `tls.cc` itself,
which means it should be safe to use `std::string_view` instead.

*   Replaced `extern sstring magic_key_suffix` in the websocket header with `constexpr std::string_view` in the `.cc` file.
*   Replaced `static const sstring` in `tls.cc` with `constexpr std::string_view`.
*   Replaced the `sstring` key in the `credentials_builder::_blobs` map with `std::string_view`.

The Seastar memory allocator + ASAN is quite a complex interaction I can't entirely grasp.
The issue might be deeper and the solution should be different, but this patch seems good to me anyway.

Fixes the following issue:

```
###### End of recommended dictionary. ######
Done 28745 runs in 2 second(s)
munmap_chunk(): invalid pointer
==350803== ERROR: libFuzzer: deadly signal
    #0 0x560609c161aa in __sanitizer_print_stack_trace (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/iobuf_fuzz_test+0x1df1aa)
    #1 0x560609b0fc50 in fuzzer::PrintStackTrace() (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/iobuf_fuzz_test+0xd8c50)
    #2 0x560609aea8b6 in fuzzer::Fuzzer::CrashCallback() (.part.0) (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/iobuf_fuzz_test+0xb38b6)
    #3 0x560609aea97a in fuzzer::Fuzzer::StaticCrashSignalCallback() (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/iobuf_fuzz_test+0xb397a)
    #4 0x7f96d4c4146f  (/lib/libc.so.6+0x4146f) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #5 0x7f96d4c99cdb in __pthread_kill_implementation (/lib/libc.so.6+0x99cdb) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #6 0x7f96d4c413c5 in gsignal (/lib/libc.so.6+0x413c5) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #7 0x7f96d4c28939 in abort (/lib/libc.so.6+0x28939) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #8 0x7f96d4c299a2 in __libc_message_impl.cold (/lib/libc.so.6+0x299a2) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #9 0x7f96d4ca44e6 in malloc_printerr (/lib/libc.so.6+0xa44e6) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #10 0x7f96d4ca471b in munmap_chunk (/lib/libc.so.6+0xa471b) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #11 0x7f96d4ca91df in cfree@GLIBC_2.2.5 (/lib/libc.so.6+0xa91df) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #12 0x7f96d5d5cba7 in seastar::memory::cpu_pages::do_foreign_free(void*) (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/../../../_solib_k8/libexternal_Sseastar_Slibseastar.so+0x35cba7)
    #13 0x7f96d5d5a901 in seastar::basic_sstring<char, unsigned int, 15u, true>::~basic_sstring() (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/../../../_solib_k8/libexternal_Sseastar_Slibseastar.so+0x35a901)
    #14 0x7f96d4c436a8 in __cxa_finalize (/lib/libc.so.6+0x436a8) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #15 0x7f96d5cf2516 in __do_global_dtors_aux (/home/pah/.cache/bazel/_bazel_pah/34885b646b755ae770da77ae3333708f/execroot/_main/bazel-out/k8-opt/bin/rt/bytes/tests/../../../_solib_k8/libexternal_Sseastar_Slibseastar.so+0x2f2516)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 2 CrossOver-EraseBytes-; base unit: a2d527d7bfc7c47ac0f32792d1246baaa28f66da
```

```
(lldb) rbreak seastar::basic_sstring<.*>::~basic_sstring
(lldb) r
[...]
* thread #1, name = 'iobuf_fuzz_test', stop reason = breakpoint 1.1
    frame #0: 0x00007ffff775a870 libexternal_Sseastar_Slibseastar.so`seastar::basic_sstring<char, unsigned int, 15u, true>::~basic_sstring()
libexternal_Sseastar_Slibseastar.so`seastar::basic_sstring<char, unsigned int, 15u, true>::~basic_sstring:
->  0x7ffff775a870 <+0>: pushq  %rbp
    0x7ffff775a871 <+1>: movq   %rsp, %rbp
    0x7ffff775a874 <+4>: pushq  %r14
    0x7ffff775a876 <+6>: pushq  %rbx
(lldb) bt
* thread #1, name = 'iobuf_fuzz_test', stop reason = breakpoint 1.1
  * frame #0: 0x00007ffff775a870 libexternal_Sseastar_Slibseastar.so`seastar::basic_sstring<char, unsigned int, 15u, true>::~basic_sstring()
    frame #1: 0x00007ffff68436a9 libc.so.6`__cxa_finalize + 361
    frame #2: 0x00007ffff76f2517 libexternal_Sseastar_Slibseastar.so`__do_global_dtors_aux + 39
    frame #3: 0x00007ffff7fc60f2 ld-linux-x86-64.so.2`_dl_call_fini + 82
    frame #4: 0x00007ffff7fc946e ld-linux-x86-64.so.2`_dl_fini + 494
    frame #5: 0x00007ffff6843bf1 libc.so.6`__run_exit_handlers + 433
    frame #6: 0x00007ffff6843cb0 libc.so.6`exit + 32
    frame #7: 0x0000555555598567 iobuf_fuzz_test`fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) + 12311
    frame #8: 0x00005555555d79f3 iobuf_fuzz_test`main + 35
    frame #9: 0x00007ffff682a47e libc.so.6`__libc_start_call_main + 126
    frame #10: 0x00007ffff682a539 libc.so.6`__libc_start_main@@GLIBC_2.34 + 137
    frame #11: 0x0000555555581e25 iobuf_fuzz_test`_start + 37
(lldb) register read rdi
     rdi = 0x00007ffff7a57558  libexternal_Sseastar_Slibseastar.so`seastar::experimental::websocket::magic_key_suffix
```