### PR TITLE
test: fix race condition in test_connection_statistics

### DIFF
--- a/apps/memcached/tests/test_memcached.py
+++ b/apps/memcached/tests/test_memcached.py
@@ -210,9 +210,14 @@ class TcpSpecificTests(MemcacheTest):
     @slow
     def test_connection_statistics(self):
         with tcp_connection() as conn:
+            # Issue some command to ensure server has fully processed this
+            # connection, otherwise our stats query will race with the server
+            # userspace accepting the connection and registering it
+            conn('version\r\n')
             curr_connections = int(self.getStat('curr_connections', call_fn=conn))
             total_connections = int(self.getStat('total_connections', call_fn=conn))
             with tcp_connection() as conn2:
+                conn2('version\r\n')
                 self.assertEqual(curr_connections + 1, int(self.getStat('curr_connections', call_fn=conn)))
                 self.assertEqual(total_connections + 1, int(self.getStat('total_connections', call_fn=conn)))
             self.assertEqual(total_connections + 1, int(self.getStat('total_connections', call_fn=conn)))


### PR DESCRIPTION
The test was flaky because it queried connection stats immediately after opening a TCP connection. While socket.connect() returns once the client-side TCP handshake completes, the server may not have finished accepting the connection and updating its stats counter yet.

Fix by issuing a version command on each new connection before querying stats, ensuring the server has fully processed the connection.

It has been flaking quite a bit in GHA CI.

Before this change it fails fairly reliably within ~10 runs for me locally, after I could not get it to fail in ~100 runs.