### PR TITLE
ioinfo: report actual I/O latency goal instead of configured value

### DIFF
--- a/apps/io_tester/ioinfo.cc
+++ b/apps/io_tester/ioinfo.cc
@@ -60,7 +60,7 @@ int main(int ac, char** av) {
 
                             out << YAML::Key << "device" << YAML::Value << st.st_dev;
                             out << YAML::Key << "io_latency_goal_ms" << YAML::Value <<
-                                    std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(cfg.rate_limit_duration).count();
+                                    std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(ioq.get_io_latency_goal()).count();
                             out << YAML::Key << "io_queue" << YAML::BeginMap;
                             out << YAML::Key << "id" << YAML::Value << ioq.id();
                             out << YAML::Key << "req_count_rate" << YAML::Value << cfg.req_count_rate;

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -231,6 +231,7 @@ public:
 
     request_limits get_request_limits() const noexcept;
     const config& get_config() const noexcept;
+    std::chrono::duration<double> get_io_latency_goal() const noexcept;
     std::optional<uint32_t> physical_block_size() const noexcept { return _physical_block_size; }
 
 private:

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -927,6 +927,10 @@ io_queue::request_limits io_queue::get_request_limits() const noexcept {
     return l;
 }
 
+std::chrono::duration<double> io_queue::get_io_latency_goal() const noexcept {
+    return _group->io_latency_goal();
+}
+
 future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
     return futurize_invoke([pc = std::move(pc), dnl = std::move(dnl), req = std::move(req), this, intent, iovs = std::move(iovs)] () mutable {
         // First time will hit here, and then we create the class. It is important


### PR DESCRIPTION
The ioinfo tool was displaying cfg.rate_limit_duration (the configured latency goal, typically 0.75ms) instead of the actual latency goal after token bucket limit adjustment (e.g., 6.55ms).

The token bucket limit can be increased beyond the configured rate_limit_duration to accommodate the minimum 64KB request size requirement (block_count_limit_min). When this happens, the actual I/O latency goal is larger than configured, and a warning is logged: "IO queue uses X.XXms latency goal for <mountpoint>".

This change:
- Adds io_queue::get_io_latency_goal() that returns the actual latency goal calculated from the token bucket limit
- Updates ioinfo to use this method instead of cfg.rate_limit_duration

Now ioinfo correctly reports the actual latency goal (6.55ms) that matches the warning messages and the token bucket behavior.

Example io-props file which reports 6.55ms goal:

```
disks:
  - mountpoint: /mnt/xfs
    read_iops: 1000000
    read_bandwidth: 10000000
    write_iops: 1000000
    write_bandwidth: 10000000
```