### PR TITLE
scheduling: Introduce per supergroup children count

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -313,6 +313,7 @@ private:
         int64_t _last_vruntime = 0;
         scheduler_list _active;
         scheduler_list _activating;;
+        unsigned _max_children = max_scheduling_groups();
         unsigned _nr_children = 0;
 
         virtual bool run_tasks() override;
@@ -320,6 +321,8 @@ private:
 
         bool active() const noexcept;
         void activate(sched_entity*);
+        void set_maximum_children(unsigned count) noexcept;
+
     private:
         void insert_active_entity(sched_entity*);
         sched_entity* pop_active_entity(sched_clock::time_point now);
@@ -737,6 +740,7 @@ private:
     friend future<scheduling_supergroup> create_scheduling_supergroup(float shares) noexcept;
     friend future<> destroy_scheduling_supergroup(scheduling_supergroup sg) noexcept;
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
+    friend future<> seastar::set_maximum_subgroups(scheduling_supergroup, unsigned) noexcept;
     friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
     friend seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const task_queue& tq);

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -354,6 +354,14 @@ public:
     float get_shares() const noexcept;
 };
 
+/// Configures the maximum number of child groups this supergroup can have
+///
+/// Changes the limit on all shards
+/// Resolves into exceptional future if the number is too large
+/// Only affects future groups creation, the new count will be applied even
+/// if the current number of subgroups is above it
+future<> set_maximum_subgroups(scheduling_supergroup sg, unsigned count) noexcept;
+
 /// \brief Identifies function calls that are accounted as a group
 ///
 /// A `scheduling_group` is a tag that can be used to mark a function call.


### PR DESCRIPTION
Currently there's a global limit on the number of scheduling groups (not supergroups), regardless of where those groups are -- in the root super group or not.

This maximum number has implicit dependency from Scylla service levels. When compiling, Scylla defines some maximum number of groups, and when running it creates a fixed amount of pre-defined groups. The remainder is thus implicit limit on the number of dynamically created SL groups.

There's an ongoing work to move all SL groups into their own supergroup (scylladb/scylladb#28235) and later to split streaming/maintenance group into sub-groups. The latter part will affect the number of pre-defined groups and will, thus, touch that implicit limit on the number of SL groups. Since this number is already the part of top-level user API, breaking it won't be good, so likely the compile-time limit on the number of groups will be changed.

By and large, all those manipulations are fragile and require extra care. This patch will help to pin the SL groups count contract by imposing an explicit limit on the supergroup with SL groups.