### PR TITLE
treewide: remove remnants of SEASTAR_MODULE

### DIFF
--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -20,9 +20,6 @@
  * Copyright (C) 2018 Red Hat
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <compare>
 #include <atomic>
@@ -30,14 +27,10 @@ module;
 #include <memory>
 #include <vector>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/alien.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/prefetch.hh>
-#endif
 
 namespace seastar {
 namespace alien {

--- a/src/core/disk_params.cc
+++ b/src/core/disk_params.cc
@@ -20,9 +20,6 @@
  */
 
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <chrono>
 #include <unordered_set>
@@ -32,16 +29,12 @@ module;
 #include <sys/stat.h>
 #include <yaml-cpp/yaml.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/disk_params.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/smp_options.hh>
 #include <seastar/util/conversions.hh>
 
-#endif
 
 using namespace std::chrono_literals;
 

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -32,9 +29,6 @@ module;
 #include <utility>
 #include <seastar/util/assert.hh>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/fstream.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -42,7 +36,6 @@ module seastar;
 #include <seastar/core/reactor.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/io_intent.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -18,23 +18,11 @@
 /*
  * Copyright (C) 2017 ScyllaDB
  */
-#ifdef SEASTAR_MODULE
-module;
-#include <cstddef>
-#include <exception>
-#include <iosfwd>
-#include <memory>
-#include <optional>
-#include <utility>
-#include <vector>
-module seastar;
-#else
 #include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/semaphore.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -19,9 +19,6 @@
  * Copyright 2019 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <array>
 #include <chrono>
@@ -35,9 +32,6 @@ module;
 #include <sys/uio.h>
 #include <seastar/util/assert.hh>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/file.hh>
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/io_intent.hh>
@@ -48,7 +42,6 @@ module seastar;
 #include <seastar/core/internal/io_sink.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/util/log.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <memory>
 #include <regex>
@@ -33,14 +30,10 @@ module;
 #include <boost/range/algorithm_ext/erase.hpp>
 #include <fmt/ranges.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>
 #include <seastar/core/reactor.hh>
-#endif
 
 namespace seastar {
 extern seastar::logger seastar_logger;

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <memory>
 #include <set>
@@ -33,13 +30,9 @@ module;
 #include <sys/mman.h>
 #include <sys/inotify.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/posix.hh>
 #include <seastar/core/align.hh>
 #include <seastar/util/critical_alloc_section.hh>
-#endif
 #include <seastar/util/assert.hh>
 
 namespace seastar {

--- a/src/core/program_options.hh
+++ b/src/core/program_options.hh
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#ifndef SEASTAR_MODULE
 #include <boost/program_options.hpp>
 #include <optional>
 #include <stack>
-#endif
 
 #include <seastar/util/program-options.hh>
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -19,10 +19,6 @@
  * Copyright 2014 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
-
 #include <atomic>
 #include <chrono>
 #include <cmath>

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -18,9 +18,6 @@
 /*
  * Copyright 2019 ScyllaDB
  */
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <atomic>
 #include <chrono>
@@ -41,9 +38,6 @@ module;
 #include <liburing.h>
 #endif
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include "core/reactor_backend.hh"
 #include "core/thread_pool.hh"
 #include "core/syscall_result.hh"
@@ -55,7 +49,6 @@ module seastar;
 #include <seastar/core/smp.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -29,7 +29,6 @@
 #include <seastar/core/internal/linux-aio.hh>
 #include <seastar/core/cacheline.hh>
 
-#ifndef SEASTAR_MODULE
 #include <fmt/ostream.h>
 #include <sys/time.h>
 #include <thread>
@@ -38,7 +37,6 @@
 #include <boost/program_options.hpp>
 #include <boost/container/static_vector.hpp>
 
-#endif
 
 namespace seastar {
 

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -20,9 +20,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
@@ -38,9 +35,6 @@ module;
 #include <fmt/core.h>
 #include <seastar/util/assert.hh>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/resource.hh>
 #include <seastar/core/memory.hh>
 #include <seastar/core/align.hh>
@@ -51,7 +45,6 @@ module seastar;
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/print.hh>
 #include "cgroup.hh"
-#endif
 
 #if SEASTAR_HAVE_HWLOC
 #include <hwloc.h>

--- a/src/core/semaphore.cc
+++ b/src/core/semaphore.cc
@@ -19,17 +19,10 @@
  * Copyright (C) 2020 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <fmt/format.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/semaphore.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/sharded.cc
+++ b/src/core/sharded.cc
@@ -19,18 +19,11 @@
  * Copyright (C) 2018 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <ranges>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/sharded.hh>
 #include <seastar/core/loop.hh>
-#endif
 
 namespace seastar {
 

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -18,9 +18,6 @@
 /*
  * Copyright 2019 ScyllaDB
  */
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/range/algorithm/find_if.hpp>
 #include <atomic>
@@ -30,9 +27,6 @@ module;
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/smp.hh>
 #include <seastar/core/alien.hh>
 #include <seastar/core/resource.hh>
@@ -43,7 +37,6 @@ module seastar;
 #include <seastar/core/posix.hh>
 #include <seastar/core/align.hh>
 #include "prefault.hh"
-#endif
 
 namespace seastar {
 

--- a/src/core/sstring.cc
+++ b/src/core/sstring.cc
@@ -19,15 +19,7 @@
  * Copyright (C) 2020 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <cstddef>
-#include <new>
-#include <stdexcept>
-module seastar;
-#else
 #include <seastar/core/sstring.hh>
-#endif
 
 using namespace seastar;
 

--- a/src/core/syscall_work_queue.hh
+++ b/src/core/syscall_work_queue.hh
@@ -26,9 +26,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/noncopyable_function.hh>
-#ifndef SEASTAR_MODULE
 #include <boost/lockfree/spsc_queue.hpp>
-#endif
 
 namespace seastar {
 

--- a/src/core/uname.cc
+++ b/src/core/uname.cc
@@ -20,9 +20,6 @@
  * Copyright (C) 2019 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <memory>
 #include <optional>
@@ -31,11 +28,7 @@ module;
 #include <sys/utsname.h>
 #include <iostream>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/internal/uname.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <cassert>
 #include <concepts>
@@ -31,9 +28,6 @@ module;
 #include <stdexcept>
 #include <utility>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/reactor.hh>
@@ -45,7 +39,6 @@ module seastar;
 #include <seastar/util/defer.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/string_utils.hh>
-#endif
 
 namespace seastar {
 logger http_log("http");

--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -19,9 +19,6 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <cstdlib>
 #include <memory>
@@ -29,12 +26,8 @@ module;
 #include <numeric>
 #include <span>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/common.hh>
 #include <seastar/core/iostream-impl.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -19,17 +19,11 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <algorithm>
 #include <iostream>
 #include <memory>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/file_handler.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/reactor.hh>
@@ -37,7 +31,6 @@ module seastar;
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/http/exception.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -19,9 +19,6 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <memory>
 #include <algorithm>
@@ -36,9 +33,6 @@ module;
 #include <unordered_map>
 #include <vector>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/sstring.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -53,7 +47,6 @@ module seastar;
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/string_utils.hh>
-#endif
 
 
 using namespace std::chrono_literals;

--- a/src/http/json_path.cc
+++ b/src/http/json_path.cc
@@ -19,13 +19,7 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <vector>
-module seastar;
-#else
 #include <seastar/http/json_path.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/matcher.cc
+++ b/src/http/matcher.cc
@@ -19,17 +19,10 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <iostream>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/matcher.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/mime_types.cc
+++ b/src/http/mime_types.cc
@@ -8,17 +8,10 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <string_view>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/mime_types.hh>
-#endif
 
 
 namespace seastar {

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -29,20 +29,12 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifdef SEASTAR_MODULE
-module;
-#include <iostream>
-#include <utility>
-#include <unordered_map>
-module seastar;
-#else
 #include <seastar/http/reply.hh>
 #include <seastar/core/print.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/common.hh>
 #include <seastar/http/response_parser.hh>
 #include <seastar/core/loop.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -19,21 +19,14 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <string_view>
 #include <unordered_map>
 #include <utility>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/request.hh>
 #include <seastar/http/url.hh>
 #include <seastar/http/common.hh>
-#endif
 #include <seastar/util/assert.hh>
 
 namespace seastar {

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -21,10 +21,8 @@
 
 #pragma once
 
-#ifndef SEASTAR_MODULE
 #include <memory>
 #include <unordered_map>
-#endif
 
 #include <seastar/core/ragel.hh>
 #include <seastar/http/reply.hh>

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -6,22 +6,15 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <chrono>
 #include <coroutine>
 #include <gnutls/gnutls.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/exception.hh>
 #include <seastar/http/retry_strategy.hh>
 #include <seastar/util/short_streams.hh>
 
-#endif
 
 using namespace std::chrono_literals;
 

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -19,18 +19,11 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <exception>
-#include <memory>
-module seastar;
-#else
 #include <seastar/http/routes.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/http/json_path.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/transformers.cc
+++ b/src/http/transformers.cc
@@ -19,21 +19,14 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/algorithm/string/replace.hpp>
 #include <list>
 #include <memory>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/http/transformers.hh>
-#endif
 
 namespace seastar {
 

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -19,17 +19,10 @@
  * Copyright (C) 2022 Scylladb, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <string_view>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/http/url.hh>
-#endif
 
 namespace seastar {
 namespace http {

--- a/src/json/formatter.cc
+++ b/src/json/formatter.cc
@@ -19,9 +19,6 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <cmath>
 #include <algorithm>
@@ -30,12 +27,8 @@ module;
 #include <sstream>
 #include <string_view>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/json/formatter.hh>
 #include <seastar/json/json_elements.hh>
-#endif
 
 namespace seastar {
 

--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -19,9 +19,6 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <string.h>
 #include <string>
@@ -29,13 +26,9 @@ module;
 #include <sstream>
 #include <fmt/core.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/print.hh>
 #include <seastar/json/json_elements.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/arp.cc
+++ b/src/net/arp.cc
@@ -19,15 +19,7 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <cstdint>
-#include <optional>
-#include <utility>
-module seastar;
-#else
 #include <seastar/net/arp.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/config.cc
+++ b/src/net/config.cc
@@ -19,9 +19,6 @@
  * Copyright 2017 Marek Waszkiewicz ( marek.waszkiewicz77@gmail.com )
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/none_of.hpp>
@@ -33,12 +30,8 @@ module;
 #include <unordered_map>
 #include <string>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/config.hh>
 #include <seastar/core/print.hh>
-#endif
 
 using namespace boost::algorithm;
 

--- a/src/net/dhcp.cc
+++ b/src/net/dhcp.cc
@@ -19,9 +19,6 @@
  * Copyright 2014 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <chrono>
 #include <unordered_map>
@@ -30,14 +27,10 @@ module;
 #include <iostream>
 #include <arpa/inet.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/dhcp.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/net/udp.hh>
 #include <seastar/net/stack.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -20,9 +20,6 @@
  */
 #ifdef SEASTAR_HAVE_DPDK
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <cinttypes>
 #include <atomic>
@@ -44,9 +41,6 @@ module;
 
 #include <boost/preprocessor.hpp>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/posix.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/virtio-interface.hh>
@@ -69,7 +63,6 @@ module seastar;
 #include <seastar/net/toeplitz.hh>
 #include <seastar/net/native-stack.hh>
 #include "core/vla.hh"
-#endif
 
 #if RTE_VERSION <= RTE_VERSION_NUM(2,0,0,16)
 
@@ -2298,15 +2291,8 @@ std::unique_ptr<net::device> create_dpdk_net_device(
 
 #else
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/dpdk.hh>
-#endif
 
 #endif // SEASTAR_HAVE_DPDK
 

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <algorithm>
 #include <ostream>
@@ -29,16 +26,12 @@ module;
 #include <boost/functional/hash.hpp>
 #include <fmt/ostream.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/print.hh>
-#endif
 
 static_assert(std::is_nothrow_default_constructible_v<seastar::net::ipv4_address>);
 static_assert(std::is_nothrow_copy_constructible_v<seastar::net::ipv4_address>);

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -20,20 +20,11 @@
  *
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <chrono>
-#include <string>
-#include <boost/asio/ip/address_v4.hpp>
-#include <fmt/core.h>
-module seastar;
-#else
 #include <seastar/net/ip.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/toeplitz.hh>
 #include <seastar/core/metrics.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/ip_checksum.cc
+++ b/src/net/ip_checksum.cc
@@ -19,18 +19,10 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
-
 #include <arpa/inet.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/ip_checksum.hh>
 #include <seastar/net/net.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <chrono>
 #include <fstream>
@@ -38,9 +35,6 @@ module;
 #include <arpa/inet.h>
 #include <unistd.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/native-stack.hh>
 #include "net/native-stack-impl.hh"
 #include <seastar/net/net.hh>
@@ -54,7 +48,6 @@ module seastar;
 #include <seastar/net/dhcp.hh>
 #include <seastar/net/config.hh>
 #include <seastar/core/reactor.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -20,18 +20,12 @@
  *
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/asio/ip/address_v4.hpp>
 #include <boost/algorithm/string.hpp>
 #include <map>
 #include <utility>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/net.hh>
 #include <seastar/net/toeplitz.hh>
 #include <seastar/core/internal/poll.hh>
@@ -39,7 +33,6 @@ module seastar;
 #include <seastar/core/metrics.hh>
 #include <seastar/core/print.hh>
 #include <seastar/net/inet_address.hh>
-#endif
 #include <seastar/util/assert.hh>
 
 namespace seastar {

--- a/src/net/packet.cc
+++ b/src/net/packet.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <iostream>
 #include <algorithm>
@@ -30,13 +27,9 @@ module;
 #include <functional>
 #include <memory>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/print.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/net/packet.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <chrono>
 #include <cstring>
@@ -41,9 +38,6 @@ module;
 #include <sys/socket.h>
 #include <seastar/util/assert.hh>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>
@@ -54,7 +48,6 @@ module seastar;
 #include <seastar/net/api.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/util/std-compat.hh>
-#endif
 
 namespace std {
 

--- a/src/net/proxy.cc
+++ b/src/net/proxy.cc
@@ -15,9 +15,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <utility>
 #include <vector>
@@ -25,11 +22,7 @@ module;
 #include <cstdint>
 #include <memory>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/proxy.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/socket_address.cc
+++ b/src/net/socket_address.cc
@@ -23,23 +23,16 @@
 
     Extracted from inet_address.cc.
  */
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <arpa/inet.h>
 #include <sys/un.h>
 #include <ostream>
 #include <boost/functional/hash.hpp>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/print.hh>
-#endif
 
 using namespace std::string_literals;
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -19,23 +19,16 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <memory>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/tcp.cc
+++ b/src/net/tcp.cc
@@ -19,22 +19,12 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <compare>
-#include <atomic>
-#include <cstdint>
-#include <memory>
-#include <utility>
-module seastar;
-#else
 #include <seastar/net/tcp.hh>
 #include <seastar/net/tcp-stack.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/future.hh>
 #include "net/native-stack-impl.hh"
-#endif
 #include <seastar/util/assert.hh>
 
 namespace seastar {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -19,9 +19,6 @@
  * Copyright 2015 Cloudius Systems
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <any>
 #include <filesystem>
@@ -47,9 +44,6 @@ module;
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
@@ -65,7 +59,6 @@ module seastar;
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/variant_utils.hh>
 #include <seastar/core/fsnotify.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/udp.cc
+++ b/src/net/udp.cc
@@ -19,21 +19,9 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <cstdint>
-#include <utility>
-#include <cstring>
-#include <exception>
-#include <system_error>
-#include <optional>
-#include <memory>
-module seastar;
-#else
 #include <seastar/net/ip.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/net/inet_address.hh>
-#endif
 
 namespace seastar {
 

--- a/src/net/virtio.cc
+++ b/src/net/virtio.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <atomic>
 #include <algorithm>
@@ -37,9 +34,6 @@ module;
 #include <net/if.h>
 #include <seastar/util/assert.hh>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/net/virtio.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/internal/pollable_fd.hh>
@@ -55,7 +49,6 @@ module seastar;
 #include <seastar/net/ip.hh>
 #include <seastar/net/const.hh>
 #include <seastar/net/native-stack.hh>
-#endif
 
 namespace seastar {
 

--- a/src/util/alloc_failure_injector.cc
+++ b/src/util/alloc_failure_injector.cc
@@ -19,18 +19,10 @@
  * Copyright 2017 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <cstdint>
-#include <new>
-#include <utility>
-module seastar;
-#else
 #include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/defer.hh>
-#endif
 
 namespace seastar {
 namespace memory {

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -18,9 +18,6 @@
 /*
  * Copyright 2017 ScyllaDB
  */
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <link.h>
 #include <sys/types.h>
@@ -36,14 +33,10 @@ module;
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/util/backtrace.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
-#endif
 
 namespace seastar {
 

--- a/src/util/conversions.cc
+++ b/src/util/conversions.cc
@@ -19,20 +19,13 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cctype>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/util/conversions.hh>
 #include <seastar/core/print.hh>
-#endif
 
 namespace seastar {
 

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -20,9 +20,6 @@
  * Copyright 2020 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <cstdint>
 #include <list>
@@ -34,14 +31,10 @@ module;
 #include <coroutine>
 #include <sys/statvfs.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/util/file.hh>
-#endif
 
 namespace seastar {
 

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -19,9 +19,6 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <iostream>
 #include <map>
@@ -46,9 +43,6 @@ module;
 #include <unistd.h>
 
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
 
@@ -59,7 +53,6 @@ module seastar;
 
 
 #include "core/program_options.hh"
-#endif
 
 using namespace std::chrono_literals;
 

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -20,23 +20,12 @@
  * Copyright (C) 2022 Kefu Chai ( tchaikov@gmail.com )
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <csignal>
-#include <cstdint>
-#include <filesystem>
-#include <memory>
-#include <vector>
-#include <utility>
-module seastar;
-#else
 #include <seastar/core/fstream.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/process.hh>
-#endif
 #include <seastar/util/assert.hh>
 
 namespace seastar::experimental {

--- a/src/util/program-options.cc
+++ b/src/util/program-options.cc
@@ -20,20 +20,13 @@
  * Copyright (C) 2017 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
 
 #include <boost/any.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/program_options.hpp>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/util/program-options.hh>
 #include <seastar/util/log-cli.hh>
-#endif
 
 namespace bpo = boost::program_options;
 

--- a/src/util/read_first_line.cc
+++ b/src/util/read_first_line.cc
@@ -1,12 +1,5 @@
-#ifdef SEASTAR_MODULE
-module;
-#include <filesystem>
-#include <fcntl.h>
-module seastar;
-#else
 #include <seastar/core/posix.hh>
 #include <seastar/util/read_first_line.hh>
-#endif
 
 namespace seastar {
 

--- a/src/util/short_streams.cc
+++ b/src/util/short_streams.cc
@@ -19,16 +19,9 @@
  * Copyright (C) 2021 ScyllaDB
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#include <utility>
-#include <vector>
-module seastar;
-#else
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>
-#endif
 
 namespace seastar {
 


### PR DESCRIPTION
In 719d7880eca70 ("modules: make module support standards-compliant") we unifdefed the source tree for SEASTAR_MODULE and removed the definition. However, the unifdef was incomplete since unifdef terminates when it sees a C++ literal with "'" separators.

Here we complete the unifdefing. Since SEASTAR_MODULE is never defined, it's a no-op for current compilers, and allows clang 23 to build the tree.