### PR TITLE
http: allow minimal/zero HTTP headers in reply

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -132,6 +132,8 @@ class http_server {
     timer<> _date_format_timer { [this] {_date = http_date();} };
     size_t _content_length_limit = std::numeric_limits<size_t>::max();
     bool _content_streaming = false;
+    std::optional<sstring> _server_header = sstring("Seastar httpd");
+    bool _generate_date_header = true;
     gate _task_gate;
     std::optional<net::keepalive_params> _keepalive_params;
 public:
@@ -181,6 +183,21 @@ public:
     bool get_content_streaming() const;
 
     void set_content_streaming(bool b);
+
+    /// Returns the value of the "Server" header that will be added to each response.
+    /// std::nullopt means the header will not be added.
+    const std::optional<sstring>& get_server_header() const;
+
+    /// Sets the value of the "Server" header added to each response.
+    /// Pass std::nullopt to suppress the header entirely.
+    void set_server_header(std::optional<sstring> value);
+
+    /// Returns whether the server adds a "Date" header to each response.
+    bool get_generate_date_header() const;
+
+    /// Controls whether the server adds a "Date" header to each response.
+    /// When set to false the periodic date-update timer is also stopped.
+    void set_generate_date_header(bool b);
 
     future<> listen(socket_address addr, server_credentials_ptr credentials);
     future<> listen(socket_address addr, listen_options lo, server_credentials_ptr credentials);

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -31,6 +31,7 @@
 //
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 #include <string_view>
 #include <seastar/core/sstring.hh>
@@ -202,12 +203,21 @@ struct reply {
      * 2. If a "/" is missing in the given string, we look it up in a list of
      *    common file extensions listed in the http::mime_types map. For
      *    example "html" will be mapped to "text/html".
+     *
+     * std::nullopt and empty string are both no-ops (an empty media-type is
+     * invalid per RFC 9110).  To remove a previously set Content-Type use
+     * _headers.erase("Content-Type").  To force an empty value use
+     * add_header("Content-Type", "").
      */
-    reply& set_content_type(std::string_view content_type) {
-        if (content_type.find('/') == std::string_view::npos) {
-            content_type = http::mime_types::extension_to_type(content_type);
+    reply& set_content_type(std::optional<std::string_view> content_type) {
+        if (!content_type) {
+            return *this;
         }
-        _headers["Content-Type"] = sstring(content_type);
+        std::string_view ct = *content_type;
+        if (ct.find('/') == std::string_view::npos) {
+            ct = http::mime_types::extension_to_type(ct);
+        }
+        _headers["Content-Type"] = sstring(ct);
         return *this;
     }
 
@@ -249,7 +259,8 @@ struct reply {
      * with a function.
      *
      * \param content_type - is used to choose the content type of the body. Use the file extension
-     *  you would have used for such a content, (i.e. "txt", "html", "json", etc')
+     *  you would have used for such a content, (i.e. "txt", "html", "json", etc').
+     *  std::nullopt or an empty string skips setting Content-Type (see set_content_type()).
      * \param body_writer - a function that accept an output stream and use that stream to write the body.
      *   The function should take ownership of the stream while using it and must close the stream when it
      *   is done.
@@ -258,7 +269,7 @@ struct reply {
      *
      */
 
-    void write_body(const sstring& content_type, http::body_writer_type&& body_writer);
+    void write_body(std::optional<std::string_view> content_type, http::body_writer_type&& body_writer);
 
     /*!
      * \brief use and output stream to write the message body
@@ -268,7 +279,7 @@ struct reply {
      */
     template <typename W>
     requires std::is_invocable_r_v<future<>, W, output_stream<char>&>
-    void write_body(const sstring& content_type, W&& body_writer) {
+    void write_body(std::optional<std::string_view> content_type, W&& body_writer) {
         write_body(content_type, [body_writer = std::move(body_writer)] (output_stream<char>&& out) mutable -> future<> {
             return util::write_to_stream_and_close(std::move(out), std::move(body_writer));
         });
@@ -278,12 +289,13 @@ struct reply {
      * \brief Write a string as the reply
      *
      * \param content_type - is used to choose the content type of the body. Use the file extension
-     *  you would have used for such a content, (i.e. "txt", "html", "json", etc')
+     *  you would have used for such a content, (i.e. "txt", "html", "json", etc').
+     *  std::nullopt or an empty string skips setting Content-Type (see set_content_type()).
      * \param content - the message content.
      * This would set the the content and content type of the message along
      * with any additional information that is needed to send the message.
      */
-    void write_body(const sstring& content_type, sstring content);
+    void write_body(std::optional<std::string_view> content_type, sstring content);
 
     // RFC7231 Sec. 4.3.2
     // For HEAD replies collect everything from the handler, but don't write the body itself

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -327,8 +327,12 @@ future<> connection::respond() {
 }
 
 void connection::set_headers(http::reply& resp) {
-    resp._headers["Server"] = "Seastar httpd";
-    resp._headers["Date"] = _server._date;
+    if (_server._server_header.has_value()) {
+        resp._headers["Server"] = *_server._server_header;
+    }
+    if (_server._generate_date_header) {
+        resp._headers["Date"] = _server._date;
+    }
 }
 
 future<bool> connection::generate_reply(std::unique_ptr<http::request> req) {
@@ -370,6 +374,31 @@ bool http_server::get_content_streaming() const {
 
 void http_server::set_content_streaming(bool b) {
     _content_streaming = b;
+}
+
+const std::optional<sstring>& http_server::get_server_header() const {
+    return _server_header;
+}
+
+void http_server::set_server_header(std::optional<sstring> value) {
+    _server_header = std::move(value);
+}
+
+bool http_server::get_generate_date_header() const {
+    return _generate_date_header;
+}
+
+void http_server::set_generate_date_header(bool b) {
+    if (b == _generate_date_header) {
+        return;
+    }
+    _generate_date_header = b;
+    if (b) {
+        _date = http_date();
+        _date_format_timer.arm_periodic(1s);
+    } else {
+        _date_format_timer.cancel();
+    }
 }
 
 future<> http_server::listen(socket_address addr, listen_options lo,

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -114,12 +114,12 @@ sstring reply::response_line() const {
     });
 }
 
-void reply::write_body(const sstring& content_type, body_writer_type&& body_writer) {
+void reply::write_body(std::optional<std::string_view> content_type, body_writer_type&& body_writer) {
     set_content_type(content_type);
-    _body_writer  = std::move(body_writer);
+    _body_writer = std::move(body_writer);
 }
 
-void reply::write_body(const sstring& content_type, sstring content) {
+void reply::write_body(std::optional<std::string_view> content_type, sstring content) {
     set_content_type(content_type);
     _content = std::move(content);
 }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1449,18 +1449,28 @@ struct echo_string_handler : public echo_handler {
     }
 };
 
-/*
- * Checks if the server responds to the request equivalent to the concatenation of all req_parts with a reply containing
- * the resp_parts strings, assuming that the content streaming is set to stream and the /test route is handled by handl
- * */
-future<> check_http_reply (std::vector<sstring>&& req_parts, std::vector<std::string>&& resp_parts, bool stream, handler_base* handl) {
-    return seastar::async([req_parts = std::move(req_parts), resp_parts = std::move(resp_parts), stream, handl] {
+// Check that the HTTP response to the concatenation of req_parts:
+//  - contains every string in resp_parts
+//  - does not contain any string in absent_parts
+// The server uses content streaming mode `stream` and routes /test to `handl`.
+// An optional configure_server callback can be used to set server options before accepting.
+future<> check_http_reply(std::vector<sstring>&& req_parts, std::vector<std::string>&& resp_parts,
+        bool stream, handler_base* handl,
+        std::vector<std::string>&& absent_parts = {},
+        std::function<void(http_server&)> configure_server = {}) {
+    return seastar::async([req_parts = std::move(req_parts), resp_parts = std::move(resp_parts),
+            absent_parts = std::move(absent_parts), configure_server = std::move(configure_server),
+            stream, handl] {
         loopback_connection_factory lcf(1);
         http_server server("test");
         server.set_content_streaming(stream);
+        if (configure_server) {
+            configure_server(server);
+        }
         loopback_socket_impl lsi(lcf);
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
-        future<> client = seastar::async([req_parts = std::move(req_parts), resp_parts = std::move(resp_parts), &lsi] {
+        future<> client = seastar::async([req_parts = std::move(req_parts), resp_parts = std::move(resp_parts),
+                absent_parts = std::move(absent_parts), &lsi] {
             connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
             input_stream<char> input(c_socket.input());
             output_stream<char> output(c_socket.output());
@@ -1470,8 +1480,12 @@ future<> check_http_reply (std::vector<sstring>&& req_parts, std::vector<std::st
                 output.flush().get();
             }
             auto resp = input.read().get();
+            std::string resp_str(resp.get(), resp.size());
             for (auto& str : resp_parts) {
-                BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find(std::move(str)), std::string::npos);
+                BOOST_REQUIRE_NE(resp_str.find(str), std::string::npos);
+            }
+            for (auto& str : absent_parts) {
+                BOOST_REQUIRE_EQUAL(resp_str.find(str), std::string::npos);
             }
 
             input.close().get();
@@ -1809,6 +1823,47 @@ SEASTAR_TEST_CASE(test_close_response) {
         return check_http_reply({
             "/test\r\n\r\n"
         }, {"400 Bad Request", "Connection: close", "Can't parse the request"}, false, new echo_string_handler());
+    });
+}
+
+SEASTAR_TEST_CASE(test_server_header_default) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\n\r\n"
+    }, {"Server: Seastar httpd"}, false, new echo_string_handler());
+}
+
+SEASTAR_TEST_CASE(test_server_header_custom) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\n\r\n"
+    }, {"Server: MyApp"}, false, new echo_string_handler(), {}, [] (http_server& s) {
+        s.set_server_header("MyApp");
+    });
+}
+
+SEASTAR_TEST_CASE(test_server_header_empty) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\n\r\n"
+    }, {}, false, new echo_string_handler(), {"Server:"}, [] (http_server& s) {
+        s.set_server_header(std::nullopt);
+    });
+}
+
+SEASTAR_TEST_CASE(test_date_header_default) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\n\r\n"
+    }, {"Date:"}, false, new echo_string_handler());
+}
+
+SEASTAR_TEST_CASE(test_date_header_disabled) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\n\r\n"
+    }, {}, false, new echo_string_handler(), {"Date:"}, [] (http_server& s) {
+        // Exercise double-enable (timer already armed from constructor)
+        s.set_generate_date_header(true);
+        s.set_generate_date_header(true);
+        // Disable, then re-disable
+        s.set_generate_date_header(false);
+        s.set_generate_date_header(false);
     });
 }
 
@@ -2413,6 +2468,31 @@ SEASTAR_THREAD_TEST_CASE(test_write_reply_body_writer) {
     // chunk: "2\r\n{}\r\n" followed by terminal "0\r\n\r\n"
     BOOST_REQUIRE_NE(s.find("2\r\n{}\r\n"), std::string::npos);
     BOOST_REQUIRE(s.ends_with("0\r\n\r\n"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_write_reply_body_no_content_type) {
+    // Tests write_body() with std::nullopt content_type:
+    // - response line is correctly formatted
+    // - Content-Type header is NOT added
+    // - Content-Length header matches the body
+    // - body is written verbatim
+    http::reply reply;
+    reply.set_version("1.1");
+    reply.set_status(http::reply::status_type::ok);
+    reply.write_body(std::nullopt, sstring("hello"));
+
+    std::stringstream ss;
+    auto os = output_stream<char>(data_sink(std::make_unique<testing::memory_data_sink_impl>(ss)));
+    auto close_os = deferred_close(os);
+
+    reply.write_reply(os).get();
+    os.flush().get();
+
+    auto s = ss.str();
+    BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
+    BOOST_REQUIRE_EQUAL(s.find("Content-Type:"), std::string::npos);
+    BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
+    BOOST_REQUIRE(s.ends_with("hello"));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_reply_cookies) {


### PR DESCRIPTION
Seastar's HTTP server adds Server and Date headers to every response
by default, and the write_body() helpers implicitly set Content-Type.
Applications embedding the server (e.g. ScyllaDB) may need to
customize or suppress these headers.  While one could remove them
after the fact, this is wasteful and not discoverable.  Per RFC 9110:
the Server header is optional (MAY); the Date header is required
(MUST) for origin servers with a clock, though the RFC does allow
origin servers without a clock to omit it; and Content-Type is
recommended (SHOULD).  This change gives applications explicit
control over all three, letting each decide which RFC trade-offs are
acceptable for its use case.

- Add set_server_header(sstring) to http_server: sets the Server
  header value; an empty string suppresses the header entirely
  (default: "Seastar httpd").
- Add set_generate_date_header(bool) to http_server: when false,
  omits the Date header and stops the periodic date-update timer
  (default: true).
- In write_body(), treat an empty content_type as "don't set
  Content-Type" rather than adding an empty header.  An empty
  media-type is invalid per RFC 9110, so no legitimate value is
  lost.  Note: set_content_type("") previously fell through to
  "text/plain" via the extension lookup; it is now a no-op.

Fixes https://github.com/scylladb/seastar/issues/3216