### PR TITLE
json: formatter: fix formatting of std:string_view

### DIFF
--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -53,7 +53,7 @@ template<typename T>
 concept is_string_like =
     std::convertible_to<const T&, std::string_view> &&
     requires (T s) {
-        { s.data() } -> std::same_as<char*>;
+        { s.data() } -> std::convertible_to<const char*>;
         // sstring::length() and sstring::find() return size_t instead of
         // size_type (i.e., uint32_t), so we cannot check their return type
         // with T::size_type

--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -177,10 +177,10 @@ public:
 
     /**
      * return a json formatted string
-     * @param str the string to format
+     * @param str the string_view to format
      * @return the given string in a json format
      */
-    static sstring to_json(const sstring& str);
+    static sstring to_json(std::string_view str);
 
     /**
      * return a json formatted int
@@ -276,14 +276,12 @@ public:
      */
     static sstring to_json(unsigned long l);
 
-
-
     /**
      * return a json formatted string
-     * @param str the string to format
+     * @param str the string_view to format
      * @return the given string in a json format
      */
-    static future<> write(output_stream<char>& s, const sstring& str) {
+    static future<> write(output_stream<char>& s, std::string_view str) {
         return s.write(to_json(str));
     }
 

--- a/src/json/formatter.cc
+++ b/src/json/formatter.cc
@@ -113,7 +113,7 @@ static sstring string_view_to_json(const string_view& str) {
     return oss.str();
 }
 
-sstring formatter::to_json(const sstring& str) {
+sstring formatter::to_json(std::string_view str) {
     return string_view_to_json(str);
 }
 

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -32,6 +32,10 @@
 using namespace seastar;
 using namespace json;
 
+static_assert(internal::is_string_like<std::string_view>);
+static_assert(internal::is_string_like<std::string>);
+static_assert(internal::is_string_like<sstring>);
+
 SEASTAR_TEST_CASE(test_simple_values) {
     BOOST_CHECK_EQUAL("3", formatter::to_json(3));
     BOOST_CHECK_EQUAL("3", formatter::to_json(3.0));


### PR DESCRIPTION
Currently, to_json of a std::string_view resolved to
the Range overload, and so it is printed as array of integers
rather than as a string.

For example: std::string_view("hello, world") is wrongly formatted
as [104,101,108,108,111,44,32,119,111,114,108,100]

Note that we add formatting both for std::string_view and for std::string.
The latter is required to resolve ambiguities with formatting of
seastar::sstring (when Seastar_SSTRING is ON).

Fixes #3183