### PR TITLE
http: Move client code out of experimental namespace

### DIFF
--- a/demos/http_client_demo.cc
+++ b/demos/http_client_demo.cc
@@ -66,15 +66,15 @@ int main(int ac, char** av) {
 
         return seastar::async([=] {
             net::hostent e = net::dns::get_host_by_name(host, net::inet_address::family::INET).get();
-            std::unique_ptr<http::experimental::client> cln;
+            std::unique_ptr<http::client> cln;
             if (https) {
                 auto certs = ::make_shared<tls::certificate_credentials>();
                 certs->set_system_trust().get();
                 fmt::print("{} {}:443{}\n", method, e.addr_entries.front().addr, path);
-                cln = std::make_unique<http::experimental::client>(socket_address(e.addr_entries.front().addr, 443), std::move(certs), host);
+                cln = std::make_unique<http::client>(socket_address(e.addr_entries.front().addr, 443), std::move(certs), host);
             } else {
                 fmt::print("{} {}:80{}\n", method, e.addr_entries.front().addr, path);
-                cln = std::make_unique<http::experimental::client>(socket_address(e.addr_entries.front().addr, 80));
+                cln = std::make_unique<http::client>(socket_address(e.addr_entries.front().addr, 80));
             }
             auto req = http::request::make(method, host, path);
             if (body != "") {

--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -39,24 +39,22 @@ namespace tls { class certificate_credentials; }
 
 namespace http {
 
-namespace experimental { class client; }
+class client;
 struct request;
 struct reply;
 
 namespace internal {
 
 class client_ref {
-    http::experimental::client* _c;
+    http::client* _c;
 public:
-    client_ref(http::experimental::client* c) noexcept;
+    client_ref(http::client* c) noexcept;
     ~client_ref();
     client_ref(client_ref&& o) noexcept : _c(std::exchange(o._c, nullptr)) {}
     client_ref(const client_ref&) = delete;
 };
 
 }
-
-namespace experimental {
 
 /**
  * \brief Class connection represents an HTTP connection over a given transport
@@ -378,8 +376,6 @@ public:
         return _requests_queued;
     }
 };
-
-} // experimental namespace
 
 } // http namespace
 

--- a/include/seastar/http/connection_factory.hh
+++ b/include/seastar/http/connection_factory.hh
@@ -22,7 +22,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 
-namespace seastar::http::experimental {
+namespace seastar::http {
 
 /**
  * \brief Factory that provides transport for \ref client

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -46,7 +46,7 @@ namespace seastar {
 
 namespace http {
 
-namespace experimental { class connection; }
+class connection;
 
 /**
  * A request received from a client.
@@ -416,7 +416,7 @@ public:
     future<> write_request_headers(output_stream<char>& out) const;
 private:
     void add_query_param(std::string_view param);
-    friend class experimental::connection;
+    friend class connection;
 };
 
 namespace internal {

--- a/include/seastar/http/retry_strategy.hh
+++ b/include/seastar/http/retry_strategy.hh
@@ -10,9 +10,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/http/reply.hh>
 
-namespace seastar {
-
-namespace http::experimental {
+namespace seastar::http {
 
 class retry_strategy {
 public:
@@ -35,6 +33,5 @@ class no_retry_strategy final : public retry_strategy {
 public:
     future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
 };
-} // namespace http::experimental
 
-} // namespace seastar
+} // namespace seastar::http

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -44,7 +44,7 @@ logger http_log("http");
 namespace http {
 namespace internal {
 
-client_ref::client_ref(http::experimental::client* c) noexcept : _c(c) {
+client_ref::client_ref(http::client* c) noexcept : _c(c) {
     _c->_nr_connections++;
 }
 
@@ -56,8 +56,6 @@ client_ref::~client_ref() {
 }
 
 }
-
-namespace experimental {
 
 connection::connection(connected_socket&& fd, internal::client_ref cr)
         : _fd(std::move(fd))
@@ -463,6 +461,5 @@ future<> client::close() {
     });
 }
 
-} // experimental namespace
 } // http namespace
 } // seastar namespace

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -21,7 +21,7 @@ using namespace std::chrono_literals;
 namespace seastar {
 extern logger http_log;
 
-namespace http::experimental {
+namespace http {
 logger rs_logger("default_http_retry_strategy");
 
 static bool is_retryable_exception(std::exception_ptr ex) {

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -724,12 +724,12 @@ using seastar::http::request;
 
 }
 
-export namespace seastar::http::experimental {
+export namespace seastar::http {
 
-using seastar::http::experimental::client;
-using seastar::http::experimental::connection_factory;
-using seastar::http::experimental::retry_strategy;
-using seastar::http::experimental::no_retry_strategy;
+using seastar::http::client;
+using seastar::http::connection_factory;
+using seastar::http::retry_strategy;
+using seastar::http::no_retry_strategy;
 
 }
 

--- a/tests/perf/http_client_perf.cc
+++ b/tests/perf/http_client_perf.cc
@@ -20,7 +20,7 @@
  */
 
 /*
- * The test runs http::experimental::client against minimalistic (see below) server on
+ * The test runs http::client against minimalistic (see below) server on
  * one shard using single "in-memory" connection.
  *
  * The client sents one request at-a-time, waiting for the server response before sending
@@ -87,7 +87,7 @@ public:
     }
 };
 
-class loopback_http_factory : public http::experimental::connection_factory {
+class loopback_http_factory : public http::connection_factory {
     loopback_socket_impl lsi;
 public:
     explicit loopback_http_factory(loopback_connection_factory& f) : lsi(f) {}
@@ -97,7 +97,7 @@ public:
 };
 
 class client {
-    seastar::http::experimental::client _cln;
+    seastar::http::client _cln;
     const unsigned _warmup_limit;
     const unsigned _limit;
     linux_perf_event _instructions;

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -48,7 +48,7 @@ public:
     }
 };
 
-class loopback_http_factory : public http::experimental::connection_factory {
+class loopback_http_factory : public http::connection_factory {
     loopback_socket_impl lsi;
 public:
     explicit loopback_http_factory(loopback_connection_factory& f) : lsi(f) {}
@@ -897,7 +897,7 @@ SEASTAR_TEST_CASE(test_client_unexpected_reply_status) {
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
             {
                 auto req = http::request::make("GET", "test", "/test");
                 BOOST_REQUIRE_THROW(cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
@@ -953,7 +953,7 @@ SEASTAR_TEST_CASE(test_client_response_eof) {
         });
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
             auto req = http::request::make("GET", "test", "/test");
             BOOST_REQUIRE_EXCEPTION(cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
@@ -984,7 +984,7 @@ SEASTAR_TEST_CASE(test_client_head_empty_body) {
         });
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
             auto req = http::request::make("HEAD", "test", "/test");
             cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
                 return seastar::async([&rep, in = std::move(in)] () mutable {
@@ -1032,7 +1032,7 @@ SEASTAR_TEST_CASE(test_client_retry_nested) {
         });
 
         future<> client_ex = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 2, http::experimental::client::retry_requests::yes);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 2, http::client::retry_requests::yes);
             auto req = http::request::make("GET", "test", "/test");
             size_t count = 0;
             BOOST_REQUIRE_EXCEPTION(cln.make_request(
@@ -1082,7 +1082,7 @@ SEASTAR_TEST_CASE(test_client_response_parse_error) {
         });
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
             auto req = http::request::make("GET", "test", "/test");
             BOOST_REQUIRE_EXCEPTION(cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
@@ -1098,7 +1098,7 @@ SEASTAR_TEST_CASE(test_client_response_parse_error) {
 }
 
 SEASTAR_TEST_CASE(test_client_abort_new_conn) {
-    class delayed_factory : public http::experimental::connection_factory {
+    class delayed_factory : public http::connection_factory {
     public:
         virtual future<connected_socket> make(abort_source* as) override {
             SEASTAR_ASSERT(as != nullptr);
@@ -1109,7 +1109,7 @@ SEASTAR_TEST_CASE(test_client_abort_new_conn) {
     };
 
     return seastar::async([] {
-        auto cln = http::experimental::client(std::make_unique<delayed_factory>());
+        auto cln = http::client(std::make_unique<delayed_factory>());
         abort_source as;
         auto f = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
             return make_exception_future<>(std::runtime_error("Shouldn't happen"));
@@ -1139,7 +1139,7 @@ SEASTAR_TEST_CASE(test_client_abort_cached_conn) {
         });
 
         future<> client = seastar::async([&] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
             // this request gets handled by server and ...
             auto f1 = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
@@ -1179,7 +1179,7 @@ SEASTAR_TEST_CASE(test_client_abort_send_request) {
         });
 
         future<> client = seastar::async([&] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
             abort_source as;
             auto req = http::request::make("GET", "test", "/test");
             promise<> client_paused;
@@ -1225,7 +1225,7 @@ SEASTAR_TEST_CASE(test_client_abort_recv_response) {
         });
 
         future<> client = seastar::async([&] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 1 /* max connections */);
             abort_source as;
             auto f = cln.make_request(http::request::make("GET", "test", "/test"), [] (const auto& rep, auto&& in) {
                 return make_exception_future<>(std::runtime_error("Shouldn't happen"));
@@ -1269,7 +1269,7 @@ SEASTAR_TEST_CASE(test_client_retry_request) {
         });
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 2, http::experimental::client::retry_requests::yes);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 2, http::client::retry_requests::yes);
             auto req = http::request::make("GET", "test", "/test");
             bool got_response = false;
             cln.make_request(std::move(req), [&] (const http::reply& rep, input_stream<char>&& in) {
@@ -1567,7 +1567,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
         }
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
         future<> client = seastar::async([&lcf, chunked_reply] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
 
             {
                 fmt::print("Simple request test\n");
@@ -2136,7 +2136,7 @@ SEASTAR_TEST_CASE(test_redirect_exception) {
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
 
         future<> client = seastar::async([&lcf] {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf));
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
 
             auto test = [&](sstring path, sstring expected_dest, http::reply::status_type expected_status) {
                 auto req = http::request::make("GET", "test", path);
@@ -2255,7 +2255,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_with_broken_wire) {
     auto server = seastar::listen(::make_ipv4_address( {0x7f000001, 0}), opts);
     auto addr = server.local_address();
 
-    http::experimental::client c(addr, creds);
+    http::client c(addr, creds);
     http::request req;
     req._version = "1.1";
     req.write_body("html", std::string(5134, 'a'));
@@ -2280,7 +2280,7 @@ future<> test_client_close_connection(bool chunked) {
     return async([chunked] {
         loopback_connection_factory lcf(1);
         auto make_test_request = [&lcf, chunked]() {
-            auto cln = http::experimental::client(std::make_unique<loopback_http_factory>(lcf), 1, http::experimental::client::retry_requests::no);
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf), 1, http::client::retry_requests::no);
             size_t content_length = 0;
             for (auto _ [[maybe_unused]] : {1, 2}) {
                 auto req = http::request::make("GET", "test", "/test");


### PR DESCRIPTION
The http client is now stable and mature enough not to be considered experimental any longer.

For the record: it started 3+ years ago 2a3d7c4ff8