### PR TITLE
scheduling: Unfriend some methods from scheduling_group

### DIFF
--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -411,9 +411,6 @@ public:
     /// \return a future that is ready when the bandwidth update is applied
     future<> update_io_bandwidth(uint64_t bandwidth) const;
 
-    friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares, scheduling_supergroup) noexcept;
-    friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;
-    friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend class reactor;
     friend unsigned internal::scheduling_group_index(scheduling_group sg) noexcept;
     friend scheduling_group internal::scheduling_group_from_index(unsigned index) noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5236,7 +5236,7 @@ rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_short
         return make_exception_future<>(make_backtraced_exception_ptr<std::runtime_error>("Attempt to rename the default scheduling group"));
     }
     return smp::invoke_on_all([sg, new_name, new_shortname] {
-        engine()._task_queues[sg._id]->rename(new_name, new_shortname);
+        engine()._task_queues[internal::scheduling_group_index(sg)]->rename(new_name, new_shortname);
         internal::execution_stage_manager::get().update_scheduling_group_name(sg);
         engine().rename_queues(internal::priority_class(sg), new_name);
         return engine().rename_scheduling_group_specific_data(sg);


### PR DESCRIPTION
It's mostly unused now. Except for rename_scheduling_group(), but it can use internal::scheduling_group_index helper, like other similar functions do.