### PR TITLE
core/loop: repeater,repeat_until_value: don't rethrow exceptions

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -78,6 +78,11 @@ public:
                     internal::set_callback(std::move(f), this);
                     return;
                 }
+                if (f.failed()) {
+                    _promise.set_exception(f.get_exception());
+                    delete this;
+                    return;
+                }
                 if (f.get() == stop_iteration::yes) {
                     _promise.set_value();
                     delete this;
@@ -193,6 +198,11 @@ public:
                 auto f = futurize_invoke(_action);
                 if (!f.available()) {
                     internal::set_callback(std::move(f), this);
+                    return;
+                }
+                if (f.failed()) {
+                    _promise.set_exception(f.get_exception());
+                    delete this;
                     return;
                 }
                 auto ret = f.get();


### PR DESCRIPTION
Poll f.failed() before calling f.get(), so if f contains an exception it is propagated up without rethrowing. If _action() is careful enough to avoid throwing itself (instead uses make_exception_future()), the repeater should not regress to throwing.
The other loop primitives in loop.hh already use this approach.