### PR TITLE
net: expose DNS TTL via net::hostent

### DIFF
--- a/include/seastar/net/dns.hh
+++ b/include/seastar/net/dns.hh
@@ -55,6 +55,7 @@ struct hostent {
     std::vector<sstring> names;
     // Primary address is also always first.
     std::vector<inet_address> addr_list;
+    std::vector<unsigned int> addr_ttls;
 };
 
 typedef std::optional<inet_address::family> opt_family;

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -1002,12 +1002,17 @@ dns_resolver::impl::make_hostent(const ares_addrinfo* ai) {
         e.names.emplace_back(cname->alias);
     }
     for (auto node = ai->nodes; node != nullptr; node = node->ai_next) {
+        // The TTL can be zero (dont cache) or greater up to 2^31 - 1 (in seconds)
+        // https://datatracker.ietf.org/doc/html/rfc2181#section-8
+        // https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.1
         switch (node->ai_family) {
             case AF_INET:
                 e.addr_list.emplace_back(reinterpret_cast<const sockaddr_in*>(node->ai_addr)->sin_addr);
+                e.addr_ttls.emplace_back(std::max(0, node->ai_ttl));
                 break;
             case AF_INET6:
                 e.addr_list.emplace_back(reinterpret_cast<const sockaddr_in6*>(node->ai_addr)->sin6_addr);
+                e.addr_ttls.emplace_back(std::max(0, node->ai_ttl));
                 break;
         }
     }

--- a/tests/unit/dns_test.cc
+++ b/tests/unit/dns_test.cc
@@ -41,6 +41,10 @@ static future<> test_resolve(dns_resolver::options opts) {
 
     for (auto hostname : {"seastar.io", "scylladb.com", "kernel.org", "www.google.com"}) {
         hostent e = co_await d.get_host_by_name(hostname, inet_address::family::INET);
+        for (auto ttl: e.addr_ttls) {
+            BOOST_REQUIRE(ttl > 0);
+        }
+
         hostent a;
         try {
             a = co_await d.get_host_by_addr(e.addr_list.front());


### PR DESCRIPTION
Add vector of integers field to net::hostent to carry the DNS TTL, and populate it when resolving addresses through `ares`.