### PR TITLE
treewide: drop the support of fmtlib < 9.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ find_package (Valgrind REQUIRED)
 
 cmake_dependent_option (Seastar_LOGGER_COMPILE_TIME_FMT
   "Enable the compile-time {fmt} check when formatting logging messages" ON
-  "fmt_VERSION VERSION_GREATER_EQUAL 8.0.0" OFF)
+  "fmt_VERSION VERSION_GREATER_EQUAL 9.0.0" OFF)
 
 #
 # Code generation helpers.

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -308,6 +308,4 @@ public:
 
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::fair_queue_ticket> : fmt::ostream_formatter {};
-#endif

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -874,7 +874,6 @@ struct fmt::range_format_kind<seastar::basic_sstring<char_type, Size, max_size, 
 
 #endif
 
-#if FMT_VERSION >= 90000
 
 // Due to https://github.com/llvm/llvm-project/issues/68849, we inherit
 // from formatter<string_view> publicly rather than privately
@@ -890,4 +889,3 @@ struct fmt::formatter<seastar::basic_sstring<char_type, Size, max_size, NulTermi
     }
 };
 
-#endif

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -310,6 +310,4 @@ using reply [[deprecated("Use http::reply instead")]] = http::reply;
 
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::http::reply::status_type> : fmt::ostream_formatter {};
-#endif

--- a/include/seastar/net/ethernet.hh
+++ b/include/seastar/net/ethernet.hh
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#if FMT_VERSION >= 90000
 #include <fmt/ostream.h>
-#endif
 
 #include <array>
 #include <algorithm>
@@ -99,6 +97,4 @@ ethernet_address parse_ethernet_address(std::string addr);
 
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::net::ethernet_address> : fmt::ostream_formatter {};
-#endif

--- a/include/seastar/net/inet_address.hh
+++ b/include/seastar/net/inet_address.hh
@@ -132,7 +132,5 @@ struct hash<seastar::net::inet_address> {
 };
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::net::inet_address> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<seastar::net::inet_address::family> : fmt::ostream_formatter {};
-#endif

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -187,8 +187,6 @@ struct hash<seastar::transport> {
 
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::socket_address> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<seastar::ipv4_addr> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<seastar::ipv6_addr> : fmt::ostream_formatter {};
-#endif

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#if FMT_VERSION >= 90000
 #include <fmt/ostream.h>
-#endif
 #if FMT_VERSION >= 100000
 #include <fmt/std.h>
 #endif
@@ -439,9 +437,7 @@ struct tuple_element<I, seastar::rpc::tuple<T...>> : tuple_element<I, tuple<T...
 
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_formatter {};
-#endif
 
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -546,10 +546,8 @@ std::ostream& operator<<(std::ostream&, const std::exception&);
 std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<std::exception_ptr> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<std::exception> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<std::system_error> : fmt::ostream_formatter {};
-#endif
 
 /// @}

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -192,12 +192,10 @@ merge(numa_layout one, numa_layout two) {
 
 #ifndef SEASTAR_DEFAULT_ALLOCATOR
 
-#if FMT_VERSION >= 90000
 namespace seastar::memory {
 struct human_readable_value;
 }
 template <> struct fmt::formatter<struct seastar::memory::human_readable_value> : fmt::ostream_formatter {};
-#endif
 
 namespace seastar {
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -356,8 +356,6 @@ public:
 
 }
 
-#if FMT_VERSION >= 90000
 
 template <> struct fmt::formatter<seastar::reactor_backend_selector> : fmt::ostream_formatter {};
 
-#endif

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -85,9 +85,7 @@ std::ostream& operator<<(std::ostream& os, const opt_family& f) {
 typedef struct ares_channeldata ares_channel_t;
 #endif
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::net::opt_family> : fmt::ostream_formatter {};
-#endif
 
 #include <seastar/util/log.hh>
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -15,9 +15,7 @@
 #include <boost/range/numeric.hpp>
 #include <fmt/ostream.h>
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<seastar::rpc::streaming_domain_type> : fmt::ostream_formatter {};
-#endif
 
 namespace seastar {
 

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -46,12 +46,10 @@
 
 #include <signal.h>
 
-#if FMT_VERSION >= 90000
 namespace perf_tests::internal {
     struct duration;
 }
 template <> struct fmt::formatter<perf_tests::internal::duration> : fmt::ostream_formatter {};
-#endif
 
 namespace perf_tests {
 namespace internal {

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -315,7 +315,6 @@ BOOST_AUTO_TEST_CASE(test_compares_left_hand_not_string) {
 #endif
 }
 
-#if FMT_VERSION >= 90000
 
 BOOST_AUTO_TEST_CASE(test_fmt) {
 #if FMT_VERSION >= FMT_VERSION_OPTIONAL_FORMAT
@@ -326,4 +325,3 @@ BOOST_AUTO_TEST_CASE(test_fmt) {
     std::ignore = fmt::format("{}", strings);
 }
 
-#endif


### PR DESCRIPTION
Since we've bumped up the minimum supported fmtlib version to 9.0.0, we now have the luxury of dropping the support of fmtlib < 9.0.0 for a cleaner code base.

In this change, the support of fmtlib < 9.0.0 is dropped by removing all #if FMT_VERSION >= 90000 guards.

Notable features available in fmt 9.0.0:
- Improved floating-point formatting with consistent cross-platform rounding
- std::variant and std::filesystem::path formatting support
- fmt::ostream_formatter for custom formatters
- ADL-based format_as extension API for enums
- Nested format specifiers for ranges (e.g., {:#x})