### PR TITLE
sstring: fix npos to be size_t for consistency with std::string

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -113,7 +113,7 @@ public:
     // FIXME: add reverse_iterator and friend
     using difference_type = ssize_t;  // std::make_signed_t<Size> can be too small
     using size_type = Size;
-    static constexpr size_type  npos = static_cast<size_type>(-1);
+    static constexpr size_t npos = static_cast<size_t>(-1);
     static constexpr unsigned padding() { return unsigned(NulTerminate); }
 public:
     struct initialized_later {};


### PR DESCRIPTION
## Summary

The `npos` constant was defined as `size_type(-1)` where `size_type` is `uint32_t`, resulting in `npos` being `0xFFFFFFFF`. `std::string` and `string_view` however using `size_t` resulting in a gratuitous incompatibility.

Furthermore, the `find` functions return `size_t`, so when comparing against `std::string::npos` (which is `size_t(-1)` = `0xFFFFFFFFFFFFFFFF` on 64-bit), the values would not match.

This changes `npos` to be `size_t(-1)` to match `std::string` behavior and the actual return type of find functions.

## Test plan

- Verified that `sstring::npos == std::string::npos` now holds true
- Existing unit tests pass