### PR TITLE
fix trailing whitespace

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -358,7 +358,7 @@ struct result {
     float_stats<> overhead;  // overhead percentage from start/stop timing calls
 };
 
-struct duration { 
+struct duration {
     double value;  // in nanoseconds
 
     constexpr explicit duration(double nanos = 0) : value(nanos) {}


### PR DESCRIPTION
Hopefully for the last time. It snuck in due to a race with the change that introduced the check in CI.