### PR TITLE
pollable_fd: Unfriend everything

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -210,14 +210,12 @@ public:
     future<> poll_rdhup() {
         return _s->poll_rdhup();
     }
-protected:
     int get_fd() const { return _s->fd.get(); }
+
+protected:
     void maybe_no_more_recv() { return _s->maybe_no_more_recv(); }
     void maybe_no_more_send() { return _s->maybe_no_more_send(); }
-    friend class reactor;
-    friend class readable_eventfd;
-    friend class writeable_eventfd;
-    friend class aio_storage_context;
+
 private:
     pollable_fd_state_ptr _s;
 };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3773,7 +3773,7 @@ file_desc readable_eventfd::try_create_eventfd(size_t initial) {
 }
 
 future<size_t> readable_eventfd::wait() {
-    return engine().readable(*_fd._s).then([this] {
+    return _fd.readable().then([this] {
         uint64_t count;
         int r = ::read(_fd.get_fd(), &count, sizeof(count));
         SEASTAR_ASSERT(r == sizeof(count));


### PR DESCRIPTION
There are four friend classes in it, but none really needs it. All of them want to call get_fd() method, which can be safely made public (it's pollable FD, why not export the fd value itself?). One exception is readable_eventfd that tries to access pollable_fd_state pointer, it needs it to pass one into reactor::readable() and pollable_fd itself has the readable() method that does the same and is pubic.