### PR TITLE
reactor: Move _dying bit to epoll backend

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -364,7 +364,6 @@ private:
     sched_clock::time_point _start_time = now();
     output_stream<char>::batch_flush_list_t _flush_batching;
     std::atomic<bool> _sleeping alignas(seastar::cache_line_size){0};
-    std::atomic<bool> _dying{false};
     gate _background_gate;
 
     inline auto& get_sg_data(const scheduling_group& sg) {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -754,7 +754,7 @@ reactor_backend_epoll::task_quota_timer_thread_fn() {
         _r.request_preemption();
     }
 
-    while (!_r._dying.load(std::memory_order_relaxed)) {
+    while (!_dying.load(std::memory_order_relaxed)) {
         // Wait for either the task quota timer, or the high resolution timer, or both,
         // to expire.
         struct pollfd pfds[2] = {};
@@ -795,7 +795,7 @@ void reactor_backend_epoll::start_tick() {
 }
 
 void reactor_backend_epoll::stop_tick() {
-    _r._dying.store(true, std::memory_order_relaxed);
+    _dying.store(true, std::memory_order_relaxed);
     _r._task_quota_timer.timerfd_settime(0, seastar::posix::to_relative_itimerspec(1ns, 1ms)); // Make the timer fire soon
     _task_quota_timer_thread.join();
 }

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -236,6 +236,7 @@ class reactor_backend_epoll : public reactor_backend {
     // Only one of the two is active at any time.
     file_desc _steady_clock_timer_reactor_thread;
     file_desc _steady_clock_timer_timer_thread;
+    std::atomic<bool> _dying{false};
 private:
     file_desc _epollfd;
     void task_quota_timer_thread_fn();


### PR DESCRIPTION
It's only used by this backend to stop task quota timer thread. No need to keep it on generic reactor part.