### PR TITLE
http: add virtual close() to connection_factory

### DIFF
--- a/include/seastar/http/connection_factory.hh
+++ b/include/seastar/http/connection_factory.hh
@@ -40,6 +40,15 @@ public:
      * be used by \ref client as transport for its http connections
      */
     virtual future<connected_socket> make(abort_source*) = 0;
+    /**
+    * \brief Shutdown the factory
+    *
+    * The implementations of this method should perform needed cleanup of the factory that will
+    * be called by \ref client when it is being closed.
+    */
+    virtual future<> close() {
+        return make_ready_future<>();
+    };
     virtual ~connection_factory() {}
 };
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -457,7 +457,7 @@ future<> client::do_make_request(connection& con, const request& req, reply_hand
 
 future<> client::close() {
     if (_pool.empty()) {
-        return make_ready_future<>();
+        return _new_connections->close();
     }
 
     connection_ptr con = _pool.front().shared_from_this();


### PR DESCRIPTION
Provide a virtual `close()` method so factories can perform cleanup during shutdown when required.