### PR TITLE
http: Add formatters for http::request and http::reply

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -298,6 +298,7 @@ struct reply {
 private:
     http::body_writer_type _body_writer;
     friend class httpd::routes;
+    friend struct ::fmt::formatter<reply>;
 };
 
 std::ostream& operator<<(std::ostream& os, reply::status_type st);
@@ -311,3 +312,20 @@ using reply [[deprecated("Use http::reply instead")]] = http::reply;
 }
 
 template <> struct fmt::formatter<seastar::http::reply::status_type> : fmt::ostream_formatter {};
+
+template <>
+struct fmt::formatter<seastar::http::reply> {
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const seastar::http::reply& rp, FormatContext& ctx) const {
+        auto out = fmt::format_to(ctx.out(), "{}", rp._status);
+        for (const auto& h : rp._headers) {
+            out = fmt::format_to(out, " {}:{}", h.first, h.second);
+        }
+        if (!rp._body_writer && !rp._content.empty()) {
+            out = fmt::format_to(out, " {}", rp._content);
+        }
+        return out;
+    }
+};

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -434,3 +434,23 @@ using request [[deprecated("Use http::request instead")]] = http::request;
 }
 
 }
+
+template <>
+struct fmt::formatter<seastar::http::request> {
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const seastar::http::request& rq, FormatContext& ctx) const {
+        auto out = fmt::format_to(ctx.out(), "{} {}", rq._method, rq._url);
+        for (const auto& h : rq._headers) {
+            out = fmt::format_to(out, " {}:{}", h.first, h.second);
+        }
+        if (!rq.body_writer) {
+            const auto& body = seastar::http::internal::deprecated_content(rq);
+            if (!body.empty()) {
+                out = fmt::format_to(out, " {}", body);
+            }
+        }
+        return out;
+    }
+};

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2390,3 +2390,46 @@ SEASTAR_THREAD_TEST_CASE(test_reply_cookies) {
     BOOST_REQUIRE_EQUAL(lines[1], "Set-Cookie: cookie1=1");
     BOOST_REQUIRE_EQUAL(lines[2], "Set-Cookie: cookie2=2");
 }
+
+SEASTAR_TEST_CASE(test_http_request_formatting) {
+    auto req = http::request::make("PUT", "host", "/test");
+    req.write_body("txt", "body-content");
+
+    // Plain conversion to string
+    auto str = fmt::to_string(req);
+    fmt::print("{}\n", str);
+    std::vector<std::string> parts;
+    boost::split(parts, str, boost::is_any_of(" "));
+    BOOST_REQUIRE_EQUAL(parts.size(), 6);
+    std::sort(parts.begin() + 2, parts.begin() + 5); // headers can come in any order
+    BOOST_REQUIRE_EQUAL(parts[0], "PUT");
+    BOOST_REQUIRE_EQUAL(parts[1], "/test");
+    BOOST_REQUIRE_EQUAL(parts[2], "Content-Length:12");
+    BOOST_REQUIRE_EQUAL(parts[3], "Content-Type:text/plain");
+    BOOST_REQUIRE_EQUAL(parts[4], "Host:host");
+    BOOST_REQUIRE_EQUAL(parts[5], "body-content");
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_http_reply_formatting) {
+    auto rep = http::reply();
+    rep.set_status(http::reply::status_type::ok);
+    rep._headers["Server"] = "test_server";
+    rep.write_body("txt", "body-content");
+
+    // Plain conversion to string
+    auto str = fmt::to_string(rep);
+    fmt::print("{}\n", str);
+    std::vector<std::string> parts;
+    boost::split(parts, str, boost::is_any_of(" "));
+    BOOST_REQUIRE_EQUAL(parts.size(), 5);
+    std::sort(parts.begin() + 2, parts.begin() + 4); // headers can come in any order
+    BOOST_REQUIRE_EQUAL(parts[0], "200");
+    BOOST_REQUIRE_EQUAL(parts[1], "OK");
+    BOOST_REQUIRE_EQUAL(parts[2], "Content-Type:text/plain");
+    BOOST_REQUIRE_EQUAL(parts[3], "Server:test_server");
+    BOOST_REQUIRE_EQUAL(parts[4], "body-content");
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
It's useful to print both while debugging http(s) communication. In Scylla we have a custom formatter for http::request, and an attempt to add one more :) in another module. It's worth having a "standard" one.

This would solve the need to access a deprecated request::content member to print the request body.