### PR TITLE
file: provide a default implementation for file_impl::statat

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -149,7 +149,7 @@ public:
 
     virtual future<> flush() = 0;
     virtual future<struct stat> stat() = 0;
-    virtual future<struct stat> statat(std::string_view name, int flags = 0) = 0;
+    virtual future<struct stat> statat(std::string_view name, int flags = 0);
     virtual future<> truncate(uint64_t length) = 0;
     virtual future<> discard(uint64_t offset, uint64_t length) = 0;
     virtual future<int> ioctl(uint64_t cmd, void* argp) noexcept;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1509,6 +1509,10 @@ future<int> file_impl::fcntl_short(int op, uintptr_t arg) noexcept {
     return make_exception_future<int>(std::runtime_error("this file type does not support fcntl_short"));
 }
 
+future<struct stat> file_impl::statat(std::string_view name, int flags) {
+    return make_exception_future<struct stat>(std::runtime_error("this file type does not support statat"));
+}
+
 future<file> open_file_dma(std::string_view name, open_flags flags) noexcept {
     return engine().open_file_dma(name, flags, file_open_options());
 }


### PR DESCRIPTION
By default, file_impl::statat now throws a runtime_error similar to other unsupported methods.

Note that posix_file_impl does override statat with an implementation based on the statat system call.