### PR TITLE
reactor_backend: Fix iocb double-free during AIO teardown

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -115,6 +115,9 @@ aio_storage_context::iocb_pool::iocb_pool() {
     for (unsigned i = 0; i != max_aio; ++i) {
         _free_iocbs.push(&_all_iocbs[i]);
     }
+#ifdef SEASTAR_IOCB_POOL_DEBUG
+    _iocb_allocated.reset();
+#endif
 }
 
 aio_storage_context::aio_storage_context(reactor& r)
@@ -130,10 +133,43 @@ aio_storage_context::~aio_storage_context() {
     internal::io_destroy(_io_context);
 }
 
+void aio_storage_context::reap_pending_retries() {
+    // Drain pending retries and complete them with -ECANCELED.
+    for (auto iocb : _pending_aio_retry) {
+        _iocb_pool.put_one(iocb);
+        auto desc = get_user_data<kernel_completion>(*iocb);
+        desc->complete_with(-ECANCELED);
+    }
+    _pending_aio_retry.clear();
+
+    // _aio_retries is empty in the normal call path: this function only runs
+    // after the retry loop's future has resolved, and that loop's predicate
+    // only returns true when both vectors are empty. The drain below is
+    // defensive — if a future change to schedule_retry() leaves entries
+    // here, we still avoid leaking iocbs.
+    for (auto iocb : _aio_retries) {
+        _iocb_pool.put_one(iocb);
+        auto desc = get_user_data<kernel_completion>(*iocb);
+        desc->complete_with(-ECANCELED);
+    }
+    _aio_retries.clear();
+}
+
 future<> aio_storage_context::stop() noexcept {
+    // Set _stopping first so any reap_completions() and schedule_retry()
+    // calls that race with the drain below see the right state.
+    _stopping = true;
+
+    // Drain items in io_sink (operations without allocated iocbs yet).
+    _r._io_sink.drain([] (const internal::io_request& req, io_completion* desc) -> bool {
+        desc->complete_with(-ECANCELED);
+        return true;
+    });
+
     return std::exchange(_pending_aio_retry_fut, make_ready_future<>()).finally([this] {
         return do_until([this] { return !_iocb_pool.outstanding(); }, [this] {
-            reap_completions(false);
+            reap_completions();
+            reap_pending_retries();
             return make_ready_future<>();
         });
     });
@@ -144,12 +180,29 @@ internal::linux_abi::iocb&
 aio_storage_context::iocb_pool::get_one() {
     auto io = _free_iocbs.top();
     _free_iocbs.pop();
+#ifdef SEASTAR_IOCB_POOL_DEBUG
+    auto index = io - _all_iocbs.data();
+    SEASTAR_ASSERT(index < max_aio);
+    SEASTAR_ASSERT(!_iocb_allocated[index] && "Double allocation of iocb");
+    _iocb_allocated[index] = true;
+#endif
     return *io;
 }
 
 inline
 void
 aio_storage_context::iocb_pool::put_one(internal::linux_abi::iocb* io) {
+#ifdef SEASTAR_IOCB_POOL_DEBUG
+    auto index = io - _all_iocbs.data();
+    SEASTAR_ASSERT(index < max_aio && "iocb pointer out of range");
+    if (!_iocb_allocated[index]) {
+        seastar_logger.error("Double-free detected: iocb at index {} (ptr={}) is being returned but was not allocated",
+                           index, fmt::ptr(io));
+        std::abort();
+    }
+    _iocb_allocated[index] = false;
+    SEASTAR_ASSERT(_free_iocbs.size() < max_aio && "Double-free: iocb pool already full");
+#endif
     _free_iocbs.push(io);
 }
 
@@ -243,7 +296,7 @@ aio_storage_context::submit_work() {
         did_work = true;
     }
 
-    if (need_to_retry() && !retry_in_progress()) {
+    if (need_to_retry()) {
         schedule_retry();
     }
 
@@ -251,6 +304,15 @@ aio_storage_context::submit_work() {
 }
 
 void aio_storage_context::schedule_retry() {
+    // Don't start a new retry loop if either:
+    //   (a) one is already in flight  (!_pending_aio_retry_fut.available()),
+    //   (b) we're shutting down       (_stopping) — stop() will drain the
+    //       queues itself; starting a second loop here would race with
+    //       stop()'s drain on the same iocb pool (the original double-free).
+    if (!_pending_aio_retry_fut.available() || _stopping) {
+        return;
+    }
+
     // loop until both _pending_aio_retry and _aio_retries are empty.
     // While retrying _aio_retries, new retries may be queued onto _pending_aio_retry.
     _pending_aio_retry_fut = do_until([this] {
@@ -296,6 +358,11 @@ void aio_storage_context::schedule_retry() {
 
 bool aio_storage_context::reap_completions(bool allow_retry)
 {
+    // During shutdown, complete EAGAIN iocbs immediately instead of
+    // queuing them for retry — schedule_retry() is gated on _stopping.
+    if (_stopping) {
+        allow_retry = false;
+    }
     struct timespec timeout = {0, 0};
     auto n = io_getevents(_io_context, 1, max_aio, _ev_buffer, &timeout, _r._cfg.force_io_getevents_syscall);
     if (n == -1 && errno == EINTR) {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -32,12 +32,17 @@
 
 #include <fmt/ostream.h>
 #include <sys/time.h>
+#include <bitset>
 #include <thread>
 #include <stack>
 #include <boost/any.hpp>
 #include <boost/program_options.hpp>
 #include <boost/container/static_vector.hpp>
 
+
+#ifdef SEASTAR_DEBUG
+#define SEASTAR_IOCB_POOL_DEBUG
+#endif
 
 namespace seastar {
 
@@ -63,6 +68,11 @@ class aio_storage_context {
     class iocb_pool {
         alignas(cache_line_size) std::array<internal::linux_abi::iocb, max_aio> _all_iocbs;
         std::stack<internal::linux_abi::iocb*, boost::container::static_vector<internal::linux_abi::iocb*, max_aio>> _free_iocbs;
+#ifdef SEASTAR_IOCB_POOL_DEBUG
+        // Track which iocbs are currently allocated (not in free list)
+        // This helps detect double-free bugs
+        std::bitset<max_aio> _iocb_allocated;
+#endif
     public:
         iocb_pool();
         internal::linux_abi::iocb& get_one();
@@ -80,15 +90,14 @@ class aio_storage_context {
     pending_aio_retry_t _pending_aio_retry; // Pending retries iocbs
     pending_aio_retry_t _aio_retries;       // Currently retried iocbs
     future<> _pending_aio_retry_fut = make_ready_future<>();
+    bool _stopping = false;
     internal::linux_abi::io_event _ev_buffer[max_aio];
 
     bool need_to_retry() const noexcept {
         return !_pending_aio_retry.empty() || !_aio_retries.empty();
     }
 
-    bool retry_in_progress() const noexcept {
-        return !_pending_aio_retry_fut.available();
-    }
+    void reap_pending_retries();
 
 public:
     explicit aio_storage_context(reactor& r);


### PR DESCRIPTION
Fix the double-free bug in iocb pool management that causes bad_alloc during AIO teardown (issue #3169, https://github.com/scylladb/scylladb/issues/17369, https://github.com/scylladb/scylladb/issues/26481).

Root Cause:
The bug occurs when stop() is called while AIO retry operations are in progress. The race condition:

1. schedule_retry() A is processing iocbs in _aio_retries
2. stop() calls std::exchange(_pending_aio_retry_fut, ready_future)
3. New I/Os complete with -EAGAIN, added to _pending_aio_retry
4. submit_work() sees need_to_retry()=TRUE && !retry_in_progress() (because we exchanged the future) and starts a NEW schedule_retry() B
5. schedule_retry() A completes, .finally() block runs
6. .finally() calls reap_completions(false) which returns -EAGAIN iocbs to the pool (since allow_retry=false)
7. But schedule_retry() B is still running with those same iocbs in _aio_retries!
8. When B tries to process them and encounters errors, handle_aio_error() calls put_one() again
9. Double-free: attempting to push to a full 1024-capacity free list, causing boost::container::bad_alloc

The Fix:
Add a _stopping flag that is set at the start of stop(). Check this flag in need_to_retry() to prevent new schedule_retry() loops from starting during shutdown. This eliminates the race window where a second retry loop could start after the future is exchanged.

The existing retry loop completes normally, and stop()'s .finally() block simply waits for all in-flight iocbs to be reaped and returned. No iocbs are leaked, and no double-free can occur.

Additionally, add debug-mode tracking (_iocb_allocated[]) to detect future double-free bugs and provide diagnostic information.

Fixes: #3169