### PR TITLE
http: Remove connection::write_body()

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -114,8 +114,6 @@ public:
     future<bool> generate_reply(std::unique_ptr<http::request> req);
     void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg);
 
-    future<> write_body();
-
     output_stream<char>& out();
 };
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -327,11 +327,6 @@ future<> connection::respond() {
     });
 }
 
-future<> connection::write_body() {
-    return _write_buf.write(_resp->_content.data(),
-            _resp->_content.size());
-}
-
 void connection::set_headers(http::reply& resp) {
     resp._headers["Server"] = "Seastar httpd";
     resp._headers["Date"] = _server._date;


### PR DESCRIPTION
The method is unused since #2870, more specifically 720feca0da (http/reply: encapsulate reply writing in write_reply())