### PR TITLE
reactor: handle transient EPERM / EACCES in touch_directory

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2375,9 +2375,33 @@ reactor::touch_directory(std::string_view name_view, file_permissions permission
         auto mode = static_cast<mode_t>(permissions);
         return wrap_syscall<int>(::mkdir(name.c_str(), mode));
     });
-    if (sr.result == -1 && sr.error != EEXIST) {
-        sr.throw_fs_exception("mkdir failed", fs::path(name));
+
+    if (sr.result != -1) {
+        // Directory created successfully
+        co_return;
     }
+
+    if (sr.error == EEXIST) {
+        // Directory already exists, that's fine
+        co_return;
+    }
+
+    if (sr.error == EPERM || sr.error == EACCES) {
+        // Check if the directory actually exists and has the right permissions
+        try {
+            auto sd = co_await file_stat(name, follow_symlink::no);
+            if (sd.type == directory_entry_type::directory &&
+                    (sd.mode & static_cast<mode_t>(file_permissions::all_permissions)) == static_cast<mode_t>(permissions)) {
+                co_return;
+            }
+            // Directory exists but has wrong type or permissions - fall through to throw EPERM
+        } catch (...) {
+            // file_stat failed (e.g., ENOENT, EACCES), fall through to throw original EPERM error
+        }
+    }
+
+    // Some other error occurred, report it
+    sr.throw_fs_exception("mkdir failed", fs::path(name));
 }
 
 future<>


### PR DESCRIPTION
**Problem Statement:** We have observed intermittent EPERM failures inside `touch_directory()` concurrent calls on specific CI runners. Despite extensive local testing on XFS, Docker, and OverlayFS, the error is highly environmental and difficult to reproduce on demand.

**Technical Justification**: While mkdir should ideally return EEXIST when a directory already exists, the Linux VFS layer and Linux Security Modules (LSMs) like AppArmor can return EPERM or EACCES under heavy dentry contention. This could happens when:
1. **OverlayFS Copy-Up**: A "copy-up" operation is in progress from a lower to an upper layer, and a second thread attempts to access the dentry before the transition is finalized.
2. **LSM Interference**: The security module intercepts a concurrent syscall during a metadata lock and rejects it as a conflict rather than allowing the filesystem driver to return a standard EEXIST.

**The "Idempotent Verification" Strategy**: Rather than blindly ignoring EPERM, this PR implements a "Verify-After-Error" pattern:
* Step 1: Attempt mkdir.
* Step 2: If EPERM or EACCES is returned, perform a stat().
* Step 3: If stat() confirms the path exists and is a directory, we consider the goal achieved.
* Step 4: If the directory is missing, we re-throw the original error.

**Why this is safe even without a local repro**: This change does not mask genuine failures. It only converts a "Permission Denied" into a "Success" if we can prove (via stat) that the operation's intended outcome was actually reached.

Fixes: scylladb/scylladb#28259