### PR TITLE
rpc_tester: introduce rpc_streaming job based on streaming API

### DIFF
--- a/apps/rpc_tester/sample-conf.yaml
+++ b/apps/rpc_tester/sample-conf.yaml
@@ -13,8 +13,9 @@ jobs:
     timeout: # optional rpc send timeout duration
   - name: # any parseable string
     type: rpc_streaming
-    verb: # string: bidirectional
+    verb: # string, one of: bidirectional, unidirectional
            # - bidirectional: client sends payload_t, server responds asynchronously with received data
+           # - unidirectional: client sends payload_t, server consumes without responding
     parallelism: # number of streaming workers to run simultaneously
     shares: # sched group shares (100 by default)
     payload: # number of bytes in the payload sent from client to server, accepts kB suffix


### PR DESCRIPTION
In this PR we introduce new `rpc_streaming` job - with `STREAM_UNIDIRECTIONAL` and `STREAM_BIDIRECTIONAL` verbs.

## Overview

The streaming job uses Seastar’s RPC streaming API by continuously sending payloads from workers to the server, optionally receiving responses on a return stream. It is intended for measuring end-to-end throughput.

Similar to the `rpc` job's `rpc_verb::write` behavior but replaces per-payload RPC calls with the streaming API and doesn't wait for response from the server between writes.

### Metrics

- *messages* - total number of `payload_t` that was put by workers.
- *throughput* - estimated number of bytes send per second - `_total_messages * _payload_size_bytes / _total_duration.count()`, measured in `kB/s`.
- *messages per second* - `messages / _total_duration.count()`

### Benchmark

Below you can find a simple benchmark that was run on `potwor2` for 30s machine with:
- client: `cpuset=0-7`
- server: `cpuset=8-15`

```
        parallelism: 10
        shares: 100
        payload: 64kB
```

All configs:
[suite.yaml](https://github.com/user-attachments/files/24274096/suite.yaml)

#### rpc_streaming::bidirectional

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/3dd48330-f1bf-4c7a-a6bc-7d8d01510202" />

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/ec139d4e-716d-44a9-85b0-b36da0a45ea6" />

#### rpc_streaming::unidirectional

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/455a94a9-7db1-46b8-8f94-c980eaf17942" />

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/ff8e7c8e-1426-4e19-91ad-4a2526d32b05" />

#### rpc::write

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/d9fb3ee2-39d5-4a3a-a57d-5882139244b0" />

*rpc::write doesn't produce throughput metric*

### Client

In `client` mode app:
1. Connects to the server.
2. Spawns *parallelism* workers, each starting with own delay if *sleep_time* was specified.
3. Each worker
   -  Creates `rpc::sink<payload_t>`, send it to the server and receives a corresponding `source<uint64_t>`
   - Performs the streaming phase:
      - Streams *payload* bytes in a loop through the sink until *duration* elapses.
      - For bidirectional streaming, simultaneously reads responses from the received source.
    - Waits for the server to close it's sink so the client can shut down the connection safely.

### Server

- For each `STREAM_UNIDIRECTIONAL` or `STREAM_BIDIRECTIONAL` call:
    1. Creates a  `rpc::sink<uint64_t>`
    2. Schedules background processing for the `rpc::source<payload_t>` received from the client.
    3. Returns the `rpc::source<uint64_t>` associated with the created `rpc::sink<uint64_t>`, used for streaming back the number of bytes received.
    
- For the bidirectional verb, the server sends back, on its stream, the number of bytes received for each chunk of data.

- After client closes their `rpc::sink<payload_t>`, the server writes the final total number of bytes into corresponding `rpc::sink<uint64_t>` and then closes it.