### PR TITLE
reactor: Unfriend pollable_fd via pollable_fd_state::make()

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -132,13 +132,17 @@ private:
         ++fd->_refs;
     }
     friend void intrusive_ptr_release(pollable_fd_state* fd);
+    static pollable_fd_state_ptr make(file_desc, speculation);
 };
 
 class pollable_fd {
 public:
     using speculation = pollable_fd_state::speculation;
     pollable_fd() = default;
-    pollable_fd(file_desc fd, speculation speculate = speculation());
+    pollable_fd(file_desc fd, speculation speculate = speculation())
+        : _s(pollable_fd_state::make(std::move(fd), speculate))
+    {}
+
 public:
     future<size_t> read_some(char* buffer, size_t size) {
         return _s->read_some(buffer, size);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -717,7 +717,6 @@ private:
 
     future<> run_exit_tasks();
     void stop();
-    friend class pollable_fd;
     friend class pollable_fd_state;
     friend class posix_file_impl;
     friend class blockdev_file_impl;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1660,9 +1660,9 @@ void intrusive_ptr_release(pollable_fd_state* fd) {
     }
 }
 
-pollable_fd::pollable_fd(file_desc fd, pollable_fd::speculation speculate)
-    : _s(engine()._backend->make_pollable_fd_state(std::move(fd), speculate))
-{}
+pollable_fd_state_ptr pollable_fd_state::make(file_desc fd, speculation speculate) {
+    return engine()._backend->make_pollable_fd_state(std::move(fd), speculate);
+}
 
 void pollable_fd::shutdown(int how, shutdown_kernel_only kernel_only) {
     if (!kernel_only) {


### PR DESCRIPTION
The only reason why pollable_fd is friend of reactor is for the former to call engine()._backend->... method. The pollable_fd is assumed to be a lightweight pimpl-style wrapper over pollable_fd_state which, in turn, has access to reactor/reactor_backend methods.

This patch applies this design to pollable_fd constructor as well.