### PR TITLE
http/client: Count and export integrated queue length

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -28,6 +28,7 @@
 #include <seastar/http/retry_strategy.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/util/integrated-length.hh>
 
 namespace bi = boost::intrusive;
 
@@ -162,6 +163,7 @@ private:
     unsigned long _total_new_connections = 0;
     std::unique_ptr<retry_strategy> _retry_strategy;
     condition_variable _wait_con;
+    util::integrated_length<unsigned, lowres_clock, std::chrono::microseconds> _requests_queued;
     connections_list_t _pool;
 
     using connection_ptr = seastar::shared_ptr<connection>;
@@ -360,6 +362,20 @@ public:
 
     unsigned long total_new_connections_nr() const noexcept {
         return _total_new_connections;
+    }
+
+    /**
+     * \brief Returns the integrated_length<> for the number of requests waiting for connection
+     *
+     * The caller may choose to
+     * - export the immediate .value() as GAUGE metrics or
+     * - export the .integral() value as COUNTER metrics
+     *
+     * The latter option is preferred, when rate()-d it provides an average over scrape time
+     * value of the queue length.
+     */
+    const auto& integrated_requests_queued() const noexcept {
+        return _requests_queued;
     }
 };
 


### PR DESCRIPTION
There's an implicit queue of requests in the client -- when the connection pool exhausts the client waits for a free socket to become available. Since there can be many parallel fibers trying to call .make_request(), this forms a queue of requests.

This patch counts the number of "queued" requests into the integrated length value merged recently. Checkpoint happens once the request gets its socket and proceeds.

Exporting should be performed by the caller. For that the client provides const reference to the integrated length value itself. It's preferred that called exports .integral() value as COUNTER metrics and rate()-s it on the dashboard.