### PR TITLE
resource: Hide hwloc from public interface

### DIFF
--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -32,9 +32,9 @@
 #include <set>
 #include <sched.h>
 #include <unordered_map>
-#ifdef SEASTAR_HAVE_HWLOC
-#include <hwloc.h>
-#endif
+
+struct hwloc_topology;
+using hwloc_topology_t = hwloc_topology*;
 
 namespace seastar {
 

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -37,9 +37,6 @@ module;
 #include <unordered_map>
 #include <fmt/core.h>
 #include <seastar/util/assert.hh>
-#if SEASTAR_HAVE_HWLOC
-#include <hwloc/glibc-sched.h>
-#endif
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -54,7 +51,11 @@ module seastar;
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/print.hh>
 #include "cgroup.hh"
+#endif
 
+#if SEASTAR_HAVE_HWLOC
+#include <hwloc.h>
+#include <hwloc/glibc-sched.h>
 #endif
 
 namespace seastar {


### PR DESCRIPTION
Forward-delcare hwloc pointer hwloc_topology_t type instead of including hwloc.h in the public interface. This reduces compile times both by trimming the inclusion tree but also by not requiring that hwloc be built before seastar can build (which happens when hwloc is a black-box "foreign cc" compile in bazel).

The main benefit though is not injecting the hwloc header into seastar's public interface.