### PR TITLE
reactor: Remove get_sg_data(unsigned) overload

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -370,10 +370,6 @@ private:
         return _scheduling_group_specific_data.per_scheduling_group_data[sg._id];
     }
 
-    inline auto& get_sg_data(unsigned sg_id) {
-        return _scheduling_group_specific_data.per_scheduling_group_data[sg_id];
-    }
-
 private:
     static std::chrono::nanoseconds calculate_poll_time();
     static void block_notifier(int);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1104,8 +1104,9 @@ reactor::~reactor() {
         if (tq) {
             // The following line will preserve the convention that constructor and destructor functions
             // for the per sg values are called in the context of the containing scheduling group.
-            *internal::current_scheduling_group_ptr() = scheduling_group(tq->_id);
-            get_sg_data(tq->_id).specific_vals.clear();
+            auto sg = scheduling_group(tq->_id);
+            *internal::current_scheduling_group_ptr() = sg;
+            get_sg_data(sg).specific_vals.clear();
         }
     }
 }


### PR DESCRIPTION
There's another one, that gets sg_data from scheduling_group itself. The only caller of the index-based overload has sched group at hand and can use it.