### PR TITLE
prometheus: support multiple __name__ filters and prefixed names

### DIFF
--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -69,8 +69,17 @@ future<> add_prometheus_routes(httpd::http_server& server, config ctx);
 namespace details {
 using filter_t = std::function<bool(const metrics::impl::labels_type&)>;
 
+struct write_body_args {
+    filter_t filter;
+    sstring metric_family_name;
+    bool use_protobuf_format;
+    bool use_prefix;
+    bool show_help;
+    bool enable_aggregation;
+};
+
 class test_access {
-    future<> write_body(config cfg, bool use_protobuf_format, sstring metric_family_name, bool prefix, bool show_help, bool enable_aggregation, filter_t filter, output_stream<char>&& s);
+    future<> write_body(config cfg, write_body_args args, output_stream<char>&& s);
 
     friend struct metrics_perf_fixture;
     friend struct ::prometheus_test_fixture;

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -68,12 +68,22 @@ future<> add_prometheus_routes(httpd::http_server& server, config ctx);
 
 namespace details {
 using filter_t = std::function<bool(const metrics::impl::labels_type&)>;
+using family_filter_t = std::function<bool(std::string_view)>;
+
+struct name_filter {
+    sstring name;
+    bool is_prefix;
+};
+
+// Creates a family filter from multiple name filters.
+// Returns true if the family name matches any of the filters.
+// If filters is empty, returns a filter that matches all families.
+family_filter_t make_family_filter(std::vector<name_filter> filters);
 
 struct write_body_args {
     filter_t filter;
-    sstring metric_family_name;
+    family_filter_t family_filter;
     bool use_protobuf_format;
-    bool use_prefix;
     bool show_help;
     bool enable_aggregation;
 };

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -78,7 +78,9 @@ struct name_filter {
 // Creates a family filter from multiple name filters.
 // Returns true if the family name matches any of the filters.
 // If filters is empty, returns a filter that matches all families.
-family_filter_t make_family_filter(std::vector<name_filter> filters);
+// If prefix is provided, filter names starting with "{prefix}_" will have the prefix stripped,
+// allowing users to query with either "foo" or "seastar_foo" when prefix is "seastar".
+family_filter_t make_family_filter(std::vector<name_filter> filters, std::string_view prefix = "");
 
 struct write_body_args {
     filter_t filter;

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -100,6 +100,7 @@ namespace pm = io::prometheus::client;
 namespace mi = metrics::impl;
 
 using mi::labels_type;
+using write_body_args = details::write_body_args;
 
 namespace {
 
@@ -888,15 +889,6 @@ void write_value_as_string(buf_t& s, const mi::metric_value& value) noexcept {
     }
 }
 
-struct write_body_args {
-    details::filter_t filter;
-    sstring metric_family_name;
-    bool use_protobuf_format;
-    bool use_prefix;
-    bool show_help;
-    bool enable_aggregation;
-};
-
 struct write_context {
     output_stream<char>& out;
     const config& ctx;
@@ -1098,17 +1090,9 @@ private:
     friend details::test_access;
 };
 
-future<> details::test_access::write_body(config cfg, bool use_protobuf_format, sstring metric_family_name, bool prefix, bool show_help, bool enable_aggregation, filter_t filter, output_stream<char>&& s) {
+future<> details::test_access::write_body(config cfg, write_body_args args, output_stream<char>&& s) {
     metrics_handler handler(std::move(cfg));
-
-    co_return co_await handler.write_body({
-        .filter = filter,
-        .metric_family_name = metric_family_name,
-        .use_protobuf_format = use_protobuf_format,
-        .use_prefix = prefix,
-        .show_help = show_help,
-        .enable_aggregation = enable_aggregation
-    }, std::move(s));
+    co_return co_await handler.write_body(std::move(args), std::move(s));
 }
 
 std::function<bool(const mi::labels_type&)> metrics_handler::_true_function = [](const mi::labels_type&) {

--- a/tests/perf/metrics_perf.cc
+++ b/tests/perf/metrics_perf.cc
@@ -108,7 +108,9 @@ struct metrics_perf_fixture {
 
     template <typename COUNTER_TYPE = double>
     seastar::future<size_t> run_metrics_bench(
-        size_t group_count, size_t families_per_group, size_t series_per_family, data_type type, bool enable_aggregation = false, bool use_protobuf = false) {
+        size_t group_count, size_t families_per_group, size_t series_per_family, data_type type,
+        bool enable_aggregation = false, bool use_protobuf = false,
+        family_filter_t family_filter = [](std::string_view) { return true; }) {
         using namespace seastar;
         using namespace seastar::metrics;
 
@@ -186,7 +188,7 @@ struct metrics_perf_fixture {
             co_await access{}.write_body(config,
                 write_body_args{
                     .filter = always_true,
-                    .family_filter = [](std::string_view) { return true; },
+                    .family_filter = family_filter,
                     .use_protobuf_format = use_protobuf,
                     .show_help = true,
                     .enable_aggregation = enable_aggregation
@@ -263,6 +265,24 @@ PERF_TEST_CN(metrics_perf_fixture, test_histogram_protobuf) {
 
 PERF_TEST_CN(metrics_perf_fixture, test_histogram_aggr) {
     co_return co_await run_metrics_bench(1, 100, 10, data_type::HISTOGRAM, true);
+}
+
+PERF_TEST_CN(metrics_perf_fixture, test_name_filter_exact_match) {
+    // Many families but filter to only one using exact name match.
+    // Tests overhead of iterating families when most are filtered out.
+    auto filter = make_family_filter({name_filter{"group-0_gauge______________________________________________0", false}});
+    co_return co_await run_metrics_bench(1, 1000, 10, data_type::COUNTER, false, false, filter);
+}
+
+PERF_TEST_CN(metrics_perf_fixture, test_name_filter_many_no_match) {
+    // 100 exact name filters, none of which match any metrics.
+    // Tests overhead of checking many filters when none match.
+    std::vector<name_filter> filters;
+    for (int i = 0; i < 100; ++i) {
+        filters.emplace_back(fmt::format("group-{}_nomatch", i), false);
+    }
+    auto filter = make_family_filter(std::move(filters));
+    co_return co_await run_metrics_bench(1, 1000, 10, data_type::COUNTER, false, false, filter);
 }
 
 }

--- a/tests/perf/metrics_perf.cc
+++ b/tests/perf/metrics_perf.cc
@@ -183,8 +183,15 @@ struct metrics_perf_fixture {
         perf_tests::start_measuring_time();
         for ([[maybe_unused]] auto _: irange(iterations)) {
             output_stream<char> out{counting_data_sink{}};
-            co_await access{}.write_body(config, use_protobuf, "", false, true,
-                 enable_aggregation, always_true, std::move(out));
+            co_await access{}.write_body(config,
+                write_body_args{
+                    .filter = always_true,
+                    .family_filter = [](std::string_view) { return true; },
+                    .use_protobuf_format = use_protobuf,
+                    .show_help = true,
+                    .enable_aggregation = enable_aggregation
+                },
+                std::move(out));
         }
         perf_tests::stop_measuring_time();
 

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -80,6 +80,7 @@ struct test_config {
     // number of labels on each metric
     size_t labels_per_metric = 1;
     std::optional<sp::details::filter_t> filter;
+    std::optional<sp::details::family_filter_t> family_filter;
     bool show_help = true;
     aggr_mode aggregation_mode = aggr_mode::NO_AGGR;
     bool same_metric_name = false;
@@ -172,12 +173,12 @@ struct prometheus_test_fixture {
         std::stringstream ss;
         output_stream<char> out{data_sink{std::make_unique<testing::memory_data_sink_impl>(ss, 10)}};
         auto filter = test_conf.filter.value_or(always_true);
+        auto family_filter = test_conf.family_filter.value_or([](std::string_view) { return true; });
         co_await access{}.write_body(config,
             sp::details::write_body_args{
                 .filter = filter,
-                .metric_family_name = "",
+                .family_filter = family_filter,
                 .use_protobuf_format = false,
-                .use_prefix = false,
                 .show_help = test_conf.show_help,
                 .enable_aggregation = test_conf.aggregation_mode != aggr_mode::NO_AGGR
             },
@@ -670,5 +671,126 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_same_metric_added_twice) {
     BOOST_REQUIRE_EQUAL(it->second.m.d(), 250);
 
     return make_ready_future<>();
+}
+
+// Tests for family_filter functionality
+// These tests use make_family_filter to exercise the same filtering logic used by the HTTP handler
+
+using name_filter = sp::details::name_filter;
+
+SEASTAR_TEST_CASE(test_family_filter_exact_match) {
+    // Filter to match only metric_1 by exact name
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"group_1_metric_1", false}
+    });
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_1 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_1 counter)" "\n"
+        R"(seastar_group_1_metric_1{label-0="label-0-1",shard="0"} 123)" "\n"
+    );
+}
+
+SEASTAR_TEST_CASE(test_family_filter_prefix_match) {
+    // Filter to match metrics starting with "group_1_metric_" (prefix match)
+    // This should match all 3 metrics
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"group_1_metric_", true}
+    });
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_0 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_0 counter)" "\n"
+        R"(seastar_group_1_metric_0{label-0="label-0-0",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_1 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_1 counter)" "\n"
+        R"(seastar_group_1_metric_1{label-0="label-0-1",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_2 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_2 counter)" "\n"
+        R"(seastar_group_1_metric_2{label-0="label-0-2",shard="0"} 123)" "\n"
+    );
+}
+
+SEASTAR_TEST_CASE(test_family_filter_multiple_exact_matches) {
+    // Filter to match metric_0 and metric_2 by exact name (not metric_1)
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"group_1_metric_0", false},
+        name_filter{"group_1_metric_2", false}
+    });
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_0 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_0 counter)" "\n"
+        R"(seastar_group_1_metric_0{label-0="label-0-0",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_2 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_2 counter)" "\n"
+        R"(seastar_group_1_metric_2{label-0="label-0-2",shard="0"} 123)" "\n"
+    );
+}
+
+SEASTAR_TEST_CASE(test_family_filter_combined_exact_and_prefix) {
+    // Filter that matches metric_0 exactly OR any metric starting with "group_1_metric_2"
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"group_1_metric_0", false},
+        name_filter{"group_1_metric_2", true}
+    });
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_0 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_0 counter)" "\n"
+        R"(seastar_group_1_metric_0{label-0="label-0-0",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_2 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_2 counter)" "\n"
+        R"(seastar_group_1_metric_2{label-0="label-0-2",shard="0"} 123)" "\n"
+    );
+}
+
+SEASTAR_TEST_CASE(test_family_filter_empty_matches_all) {
+    // Empty filter list matches all metrics
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({});
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_0 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_0 counter)" "\n"
+        R"(seastar_group_1_metric_0{label-0="label-0-0",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_1 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_1 counter)" "\n"
+        R"(seastar_group_1_metric_1{label-0="label-0-1",shard="0"} 123)" "\n"
+        R"(# HELP seastar_group_1_metric_2 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_2 counter)" "\n"
+        R"(seastar_group_1_metric_2{label-0="label-0-2",shard="0"} 123)" "\n"
+    );
+}
+
+SEASTAR_TEST_CASE(test_family_filter_no_match) {
+    // Filter with non-existent metric name - should produce empty output
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"nonexistent_metric", false}
+    });
+    return prometheus_test_fixture::run_metrics_test(cfg, {}, "");
+}
+
+SEASTAR_TEST_CASE(test_family_filter_with_label_filter) {
+    // Combine family filter with label filter
+    // Family filter: only metric_0 and metric_1
+    // Label filter: exclude label-0-0
+    // Result: only metric_1 (metric_0 excluded by label filter)
+    sp::details::filter_t label_filter = [](const sm::impl::labels_type& labels) {
+        auto it = labels.find("label-0");
+        return it == labels.end() || it->second.value() != "label-0-0";
+    };
+
+    test_config cfg{data_type::COUNTER, 3};
+    cfg.family_filter = sp::details::make_family_filter({
+        name_filter{"group_1_metric_0", false},
+        name_filter{"group_1_metric_1", false}
+    });
+    cfg.filter = label_filter;
+    return prometheus_test_fixture::run_metrics_test(cfg, {},
+        R"(# HELP seastar_group_1_metric_1 metric description)" "\n"
+        R"(# TYPE seastar_group_1_metric_1 counter)" "\n"
+        R"(seastar_group_1_metric_1{label-0="label-0-1",shard="0"} 123)" "\n"
+    );
 }
 

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -173,12 +173,14 @@ struct prometheus_test_fixture {
         output_stream<char> out{data_sink{std::make_unique<testing::memory_data_sink_impl>(ss, 10)}};
         auto filter = test_conf.filter.value_or(always_true);
         co_await access{}.write_body(config,
-            false,
-            "",    // metric family name
-            false, // use protobuf
-            test_conf.show_help,
-            test_conf.aggregation_mode != aggr_mode::NO_AGGR,
-            filter,
+            sp::details::write_body_args{
+                .filter = filter,
+                .metric_family_name = "",
+                .use_protobuf_format = false,
+                .use_prefix = false,
+                .show_help = test_conf.show_help,
+                .enable_aggregation = test_conf.aggregation_mode != aggr_mode::NO_AGGR
+            },
             std::move(out));
 
         BOOST_REQUIRE_MESSAGE(expected == ss.str(),


### PR DESCRIPTION
## Summary
- Enhance the existing `__name__` filter implementation to handle the case __name__ is passed multiple times, returning any of the provided names
- Support using either prefixed (`seastar_foo*`) or unprefixed (`foo*`) metric names in filters
- Add benchmarks for name filter performance
- Update documentation with filtering best practices

## Motivation
When querying a subset of metrics, it's useful to be able to specify multiple metric names in a single request. Previously only a single `__name__` parameter was supported.

Additionally, users see metric names like `seastar_scheduler_tasks_pending` in prometheus output and would naturally use these full names when filtering. The prefix is an internal implementation detail that users shouldn't need to know about. This change allows both prefixed and unprefixed names to work identically.

## Test plan
- [x] Added unit tests for family_filter functionality (exact match, prefix match, multiple filters, combined filters)
- [x] Added unit tests for prefix stripping behavior
- [x] Added HTTP-level test for multiple `__name__` parameters
- [x] Added performance benchmarks for name filtering
- [x] All prometheus tests pass: `./test.py --mode dev --name prometheus -v`