### PR TITLE
Add metric description override functionality

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -134,6 +134,10 @@ public:
     const sstring& str() const {
         return _s;
     }
+    description& operator=(const sstring& s) {
+        _s = s;
+        return *this;
+    }
 private:
     sstring _s;
 };

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -451,6 +451,7 @@ class impl {
     std::vector<relabel_config> _relabel_configs;
     std::vector<metric_family_config> _metric_family_configs;
     internalized_set _internalized_labels;
+    std::unordered_map<std::string, std::string> _description_overrides;
 public:
     value_map& get_value_map() {
         return _value_map;
@@ -472,7 +473,7 @@ public:
     void set_config(const config& c) {
         _config = c;
     }
-
+    void set_description_overrides(const std::unordered_map<std::string, std::string>& description_overrides);
     shared_ptr<metric_metadata> metadata();
 
     std::vector<std::deque<metric_function>>& functions();
@@ -609,6 +610,19 @@ const std::vector<relabel_config>& get_relabel_configs();
  * sm::set_metric_family_configs(fc);
  */
 void set_metric_family_configs(const std::vector<metric_family_config>& metrics_config);
+
+/*
+ * \brief Set an override description map for metrics
+ *
+ * Maps metric names to replacement description strings. When a metric name appears in the map,
+ * the provided description replaces the original description specified during metric registration.
+ *
+ * This affects both existing metrics (descriptions are updated immediately) and metrics that
+ * will be added later (the override is applied when they are registered).
+ *
+ * \param description_overrides Map from metric name to description string
+ */
+void set_description_overrides(const std::unordered_map<std::string, std::string>& description_overrides);
 
 /*
  * \brief return the current metric_family_config

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -136,6 +136,10 @@ void set_metric_family_configs(const std::vector<metric_family_config>& family_c
     impl::get_local_impl()->set_metric_family_configs(family_config);
 }
 
+void set_description_overrides(const std::unordered_map<std::string, std::string>& description_overrides) {
+    impl::get_local_impl()->set_description_overrides(description_overrides);
+}
+
 const std::vector<metric_family_config>& get_metric_family_configs() {
     return impl::get_local_impl()->get_metric_family_configs();
 }
@@ -531,7 +535,7 @@ register_ref impl::add_registration(const metric_id& id, const metric_type& type
         }
     } else {
         _value_map[name].info().type = type.base_type;
-        _value_map[name].info().d = d;
+        _value_map[name].info().d = (_description_overrides.find(name) != _description_overrides.end()) ? description(_description_overrides[name]) : d;
         _value_map[name].info().inherit_type = type.type_name;
         _value_map[name].info().name = id.full_name();
         _value_map[name].info().aggregate_labels = aggregate_labels;
@@ -613,6 +617,31 @@ void impl::set_metric_family_configs(const std::vector<metric_family_config>& fa
             if (fc.name == mf_metadata.mf.name || fc.regex_name.match(mf_metadata.mf.name)) {
                 mf_metadata.mf.aggregate_labels = fc.aggregate_labels;
             }
+        }
+    }
+}
+void impl::set_description_overrides(const std::unordered_map<std::string, std::string>& description_overrides) {
+    _description_overrides = description_overrides;
+    for (auto& [name, description] : _description_overrides) {
+        if (_value_map.find(name) != _value_map.end()) {
+            _value_map[name].info().d = description;
+        }
+
+    }
+
+    if (!_metadata) {
+        // The metadata structure may not have been built yet,
+        // or it may rebuild right now, in this case just return
+        // and it will be updated the next time, setting the dirty to true
+        // is just in case we are somehow in the middle of rebuilding the
+        // metadata.
+        dirty();
+        return;
+    }
+    for (auto& mf_metadata: *_metadata) {
+        auto it = _description_overrides.find(mf_metadata.mf.name);
+        if (it != _description_overrides.end()) {
+            mf_metadata.mf.d = it->second;
         }
     }
 }

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -413,3 +413,70 @@ SEASTAR_THREAD_TEST_CASE(test_estimated_histogram) {
         BOOST_CHECK_EQUAL(mh.buckets[i].count, 33 + i);
     }
 }
+
+static seastar::sstring get_metric_description(const seastar::sstring& metric_name) {
+    seastar::foreign_ptr<seastar::metrics::impl::values_reference> values = seastar::metrics::impl::get_values();
+    for (auto&& md : (*values->metadata)) {
+        if (md.mf.name == metric_name) {
+            return md.mf.d.str();
+        }
+    }
+    return "";
+}
+
+SEASTAR_THREAD_TEST_CASE(test_description_overrides_before_metric_added) {
+    using namespace seastar::metrics;
+    namespace sm = seastar::metrics;
+
+    // Set override descriptions before metrics are added
+    std::unordered_map<std::string, std::string> override_map;
+    override_map["test_override_gauge"] = "Overridden gauge description";
+    override_map["test_override_counter"] = "Overridden counter description";
+    sm::set_description_overrides(override_map);
+
+    // Now add the metrics
+    sm::metric_groups app_metrics;
+    app_metrics.add_group("test_override", {
+        sm::make_gauge("gauge", sm::description("Original gauge description"), [] { return 100; }),
+        sm::make_counter("counter", sm::description("Original counter description"), [] { return 200; })
+    });
+
+    // Verify that the descriptions were overridden
+    seastar::sstring gauge_desc = get_metric_description("test_override_gauge");
+    seastar::sstring counter_desc = get_metric_description("test_override_counter");
+
+    BOOST_CHECK_EQUAL(gauge_desc, "Overridden gauge description");
+    BOOST_CHECK_EQUAL(counter_desc, "Overridden counter description");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_description_overrides_after_metric_added) {
+    using namespace seastar::metrics;
+    namespace sm = seastar::metrics;
+
+    // Add metrics first with original descriptions
+    sm::metric_groups app_metrics;
+    app_metrics.add_group("test_override_after", {
+        sm::make_gauge("gauge", sm::description("Original gauge description"), [] { return 100; }),
+        sm::make_counter("counter", sm::description("Original counter description"), [] { return 200; })
+    });
+
+    // Verify original descriptions are in place
+    seastar::sstring gauge_desc = get_metric_description("test_override_after_gauge");
+    seastar::sstring counter_desc = get_metric_description("test_override_after_counter");
+
+    BOOST_CHECK_EQUAL(gauge_desc, "Original gauge description");
+    BOOST_CHECK_EQUAL(counter_desc, "Original counter description");
+
+    // Now set override descriptions after metrics are already added
+    std::unordered_map<std::string, std::string> override_map;
+    override_map["test_override_after_gauge"] = "Overridden gauge description";
+    override_map["test_override_after_counter"] = "Overridden counter description";
+    sm::set_description_overrides(override_map);
+
+    // Verify that the descriptions were overridden
+    gauge_desc = get_metric_description("test_override_after_gauge");
+    counter_desc = get_metric_description("test_override_after_counter");
+
+    BOOST_CHECK_EQUAL(gauge_desc, "Overridden gauge description");
+    BOOST_CHECK_EQUAL(counter_desc, "Overridden counter description");
+}


### PR DESCRIPTION
Currently, metric descriptions are hardcoded at registration time and cannot
be modified without changing source code. This makes it difficult to maintain
documentation separately, update descriptions across versions, or load
descriptions from configuration files.

This series adds a mechanism to override metric descriptions dynamically at
runtime. The implementation adds the set_description_overrides() API that accepts
a map from metric names to description strings. Overrides apply both to
existing metrics (updated immediately) and future metrics (applied during
registration).

Example usage:

    std::unordered_map<std::string, std::string> overrides;
    overrides["reactor_utilization"] = "CPU utilization per reactor (0-1)";
    overrides["memory_allocated_bytes"] = "Total allocated memory in bytes";
    
    seastar::metrics::set_description_overrides(overrides);
    
    // Metrics registered after this will use overridden descriptions
    metric_groups app_metrics;
    app_metrics.add_group("reactor", {
        sm::make_gauge("utilization", sm::description("util"), 
                       [] { return get_utilization(); })
    });

This enables loading descriptions from configuration files or maintaining
centralized documentation databases without requiring recompilation.

Additional tests were added for the new functionality