### PR TITLE
Revert to ~old lifetime semantics for lvalues passed to then()-alikes

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -358,6 +358,25 @@ static constexpr bool is_tuple_effectively_trivially_move_constructible_and_dest
 
 }
 
+// Helper to convert lvalue reference functions to rvalue.
+// This is used early in then()-alike entry points to convert lvalue references into
+// rvalues (which are used to recursively call back into the same entry point) to
+// avoid having to handle both lvalues and rvalues downstream: we convert them all
+// to rvalues. This helper handles both references to callable objects such as lambdas,
+// copying them, and references to functions, decaying them to function pointers.
+template <typename Func>
+static constexpr auto func_to_rvalue(Func&& func) {
+    static_assert(std::is_lvalue_reference_v<Func>, "call with lvalue reference");
+    if constexpr (std::is_function_v<std::remove_reference_t<Func>>) {
+        // return decayed function pointer
+        return +func;
+    } else {
+        // return a copy (used as an rvalue by the called)
+        return std::forward<Func>(func);
+    }
+}
+
+
 //
 // A future/promise pair maintain one logical value (a future_state).
 // There are up to three places that can store it, but only one is
@@ -1141,6 +1160,15 @@ struct result_of_apply<Func, std::tuple<T...>> : std::invoke_result<Func, T...> 
 template <typename Func, typename... T>
 using result_of_apply_t = typename result_of_apply<Func, T...>::type;
 
+// To simply implementation, at various top-level (user-callable) entry-points
+// like then(), finally(), handle_exception(), etc, we convert lvalue callables
+// into rvalues, using a recursive call back to that entry point, so that all
+// the downstream implementation functions can deal with rvalues only. Inside
+// those functions we then assert on this trait to ensure we do only have rvalues
+// since we can't match rvalue references directly (because that syntax was
+// co-opted for universal references).
+template <typename Func>
+constexpr bool expect_only_rvalue_refs = !std::is_lvalue_reference_v<Func>;
 }
 
 template <typename Promise, typename T>
@@ -1226,6 +1254,7 @@ private:
     }
     template <typename Pr, typename Func, typename Wrapper>
     void schedule(Pr&& pr, Func&& func, Wrapper&& wrapper) noexcept {
+        static_assert(internal::expect_only_rvalue_refs<Func>);
         // If this new throws a std::bad_alloc there is nothing that
         // can be done about it. The corresponding future is not ready
         // and we cannot break the chain. Since this function is
@@ -1341,6 +1370,11 @@ public:
     /// If the future failed, the function is not called, and the exception
     /// is propagated into the return value of then().
     ///
+    /// The passed function is moved (if an rvalue) or copied (if an lvalue) into
+    /// the continuation, so their lifetime is automatically extended until the
+    /// continuation runs (but not further - if the function itself may suspend
+    /// you will need to ensure its lifetime is sufficiently long).
+    ///
     /// \param func - function to be called when the future becomes available,
     ///               unless it has failed.
     /// \return a \c future representing the return value of \c func, applied
@@ -1353,7 +1387,7 @@ public:
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return then(std::ref(func));
+        return then(func_to_rvalue(func));
       } else {
 #ifndef SEASTAR_TYPE_ERASE_MORE
         return then_impl(std::move(func));
@@ -1394,10 +1428,8 @@ public:
     requires ::seastar::CanApplyTuple<Func, T>
     Result
     then_unpack(Func&& func) noexcept {
-      // Avoid having to special-case lvalue-references downstream by converting
-      // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return then_unpack(std::ref(func));
+        return then_unpack(func_to_rvalue(func));
       } else {
         return then([func = std::forward<Func>(func)] (T&& tuple) mutable {
             // sizeof...(tuple) is required to be 1
@@ -1432,6 +1464,7 @@ private:
     template <typename Func, typename Result = futurize_t<internal::future_result_t<Func, T>>>
     Result
     then_impl(Func&& func) noexcept {
+        static_assert(internal::expect_only_rvalue_refs<Func>);
 #ifndef SEASTAR_DEBUG
         using futurator = futurize<internal::future_result_t<Func, T>>;
         if (failed()) {
@@ -1465,7 +1498,7 @@ public:
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return then_wrapped(std::ref(func));
+        return then_wrapped(func_to_rvalue(func));
       } else {
         return then_wrapped_maybe_erase<false, FuncResult>(std::forward<Func>(func));
       }
@@ -1477,7 +1510,7 @@ public:
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return std::move(*this).then_wrapped(std::ref(func));
+        return std::move(*this).then_wrapped(func_to_rvalue(func));
       } else {
         return then_wrapped_maybe_erase<true, FuncResult>(std::forward<Func>(func));
       }
@@ -1488,6 +1521,7 @@ private:
     template <bool AsSelf, typename FuncResult, typename Func>
     futurize_t<FuncResult>
     then_wrapped_maybe_erase(Func&& func) noexcept {
+        static_assert(internal::expect_only_rvalue_refs<Func>);
 #ifndef SEASTAR_TYPE_ERASE_MORE
         return then_wrapped_common<AsSelf, FuncResult>(std::forward<Func>(func));
 #else
@@ -1586,13 +1620,15 @@ public:
      * If both of them are exceptional - the seastar::nested_exception exception
      * with the callback exception on top and the original future exception
      * nested will be propagated.
+     *
+     * See then() for lifetime and call semantics.
      */
     template <std::invocable Func>
     future<T> finally(Func&& func) noexcept {
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return finally(std::ref(func));
+        return finally(func_to_rvalue(func));
       } else {
         return then_wrapped(finally_body<Func, is_future<std::invoke_result_t<Func>>::value>(std::forward<Func>(func)));
       }
@@ -1607,7 +1643,9 @@ public:
         Func _func;
 
         finally_body(Func&& func) noexcept : _func(std::forward<Func>(func))
-        { }
+        {
+            static_assert(internal::expect_only_rvalue_refs<Func>);
+        }
 
         future<T> operator()(future<T>&& result) && noexcept {
             return futurize_invoke(std::move(_func)).then_wrapped([result = std::move(result)](auto&& f_res) mutable {
@@ -1683,7 +1721,7 @@ public:
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return handle_exception(std::ref(func));
+        return handle_exception(func_to_rvalue(func));
       } else {
         return then_wrapped([func = std::forward<Func>(func)]
                              (auto&& fut) mutable -> future<T> {
@@ -1711,7 +1749,7 @@ public:
       // Avoid having to special-case lvalue-references downstream by converting
       // them to an rvalue reference here.
       if constexpr (std::is_lvalue_reference_v<Func>) {
-        return handle_exception_type(std::ref(func));
+        return handle_exception_type(func_to_rvalue(func));
       } else {
         using trait = function_traits<Func>;
         static_assert(trait::arity == 1, "func can take only one parameter");


### PR DESCRIPTION
Commit https://github.com/scylladb/seastar/commit/1f233b4ebe6c943e5b8e60cee4994efeba7b2f6e changed the lifetime semantics for continuations passed
as lvalues to future methods (then, then_wrapped, finally, etc).
Previously, the continuation was moved or copied (itself an
inconsistency as the copy vs move behavior depended on the "type erase
more" configuration and moving from an lvalue is very surprising).

This effectively extended the lifetime of the continuation until it was
run. After that commit, the continuation is wrapped in std::ref, which
means no copy or move is performed and the relevant continuation is
the original lvalue passed in, which often dies quickly if it is e.g.,
from the stack of the function where then() was called.

The second patch in this series effectively reverts to the old behavior, this time by
copying lvalues instead of wrapping them in std::ref. This means that
lvalues are converted into rvalues (via copy) which preserves the
intent of the prior change which was to deal only with rvalues in the
downstream implementation, but also extends the lifetime.

This requires the continuation type to be copyable, but that was already
the case before https://github.com/scylladb/seastar/commit/1f233b4ebe6c943e5b8e60cee4994efeba7b2f6e. The introduction of a copy is undesirable
for performance, but lvalue use is quite rare and I don't see any way
to preserve all of the following:

 - Allow lvalues to be passed
 - Do not move out of the passed lvalue (bug, surprising)
 - Extend the lifetime as before

In the future we may simply disable lvalue support entirely, per the
discussion in https://github.com/scylladb/seastar/issues/3157.

This change also adds various test_lifetimes_and_movement tests to
verify continuation handling semantics. This counts the number of copies
and moves to catch cases where the behavior changes (the existing counts
are not somehow sacred, so the tests can be updated after checking if
this was intended). It also checks explicitly this case of lvalue
lifetime extension and fails before the changes in this patch. It checks
a few other attributes too, e.g., that we don't call a moved from
lambda, etc.

It tests more than just then(), also then_wrapped() and finally(), each
in two variations as internally the implementation as variations for
when then_wrapped takes future&& or future by value, and when finally
returns a future or not. This turned up additional issues in those
methods which didn't select the operator() && overload, which are fixed
in the first change in this series.

Test details:

The test_lifetimes_and_movement<Traits>() template function provides a
trait-based framework for testing different future continuation methods
with consistent test cases. It is instantiated with multiple trait types
to cover:
- then() - standard continuation chaining
- then_wrapped() - continuations that receive the future itself
- then_wrapped() with future&& - reference-based variant
- finally() - cleanup handlers returning futures
- finally() returning void - non-future cleanup handlers

Each instantiation runs 6 test cases:
1. Passing move-only rvalue callable - verifies zero-copy rvalue
   forwarding
2. Passing lvalue callable - verifies lvalue is copied (not moved)
3. Passing std::move(lvalue) - verifies explicit move semantics
4. Ready future with rvalue callable - tests fast-path optimization
5. Ready future with lvalue callable - tests fast-path with copies
6. Local lvalue lifetime extension - ensures continuations don't use
   after destruction (addresses
   https://github.com/scylladb/seastar/issues/3157)

Test infrastructure includes:
- canary class with moved_from/alive/destroyed state tracking
- canary_stats to count copies, moves, assignments, and operator() calls
- canary_callable_base template supporting both copyable and move-only
  variants
- BOOST_TEST_CHECKPOINT markers for each test case to aid debugging

The tests verify:
- Exact counts of copy/move operations (with conditional checks for
  SEASTAR_TYPE_ERASE_MORE and SEASTAR_DEBUG configurations)
- Correct operator() overload selection (lvalue vs rvalue-qualified)
- Original lvalues remain valid after passing to continuations
- Moved-from objects are properly marked and not used
- Objects are not accessed after destruction

This test suite serves as a regression test for continuation handling
and documents the expected behavior of future continuation APIs.

Fixes #3157.