### PR TITLE
reactor: Make do_dump_task_queue a task_queue method

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -305,6 +305,7 @@ private:
         void rename(sstring new_name, sstring new_shortname);
     private:
         void register_stats();
+        internal::log_buf::inserter_iterator do_dump(seastar::internal::log_buf::inserter_iterator it) const;
     };
 
     struct task_queue_group final : public sched_entity {
@@ -740,7 +741,6 @@ private:
     friend future<> seastar::destroy_scheduling_group(scheduling_group) noexcept;
     friend future<> seastar::rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;
     friend future<scheduling_group_key> scheduling_group_key_create(scheduling_group_key_config cfg) noexcept;
-    friend seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const task_queue& tq);
     friend void internal::set_current_task(task* t);
     friend scheduling_supergroup internal::scheduling_supergroup_for(scheduling_group sg) noexcept;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2641,10 +2641,10 @@ void reactor::register_metrics() {
     });
 }
 
-seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::internal::log_buf::inserter_iterator it, const reactor::task_queue& tq) {
+seastar::internal::log_buf::inserter_iterator reactor::task_queue::do_dump(seastar::internal::log_buf::inserter_iterator it) const {
     memory::scoped_critical_alloc_section _;
     std::unordered_map<std::pair<std::string_view, int>, std::pair<unsigned, task*>> infos;
-    for (const auto& tp : tq._q) {
+    for (const auto& tp : _q) {
         std::string_view name = tp->get_resume_point().file_name();
         if (name.empty()) {
             name = typeid(*tp).name();
@@ -2653,7 +2653,7 @@ seastar::internal::log_buf::inserter_iterator do_dump_task_queue(seastar::intern
         ++count;
         task = tp;
     }
-    it = fmt::format_to(it, "Too long queue accumulated for {} ({} tasks)\n", tq._name, tq._q.size());
+    it = fmt::format_to(it, "Too long queue accumulated for {} ({} tasks)\n", _name, _q.size());
     auto dump_task = [](auto it, task& task) {
         const auto rp = task.get_resume_point();
         const std::string_view file_name = rp.file_name();
@@ -2701,7 +2701,7 @@ bool reactor::task_queue::run_tasks() {
                 lowres_clock::update();
 
                 static thread_local logger::rate_limit rate_limit(std::chrono::seconds(10));
-                logger::lambda_log_writer writer([this] (auto it) { return do_dump_task_queue(it, *this); });
+                logger::lambda_log_writer writer([this] (auto it) { return do_dump(it); });
                 seastar_logger.log(log_level::warn, rate_limit, writer);
                 if (r._cfg.abort_on_too_long_task_queue) {
                     auto msg = fmt::format("Too long task queue: {}, max_task_backlog={}", _q.size(), r._cfg.max_task_backlog);


### PR DESCRIPTION
This helper function dump the contents of a task_queue when queue stall event occurs. For that it's declared as reactor friend, but it's an overkill -- making it (private) method of task_queue itself solves the class members access and makes this code itself a bit shorter to write.