### PR TITLE
reactor: add pure-epoll backend

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -99,13 +99,13 @@ public:
     future<size_t> read_some(const std::vector<iovec>& iov);
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba);
 #if SEASTAR_API_LEVEL >= 9
-    future<size_t> write_some(std::span<iovec> iovs);
-    future<> write_all(std::span<iovec> iovs);
+    future<size_t> send_some(std::span<iovec> iovs);
+    future<> send_all(std::span<iovec> iovs);
 #else
-    future<size_t> write_some(net::packet& p);
-    future<> write_all(net::packet& p);
-    future<> write_all(const char* buffer, size_t size);
-    future<> write_all(const uint8_t* buffer, size_t size);
+    future<size_t> send_some(net::packet& p);
+    future<> send_all(net::packet& p);
+    future<> send_all(const char* buffer, size_t size);
+    future<> send_all(const uint8_t* buffer, size_t size);
 #endif
     future<> readable();
     future<> writeable();
@@ -113,8 +113,8 @@ public:
     future<std::tuple<pollable_fd, socket_address>> accept();
     future<> connect(socket_address& sa);
     future<temporary_buffer<char>> recv_some(internal::buffer_allocator* ba);
-    future<size_t> sendmsg(struct msghdr *msg);
-    future<size_t> recvmsg(struct msghdr *msg);
+    future<size_t> send(struct msghdr *msg);
+    future<size_t> recv(struct msghdr *msg);
     future<size_t> sendto(socket_address addr, const void* buf, size_t len);
     future<> poll_rdhup();
     void shutdown(int how);
@@ -153,24 +153,24 @@ public:
         return _s->read_some(ba);
     }
 #if SEASTAR_API_LEVEL >= 9
-    future<size_t> write_some(std::span<iovec> iov) {
-        return _s->write_some(iov);
+    future<size_t> send_some(std::span<iovec> iov) {
+        return _s->send_some(iov);
     }
-    future<> write_all(std::span<iovec> iov) {
-        return _s->write_all(iov);
+    future<> send_all(std::span<iovec> iov) {
+        return _s->send_all(iov);
     }
 #else
-    future<size_t> write_some(net::packet& p) {
-        return _s->write_some(p);
+    future<size_t> send_some(net::packet& p) {
+        return _s->send_some(p);
     }
-    future<> write_all(net::packet& p) {
-        return _s->write_all(p);
+    future<> send_all(net::packet& p) {
+        return _s->send_all(p);
     }
-    future<> write_all(const char* buffer, size_t size) {
-        return _s->write_all(buffer, size);
+    future<> send_all(const char* buffer, size_t size) {
+        return _s->send_all(buffer, size);
     }
-    future<> write_all(const uint8_t* buffer, size_t size) {
-        return _s->write_all(buffer, size);
+    future<> send_all(const uint8_t* buffer, size_t size) {
+        return _s->send_all(buffer, size);
     }
 #endif
     future<> readable() {
@@ -191,11 +191,11 @@ public:
     future<temporary_buffer<char>> recv_some(internal::buffer_allocator* ba) {
         return _s->recv_some(ba);
     }
-    future<size_t> sendmsg(struct msghdr *msg) {
-        return _s->sendmsg(msg);
+    future<size_t> send(struct msghdr *msg) {
+        return _s->send(msg);
     }
-    future<size_t> recvmsg(struct msghdr *msg) {
-        return _s->recvmsg(msg);
+    future<size_t> recv(struct msghdr *msg) {
+        return _s->recv(msg);
     }
     future<size_t> sendto(socket_address addr, const void* buf, size_t len) {
         return _s->sendto(addr, buf, len);

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -98,6 +98,10 @@ public:
     future<size_t> read_some(uint8_t* buffer, size_t size);
     future<size_t> read_some(const std::vector<iovec>& iov);
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba);
+    future<size_t> write_some(const void* buffer, size_t size);
+    future<size_t> write_some(std::span<iovec> iov);
+    future<> write_all(const void* buffer, size_t size);
+    future<> write_all(std::span<iovec> iov);
 #if SEASTAR_API_LEVEL >= 9
     future<size_t> send_some(std::span<iovec> iovs);
     future<> send_all(std::span<iovec> iovs);
@@ -151,6 +155,18 @@ public:
     }
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba) {
         return _s->read_some(ba);
+    }
+    future<size_t> write_some(const void* buffer, size_t size) {
+        return _s->write_some(buffer, size);
+    }
+    future<size_t> write_some(std::span<iovec> iov) {
+        return _s->write_some(iov);
+    }
+    future<> write_all(const void* buffer, size_t size) {
+        return _s->write_all(buffer, size);
+    }
+    future<> write_all(std::span<iovec> iov) {
+        return _s->write_all(iov);
     }
 #if SEASTAR_API_LEVEL >= 9
     future<size_t> send_some(std::span<iovec> iov) {

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -100,11 +100,13 @@ public:
     future<size_t> read_some(uint8_t* buffer, size_t size);
     future<size_t> read_some(const std::vector<iovec>& iov);
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba);
+    future<size_t> write_some(const void* buffer, size_t size);
+    future<size_t> write_some(std::span<iovec> iov);
+    future<> write_all(const void* buffer, size_t size);
+    future<> write_all(std::span<iovec> iov);
 #if SEASTAR_API_LEVEL >= 9
     future<size_t> send_some(std::span<iovec> iovs);
-    future<size_t> write_some(std::span<iovec> iovs);
     future<> send_all(std::span<iovec> iovs);
-    future<> write_all(std::span<iovec> iovs);
 #else
     future<size_t> send_some(net::packet& p);
     future<> send_all(net::packet& p);
@@ -160,18 +162,24 @@ public:
     future<temporary_buffer<char>> read_some(internal::buffer_allocator* ba) {
         return _s->read_some(ba);
     }
-#if SEASTAR_API_LEVEL >= 9
-    future<size_t> send_some(std::span<iovec> iov) {
-        return _s->send_some(iov);
+    future<size_t> write_some(const void* buffer, size_t size) {
+        return _s->write_some(buffer, size);
     }
     future<size_t> write_some(std::span<iovec> iov) {
         return _s->write_some(iov);
     }
-    future<> send_all(std::span<iovec> iov) {
-        return _s->send_all(iov);
+    future<> write_all(const void* buffer, size_t size) {
+        return _s->write_all(buffer, size);
     }
     future<> write_all(std::span<iovec> iov) {
         return _s->write_all(iov);
+    }
+#if SEASTAR_API_LEVEL >= 9
+    future<size_t> send_some(std::span<iovec> iov) {
+        return _s->send_some(iov);
+    }
+    future<> send_all(std::span<iovec> iov) {
+        return _s->send_all(iov);
     }
 #else
     future<size_t> send_some(net::packet& p) {

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -106,10 +106,10 @@ public:
     future<> send_all(std::span<iovec> iovs);
     future<> write_all(std::span<iovec> iovs);
 #else
-    future<size_t> write_some(net::packet& p);
-    future<> write_all(net::packet& p);
-    future<> write_all(const char* buffer, size_t size);
-    future<> write_all(const uint8_t* buffer, size_t size);
+    future<size_t> send_some(net::packet& p);
+    future<> send_all(net::packet& p);
+    future<> send_all(const char* buffer, size_t size);
+    future<> send_all(const uint8_t* buffer, size_t size);
 #endif
     future<> readable();
     future<> writeable();
@@ -117,8 +117,8 @@ public:
     future<std::tuple<pollable_fd, socket_address>> accept();
     future<> connect(socket_address& sa);
     future<temporary_buffer<char>> recv_some(internal::buffer_allocator* ba);
-    future<size_t> sendmsg(struct msghdr *msg);
-    future<size_t> recvmsg(struct msghdr *msg);
+    future<size_t> send(struct msghdr *msg);
+    future<size_t> recv(struct msghdr *msg);
     future<size_t> sendto(socket_address addr, const void* buf, size_t len);
     future<> poll_rdhup();
     void shutdown(int how);
@@ -174,17 +174,17 @@ public:
         return _s->write_all(iov);
     }
 #else
-    future<size_t> write_some(net::packet& p) {
-        return _s->write_some(p);
+    future<size_t> send_some(net::packet& p) {
+        return _s->send_some(p);
     }
-    future<> write_all(net::packet& p) {
-        return _s->write_all(p);
+    future<> send_all(net::packet& p) {
+        return _s->send_all(p);
     }
-    future<> write_all(const char* buffer, size_t size) {
-        return _s->write_all(buffer, size);
+    future<> send_all(const char* buffer, size_t size) {
+        return _s->send_all(buffer, size);
     }
-    future<> write_all(const uint8_t* buffer, size_t size) {
-        return _s->write_all(buffer, size);
+    future<> send_all(const uint8_t* buffer, size_t size) {
+        return _s->send_all(buffer, size);
     }
 #endif
     future<> readable() {
@@ -205,11 +205,11 @@ public:
     future<temporary_buffer<char>> recv_some(internal::buffer_allocator* ba) {
         return _s->recv_some(ba);
     }
-    future<size_t> sendmsg(struct msghdr *msg) {
-        return _s->sendmsg(msg);
+    future<size_t> send(struct msghdr *msg) {
+        return _s->send(msg);
     }
-    future<size_t> recvmsg(struct msghdr *msg) {
-        return _s->recvmsg(msg);
+    future<size_t> recv(struct msghdr *msg) {
+        return _s->recv(msg);
     }
     future<size_t> sendto(socket_address addr, const void* buf, size_t len) {
         return _s->sendto(addr, buf, len);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -172,6 +172,7 @@ private:
     friend class internal::reactor_stall_sampler;
     friend class preempt_io_context;
     friend struct hrtimer_aio_completion;
+    friend class reactor_backend_epoll_base;
     friend class reactor_backend_epoll;
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -459,6 +459,11 @@ private:
     future<temporary_buffer<char>>
     do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 
+    future<size_t> do_write(pollable_fd_state& fd, const void* buffer, size_t size);
+    future<size_t> do_writev(pollable_fd_state& fd, std::span<iovec> iov);
+    future<> write_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed);
+    future<> write_all(pollable_fd_state& fd, const void* buffer, size_t len);
+
 #if SEASTAR_API_LEVEL < 9
     future<size_t>
     do_send(pollable_fd_state& fd, const void* buffer, size_t size);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -174,6 +174,7 @@ private:
     friend struct hrtimer_aio_completion;
     friend class reactor_backend_epoll_base;
     friend class reactor_backend_epoll;
+    friend class reactor_backend_epoll_pure;
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;
     friend class reactor_backend_selector;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -462,6 +462,10 @@ private:
     future<temporary_buffer<char>>
     do_read_some(pollable_fd_state& fd, internal::buffer_allocator* ba);
 
+    future<size_t> do_write(pollable_fd_state& fd, const void* buffer, size_t size);
+    future<> write_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed);
+    future<> write_all(pollable_fd_state& fd, const void* buffer, size_t len);
+
 #if SEASTAR_API_LEVEL < 9
     future<size_t>
     do_send(pollable_fd_state& fd, const void* buffer, size_t size);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -179,6 +179,7 @@ private:
     friend struct hrtimer_aio_completion;
     friend class reactor_backend_epoll_base;
     friend class reactor_backend_epoll;
+    friend class reactor_backend_epoll_pure;
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;
     friend class reactor_backend_uring_base;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -177,6 +177,7 @@ private:
     friend class internal::reactor_stall_sampler;
     friend class preempt_io_context;
     friend struct hrtimer_aio_completion;
+    friend class reactor_backend_epoll_base;
     friend class reactor_backend_epoll;
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1372,7 +1372,7 @@ cpu_stall_detector_linux_perf_event::cpu_stall_detector_linux_perf_event(file_de
         : cpu_stall_detector(cfg), _fd(std::move(fd)) {
     void* ret = ::mmap(nullptr, 2*getpagesize(), PROT_READ|PROT_WRITE, MAP_SHARED, _fd.get(), 0);
     if (ret == MAP_FAILED) {
-        abort();
+        throw std::system_error(errno, std::system_category(), "mmap() failed for perf_event_open");
     }
     _mmap = static_cast<struct ::perf_event_mmap_page*>(ret);
     _data_area = reinterpret_cast<char*>(_mmap) + getpagesize();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1409,7 +1409,7 @@ cpu_stall_detector_linux_perf_event::cpu_stall_detector_linux_perf_event(file_de
         : cpu_stall_detector(cfg), _fd(std::move(fd)) {
     void* ret = ::mmap(nullptr, 2*getpagesize(), PROT_READ|PROT_WRITE, MAP_SHARED, _fd.get(), 0);
     if (ret == MAP_FAILED) {
-        abort();
+        throw std::system_error(errno, std::system_category(), "mmap() failed for perf_event_open");
     }
     _mmap = static_cast<struct ::perf_event_mmap_page*>(ret);
     _data_area = reinterpret_cast<char*>(_mmap) + getpagesize();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -455,7 +455,7 @@ future<size_t> pollable_fd_state::write_some(std::span<iovec> iovs) {
     return engine()._backend->writev(*this, iovs);
 }
 #else
-future<size_t> pollable_fd_state::write_some(net::packet& p) {
+future<size_t> pollable_fd_state::send_some(net::packet& p) {
     static_assert(offsetof(iovec, iov_base) == offsetof(net::fragment, base) &&
         sizeof(iovec::iov_base) == sizeof(net::fragment::base) &&
         offsetof(iovec, iov_len) == offsetof(net::fragment, size) &&
@@ -485,21 +485,21 @@ future<> pollable_fd_state::write_all(std::span<iovec> iovs) {
     });
 }
 #else
-future<> pollable_fd_state::write_all(net::packet& p) {
-    return write_some(p).then([this, &p] (size_t size) {
+future<> pollable_fd_state::send_all(net::packet& p) {
+    return send_some(p).then([this, &p] (size_t size) {
         if (p.len() == size) {
             return make_ready_future<>();
         }
         p.trim_front(size);
-        return write_all(p);
+        return send_all(p);
     });
 }
 
-future<> pollable_fd_state::write_all(const char* buffer, size_t size) {
+future<> pollable_fd_state::send_all(const char* buffer, size_t size) {
     return engine().send_all(*this, buffer, size);
 }
 
-future<> pollable_fd_state::write_all(const uint8_t* buffer, size_t size) {
+future<> pollable_fd_state::send_all(const uint8_t* buffer, size_t size) {
     return engine().send_all(*this, buffer, size);
 }
 #endif
@@ -533,12 +533,12 @@ future<temporary_buffer<char>> pollable_fd_state::recv_some(internal::buffer_all
     return engine()._backend->recv_some(*this, ba);
 }
 
-future<size_t> pollable_fd_state::recvmsg(struct msghdr *msg) {
+future<size_t> pollable_fd_state::recv(struct msghdr *msg) {
     maybe_no_more_recv();
     return engine().readable(*this).then([this, msg] {
         auto r = fd.recvmsg(msg, 0);
         if (!r) {
-            return recvmsg(msg);
+            return recv(msg);
         }
         // We always speculate here to optimize for throughput in a workload
         // with multiple outstanding requests. This way the caller can consume
@@ -552,12 +552,12 @@ future<size_t> pollable_fd_state::recvmsg(struct msghdr *msg) {
     });
 }
 
-future<size_t> pollable_fd_state::sendmsg(struct msghdr* msg) {
+future<size_t> pollable_fd_state::send(struct msghdr* msg) {
     maybe_no_more_send();
     return engine().writeable(*this).then([this, msg] () mutable {
         auto r = fd.sendmsg(msg, 0);
         if (!r) {
-            return sendmsg(msg);
+            return send(msg);
         }
         // For UDP this will always speculate. We can't know if there's room
         // or not, but most of the time there should be so the cost of mis-

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -392,6 +392,37 @@ reactor::do_writev(pollable_fd_state& fd, std::span<iovec> iovs) {
     });
 }
 
+future<size_t>
+reactor::do_write(pollable_fd_state& fd, const void* buffer, size_t len) {
+    return writeable(fd).then([this, &fd, buffer, len] () mutable {
+        auto r = fd.fd.write(buffer, len);
+        if (!r) {
+            return do_write(fd, buffer, len);
+        }
+        if (size_t(*r) == len) {
+            fd.speculate_epoll(EPOLLOUT);
+        }
+        return make_ready_future<size_t>(*r);
+    });
+}
+
+future<>
+reactor::write_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed) {
+    if (completed == len) {
+        return make_ready_future<>();
+    } else {
+        return do_write(fd, static_cast<const char*>(buffer) + completed, len - completed).then(
+                [&fd, buffer, len, completed, this] (size_t part) mutable {
+            return write_all_part(fd, buffer, len, completed + part);
+        });
+    }
+}
+
+future<>
+reactor::write_all(pollable_fd_state& fd, const void* buffer, size_t len) {
+    return write_all_part(fd, buffer, len, 0);
+}
+
 #if SEASTAR_API_LEVEL < 9
 future<>
 reactor::send_all_part(pollable_fd_state& fd, const void* buffer, size_t len, size_t completed) {
@@ -446,13 +477,31 @@ future<temporary_buffer<char>> pollable_fd_state::read_some(internal::buffer_all
     return engine()._backend->read_some(*this, ba);
 }
 
-#if SEASTAR_API_LEVEL >= 9
-future<size_t> pollable_fd_state::send_some(std::span<iovec> iovs) {
-    return engine()._backend->sendmsg(*this, iovs, internal::iovec_len(iovs));
+future<size_t> pollable_fd_state::write_some(const void* buffer, size_t size) {
+    return engine().do_write(*this, buffer, size);
 }
 
 future<size_t> pollable_fd_state::write_some(std::span<iovec> iovs) {
     return engine()._backend->writev(*this, iovs);
+}
+
+future<> pollable_fd_state::write_all(const void* buffer, size_t size) {
+    if (size == 0) {
+        return make_ready_future<>();
+    }
+    return engine().write_all(*this, buffer, size);
+}
+
+future<> pollable_fd_state::write_all(std::span<iovec> iovs) {
+    return write_some(iovs).then([this, iovs] (size_t size) {
+        auto niovs = internal::iovec_trim_front(iovs, size);
+        return niovs.empty() ? make_ready_future<>() : write_all(niovs);
+    });
+}
+
+#if SEASTAR_API_LEVEL >= 9
+future<size_t> pollable_fd_state::send_some(std::span<iovec> iovs) {
+    return engine()._backend->sendmsg(*this, iovs, internal::iovec_len(iovs));
 }
 #else
 future<size_t> pollable_fd_state::send_some(net::packet& p) {
@@ -475,13 +524,6 @@ future<> pollable_fd_state::send_all(std::span<iovec> iovs) {
     return send_some(iovs).then([this, iovs] (size_t size) {
         auto niovs = internal::iovec_trim_front(iovs, size);
         return niovs.empty() ? make_ready_future<>() : send_all(niovs);
-    });
-}
-
-future<> pollable_fd_state::write_all(std::span<iovec> iovs) {
-    return write_some(iovs).then([this, iovs] (size_t size) {
-        auto niovs = internal::iovec_trim_front(iovs, size);
-        return niovs.empty() ? make_ready_future<>() : write_all(niovs);
     });
 }
 #else

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1956,6 +1956,7 @@ public:
 #endif
 
 static bool detect_aio_poll() {
+  try {
     auto fd = file_desc::eventfd(0, 0);
     aio_context_t ioc{};
     setup_aio_context(1, &ioc);
@@ -1977,6 +1978,10 @@ static bool detect_aio_poll() {
     // https://github.com/moby/moby/issues/38894.
     r = io_pgetevents(ioc, 1, 1, ev, nullptr, nullptr, true);
     return r == 1;
+  } catch (...) {
+    // ENOSYS
+    return false;
+  }
 }
 
 bool reactor_backend_selector::has_enough_aio_nr() {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -828,13 +828,12 @@ reactor_backend_aio::make_pollable_fd_state(file_desc fd, pollable_fd::speculati
     return pollable_fd_state_ptr(new aio_pollable_fd_state(std::move(fd), std::move(speculate)));
 }
 
-reactor_backend_epoll::reactor_backend_epoll(reactor& r)
-        : reactor_backend(uses_blocking_io::no, supports_aio_fdatasync::yes)
+reactor_backend_epoll_base::reactor_backend_epoll_base(reactor& r, supports_aio_fdatasync aio_fdatasync)
+        : reactor_backend(uses_blocking_io::no, aio_fdatasync)
         , _r(r)
         , _steady_clock_timer_reactor_thread(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC))
         , _steady_clock_timer_timer_thread(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC))
-        , _epollfd(file_desc::epoll_create(EPOLL_CLOEXEC))
-        , _storage_context(_r) {
+        , _epollfd(file_desc::epoll_create(EPOLL_CLOEXEC)) {
     ::epoll_event event;
     event.events = EPOLLIN;
     event.data.ptr = nullptr;
@@ -847,7 +846,7 @@ reactor_backend_epoll::reactor_backend_epoll(reactor& r)
 }
 
 void
-reactor_backend_epoll::task_quota_timer_thread_fn() {
+reactor_backend_epoll_base::task_quota_timer_thread_fn() {
     auto thread_name = seastar::format("timer-{}", _r._id);
     pthread_setname_np(pthread_self(), thread_name.c_str());
 
@@ -898,14 +897,10 @@ reactor_backend_epoll::task_quota_timer_thread_fn() {
     }
 }
 
-reactor_backend_epoll::~reactor_backend_epoll() = default;
+reactor_backend_epoll_base::~reactor_backend_epoll_base() = default;
 
-std::string_view reactor_backend_epoll::get_backend_name() const {
-    return "epoll";
-}
-
-void reactor_backend_epoll::start_tick() {
-    _task_quota_timer_thread = std::thread(&reactor_backend_epoll::task_quota_timer_thread_fn, this);
+void reactor_backend_epoll_base::start_tick() {
+    _task_quota_timer_thread = std::thread(&reactor_backend_epoll_base::task_quota_timer_thread_fn, this);
 
     ::sched_param sp;
     sp.sched_priority = 1;
@@ -915,19 +910,19 @@ void reactor_backend_epoll::start_tick() {
     }
 }
 
-void reactor_backend_epoll::stop_tick() {
+void reactor_backend_epoll_base::stop_tick() {
     _dying.store(true, std::memory_order_relaxed);
     _r._task_quota_timer.timerfd_settime(0, seastar::posix::to_relative_itimerspec(1ns, 1ms)); // Make the timer fire soon
     _task_quota_timer_thread.join();
 }
 
-void reactor_backend_epoll::arm_highres_timer(const ::itimerspec& its) {
+void reactor_backend_epoll_base::arm_highres_timer(const ::itimerspec& its) {
     _steady_clock_timer_deadline = its;
     _steady_clock_timer_timer_thread.timerfd_settime(TFD_TIMER_ABSTIME, its);
 }
 
 void
-reactor_backend_epoll::switch_steady_clock_timers(file_desc& from, file_desc& to) {
+reactor_backend_epoll_base::switch_steady_clock_timers(file_desc& from, file_desc& to) {
     auto& deadline = _steady_clock_timer_deadline;
     if (deadline.it_value.tv_sec == 0 && deadline.it_value.tv_nsec == 0) {
         return;
@@ -937,14 +932,14 @@ reactor_backend_epoll::switch_steady_clock_timers(file_desc& from, file_desc& to
     from.timerfd_settime(TFD_TIMER_ABSTIME, {});
 }
 
-void reactor_backend_epoll::maybe_switch_steady_clock_timers(int timeout, file_desc& from, file_desc& to) {
+void reactor_backend_epoll_base::maybe_switch_steady_clock_timers(int timeout, file_desc& from, file_desc& to) {
     if (timeout != 0) {
         switch_steady_clock_timers(from, to);
     }
 }
 
 bool
-reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigmask) {
+reactor_backend_epoll_base::wait_and_process(int timeout, const sigset_t* active_sigmask) {
     // If we plan to sleep, disable the timer thread steady clock timer (since it won't
     // wake us up from sleep, and timer thread wakeup will just waste CPU time) and enable
     // reactor thread steady clock timer.
@@ -1046,7 +1041,7 @@ public:
     }
 };
 
-bool reactor_backend_epoll::reap_kernel_completions() {
+bool reactor_backend_epoll_base::reap_kernel_completions() {
     // epoll does not have a separate submission stage, and just
     // calls epoll_ctl everytime it needs, so this method and
     // kernel_submit_work are essentially the same. Ordering also
@@ -1055,14 +1050,18 @@ bool reactor_backend_epoll::reap_kernel_completions() {
     // reactor register two pollers for completions and one for submission,
     // since completion is cheaper for other backends like aio. This avoids
     // calling epoll_wait twice.
-    //
-    // We will only reap the io completions
-    return _storage_context.reap_completions();
+    return false;
 }
 
-bool reactor_backend_epoll::kernel_submit_work() {
+bool reactor_backend_epoll::reap_kernel_completions() {
+    auto r = reactor_backend_epoll_base::reap_kernel_completions();
+    // Do not short-circuit.
+    r |= _storage_context.reap_completions();
+    return r;
+}
+
+bool reactor_backend_epoll_base::kernel_submit_work() {
     bool result = false;
-    _storage_context.submit_work();
     if (_need_epoll_events) {
         result |= wait_and_process(0, nullptr);
     }
@@ -1072,7 +1071,12 @@ bool reactor_backend_epoll::kernel_submit_work() {
     return result;
 }
 
-bool reactor_backend_epoll::complete_hrtimer() {
+bool reactor_backend_epoll::kernel_submit_work() {
+    _storage_context.submit_work();
+    return reactor_backend_epoll_base::kernel_submit_work();
+}
+
+bool reactor_backend_epoll_base::complete_hrtimer() {
     // This can be set from either the task quota timer thread, or
     // wait_and_process(), above.
     if (_highres_timer_pending.load(std::memory_order_relaxed)) {
@@ -1083,16 +1087,20 @@ bool reactor_backend_epoll::complete_hrtimer() {
     return false;
 }
 
-bool reactor_backend_epoll::kernel_events_can_sleep() const {
-    return _storage_context.can_sleep();
+bool reactor_backend_epoll_base::kernel_events_can_sleep() const {
+    return true;
 }
 
-void reactor_backend_epoll::wait_and_process_events(const sigset_t* active_sigmask) {
+bool reactor_backend_epoll::kernel_events_can_sleep() const {
+    return reactor_backend_epoll_base::kernel_events_can_sleep() && _storage_context.can_sleep();
+}
+
+void reactor_backend_epoll_base::wait_and_process_events(const sigset_t* active_sigmask) {
     wait_and_process(-1 , active_sigmask);
     complete_hrtimer();
 }
 
-void reactor_backend_epoll::complete_epoll_event(pollable_fd_state& pfd, int events, int event) {
+void reactor_backend_epoll_base::complete_epoll_event(pollable_fd_state& pfd, int events, int event) {
     if (pfd.events_requested & events & event) {
         pfd.events_requested &= ~event;
         pfd.events_known &= ~event;
@@ -1101,7 +1109,7 @@ void reactor_backend_epoll::complete_epoll_event(pollable_fd_state& pfd, int eve
     }
 }
 
-void reactor_backend_epoll::signal_received(int signo, siginfo_t* siginfo, void* ignore) {
+void reactor_backend_epoll_base::signal_received(int signo, siginfo_t* siginfo, void* ignore) {
     if (engine_is_ready()) {
         _r._signals.action(signo, siginfo, ignore);
     } else {
@@ -1109,7 +1117,7 @@ void reactor_backend_epoll::signal_received(int signo, siginfo_t* siginfo, void*
     }
 }
 
-future<> reactor_backend_epoll::get_epoll_future(pollable_fd_state& pfd, int event) {
+future<> reactor_backend_epoll_base::get_epoll_future(pollable_fd_state& pfd, int event) {
     if (pfd.events_known & event) {
         pfd.events_known &= ~event;
         return make_ready_future();
@@ -1131,23 +1139,23 @@ future<> reactor_backend_epoll::get_epoll_future(pollable_fd_state& pfd, int eve
     return fd->get_completion_future(event);
 }
 
-future<> reactor_backend_epoll::readable(pollable_fd_state& fd) {
+future<> reactor_backend_epoll_base::readable(pollable_fd_state& fd) {
     return get_epoll_future(fd, EPOLLIN);
 }
 
-future<> reactor_backend_epoll::writeable(pollable_fd_state& fd) {
+future<> reactor_backend_epoll_base::writeable(pollable_fd_state& fd) {
     return get_epoll_future(fd, EPOLLOUT);
 }
 
-future<> reactor_backend_epoll::readable_or_writeable(pollable_fd_state& fd) {
+future<> reactor_backend_epoll_base::readable_or_writeable(pollable_fd_state& fd) {
     return get_epoll_future(fd, EPOLLIN | EPOLLOUT);
 }
 
-future<> reactor_backend_epoll::poll_rdhup(pollable_fd_state& fd) {
+future<> reactor_backend_epoll_base::poll_rdhup(pollable_fd_state& fd) {
     return get_epoll_future(fd, POLLRDHUP);
 }
 
-void reactor_backend_epoll::forget(pollable_fd_state& fd) noexcept {
+void reactor_backend_epoll_base::forget(pollable_fd_state& fd) noexcept {
     if (fd.events_epoll) {
         ::epoll_ctl(_epollfd.get(), EPOLL_CTL_DEL, fd.fd.get(), nullptr);
     }
@@ -1156,69 +1164,80 @@ void reactor_backend_epoll::forget(pollable_fd_state& fd) noexcept {
 }
 
 future<std::tuple<pollable_fd, socket_address>>
-reactor_backend_epoll::accept(pollable_fd_state& listenfd) {
+reactor_backend_epoll_base::accept(pollable_fd_state& listenfd) {
     return _r.do_accept(listenfd);
 }
 
-future<> reactor_backend_epoll::connect(pollable_fd_state& fd, socket_address& sa) {
+future<> reactor_backend_epoll_base::connect(pollable_fd_state& fd, socket_address& sa) {
     return _r.do_connect(fd, sa);
 }
 
 future<size_t>
-reactor_backend_epoll::read(pollable_fd_state& fd, void* buffer, size_t len) {
+reactor_backend_epoll_base::read(pollable_fd_state& fd, void* buffer, size_t len) {
     return _r.do_read(fd, buffer, len);
 }
 
 future<size_t>
-reactor_backend_epoll::recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) {
+reactor_backend_epoll_base::recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) {
     return _r.do_recvmsg(fd, iov);
 }
 
 future<temporary_buffer<char>>
-reactor_backend_epoll::read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
+reactor_backend_epoll_base::read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
     return _r.do_read_some(fd, ba);
 }
 
 #if SEASTAR_API_LEVEL < 9
 future<size_t>
-reactor_backend_epoll::send(pollable_fd_state& fd, const void* buffer, size_t len) {
+reactor_backend_epoll_base::send(pollable_fd_state& fd, const void* buffer, size_t len) {
     return _r.do_send(fd, buffer, len);
 }
 #endif
 
 future<size_t>
-reactor_backend_epoll::sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) {
+reactor_backend_epoll_base::sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) {
     return _r.do_sendmsg(fd, iovs, len);
 }
 
 future<size_t>
-reactor_backend_epoll::writev(pollable_fd_state& fd, std::span<iovec> iovs) {
+reactor_backend_epoll_base::writev(pollable_fd_state& fd, std::span<iovec> iovs) {
     return _r.do_writev(fd, iovs);
 }
 
 future<temporary_buffer<char>>
-reactor_backend_epoll::recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
+reactor_backend_epoll_base::recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) {
     return _r.do_recv_some(fd, ba);
 }
 
 void
-reactor_backend_epoll::request_preemption() {
+reactor_backend_epoll_base::request_preemption() {
     _r._preemption_monitor.head.store(1, std::memory_order_relaxed);
 }
 
-void reactor_backend_epoll::start_handling_signal() {
+void reactor_backend_epoll_base::start_handling_signal() {
     // The epoll backend uses signals for the high resolution timer. That is used for thread_scheduling_group, so we
     // request preemption so when we receive a signal.
     request_preemption();
 }
 
 pollable_fd_state_ptr
-reactor_backend_epoll::make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) {
+reactor_backend_epoll_base::make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) {
     return pollable_fd_state_ptr(new epoll_pollable_fd_state(std::move(fd), std::move(speculate)));
 }
 
-void reactor_backend_epoll::reset_preemption_monitor() {
+void reactor_backend_epoll_base::reset_preemption_monitor() {
     _r._preemption_monitor.head.store(0, std::memory_order_relaxed);
+}
+
+reactor_backend_epoll::reactor_backend_epoll(reactor& r)
+        : reactor_backend_epoll_base(r, supports_aio_fdatasync::yes)
+        , _storage_context(r) {
+}
+
+reactor_backend_epoll::~reactor_backend_epoll() = default;
+
+std::string_view reactor_backend_epoll::get_backend_name() const {
+    return "epoll";
 }
 
 #ifdef SEASTAR_HAVE_URING

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -2610,6 +2610,7 @@ public:
 #endif
 
 static bool detect_aio_poll() {
+  try {
     auto fd = file_desc::eventfd(0, 0);
     aio_context_t ioc{};
     setup_aio_context(1, &ioc);
@@ -2631,6 +2632,10 @@ static bool detect_aio_poll() {
     // https://github.com/moby/moby/issues/38894.
     r = io_pgetevents(ioc, 1, 1, ev, nullptr, nullptr, true);
     return r == 1;
+  } catch (...) {
+    // ENOSYS
+    return false;
+  }
 }
 
 class noop_reactor_backend_configurator : public reactor_backend_configurator {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1076,6 +1076,51 @@ bool reactor_backend_epoll::kernel_submit_work() {
     return reactor_backend_epoll_base::kernel_submit_work();
 }
 
+std::string_view reactor_backend_epoll_pure::get_backend_name() const {
+    return "pure-epoll";
+}
+
+bool reactor_backend_epoll_pure::kernel_submit_work() {
+    auto r = _r._io_sink.drain([this] (const internal::io_request& req, io_completion* completion) {
+        memory::scoped_critical_alloc_section _;
+        using o = internal::io_request::operation;
+        // The returned future will be used to satisfy the promise in io_completion,
+        // (via complete_with) so we can ignore the future here.
+        (void)_r._thread_pool->submit<ssize_t>(internal::thread_pool_submit_reason::file_operation, [req]() mutable {
+            switch (req.opcode()) {
+            case o::read: {
+                auto& req_read = req.as<o::read>();
+                return ::pread(req_read.fd, req_read.addr, req_read.size, req_read.pos);
+            }
+            case o::readv: {
+                auto& req_readv = req.as<o::readv>();
+                return ::preadv(req_readv.fd, req_readv.iovec, req_readv.iov_len, req_readv.pos);
+            }
+            case o::write: {
+                auto& req_write = req.as<o::write>();
+                return ::pwrite(req_write.fd, req_write.addr, req_write.size, req_write.pos);
+            }
+            case o::writev: {
+                auto& req_writev = req.as<o::writev>();
+                return ::pwritev(req_writev.fd, req_writev.iovec, req_writev.iov_len, req_writev.pos);
+            }
+            case o::fdatasync: {
+                auto& req_fdatasync = req.as<o::fdatasync>();
+                return ssize_t(::fdatasync(req_fdatasync.fd));
+            }
+            default:
+                ::abort();
+            }
+        }).then([completion] (ssize_t res) {
+            completion->complete_with(res);
+        });
+        return true;
+    });
+
+    r |= reactor_backend_epoll_base::kernel_submit_work();
+    return r;
+}
+
 bool reactor_backend_epoll_base::complete_hrtimer() {
     // This can be set from either the task quota timer thread, or
     // wait_and_process(), above.
@@ -2653,6 +2698,8 @@ std::unique_ptr<reactor_backend> reactor_backend_selector::create(reactor& r) {
         return std::make_unique<reactor_backend_aio>(r);
     } else if (_name == "epoll") {
         return std::make_unique<reactor_backend_epoll>(r);
+    } else if (_name == "pure-epoll") {
+        return std::make_unique<reactor_backend_epoll_pure>(r);
     }
     throw std::logic_error("bad reactor backend");
 }
@@ -2675,6 +2722,7 @@ std::vector<reactor_backend_selector> reactor_backend_selector::available() {
         ret.push_back(reactor_backend_selector("linux-aio"));
     }
     ret.push_back(reactor_backend_selector("epoll"));
+    ret.push_back(reactor_backend_selector("pure-epoll"));
     return ret;
 }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1086,33 +1086,35 @@ bool reactor_backend_epoll_pure::kernel_submit_work() {
         using o = internal::io_request::operation;
         // The returned future will be used to satisfy the promise in io_completion,
         // (via complete_with) so we can ignore the future here.
-        (void)_r._thread_pool->submit<ssize_t>(internal::thread_pool_submit_reason::file_operation, [req]() mutable {
+        // errno is thread-local, so it has to be captured on the syscall thread;
+        // io_completion::complete_with() expects a negative errno, not -1.
+        (void)_r._thread_pool->submit<syscall_result<ssize_t>>(internal::thread_pool_submit_reason::file_operation, [req]() mutable {
             switch (req.opcode()) {
             case o::read: {
                 auto& req_read = req.as<o::read>();
-                return ::pread(req_read.fd, req_read.addr, req_read.size, req_read.pos);
+                return wrap_syscall(::pread(req_read.fd, req_read.addr, req_read.size, req_read.pos));
             }
             case o::readv: {
                 auto& req_readv = req.as<o::readv>();
-                return ::preadv(req_readv.fd, req_readv.iovec, req_readv.iov_len, req_readv.pos);
+                return wrap_syscall(::preadv(req_readv.fd, req_readv.iovec, req_readv.iov_len, req_readv.pos));
             }
             case o::write: {
                 auto& req_write = req.as<o::write>();
-                return ::pwrite(req_write.fd, req_write.addr, req_write.size, req_write.pos);
+                return wrap_syscall(::pwrite(req_write.fd, req_write.addr, req_write.size, req_write.pos));
             }
             case o::writev: {
                 auto& req_writev = req.as<o::writev>();
-                return ::pwritev(req_writev.fd, req_writev.iovec, req_writev.iov_len, req_writev.pos);
+                return wrap_syscall(::pwritev(req_writev.fd, req_writev.iovec, req_writev.iov_len, req_writev.pos));
             }
             case o::fdatasync: {
                 auto& req_fdatasync = req.as<o::fdatasync>();
-                return ssize_t(::fdatasync(req_fdatasync.fd));
+                return wrap_syscall(ssize_t(::fdatasync(req_fdatasync.fd)));
             }
             default:
                 ::abort();
             }
-        }).then([completion] (ssize_t res) {
-            completion->complete_with(res);
+        }).then([completion] (syscall_result<ssize_t> res) {
+            completion->complete_with(res.failed() ? -res.error : res.result);
         });
         return true;
     });

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -349,6 +349,18 @@ public:
     virtual bool kernel_events_can_sleep() const override;
 };
 
+// reactor backend using epoll for everything, including disk files.
+// "using epoll" here means waiting on thread pool completion notification
+// via epoll, not issuing io via epoll. The idea is to avoid linux-aio
+// for environments where it is not available.
+class reactor_backend_epoll_pure : public reactor_backend_epoll_base {
+public:
+    explicit reactor_backend_epoll_pure(reactor& r)
+            : reactor_backend_epoll_base(r, supports_aio_fdatasync::no) {}
+    virtual std::string_view get_backend_name() const override;
+    virtual bool kernel_submit_work() override;
+};
+
 class reactor_backend_aio : public reactor_backend {
     reactor& _r;
     file_desc _hrtimer_timerfd;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -268,8 +268,14 @@ protected:
 // Linux. Can wait on multiple file descriptors, and converts other events
 // (such as timers, signals, inter-thread notifications) into file descriptors
 // using mechanisms like timerfd, signalfd and eventfd respectively.
-class reactor_backend_epoll : public reactor_backend {
+//
+// This base class takes care of everything except disk files. Disk file
+// support is left to a derived class to allow different implementations,
+// with and without linux-aio.
+class reactor_backend_epoll_base : public reactor_backend {
+protected:
     reactor& _r;
+private:
     std::atomic<bool> _highres_timer_pending = {};
     std::thread _task_quota_timer_thread;
     ::itimerspec _steady_clock_timer_deadline = {};
@@ -287,17 +293,15 @@ private:
     void task_quota_timer_thread_fn();
     future<> get_epoll_future(pollable_fd_state& fd, int event);
     void complete_epoll_event(pollable_fd_state& fd, int events, int event);
-    aio_storage_context _storage_context;
     void switch_steady_clock_timers(file_desc& from, file_desc& to);
     void maybe_switch_steady_clock_timers(int timeout, file_desc& from, file_desc& to);
     bool wait_and_process(int timeout, const sigset_t* active_sigmask);
     bool complete_hrtimer();
     bool _need_epoll_events = false;
 public:
-    explicit reactor_backend_epoll(reactor& r);
-    virtual ~reactor_backend_epoll() override;
+    reactor_backend_epoll_base(reactor& r, supports_aio_fdatasync aio_fdatasync);
+    virtual ~reactor_backend_epoll_base() override;
 
-    virtual std::string_view get_backend_name() const override;
     virtual bool reap_kernel_completions() override;
     virtual bool kernel_submit_work() override;
     virtual bool kernel_events_can_sleep() const override;
@@ -331,6 +335,18 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+};
+
+// reactor backend using epoll for non-disk file descriptors and linux-aio for disk files.
+class reactor_backend_epoll : public reactor_backend_epoll_base {
+    aio_storage_context _storage_context;
+public:
+    explicit reactor_backend_epoll(reactor& r);
+    virtual ~reactor_backend_epoll() override;
+    virtual std::string_view get_backend_name() const override;
+    virtual bool reap_kernel_completions() override;
+    virtual bool kernel_submit_work() override;
+    virtual bool kernel_events_can_sleep() const override;
 };
 
 class reactor_backend_aio : public reactor_backend {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -878,7 +878,7 @@ future<>
 posix_data_sink_impl::put(temporary_buffer<char> buf) {
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += buf.size();
-    return _fd.write_all(buf.get(), buf.size()).then([d = buf.release()] {});
+    return _fd.send_all(buf.get(), buf.size()).then([d = buf.release()] {});
 }
 
 future<>
@@ -887,7 +887,7 @@ posix_data_sink_impl::put(packet p) {
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();
-    return _fd.write_all(_p).finally([this] { _p.reset(); });
+    return _fd.send_all(_p).finally([this] { _p.reset(); });
 }
 #endif
 
@@ -1100,7 +1100,7 @@ future<> posix_datagram_channel::send(const socket_address& dst, std::span<tempo
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     auto [ len, del ] = _send.prepare(dst, bufs);
     bytes_sent[sg_id] += len;
-    return _fd.sendmsg(&_send._hdr)
+    return _fd.send(&_send._hdr)
             .then([len, del = std::move(del) ] (size_t size) { SEASTAR_ASSERT(size == len); });
 }
 
@@ -1149,7 +1149,7 @@ public:
 future<datagram>
 posix_datagram_channel::receive() {
     _recv.prepare();
-    return _fd.recvmsg(&_recv._hdr).then([this] (size_t size) {
+    return _fd.recv(&_recv._hdr).then([this] (size_t size) {
         std::optional<socket_address> dst;
         for (auto* cmsg = CMSG_FIRSTHDR(&_recv._hdr); cmsg != nullptr; cmsg = CMSG_NXTHDR(&_recv._hdr, cmsg)) {
             if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_PKTINFO) {

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -32,7 +32,7 @@ module seastar;
 #else
 #include <seastar/core/fstream.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
-#include <seastar/core/io_queue.hh>
+#include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/process.hh>
@@ -67,29 +67,19 @@ public:
 };
 
 class pipe_data_sink_impl final : public data_sink_impl {
-    file_desc _fd;
-    io_queue& _io_queue;
+    pollable_fd _fd;
     const size_t _buffer_size;
 public:
-    explicit pipe_data_sink_impl(file_desc&& fd)
+    explicit pipe_data_sink_impl(pollable_fd&& fd)
         : _fd(std::move(fd))
-        , _io_queue(engine().get_io_queue(0))
         , _buffer_size(file_input_stream_options{}.buffer_size) {}
     static auto from_fd(file_desc&& fd) {
-        return std::make_unique<pipe_data_sink_impl>(std::move(fd));
+        return std::make_unique<pipe_data_sink_impl>(pollable_fd(std::move(fd)));
     }
 private:
     future<> do_put(temporary_buffer<char> buf) {
         size_t buf_size = buf.size();
-        auto req = internal::io_request::make_write(_fd.get(), 0, buf.get(), buf_size, false);
-        return _io_queue.submit_io_write(buf_size, std::move(req), nullptr).then(
-            [this, buf = std::move(buf), buf_size] (size_t written) mutable {
-                if (written < buf_size) {
-                    buf.trim_front(written);
-                    return do_put(std::move(buf));
-                }
-                return make_ready_future();
-            });
+        return _fd.write_all(buf.get(), buf_size).then([buf = std::move(buf)] {});
     }
 
 public:


### PR DESCRIPTION
This series adds a reactor backend that does not use linux-aio, even for
disk I/O. Instead, it uses the syscall thread for disk I/O.

The new backend is meant for deterministic replay environments such as `rr`[1]
that don't support aio APIs like linux-aio or io_uring. They emulate threading
by scheduling one thread at a time, so the limitations of the syscall thread aren't
material.

The series also improves tolerance to ENOSYS on such platforms.

[1] https://rr-project.org/