### PR TITLE
Add pre-commit with trailing whitespace hook

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,18 @@
+name: Pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@v3.0.1
+      - name: Show diff of fixes ($ at EOL)
+        if: failure()
+        # trailing whitespace is hard to see, so add $
+        # to the end of diff lines
+        run: git diff | sed '/^[+-]/s/$/$/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace

--- a/HACKING.md
+++ b/HACKING.md
@@ -189,3 +189,43 @@ g++ -o foo_bar foo.o bar.o $(pkg-config --libs --static /path/to/seastar.pc)
 ```
 
 The `--static` flag is needed to include transitive (private) dependencies of `libseastar.a`.
+
+## Development Tools
+
+### Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to enforce some basic checks. These
+checks run in CI, but you can also run them locally as a pre-commit hook as follows.
+
+#### Installation
+
+[Install pre-commit](https://pre-commit.com/#install), following those instructions or
+perhaps using `uv` to avoid polluting your global environment:
+
+```
+uv tool install pre-commit
+```
+
+#### Setup
+
+Install the git hooks:
+
+```
+pre-commit install
+```
+
+This will run the configured hooks automatically on every commit.
+
+#### Manual execution
+
+Run hooks on all files:
+
+```
+pre-commit run --all-files
+```
+
+Run hooks on staged files only:
+
+```
+pre-commit run
+```

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -543,7 +543,7 @@ private:
         }
     }
 
-    // Streaming worker: 
+    // Streaming worker:
     // - client sends payload_t
     // - in bidirectional case: server echoes back payload_t
     // - in unidirectional case: server only sends EOS at the end
@@ -601,7 +601,7 @@ public:
         if (_total_duration.count() > 0) {
             double throughput = total_bytes / _total_duration.count();
             out << YAML::Key << "throughput" << YAML::Value << throughput << YAML::Comment("B/s");
-            
+
             double messages_per_sec = _total_messages / _total_duration.count();
             out << YAML::Key << "messages per second" << YAML::Value << messages_per_sec;
         } else {
@@ -652,8 +652,8 @@ public:
                 auto data = co_await source();
                 if (!data) {
                     // We need to have some kind of synchronization with client, so they don't close the main RPC connection
-                    // until server received EOS (client -> server connection was closed). If we don't do that, server might 
-                    // receive `seastar::rpc::stream_closed` exception on reading from the source, as the stream is terminated 
+                    // until server received EOS (client -> server connection was closed). If we don't do that, server might
+                    // receive `seastar::rpc::stream_closed` exception on reading from the source, as the stream is terminated
                     // on connection close.
                     // In order to do that, we create a connection to the other side - from server to client, and keep it
                     // open until client sends EOS - then, by closing this connection, server also sends EOS.
@@ -810,7 +810,7 @@ public:
         });
         _rpc->register_handler(rpc_verb::STREAM_UNIDIRECTIONAL, [] (rpc::source<payload_t> source) {
             auto sink = source.make_sink<serializer, uint64_t>();
-            
+
             (void)job_rpc_streaming::process_uni_source(std::move(source), sink);
 
             return sink;

--- a/doc/native-stack.md
+++ b/doc/native-stack.md
@@ -48,7 +48,7 @@ You can now ping the IP address shown (`192.168.122.18`) or connect to it:
 	--- 192.168.122.18 ping statistics ---
 	6 packets transmitted, 6 received, 0% packet loss, time 4999ms
 	rtt min/avg/max/mdev = 0.093/0.116/0.160/0.023 ms
-	
+
 	$ curl http://192.168.122.18:10000/
 	"hello"
 

--- a/doc/template.css
+++ b/doc/template.css
@@ -22,7 +22,7 @@ body {
 div#header, header {
 	border-top: 1px solid #aaa;
 	border-bottom: 1px solid #aaa;
-	background: #F0F0C0;	
+	background: #F0F0C0;
 	margin: 10pt;
 	margin-left: 10%;
 	margin-right: 10%;
@@ -67,7 +67,7 @@ a {
 	text-decoration: none;
 }
 a:link, a:visited {
-	color: #0000CC;	
+	color: #0000CC;
 }
 a:hover {
 	color: #CC0000;

--- a/include/seastar/testing/test_fixture.hh
+++ b/include/seastar/testing/test_fixture.hh
@@ -70,15 +70,15 @@ public:
     template<typename... Args>
     requires std::is_constructible_v<F, const Args&...>
     async_class_based_fixture(Args&& ...args)
-        : _create([args = std::make_tuple(std::forward<Args>(args)...)] { 
+        : _create([args = std::make_tuple(std::forward<Args>(args)...)] {
             return std::apply([](auto&& ...args) {
-                return std::make_unique<F>(args...); 
+                return std::make_unique<F>(args...);
             }, args);
         })
     {}
 private:
     // Fixture interface
-    void setup() override { 
+    void setup() override {
         // create and possibly init the fixture object in reactor, on the
         // test thread.
         global_test_runner().run_sync([this] {
@@ -86,7 +86,7 @@ private:
             return detail::conditional_invoke_setup(*_inst);
         });
     }
-    void teardown() override { 
+    void teardown() override {
         // possibly de-init and destroy the fixture object in reactor, on the
         // test thread.
         global_test_runner().run_sync([this] {
@@ -110,7 +110,7 @@ public:
     {}
 private:
     // Fixture interface
-    void setup() override { 
+    void setup() override {
         if (_setup) {
             // run in reactor thread
             global_test_runner().run_sync([this] {

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -28,7 +28,7 @@ namespace seastar {
 class file_desc;
 
 namespace internal {
-// Reasons for why a function had to be submitted to the thread_pool 
+// Reasons for why a function had to be submitted to the thread_pool
 enum class thread_pool_submit_reason : size_t {
     // Used for aio operations what would block in `io_submit`.
     aio_fallback,

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1324,7 +1324,7 @@ public:
         if (!_connected) {
             return handshake();
         }
-        // Note: only applicable to server. 
+        // Note: only applicable to server.
         if (_type == type::CLIENT) {
             throw std::system_error(GNUTLS_E_INVALID_REQUEST, error_category(), "re-handshake only applicable for server socket");
         }
@@ -1531,12 +1531,12 @@ private:
 
     future<> do_put_one(const char* ptr, size_t size) {
         // #2859
-        // Normally, gnutls_record_send will break up data into gnutls_record_get_max_size() 
+        // Normally, gnutls_record_send will break up data into gnutls_record_get_max_size()
         // sized chunks for us (only processing the first 16k or so of provided buffer).
         // However, if the session is in a re-handshake state, gnutls will
         // make an intermediate alloc to prepend the requested session key
         // to the sent data. This can cause large alloc warnings.
-        // To avoid this, we explicitly break the message into 
+        // To avoid this, we explicitly break the message into
         // block sized parts (same as normal case in gnutls)
         auto max_record_len = gnutls_record_get_max_size(*this);
 
@@ -1554,9 +1554,9 @@ private:
             // NOTE: we _can_ get an EAGAIN here since the
             // addition of force_rehandshake ability (and possibly before)
             // due to the tls buffering. Just wait + retrying should work
-            // in all cases. 
+            // in all cases.
             auto f = res < 0  && res != GNUTLS_E_AGAIN
-                ? handle_output_error(res) 
+                ? handle_output_error(res)
                 : wait_for_output()
                 ;
             return f.then([] {

--- a/tests/manual/iosched_reproducers/scylla_tablet_migration.sh
+++ b/tests/manual/iosched_reproducers/scylla_tablet_migration.sh
@@ -3,7 +3,7 @@
 # Test scenario:
 # Simulation of a ScyllaDB workload which prompted some changes to the IO scheduler:
 # database queries concurrent with tablet streaming.
-# 
+#
 # All 7 shards are running a low-priority (200 shares) batch IO workload
 # and a high-priority (1000 shares), moderate-bandwidth, interactive workload.
 #
@@ -17,7 +17,7 @@
 # doesn't need more than 35% of the fair bandwidth of this shard.
 #
 # Due to the distribution of shares across IO classes, the user expects that
-# the interactive workload should be guaranteed (1000 / (1000 + 200)) == ~84% of 
+# the interactive workload should be guaranteed (1000 / (1000 + 200)) == ~84% of
 # the disk bandwidth on each shard. So if it's only asking for less than 35%,
 # the lower-priority job shouldn't disturb it.
 #

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -329,7 +329,7 @@ static sstring format_double_fit(double value, size_t width, size_t default_prec
 
 
 // Given a value in nanoseconds, scale to the first unit whose value is < 1000.
-// Progression: ns -> us -> ms -> s. 
+// Progression: ns -> us -> ms -> s.
 static inline scaled_duration calculate_units_and_scale(double nanoseconds) {
     static const std::array units = {
         "ns", "µs", "ms"
@@ -425,7 +425,7 @@ struct column {
     column(sstring header, int prec, F fn) : header{header}, fopts{default_width, prec} {
         using result_t = std::invoke_result_t<F, const result&>;
         using result_traits = value_traits<result_t>;
-        
+
         print_text = [=, fopts = fopts](const text_options& opts, const result& r) {
             printer p{fopts, opts.mad_columns.contains(header)};
             fmt::print(opts.file, "{}", p(fn(r)));
@@ -670,7 +670,7 @@ void performance_test::do_run(const config& conf)
                 auto add = [this](auto& m, double value) {
                     m.add(value, _single_run_iterations);
                 };
-                
+
                 add(r.runtime, ns);
 
                 total_iterations += _single_run_iterations;
@@ -807,14 +807,14 @@ int main(int ac, char** av)
             // calculate the effective column set
             auto selected_cols_str = split(app.configuration()["columns"].as<std::string>());
             std::set<std::string> selected_set(selected_cols_str.begin(), selected_cols_str.end());
-            
+
             columns selected_columns;
             for (const column& col : text_columns) {
                 if (selected_set.contains("all") || selected_set.contains(col.header)) {
                     selected_columns.emplace_back(col);
                 }
             }
-            
+
             auto selected_mad_str = split(app.configuration()["mad-columns"].as<std::string>());
             if (std::ranges::find(selected_mad_str, "all") != selected_mad_str.end()) {
                 selected_mad_str.clear();

--- a/tests/perf/perf_tests_perf.cc
+++ b/tests/perf/perf_tests_perf.cc
@@ -81,7 +81,7 @@ PERF_TEST(output_check, high_runtime_allocs) {
         auto* p = new int(i);
         perf_tests::do_not_optimize(p);
         delete p;
-    }   
+    }
 }
 
 PERF_TEST(output_check, highly_variable_runtime) {
@@ -94,7 +94,7 @@ PERF_TEST(output_check, highly_variable_runtime) {
         auto* p = new int(i);
         perf_tests::do_not_optimize(p);
         delete p;
-    }   
+    }
 }
 
 PERF_TEST_F(fixture, test_fixture_1) { perf_tests::do_not_optimize(sink); }

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
         BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
         BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
         BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
-    } 
+    }
 
     BOOST_REQUIRE_EQUAL(calls.dtor_called, 5);
     fifo1.clear();
@@ -295,13 +295,13 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
 
     {
         // move ctor, no element ctors are called at all
-        auto fifox{std::move(fifo1)}; 
+        auto fifox{std::move(fifo1)};
 
         BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
         BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
         BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
         BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
-    } 
+    }
 
     fill(5, fifo1);
 

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -678,7 +678,7 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_priority_class_with_requests) {
     auto pc = internal::priority_class(sg);
 
     auto fx = tio.queue_request(pc,
-        internal::io_direction_and_length(internal::io_direction_and_length::read_idx, 0), 
+        internal::io_direction_and_length(internal::io_direction_and_length::read_idx, 0),
         internal::io_request::make_write(0, 0, nullptr, 1, false),
         nullptr, {});
 

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -74,13 +74,13 @@ SEASTAR_FIXTURE_THREAD_TEST_CASE(test_single_thread_test_fixture_void_ret, SyncT
     BOOST_REQUIRE(inited);
 }
 
-// having these thread local subtly verifies that the fixture 
+// having these thread local subtly verifies that the fixture
 // is run on the proper shard.
 static thread_local int num_shared_test_fixts_setup = 0;
 static thread_local int num_shared_test_fixts_teardown = 0;
 static thread_local std::string shared_test_fixts_string;
 
-struct SharedTestFixture { 
+struct SharedTestFixture {
     SharedTestFixture()
     {}
     SharedTestFixture(const std::string& s)
@@ -98,7 +98,7 @@ struct SharedTestFixture {
     }
 };
 
-BOOST_AUTO_TEST_SUITE(shared_fixtures, 
+BOOST_AUTO_TEST_SUITE(shared_fixtures,
     *async_fixture<SharedTestFixture>()
     *async_fixture<SharedTestFixture>("los lobos")
     *async_fixture(

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -2073,7 +2073,7 @@ SEASTAR_THREAD_TEST_CASE(test_send_recv_alloc_limits) {
             auto fout = write(sout);
             auto fin = read(cin);
 
-            auto h = (i > 0 && (i & 0xff) == 0) 
+            auto h = (i > 0 && (i & 0xff) == 0)
                 ? BOOST_TEST_MESSAGE("Forcing re-handshake"), tls::force_rehandshake(s.connection)
                 : make_ready_future<>()
                 ;


### PR DESCRIPTION
Enough with the trailing whitespace, let us ban it in the repo. Also adds pre-commit to manage hit hooks for the repo, so  folks can opt into that if they don't like their change being rejected by CI.

We use [pre-commit](https://pre-commit.com/) to execute both the check locally, if the user has opted into it, and also to run the check in CI.

See an example of it failing here: https://github.com/scylladb/seastar/actions/runs/21596526786/job/62230437469

In practice this hook runs ~instantly locally, though that's something you have work at as you add more hooks.

## Summary
- Add pre-commit framework with trailing-whitespace hook
- Add GitHub Actions workflow to enforce pre-commit checks on PRs
- Add developer documentation for local pre-commit setup
- Remove existing trailing whitespace from source files

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [x] CI workflow runs successfully