### PR TITLE
posix-stack: Reuse parent class _reuseport from child

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -230,9 +230,8 @@ public:
 };
 
 class posix_network_stack : public network_stack {
-private:
-    const bool _reuseport;
 protected:
+    const bool _reuseport;
     std::pmr::polymorphic_allocator<char>* _allocator;
 public:
     explicit posix_network_stack(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator);
@@ -252,8 +251,6 @@ public:
 };
 
 class posix_ap_network_stack : public posix_network_stack {
-private:
-    const bool _reuseport;
 public:
     posix_ap_network_stack(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator);
     virtual server_socket listen(socket_address sa, listen_options opts) override;

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -935,7 +935,8 @@ posix_network_stack::listen(socket_address sa, listen_options opt) {
 }
 
 posix_ap_network_stack::posix_ap_network_stack(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator)
-        : posix_network_stack(opts, allocator), _reuseport(engine().posix_reuseport_available()) {
+        : posix_network_stack(opts, allocator)
+{
 }
 
 server_socket
@@ -949,7 +950,7 @@ posix_ap_network_stack::listen(socket_address sa, listen_options opt) {
         return server_socket(std::make_unique<posix_ap_server_socket_impl>(0, sa, _allocator));
     }
     auto protocol = static_cast<int>(opt.proto);
-    return _reuseport ?
+    return posix_network_stack::_reuseport ?
         server_socket(std::make_unique<posix_reuseport_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), _allocator))
         :
         server_socket(std::make_unique<posix_ap_server_socket_impl>(protocol, sa, _allocator));


### PR DESCRIPTION
The posix_ap_network_stack inherits from posix_network_stack, but introduces its own bool _reuseport bit. It's OK to re-use one from parent class, both are the same.