### PR TITLE
task: add symbol() method for improved task identification

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -720,7 +720,7 @@ protected:
     Promise _pr;
 };
 
-template <typename Promise, typename Func, typename Wrapper, typename T = void>
+template <typename Promise, typename Func, typename Wrapper, void* Symbol, typename T = void>
 struct continuation final : continuation_base_with_promise<Promise, T> {
     // Func is the original function passed to then/then_wrapped. The
     // Wrapper is a helper function that implements the specific logic
@@ -743,6 +743,9 @@ struct continuation final : continuation_base_with_promise<Promise, T> {
             this->_pr.set_to_current_exception();
         }
         delete this;
+    }
+    virtual void* symbol() const override {
+        return Symbol;
     }
     Func _func;
     [[no_unique_address]] Wrapper _wrapper;
@@ -1461,7 +1464,7 @@ private:
         return fut;
     }
 
-    template <typename Func, typename Result = futurize_t<internal::future_result_t<Func, T>>>
+    template <void* Symbol, typename Func, typename Result = futurize_t<internal::future_result_t<Func, T>>>
     Result
     then_impl(Func&& func) noexcept {
         static_assert(internal::expect_only_rvalue_refs<Func>);

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -58,6 +58,7 @@ public:
     void make_backtrace() noexcept {}
     shared_backtrace get_backtrace() const { return {}; }
 #endif
+    virtual void* symbol() const;
 };
 
 

--- a/include/seastar/util/noncopyable_function.hh
+++ b/include/seastar/util/noncopyable_function.hh
@@ -220,6 +220,13 @@ public:
         return _vtable->call(this, std::forward<Args>(args)...);
     }
 
+    /// Returns the address of the unique 'call' thunk for the contained function.
+    /// This address uniquely identifies the underlying lambda type in the binary.
+    /// This address can be used to output symbols for the user-provided function.
+    void* target_function_address() const noexcept {
+        return reinterpret_cast<void*>(_vtable->call);
+    }
+
     explicit operator bool() const {
         return _vtable != &_s_empty_vtable;
     }

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -38,7 +38,9 @@ module seastar;
 
 namespace seastar {
 
-parallel_for_each_state::parallel_for_each_state(size_t n) {
+parallel_for_each_state::parallel_for_each_state(size_t n, void* symbol)
+    : _symbol(symbol)
+{
     _incomplete.reserve(n);
 }
 

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -128,7 +128,7 @@ std::ostream& operator<<(std::ostream& out, const tasktrace& b) {
 }
 
 std::ostream& operator<<(std::ostream& out, const task_entry& e) {
-    fmt::print(out, "{}", e);
+    fmt::print(out, "{}", e.get_frame());
     return out;
 }
 
@@ -152,10 +152,10 @@ tasktrace current_tasktrace() noexcept {
             hash *= 31;
             if (bt) {
                 hash ^= bt->hash();
-                prev.push_back(bt);
+                prev.emplace_back(bt);
             } else {
                 const std::type_info& ti = typeid(*tsk);
-                prev.push_back(task_entry(ti));
+                prev.emplace_back(tsk->symbol());
                 hash ^= ti.hash_code();
             }
             tsk = tsk->waiting_task();
@@ -219,7 +219,7 @@ auto formatter<seastar::tasktrace>::format(const seastar::tasktrace& b, format_c
 
 auto formatter<seastar::task_entry>::format(const seastar::task_entry& e, format_context& ctx) const
     -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{}", seastar::pretty_type_name(*e._task_type));
+    return fmt::format_to(ctx.out(), "{}", e.get_frame());
 }
 
 }


### PR DESCRIPTION
Currently, we identify tasks in logs and error messages using RTTI (typeid). However, this is insufficient for generic task implementations. Most notably, all C++ coroutines share the same underlying `coroutine_traits_base::promise_type` class. As a result, logs cannot distinguish between different coroutines (e.g., `sstable_write` vs `gossip_recv`) because they all report the same type name.

Introduce a virtual `task::symbol()` method that returns a `task_symbol` (a variant of `const std::type_info*` and `void*`). This allows tasks to expose a more precise identifier:
 * `const std::type_info*`: Used for strongly-typed functor tasks where RTTI provides enough information.
 * `void*`: Used for raw addresses, such as function pointers or coroutine resume addresses.

The default implementation returns `typeid(*this)`. For coroutines, we override this to return the resume function address. We rely on the Itanium C++ ABI, which guarantees that the first pointer in the coroutine frame is the resume function pointer. This address can later be resolved to a human-readable symbol (e.g., via `addr2line`).

Note that this symbol refers to the whole coroutine function. If the coroutine contains multiple `co_await` statements, we still won't be able to distinguish between them. One way to solve this would be to declare an `await_transform` function in
`coroutine_traits_base::promise_type` and capture the optional `std::source_location` parameter there. However, this would introduce significant overhead:
 * Each coroutine frame would need to store an additional line number field.
 * Each `co_await` would have to assign it.
 * Each `co_await` point would add an item to the binary's string table (for the filename), causing significant bloat.

The current solution introduces minimal overhead and should be sufficient for most purposes.