### PR TITLE
scheduling_group_nesting_test: adjust threshold

### DIFF
--- a/tests/unit/scheduling_group_nesting_test.cc
+++ b/tests/unit/scheduling_group_nesting_test.cc
@@ -129,7 +129,7 @@ static future<> run_busyloops(std::vector<seastar::scheduling_group> groups, std
     for (unsigned i = 0; i < groups.size(); i++) {
         auto dev = float(std::abs(counts[i] / expected[i] - average_adjusted_count)) / average_adjusted_count;
         fmt::print("{}: count={} expected={:.2f} adjusted={} deviation={:.2f}\n", i, counts[i], expected[i], int(float(counts[i]) / expected[i]), dev);
-        BOOST_CHECK(dev < 0.07);
+        BOOST_CHECK(dev < 0.50);
     }
 }
 


### PR DESCRIPTION
To reduce flakes in GHA.

Adjust the allowed deviation from "perfect scheduling" from 0.07 to 0.50. Locally, even 0.50 isn't enough to prevent flakes if there is some load on the system (e.g., `stress -c 128`): tests flake ~100% of the time in that scenario even at 0.50, but hopefully on the quieter GHA runners this will help.