### PR TITLE
posix-stack: Make internal::posix_connect() resolve exceptions into f…

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1684,6 +1684,7 @@ reactor::make_pollable_fd(socket_address sa, int proto) {
 namespace internal {
 
 future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local) {
+  try {
 #ifdef IP_BIND_ADDRESS_NO_PORT
     if (!sa.is_af_unix()) {
         try {
@@ -1704,6 +1705,9 @@ future<> posix_connect(pollable_fd pfd, socket_address sa, socket_address local)
         pfd.get_file_desc().bind(local.u.sa, local.length());
     }
     return pfd.connect(sa).finally([pfd] {});
+  } catch (...) {
+    return current_exception_as_future();
+  }
 }
 
 } // internal namespace

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -490,7 +490,7 @@ class posix_socket_impl final : public socket_impl {
             _fd.get_file_desc().setsockopt(SOL_SOCKET, SO_REUSEADDR, int(_reuseaddr));
             uint16_t port = attempts++ < 5 && requested_port == 0 && proto == transport::TCP ? u(random_engine) * smp::count + this_shard_id() : requested_port;
             local.as_posix_sockaddr_in().sin_port = hton(port);
-            return futurize_invoke([this, sa, local] { return internal::posix_connect(_fd, sa, local); }).then_wrapped([port, requested_port] (future<> f) {
+            return internal::posix_connect(_fd, sa, local).then_wrapped([port, requested_port] (future<> f) {
                 try {
                     f.get();
                     return stop_iteration::yes;


### PR DESCRIPTION
…utures

The helper in question returns a future, but may sometimes throw a valid runtime exception. E.g. when binding to a busy port/path or when the call to file_desc::connect() throws itself.

When the connecting socket is not-unix one, the call to posix_connect() is properly wrapped with futurator::invoke()-s and all exceptions a caught and resolved into futures. However, unix socket connecting calls this method directly, so a thrown exception will be throws further.

Fortunately, nowadays upper level wraps posix_socket_impl::connect() into do_with(), which, in turn, uses futurize_invoke(), but it's fragile, it's better to have safer posix_connected_socket_impl::connect().