### PR TITLE
build: detect io_uring correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,11 +260,9 @@ option (Seastar_HWLOC
   "Enable hwloc support."
   ON)
 
-if (DEFINED Seastar_IO_URING)
-  option (Seastar_IO_URING
-    "Enable io_uring support."
-    ON)
-endif ()
+option (Seastar_IO_URING
+  "Enable io_uring support."
+  ON)
 
 set (Seastar_JENKINS
   ""


### PR DESCRIPTION
This got broken by 68b93f608ccd086 ("build: stop using a loop for finding dependencies"), although the broken code (which makes Seastar_IO_URING depend on itself) was introduced in 7474c474b4f60 ("build: try to enable io_uring if it is not specified")

Fix by always making the option Seastar_IO_URING available.