### PR TITLE
coroutine: introduce coroutine::schedule_at_coroutine_exit()

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -583,6 +583,48 @@ seastar::future<int> exception_propagating() {
 }
 ```
 
+## At exit clauses in coroutines
+
+In seastar continuation-based asynchronous programming, there were `finally()` and `then_wrapped()` methods available to do asynchronous cleanup.
+In coroutines, achiving the same is surprisingly difficult, due to the fact that one cannot `co_await` in a `catch` block.
+This usually resulted in code like this:
+```cpp
+seastar::future<> foo() {
+    std::exception_ptr ex;
+    try {
+        // do things that might throw
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    // do cleanup that might co_await
+
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
+}
+```
+
+`coroutine::schedule_at_coroutine_exit` is a facility to make this easier.
+It takes a lambda that is scheduled to run right after the coroutine body finishes, regardless of whether it finished normally or exceptionally.
+To keep this free for coroutines that don't need it, a coroutine must opt in by wrapping its return type in `coroutine::with_at_exit<>`: instead of returning `seastar::future<T>`, such a coroutine returns `seastar::future<coroutine::with_at_exit<T>>` (`coroutine::with_at_exit<>` for the void case).
+`coroutine::with_at_exit<T>` decays transparently to `T`, so from the caller's point of view the awaited result behaves like a plain `T`.
+Attempting to use `coroutine::schedule_at_coroutine_exit` in a coroutine that returns a plain `seastar::future<T>` is a compile-time error.
+Example:
+
+```cpp
+seastar::future<coroutine::with_at_exit<>> foo() {
+    co_await coroutine::schedule_at_coroutine_exit([] {
+        // do cleanup that might co_await
+    });
+
+    // do things that might throw
+}
+```
+
+The lambda passed to `coroutine::schedule_at_coroutine_exit` will be run when the coroutine frame is still live, so capturing variables by references is allowed.
+Optionally, the lambda can take a `std::exception_ptr` parameter, which will be passed the exception if the coroutine body threw, or `nullptr` if it finished normally.
+
 ## Concurrency in coroutines
 
 The `co_await` operator allows for simple sequential execution. Multiple coroutines can execute in parallel, but each coroutine has only one outstanding computation at a time.

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -45,6 +45,73 @@ void free_sized(void* ptr, size_t size);
 
 namespace seastar {
 
+namespace coroutine {
+
+/// \brief Return-type wrapper that opts a coroutine into asynchronous cleanup.
+///
+/// By default, a coroutine returning \c future<T> has no support for
+/// \ref coroutine::schedule_at_coroutine_exit() and pays no overhead for it.
+/// To opt into asynchronous cleanup, declare the coroutine to return
+/// \c future<coroutine::with_at_exit<T>> instead of \c future<T>. This selects
+/// a different \c std::coroutine_traits specialization whose promise carries the
+/// machinery required by \ref coroutine::schedule_at_coroutine_exit().
+///
+/// \c with_at_exit<T> wraps a value of type \c T and decays to it transparently,
+/// so callers can treat the awaited result as if it were a plain \c T:
+/// ```
+/// future<coroutine::with_at_exit<int>> foo();
+///
+/// future<> bar() {
+///     int x = co_await foo();  // with_at_exit<int> decays to int
+/// }
+/// ```
+///
+/// \tparam T the wrapped value type (may be \c void).
+template <typename T = void>
+class with_at_exit {
+    T _value;
+
+public:
+    using value_type = T;
+
+    with_at_exit() = default;
+
+    /// Construct from any value convertible to \c T. Used by the coroutine
+    /// promise to wrap the \c co_return-ed value.
+    template <typename U>
+    requires std::is_convertible_v<U&&, T>
+    with_at_exit(U&& value) noexcept(std::is_nothrow_constructible_v<T, U&&>)
+        : _value(std::forward<U>(value)) {
+    }
+
+    /// \name Transparent decay to the wrapped value.
+    /// \{
+    operator T&() & noexcept { return _value; }
+    operator const T&() const& noexcept { return _value; }
+    operator T&&() && noexcept { return std::move(_value); }
+    /// \}
+
+    /// \name Explicit access to the wrapped value.
+    /// \{
+    T& value() & noexcept { return _value; }
+    const T& value() const& noexcept { return _value; }
+    T&& value() && noexcept { return std::move(_value); }
+    /// \}
+};
+
+/// \brief \c void specialization of \ref with_at_exit.
+///
+/// Carries no value; used as the return-type wrapper for cleanup-enabled
+/// coroutines that would otherwise return \c future<>.
+template <>
+class with_at_exit<void> {
+public:
+    using value_type = void;
+    with_at_exit() = default;
+};
+
+} // namespace coroutine
+
 namespace internal {
 
 
@@ -85,6 +152,199 @@ public:
 #endif
 };
 
+using at_exit_function = noncopyable_function<future<>(std::exception_ptr)>;
+
+/// Satisfied only by coroutine promise types that opt into asynchronous cleanup,
+/// i.e. those generated for coroutines returning `future<coroutine::with_at_exit<T>>`.
+/// Used to reject `coroutine::schedule_at_coroutine_exit()` at compile time in
+/// plain `future<T>` coroutines.
+template <typename Promise>
+concept coroutine_promise_with_at_exit = requires (Promise& promise, at_exit_function&& func) {
+    promise.push_at_exit_function(std::move(func));
+};
+
+class at_exit_func_stack {
+    std::optional<at_exit_function> _func;
+    std::unique_ptr<at_exit_func_stack> _next;
+
+public:
+    at_exit_func_stack() = default;
+    explicit at_exit_func_stack(at_exit_function&& func) : _func(std::move(func)) { }
+
+    bool empty() const noexcept { return !_func; }
+
+    at_exit_function& top() noexcept { return *_func; }
+
+    void push(at_exit_function&& func) {
+        auto new_node = _func ? std::make_unique<at_exit_func_stack>(std::move(*this)) : nullptr;
+        _func = std::move(func);
+        _next = std::move(new_node);
+    }
+
+    void pop() noexcept {
+        _func.reset();
+        if (auto next = std::exchange(_next, nullptr)) {
+            new (this) at_exit_func_stack(std::move(*next));
+        }
+    }
+};
+
+template <typename U>
+void destroy_coroutine(seastar::task& coroutine_task) {
+    auto promise_ptr = static_cast<U*>(&coroutine_task);
+    auto hndl = std::coroutine_handle<U>::from_promise(*promise_ptr);
+    hndl.destroy();
+}
+
+inline std::exception_ptr combine_exceptions(std::exception_ptr ex1, std::exception_ptr ex2) noexcept {
+    if (ex1 && ex2) {
+        return std::make_exception_ptr(nested_exception(std::move(ex1), std::move(ex2)));
+    } else if (ex1) {
+        return ex1;
+    } else {
+        return ex2;
+    }
+}
+
+class at_coroutine_exit_base : public seastar::task {
+protected:
+    at_exit_func_stack _funcs;
+
+private:
+    seastar::task* _coroutine_task;
+    seastar::task* _waiting_task;
+    void (*_destroy_coroutine)(seastar::task&);
+
+    std::optional<seastar::future<>> _future;
+    std::exception_ptr _ex;
+
+private:
+    virtual std::exception_ptr get_exception() noexcept = 0;
+    virtual void resume_after_at_exit(std::exception_ptr at_exit_ex) noexcept = 0;
+
+    future<> execute_one() noexcept {
+        try {
+            return _funcs.top()(get_exception());
+        } catch (...) {
+            return seastar::make_exception_future<>(std::current_exception());
+        }
+    }
+
+public:
+    at_coroutine_exit_base() = default;
+    at_coroutine_exit_base(at_coroutine_exit_base&&) = delete;
+    at_coroutine_exit_base(const at_coroutine_exit_base&) = delete;
+
+    template <typename U>
+    void run(std::coroutine_handle<U> hndl) noexcept {
+        _coroutine_task = &hndl.promise();
+        _waiting_task = hndl.promise().waiting_task();
+        _destroy_coroutine = destroy_coroutine<U>;
+        _future = execute_one();
+
+        if (_future->available()) {
+            execute_involving_handle_destruction_in_await_suspend(this);
+        } else {
+            _future->set_coroutine(*this);
+        }
+    }
+
+    virtual void run_and_dispose() noexcept final override {
+        while (_future->available()) {
+            if (_future->failed()) {
+                _ex = combine_exceptions(std::move(_ex), _future->get_exception());
+            }
+
+            _funcs.pop();
+
+            if (!_funcs.empty()) {
+                _future = execute_one();
+                continue;
+            }
+
+            resume_after_at_exit(std::move(_ex));
+            _destroy_coroutine(*_coroutine_task);
+
+            return;
+        }
+
+        _future->set_coroutine(*this);
+    }
+
+    virtual task* waiting_task() noexcept final override {
+        return _waiting_task;
+    }
+};
+
+template <typename T = void>
+class at_coroutine_exit final : public at_coroutine_exit_base {
+    seastar::promise<T>& _proxy_promise;
+    seastar::promise<T> _return_promise;
+
+private:
+    virtual std::exception_ptr get_exception() noexcept final override {
+        return _proxy_promise.get_exception();
+    }
+
+    virtual void resume_after_at_exit(std::exception_ptr at_exit_ex) noexcept final override {
+        auto proxy_fut = _proxy_promise.get_future();
+        if (at_exit_ex) {
+            auto final_ex = combine_exceptions(std::move(at_exit_ex), _proxy_promise.get_exception());
+            proxy_fut.ignore_ready_future();
+            proxy_fut = seastar::make_exception_future<T>(std::move(final_ex));
+        }
+        proxy_fut.forward_to(std::move(_return_promise));
+    }
+
+public:
+    explicit at_coroutine_exit(seastar::promise<T>& promise)
+        : _proxy_promise(promise)
+        , _return_promise(std::exchange(_proxy_promise, seastar::promise<T>{}))
+    { }
+
+    seastar::promise<T>& get_return_promise() { return _return_promise; }
+
+    void push_at_exit_function(at_exit_function&& func) {
+        _funcs.push(std::move(func));
+    }
+};
+
+class final_awaiter final {
+    at_coroutine_exit_base* _at_exit;
+
+public:
+    explicit final_awaiter(at_coroutine_exit_base* at_exit) noexcept : _at_exit(at_exit) { }
+
+    bool await_ready() const noexcept { return !_at_exit; }
+
+    void await_resume() noexcept { }
+
+    template <typename U>
+    void await_suspend(std::coroutine_handle<U> hndl) noexcept { _at_exit->run(hndl); }
+};
+
+// Does not implement the full awaiter control semantics described at
+// https://en.cppreference.com/w/cpp/language/coroutines.html.
+// It is enough if this is compatible with our promise_type<>::final_suspend().
+template <typename U>
+void finalize_and_destroy_coroutine(std::coroutine_handle<U> hndl) {
+    auto final_suspend = hndl.promise().final_suspend();
+    if (final_suspend.await_ready()) {
+        final_suspend.await_resume();
+        hndl.destroy();
+    } else {
+        final_suspend.await_suspend(hndl);
+    }
+}
+
+// Fast path: promise type for coroutines returning `future<T>`.
+//
+// This is the default, zero-overhead promise. It has no support for
+// `coroutine::schedule_at_coroutine_exit()`: `final_suspend()` returns
+// `std::suspend_never`, so the coroutine is not suspended at its final suspend
+// point and no cleanup machinery is instantiated. Coroutines that need
+// asynchronous cleanup opt in by returning `future<coroutine::with_at_exit<T>>`,
+// which selects `coroutine_traits_with_at_exit_base<T>` below instead.
 template <typename T = void>
 class coroutine_traits_base {
 public:
@@ -188,6 +448,139 @@ public:
 
         scheduling_group set_scheduling_group(scheduling_group new_sg) noexcept {
             return task::set_scheduling_group(new_sg);
+        }
+    };
+};
+
+// Opt-in path: promise type for coroutines returning
+// `future<coroutine::with_at_exit<T>>`.
+//
+// Selected by the `std::coroutine_traits` specialization at the bottom of this
+// file. Carries the machinery required by `coroutine::schedule_at_coroutine_exit()`:
+// `final_suspend()` returns a `final_awaiter` that runs any registered at-exit
+// functions before the coroutine frame is destroyed. When no at-exit function is
+// registered, the fast path through `final_awaiter` is taken (see `final_awaiter`).
+//
+// The seastar future/promise carries `with_at_exit<T>` as its value type; the
+// caller-visible future is therefore `future<with_at_exit<T>>`, which decays to
+// `future<T>`-like semantics via `with_at_exit<T>`'s conversions.
+template <typename T = void>
+class coroutine_traits_with_at_exit_base {
+public:
+    using value_type = coroutine::with_at_exit<T>;
+
+    class promise_type final : public seastar::task, public coroutine_allocators {
+        seastar::promise<value_type> _promise;
+        seastar::promise<value_type>* _return_promise;
+        std::unique_ptr<at_coroutine_exit<value_type>> _at_exit;
+
+    public:
+        promise_type() : _return_promise(&_promise) { }
+        promise_type(promise_type&&) = delete;
+        promise_type(const promise_type&) = delete;
+
+        // this non-templated version only exists to support co_returning a braced-init-list
+        void return_value(T&& value) noexcept {
+            _promise.set_value(value_type(std::forward<T>(value)));
+        }
+
+        template<typename U>
+        requires std::is_convertible_v<U&&, T>
+        void return_value(U&& value) noexcept {
+            _promise.set_value(value_type(std::forward<U>(value)));
+        }
+
+        void return_value(coroutine::exception ce) noexcept {
+            _promise.set_exception(std::move(ce.eptr));
+        }
+
+        void set_exception(std::exception_ptr&& eptr) noexcept {
+            _promise.set_exception(std::move(eptr));
+        }
+
+        void unhandled_exception() noexcept {
+            _promise.set_exception(std::current_exception());
+        }
+
+        seastar::future<value_type> get_return_object() noexcept {
+            return _return_promise->get_future();
+        }
+
+        std::suspend_never initial_suspend() noexcept { return { }; }
+        final_awaiter final_suspend() noexcept { return final_awaiter(_at_exit.get()); }
+
+        virtual void run_and_dispose() noexcept override {
+            auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
+            handle.resume();
+        }
+
+        task* waiting_task() noexcept override { return _return_promise->waiting_task(); }
+
+        scheduling_group set_scheduling_group(scheduling_group sg) noexcept {
+            return std::exchange(this->_sg, sg);
+        }
+
+        void push_at_exit_function(at_exit_function&& func) {
+            if (!_at_exit) {
+                _at_exit = std::make_unique<at_coroutine_exit<value_type>>(_promise);
+                _return_promise = &_at_exit->get_return_promise();
+            }
+            _at_exit->push_at_exit_function(std::move(func));
+        }
+    };
+};
+
+template <>
+class coroutine_traits_with_at_exit_base<void> {
+public:
+    using value_type = coroutine::with_at_exit<void>;
+
+    class promise_type final : public seastar::task, public coroutine_allocators {
+        seastar::promise<value_type> _promise;
+        seastar::promise<value_type>* _return_promise;
+        std::unique_ptr<at_coroutine_exit<value_type>> _at_exit;
+
+    public:
+        promise_type() : _return_promise(&_promise) { }
+        promise_type(promise_type&&) = delete;
+        promise_type(const promise_type&) = delete;
+
+        void return_void() noexcept {
+            _promise.set_value(value_type{});
+        }
+
+        void set_exception(std::exception_ptr&& eptr) noexcept {
+            _promise.set_exception(std::move(eptr));
+        }
+
+        void unhandled_exception() noexcept {
+            _promise.set_exception(std::current_exception());
+        }
+
+        seastar::future<value_type> get_return_object() noexcept {
+            return _return_promise->get_future();
+        }
+
+        std::suspend_never initial_suspend() noexcept { return { }; }
+        final_awaiter final_suspend() noexcept { return final_awaiter(_at_exit.get()); }
+
+        virtual void run_and_dispose() noexcept override {
+            auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
+            handle.resume();
+        }
+
+        task* waiting_task() noexcept override { return _return_promise->waiting_task(); }
+
+        scheduling_group set_scheduling_group(scheduling_group new_sg) noexcept {
+            return task::set_scheduling_group(new_sg);
+        }
+
+        void push_at_exit_function(at_exit_function&& func) {
+            if (!_at_exit) {
+                _at_exit = std::make_unique<at_coroutine_exit<value_type>>(_promise);
+                _return_promise = &_at_exit->get_return_promise();
+            }
+            _at_exit->push_at_exit_function(std::move(func));
         }
     };
 };
@@ -318,8 +711,16 @@ auto operator co_await(internal::without_preemption_check<T> f) noexcept {
 
 namespace std {
 
+// Default: plain `future<T>` coroutines get the zero-overhead promise.
 template<typename T, typename... Args>
 class coroutine_traits<seastar::future<T>, Args...> : public seastar::internal::coroutine_traits_base<T> {
+};
+
+// Opt-in: `future<coroutine::with_at_exit<T>>` coroutines get the cleanup-capable
+// promise. This partial specialization is more specialized than the one above and
+// so is preferred when the value type is a `with_at_exit<>`.
+template<typename T, typename... Args>
+class coroutine_traits<seastar::future<seastar::coroutine::with_at_exit<T>>, Args...> : public seastar::internal::coroutine_traits_with_at_exit_base<T> {
 };
 
 } // std

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -954,6 +954,10 @@ public:
     /// but expands to less code.
     void set_to_current_exception() noexcept;
 
+    std::exception_ptr get_exception() const noexcept {
+        return _state && _state->failed() ? _state->get_exception() : std::exception_ptr();
+    }
+
     /// Returns the task which is waiting for this promise to resolve, or nullptr.
     task* waiting_task() const noexcept { return _task; }
 };
@@ -1023,6 +1027,10 @@ public:
     /// but expands to less code.
     void set_to_current_exception() noexcept {
         internal::promise_base::set_to_current_exception();
+    }
+
+    std::exception_ptr get_exception() const noexcept {
+        return internal::promise_base::get_exception();
     }
 
     /// Returns the task which is waiting for this promise to resolve, or nullptr.
@@ -1202,6 +1210,10 @@ public:
     }
 
     using internal::promise_base_with_type<T>::set_urgent_state;
+
+    std::exception_ptr get_exception() const noexcept {
+        return internal::promise_base::get_exception();
+    }
 
     template <typename U>
     friend class future;

--- a/include/seastar/coroutine/at_coroutine_exit.hh
+++ b/include/seastar/coroutine/at_coroutine_exit.hh
@@ -1,0 +1,112 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+#pragma once
+
+#include <seastar/util/noncopyable_function.hh>
+#include <seastar/core/coroutine.hh>
+
+namespace seastar::internal {
+
+template <std::invocable<> Func>
+struct at_coroutine_exit_wrapper {
+    Func func;
+
+    future<> operator()(std::exception_ptr) {
+        return func();
+    }
+};
+
+}
+
+namespace seastar::coroutine {
+
+/// \brief schedules the function to be run at coroutine exit
+///
+/// After the coroutine body has finished, but before the coroutine frame is
+/// destroyed. Useful to clean-up resources acquired in a coroutine.
+///
+/// Equivalent to injecting `co_await func()` to the end of the coroutine, to run
+/// regardless of the return path taken and regardless of whether the coroutine
+/// resolved with a value or an exception.
+///
+/// When the function is called, the coroutine frame is still alive, so capturing
+/// local variables *is* allowed.
+///
+/// Multiple calls to `schedule_at_coroutine_exit()` are allowed, the functions
+/// will be executed in reverse (LIFO) order.
+///
+/// Exceptions from `func()` will be propagated to the coroutine's caller.
+/// If both the coroutine and one or more coroutine exit func throws, the
+/// final exception will be a seastar::nested_exception containing all of them,
+/// with the inner-most exception being the one from the coroutine.
+///
+/// The lambda passed to `schedule_at_coroutine_exit()` can optionally take a single
+/// parameter of type `std::exception_ptr`, which will contain the exception the
+/// coroutine resolved with, if it resolved with an exception. Useful to do
+/// logging or different clean-up based on success/failure. The exception cannot
+/// be handled -- it will be propagated to the coroutine's caller, regardless of
+/// what is done in the `schedule_at_coroutine_exit()` function.
+///
+/// \note The enclosing coroutine must opt into asynchronous cleanup by returning
+/// `future<coroutine::with_at_exit<T>>` instead of the plain `future<T>`. This is
+/// what allows plain `future<T>` coroutines to pay no overhead for this facility.
+/// `co_await`-ing `schedule_at_coroutine_exit()` in a plain `future<T>` coroutine
+/// is a compile-time error.
+///
+/// Example:
+/// ```
+/// future<coroutine::with_at_exit<>> my_coroutine() {
+///     auto file = co_await open_file_dma("myfile");
+///
+///     co_await coroutine::schedule_at_coroutine_exit([&file] (std::exception_ptr eptr) {
+///        return file.close();
+///     });
+///
+///     // do things with file (which might throw)
+/// }
+/// ```
+class schedule_at_coroutine_exit {
+    noncopyable_function<future<>(std::exception_ptr)> _func;
+
+public:
+    explicit schedule_at_coroutine_exit(noncopyable_function<future<>(std::exception_ptr)> func) : _func(std::move(func)) {}
+
+    template <std::invocable<> Func>
+    explicit schedule_at_coroutine_exit(Func func) : _func(seastar::internal::at_coroutine_exit_wrapper{std::move(func)}) { }
+
+    bool await_ready() const noexcept { return false; }
+
+    template<typename U>
+    void await_suspend(std::coroutine_handle<U> hndl) {
+        static_assert(seastar::internal::coroutine_promise_with_at_exit<U>,
+                "coroutine::schedule_at_coroutine_exit() requires the enclosing coroutine to "
+                "return seastar::future<seastar::coroutine::with_at_exit<T>> instead of "
+                "seastar::future<T>. Wrap the coroutine's return type in "
+                "seastar::coroutine::with_at_exit<> to opt into asynchronous coroutine cleanup.");
+        hndl.promise().push_at_exit_function(std::move(_func));
+        hndl.resume();
+    }
+
+    void await_resume() const noexcept {}
+};
+
+} // namespace seastar::coroutine

--- a/include/seastar/coroutine/exception.hh
+++ b/include/seastar/coroutine/exception.hh
@@ -47,7 +47,7 @@ struct exception_awaiter {
       SEASTAR_COROUTINE_LOC_STORE(hndl.promise());
       execute_involving_handle_destruction_in_await_suspend([hndl, eptr = std::move(eptr)] () mutable {
         hndl.promise().set_exception(std::move(eptr));
-        hndl.destroy();
+        finalize_and_destroy_coroutine(hndl);
       });
     }
 

--- a/include/seastar/coroutine/try_future.hh
+++ b/include/seastar/coroutine/try_future.hh
@@ -33,7 +33,7 @@ void try_future_resume_or_destroy_coroutine(seastar::future<T>& fut, seastar::ta
 
     if (fut.failed()) {
         hndl.promise().set_exception(std::move(fut).get_exception());
-        hndl.destroy();
+        finalize_and_destroy_coroutine(hndl);
     } else {
         set_current_task(promise_ptr);
         hndl.resume();

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -26,6 +26,7 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/try_future.hh>
+#include <seastar/coroutine/at_coroutine_exit.hh>
 #include <seastar/coroutine/generator.hh>
 #include <seastar/core/circular_buffer_fixed_capacity.hh>
 #include <seastar/util/later.hh>
@@ -320,6 +321,43 @@ future<size_t> co_await_per_field_direct() {
     co_return CORO_BENCH_ITERS;
 }
 
+// Opt-in variant of per_field_process(): returns future<with_at_exit<int>> but
+// registers no at-exit function.  Measures the pure cost of opting into the
+// coroutine::schedule_at_coroutine_exit() facility (a non-trivial final_awaiter
+// at final_suspend, which blocks frame elision, plus the return-promise
+// indirection) when the facility is not actually used.  with_at_exit<int> decays
+// to int, so the caller side is identical to per_field_process().
+[[gnu::noinline]] future<coroutine::with_at_exit<int>> per_field_at_exit_unused(int v) {
+    perf_tests::do_not_optimize(v);
+    co_return v + 1;
+}
+
+// Opt-in variant that registers a single, immediately-ready at-exit function.
+// Measures the full cost of the facility on the ready path (at_coroutine_exit
+// allocation, the final_awaiter running the function stack, and resolving the
+// return promise from the proxy promise).
+[[gnu::noinline]] future<coroutine::with_at_exit<int>> per_field_at_exit_used(int v) {
+    co_await coroutine::schedule_at_coroutine_exit([] { return make_ready_future<>(); });
+    perf_tests::do_not_optimize(v);
+    co_return v + 1;
+}
+
+// Processes N fields in a loop, co_awaiting an opt-in (with_at_exit) coroutine
+// per field.  Process is per_field_at_exit_unused or per_field_at_exit_used.
+template<size_t NFields, auto Process>
+future<size_t> co_await_per_field_at_exit() {
+    perf_tests::start_measuring_time();
+    for (size_t record = 0; record < CORO_BENCH_ITERS; ++record) {
+        int acc = 0;
+        for (size_t i = 0; i < NFields; ++i) {
+            acc = co_await Process(acc);
+        }
+        perf_tests::do_not_optimize(acc);
+    }
+    perf_tests::stop_measuring_time();
+    co_return CORO_BENCH_ITERS;
+}
+
 } // anonymous namespace
 
 PERF_TEST_F(coroutine_test, cont_empty) { return co_await_in_loop(bench_empty_cont); }
@@ -355,6 +393,20 @@ PERF_TEST_F(coroutine_test, coro_per_field_1) { return co_await_per_field_direct
 PERF_TEST_F(coroutine_test, coro_per_field_10) { return co_await_per_field_direct<10>(); }
 
 PERF_TEST_F(coroutine_test, coro_per_field_40) { return co_await_per_field_direct<40>(); }
+
+// Opt-in (with_at_exit) counterparts of coro_per_field_*, with the at-exit
+// facility unused (registers no function) vs used (registers one ready function).
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_unused_1) { return co_await_per_field_at_exit<1, per_field_at_exit_unused>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_unused_10) { return co_await_per_field_at_exit<10, per_field_at_exit_unused>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_unused_40) { return co_await_per_field_at_exit<40, per_field_at_exit_unused>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_used_1) { return co_await_per_field_at_exit<1, per_field_at_exit_used>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_used_10) { return co_await_per_field_at_exit<10, per_field_at_exit_used>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_at_exit_used_40) { return co_await_per_field_at_exit<40, per_field_at_exit_used>(); }
 
 // Benchmark unbuffered generator: one suspension per element
 PERF_TEST_C(coroutine_test, unbuffered_generator)

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -39,6 +39,7 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/try_future.hh>
+#include <seastar/coroutine/at_coroutine_exit.hh>
 #include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/defer.hh>
@@ -1076,5 +1077,266 @@ SEASTAR_TEST_CASE(test_co_return_move_counter) {
             std::ignore = co_await (*fnptr)(std::move(mc));
             BOOST_CHECK_EQUAL(mc.shared->moves, 1 + copy_move_counter::co_await_moves);
         }
+    }
+}
+
+class scope_canary {
+    bool* _flag{nullptr};
+public:
+    scope_canary(bool& flag)
+        : _flag(&flag) { }
+    scope_canary(scope_canary&& c) : _flag(std::exchange(c._flag, nullptr)) { }
+    scope_canary(const scope_canary&) = delete;
+    scope_canary& operator=(const scope_canary&) = delete;
+    scope_canary& operator=(scope_canary&&) = delete;
+    ~scope_canary() {
+        if (_flag) {
+            *_flag = true;
+        }
+    }
+};
+
+struct coroutine_exception : public std::exception {
+    const char* what() const noexcept override {
+        return "exception from coroutine";
+    }
+};
+
+struct coroutine_at_exit_exception : public std::exception {
+    const char* what() const noexcept override {
+        return "exception from coroutine_at_exit";
+    }
+};
+
+using coroutine_throws_exception = seastar::bool_class<struct coroutine_throws_tag>;
+using coroutine_at_exit_throws_exception = seastar::bool_class<struct coroutine_at_exit_throws_tag>;
+using coroutine_yields = seastar::bool_class<struct coroutine_yields_tag>;
+using coroutine_at_exit_yields = seastar::bool_class<struct at_exit_yields_tag>;
+
+template <typename R, typename Func>
+future<coroutine::with_at_exit<R>> coroutine_at_exit_coroutine(scope_canary c, coroutine_yields yields, coroutine_throws_exception throws, std::list<Func> funcs) {
+    co_await coroutine::schedule_at_coroutine_exit(std::move(funcs.front()));
+    funcs.pop_front();
+
+    if (yields) {
+        co_await yield();
+    }
+
+    while (!funcs.empty()) {
+        co_await coroutine::schedule_at_coroutine_exit(std::move(funcs.front()));
+        funcs.pop_front();
+        if (yields) {
+            co_await yield();
+        }
+    }
+
+    if (throws) {
+        fmt::print("  coroutine_at_exit_coroutine(): throw\n");
+        throw coroutine_exception{};
+    }
+    fmt::print("  coroutine_at_exit_coroutine(): return\n");
+
+    if constexpr (std::is_void_v<R>) {
+        co_return;
+    } else {
+        co_return R{};
+    }
+}
+
+struct coroutine_at_exit_func_result {
+    bool called{};
+    bool waited{};
+    unsigned index{};
+    std::exception_ptr ex;
+};
+
+class basic_coroutine_at_exit_func_instance {
+protected:
+    coroutine_at_exit_func_result& _result;
+    const coroutine_at_exit_yields _yields;
+    const coroutine_at_exit_throws_exception _throws;
+    std::function<unsigned()> _get_index;
+
+    void post_yield() {
+        _result.waited = true;
+        if (_throws) {
+            fmt::print("  func in coroutine_at_exit throws\n");
+            throw coroutine_at_exit_exception{};
+        }
+    }
+
+    future<> invoke(std::exception_ptr ex) {
+        _result.called = true;
+        if (_get_index) {
+            _result.index = _get_index();
+        }
+        _result.ex = std::move(ex);
+        if (_yields) {
+            return yield().then([&] { post_yield(); });
+        }
+        post_yield();
+        return make_ready_future<>();
+    }
+
+public:
+    explicit basic_coroutine_at_exit_func_instance(coroutine_at_exit_func_result& result, coroutine_at_exit_yields yields, coroutine_at_exit_throws_exception throws, std::function<unsigned()> get_index)
+        : _result(result)
+        , _yields(yields)
+        , _throws(throws)
+        , _get_index(std::move(get_index))
+    { }
+};
+
+template <bool TakesException>
+class coroutine_at_exit_func_instance : public basic_coroutine_at_exit_func_instance { };
+
+template <>
+class coroutine_at_exit_func_instance<true> : public basic_coroutine_at_exit_func_instance {
+public:
+    coroutine_at_exit_func_instance(coroutine_at_exit_func_result& result, coroutine_at_exit_yields yields, coroutine_at_exit_throws_exception throws, std::function<unsigned()> get_next_index = {})
+        : basic_coroutine_at_exit_func_instance(result, yields, throws, std::move(get_next_index)) { }
+    future<> operator() (std::exception_ptr ex) {
+        return this->invoke(std::move(ex));
+    }
+};
+
+template <>
+class coroutine_at_exit_func_instance<false> : public basic_coroutine_at_exit_func_instance {
+public:
+    coroutine_at_exit_func_instance(coroutine_at_exit_func_result& result, coroutine_at_exit_yields yields, coroutine_at_exit_throws_exception throws, std::function<unsigned()> get_next_index = {})
+        : basic_coroutine_at_exit_func_instance(result, yields, throws, std::move(get_next_index)) { }
+    future<> operator() () {
+        return this->invoke(nullptr);
+    }
+};
+
+template <typename R, bool FuncTakesException>
+class coroutine_at_exit_tester {
+    future<> do_run(size_t num_coroutine_at_exit_functions, coroutine_yields coroutine_yields, coroutine_throws_exception coroutine_throws,
+            coroutine_at_exit_yields at_exit_yields, coroutine_at_exit_throws_exception coroutine_at_exit_throws, std::source_location sl) {
+        fmt::print("coroutine_at_exit_tester<{}, {}>::do_run(num_coroutine_at_exit_functions={}, coroutine_yields={}, coroutine_throws={}, at_exit_yields={}, coroutine_at_exit_throws={}) at {}:{}\n",
+                typeid(R).name(), FuncTakesException, num_coroutine_at_exit_functions, coroutine_yields, coroutine_throws, at_exit_yields, coroutine_at_exit_throws, sl.file_name(), sl.line());
+
+        bool scope_canary_destroyed = false;
+        unsigned index = 0;
+
+        std::vector<coroutine_at_exit_func_result> results(num_coroutine_at_exit_functions);
+        std::list<coroutine_at_exit_func_instance<FuncTakesException>> at_exit_funcs;
+        for (auto& result : results) {
+            at_exit_funcs.emplace_back(result, at_exit_yields, coroutine_at_exit_throws, [&index] { return ++index; });
+        }
+
+        std::optional<future<coroutine::with_at_exit<R>>> fopt;
+        try {
+            fopt = co_await coroutine::as_future(coroutine_at_exit_coroutine<R>(scope_canary{scope_canary_destroyed}, coroutine_yields, coroutine_throws, std::move(at_exit_funcs)));
+        } catch (...) {
+            BOOST_FAIL(fmt::format("Unexpected exception: {}", std::current_exception()));
+        }
+        auto& f = fopt.value();
+
+        if (f.failed()) {
+            auto ex = f.get_exception();
+            fmt::print("  coroutine returned exception: {}\n", ex);
+
+            BOOST_REQUIRE(coroutine_throws || coroutine_at_exit_throws);
+            if (coroutine_throws && coroutine_at_exit_throws) {
+                BOOST_REQUIRE_THROW(std::rethrow_exception(ex), seastar::nested_exception);
+            } else if (coroutine_throws) {
+                BOOST_REQUIRE_THROW(std::rethrow_exception(ex), coroutine_exception);
+            } else {
+                if (results.size() == 1) {
+                    BOOST_REQUIRE_THROW(std::rethrow_exception(ex), coroutine_at_exit_exception);
+                } else {
+                    BOOST_REQUIRE_THROW(std::rethrow_exception(ex), seastar::nested_exception);
+                }
+            }
+        } else {
+            f.ignore_ready_future();
+        }
+
+        BOOST_REQUIRE(scope_canary_destroyed);
+
+        for (unsigned i = 0; i < results.size(); ++i) {
+            const auto& result = results.at(i);
+            BOOST_REQUIRE(result.called);
+            BOOST_REQUIRE(result.waited);
+            BOOST_REQUIRE_EQUAL(result.index, results.size() - i);
+            BOOST_REQUIRE_EQUAL(bool(result.ex), FuncTakesException && bool(coroutine_throws));
+            if (result.ex) {
+                BOOST_REQUIRE_THROW(std::rethrow_exception(result.ex), coroutine_exception);
+            }
+        }
+    }
+
+public:
+    future<> operator()(std::source_location sl = std::source_location::current()) {
+        for (size_t i = 1; i < 4; ++i) {
+            for (auto coroutine_yields : {coroutine_yields::no, coroutine_yields::yes}) {
+                for (auto coroutine_throws : {coroutine_throws_exception::no, coroutine_throws_exception::yes}) {
+                    for (auto at_exit_yields : {coroutine_at_exit_yields::no, coroutine_at_exit_yields::yes}) {
+                        for (auto coroutine_at_exit_throws : {coroutine_at_exit_throws_exception::no, coroutine_at_exit_throws_exception::yes}) {
+                            co_await do_run(i, coroutine_yields, coroutine_throws, at_exit_yields, coroutine_at_exit_throws, sl);
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+SEASTAR_TEST_CASE(test_coroutine_at_exit) {
+    co_await coroutine_at_exit_tester<void, false>{}();
+    co_await coroutine_at_exit_tester<void, true>{}();
+    co_await coroutine_at_exit_tester<int, false>{}();
+    co_await coroutine_at_exit_tester<int, true>{}();
+}
+
+SEASTAR_TEST_CASE(test_coroutine_at_exit_with_return_exception_ptr) {
+    for (bool yield_before_ret : {false, true}) {
+        fmt::print("yield={}\n", yield_before_ret);
+
+        coroutine_at_exit_func_result result;
+
+        auto f = co_await coroutine::as_future([&] () -> future<coroutine::with_at_exit<>> {
+            co_await coroutine::schedule_at_coroutine_exit(coroutine_at_exit_func_instance<true>{result, coroutine_at_exit_yields::yes, coroutine_at_exit_throws_exception::no});
+            if (yield_before_ret) {
+                co_await yield();
+            }
+            co_await coroutine::return_exception_ptr(std::make_exception_ptr(coroutine_exception{}));
+        }());
+
+        BOOST_REQUIRE(f.failed());
+        BOOST_REQUIRE_THROW(f.get(), coroutine_exception);
+
+        BOOST_REQUIRE(result.called);
+        BOOST_REQUIRE(result.waited);
+        BOOST_REQUIRE(result.ex);
+        BOOST_REQUIRE_THROW(std::rethrow_exception(result.ex), coroutine_exception);
+    }
+}
+
+SEASTAR_TEST_CASE(test_coroutine_at_exit_with_try_future) {
+    auto bad_func = [] { return make_exception_future<>(coroutine_exception{}); };
+
+    for (bool yield_before_ret : {false, true}) {
+        fmt::print("yield={}\n", yield_before_ret);
+
+        coroutine_at_exit_func_result result;
+
+        auto f = co_await coroutine::as_future([&] () -> future<coroutine::with_at_exit<>> {
+            co_await coroutine::schedule_at_coroutine_exit(coroutine_at_exit_func_instance<true>{result, coroutine_at_exit_yields::yes, coroutine_at_exit_throws_exception::no});
+            if (yield_before_ret) {
+                co_await yield();
+            }
+            co_await coroutine::try_future(bad_func());
+        }());
+
+        BOOST_REQUIRE(f.failed());
+        BOOST_REQUIRE_THROW(f.get(), coroutine_exception);
+
+        BOOST_REQUIRE(result.called);
+        BOOST_REQUIRE(result.waited);
+        BOOST_REQUIRE(result.ex);
+        BOOST_REQUIRE_THROW(std::rethrow_exception(result.ex), coroutine_exception);
     }
 }


### PR DESCRIPTION
Schedules a lambda to be run right after the coroutine finishes (whether with success or failure). The lambda can optionally accept an `std::exception_ptr`, which will contain the coroutine's exception, if there was one. Coroutines opt into this facility by wrapping their return type in `coroutine::with_at_exit<>`, so coroutines that don't use it pay
no overhead (see the implementation notes below). Example:
```c++
future<coroutine::with_at_exit<>> coroutine_foo() {
    co_await coroutine::schedule_at_coroutine_exit([] { // async cleanup });
    // stuff (that might throw)
}
```

This roughly equivalent to:
```c++
future<> bar() {
    co_await coroutine_foo().finally([] { // async cleanup });
}
```

The functor passed to at coroutine exit is executed while the coroutine frame is still alive, so capturing local variables by reference is safe.

Implementation notes
====================

Opting in via the return type
-----------------------------

Supporting coroutine::schedule_at_coroutine_exit() requires extra state and work in the coroutine promise (see below), which would add overhead to *every* coroutine -- around 10 extra instructions for the simplest
coroutines -- even those that never use the facility. To avoid this, the facility is opt-in: a coroutine enables it by returning `future<coroutine::with_at_exit<T>>` instead of the plain `future<T>`.

The wrapper selects a different std::coroutine_traits specialization, coroutine_traits_with_at_exit_base<T>, whose promise carries the at-exit machinery. Plain `future<T>` coroutines keep using the original zero-overhead promise (coroutine_traits_base<T>), whose final_suspend() returns std::suspend_never and which instantiates none of the machinery.

`coroutine::with_at_exit<T>` wraps a value of type T and decays to it transparently, so callers observe the awaited result as if it were a plain T. coroutine::schedule_at_coroutine_exit() static_asserts that the enclosing coroutine opted in, producing a clear diagnostic otherwise.

Running the at-exit functions
-----------------------------

To run the registered functions, the final_suspend() extension point is used. This is invoked by the coroutines runtime after the coroutine body finished executing and the coroutine's future already resolved with
either an exception or a value, but before the coroutine frame is destroyed. final_suspend() can return an awaiter (final_awaiter in this case), which is executed with the usual semantics.

Normally, seastar schedules the coroutine's waiter immediately upon making the coroutine's future ready, even before the coroutine frame is destroyed. If the coroutine has registered coroutine::schedule_at_coroutine_exit() functors, this is undesirable: the waiters should be scheduled *after* all at exit functors finished, both to preserve ordering (follow-up code runs after cleanup) and to be able to propagate errors. To this end, when there are at-exit
function(s) registered, the coroutine's promise is split into proxy and return promises. The resolution of the coroutine's body is stored in the proxy promise and the return promise is used for the final result, which
combines the proxy promise and the result of the at exit functors.

If there is no at_exit function registered, the final_awaiter returned from final_suspend() will return true from final_awaiter::await_ready() and the subsequent call to final_awaiter::await_resume() is a no-op, resuming the coroutine's destruction immediately. This is the fast path for an opt-in coroutine that happened not to register any functor.

If there was one or more calls to coroutine::schedule_at_coroutine_exit(), final_awaiter::await_ready() will return false and the subsequent call to final_awaiter::await_suspend() will loop over the at exit functors in LIFO order, executing them one-by-one. After all finished, the return promise is resolved with the combined result of the proxy promise and the combined result of the at exit functors.