### PR TITLE
Add file::statat and a corresponding file_stat overload

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -149,6 +149,7 @@ public:
 
     virtual future<> flush() = 0;
     virtual future<struct stat> stat() = 0;
+    virtual future<struct stat> statat(std::string_view name, int flags = 0) = 0;
     virtual future<> truncate(uint64_t length) = 0;
     virtual future<> discard(uint64_t offset, uint64_t length) = 0;
     virtual future<int> ioctl(uint64_t cmd, void* argp) noexcept;
@@ -388,6 +389,12 @@ public:
 
     /// Returns \c stat information about the file.
     future<struct stat> stat() noexcept;
+
+    /// Returns \c stat information about a file in this directory.
+    ///
+    /// \param name the name of the file relative to this directory
+    /// \param flags optional flags (e.g., AT_SYMLINK_NOFOLLOW, see man fstatat)
+    future<struct stat> statat(std::string_view name, int flags = 0) noexcept;
 
     /// Truncates the file to a specified length.
     future<> truncate(uint64_t length) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -535,6 +535,7 @@ public:
     future<> touch_directory(std::string_view name, file_permissions permissions = file_permissions::default_dir_permissions) noexcept;
     future<std::optional<directory_entry_type>>  file_type(std::string_view name, follow_symlink = follow_symlink::yes) noexcept;
     future<stat_data> file_stat(std::string_view pathname, follow_symlink) noexcept;
+    future<stat_data> file_stat(file& directory, std::string_view pathname, follow_symlink) noexcept;
     future<> chown(std::string_view filepath, uid_t owner, gid_t group);
     future<std::optional<struct group_details>> getgrnam(std::string_view name);
     future<uint64_t> file_size(std::string_view pathname) noexcept;

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -355,6 +355,21 @@ using follow_symlink = bool_class<follow_symlink_tag>;
 /// with follow_symlink::yes, or for the link itself, with follow_symlink::no.
 future<stat_data> file_stat(std::string_view name, follow_symlink fs = follow_symlink::yes) noexcept;
 
+/// Return stat information about a file in a directory.
+///
+/// \param directory a open directory
+/// \param name name of the file to return its stat information
+/// \param fs a follow_symlink flag to follow symbolic links.
+///
+/// \return stat_data of the file identified by name.
+///
+/// If the pathname given in \c name is relative, then it is interpreted relative to the open \c directory.
+/// If pathname given in \c name is absolute, then \c directory is ignored.
+///
+/// If name identifies a symbolic link then stat_data is returned either for the target of the link,
+/// with follow_symlink::yes, or for the link itself, with follow_symlink::no.
+future<stat_data> file_stat(file& directory, std::string_view name, follow_symlink fs = follow_symlink::yes) noexcept;
+
 /// Wrapper around getgrnam_r.
 /// If the provided group name does not exist in the group database, this call will return an empty optional.
 /// If the provided group name exists in the group database, the optional returned will contain the struct group_details information.

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -91,6 +91,7 @@ public:
     virtual ~posix_file_impl() override;
     future<> flush() noexcept override;
     future<struct stat> stat() noexcept override;
+    future<struct stat> statat(std::string_view name, int flags = 0) noexcept override;
     future<> truncate(uint64_t length) noexcept override;
     future<> discard(uint64_t offset, uint64_t length) noexcept override;
     future<int> ioctl(uint64_t cmd, void* argp) noexcept override;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -210,6 +210,18 @@ posix_file_impl::stat() noexcept {
     co_return ret.extra;
 }
 
+future<struct stat>
+posix_file_impl::statat(std::string_view name, int flags) noexcept {
+    auto ret = co_await engine()._thread_pool->submit<syscall_result_extra<struct stat>>(
+            internal::thread_pool_submit_reason::file_operation, [fd = _fd, name = sstring(name), flags] {
+        struct stat st;
+        auto ret = ::fstatat(fd, name.data(), &st, flags);
+        return wrap_syscall(ret, st);
+    });
+    ret.throw_if_error();
+    co_return ret.extra;
+}
+
 future<>
 posix_file_impl::truncate(uint64_t length) noexcept {
     auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
@@ -1239,6 +1251,14 @@ future<struct stat> file::stat() noexcept {
   } catch (...) {
     return current_exception_as_future<struct stat>();
   }
+}
+
+future<struct stat> file::statat(std::string_view name, int flags) noexcept {
+    try {
+        return _file_impl->statat(name, flags);
+    } catch (...) {
+        return current_exception_as_future<struct stat>();
+    }
 }
 
 future<> file::flush() noexcept {

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -139,6 +139,10 @@ future<stat_data> file_stat(std::string_view name, follow_symlink follow) noexce
     return engine().file_stat(name, follow);
 }
 
+future<stat_data> file_stat(file& directory, std::string_view name, follow_symlink follow) noexcept {
+    return engine().file_stat(directory, name, follow);
+}
+
 future<std::optional<struct group_details>> getgrnam(std::string_view name) {
     return engine().getgrnam(name);
 }

--- a/tests/unit/directory_test.cc
+++ b/tests/unit/directory_test.cc
@@ -110,6 +110,7 @@ public:
 
     virtual future<> flush() override { return get_file_impl(_lower)->flush(); }
     virtual future<struct stat> stat() override { return get_file_impl(_lower)->stat(); }
+    virtual future<struct stat> statat(std::string_view name, int flags) override { return get_file_impl(_lower)->statat(name, flags); }
     virtual future<> truncate(uint64_t length) override { return get_file_impl(_lower)->truncate(length); }
     virtual future<> discard(uint64_t offset, uint64_t length) override { return get_file_impl(_lower)->discard(offset, length); }
     virtual future<> allocate(uint64_t position, uint64_t length) override { return get_file_impl(_lower)->allocate(position, length); }
@@ -154,5 +155,21 @@ SEASTAR_TEST_CASE(test_generator_fallback_early_abort) {
         auto lister = f.experimental_list_directory();
         [[maybe_unused]] auto de = co_await lister();
     } // destroys the lister object before it reports EOF
+    co_await f.close();
+}
+
+SEASTAR_TEST_CASE(test_generator_with_statat) {
+    auto f = co_await engine().open_directory(".");
+    auto lister = f.experimental_list_directory();
+
+    while (auto de = co_await lister()) {
+        auto& entry = *de;
+        auto sd1 = co_await f.statat(entry.name);
+        auto sd2 = co_await file_stat(f, entry.name, follow_symlink::no);
+        BOOST_REQUIRE_EQUAL(sd1.st_ino, sd2.inode_number);
+
+        auto sd3 = co_await file_stat(entry.name, follow_symlink::no);
+        BOOST_REQUIRE_EQUAL(sd1.st_ino, sd3.inode_number);
+    }
     co_await f.close();
 }

--- a/tests/unit/mock_file.hh
+++ b/tests/unit/mock_file.hh
@@ -85,6 +85,9 @@ public:
     virtual future<struct stat> stat() noexcept override {
         return make_exception_future<struct stat>(std::bad_function_call());
     }
+    virtual future<struct stat> statat(std::string_view name, int flags) noexcept override {
+        return make_exception_future<struct stat>(std::bad_function_call());
+    }
     virtual future<> truncate(uint64_t) noexcept override {
         return make_exception_future<>(std::bad_function_call());
     }


### PR DESCRIPTION
Exposing the fstatat system call.
To be used for efficient directory listing
where, instead of calling file_stat for the full path, the caller can use dir.statat(dirent.name) for each entry which is more efficient as it doesn't require to construct the full path and to look up the directory prefix on every call.