### PR TITLE
src/core/reactor: introduce reactor::get_backend_name()

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -499,6 +499,8 @@ public:
         return queue != _io_queues.end() ? queue->second.get() : nullptr;
     }
 
+    std::string_view get_backend_name() const;
+
 private:
     future<> update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth);
     void rename_queues(internal::priority_class pc, sstring new_name);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1118,6 +1118,10 @@ reactor::~reactor() {
     }
 }
 
+std::string_view reactor::get_backend_name() const {
+    return _backend->get_backend_name();
+}
+
 reactor::sched_stats
 reactor::get_sched_stats() const {
     sched_stats ret;

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -530,6 +530,10 @@ reactor_backend_aio::reactor_backend_aio(reactor& r)
     SEASTAR_ASSERT(e == 0);
 }
 
+std::string_view reactor_backend_aio::get_backend_name() const {
+    return "linux-aio";
+}
+
 bool reactor_backend_aio::reap_kernel_completions() {
     bool did_work = await_events(0, nullptr);
     did_work |= _storage_context.reap_completions();
@@ -782,6 +786,10 @@ reactor_backend_epoll::task_quota_timer_thread_fn() {
 }
 
 reactor_backend_epoll::~reactor_backend_epoll() = default;
+
+std::string_view reactor_backend_epoll::get_backend_name() const {
+    return "epoll";
+}
 
 void reactor_backend_epoll::start_tick() {
     _task_quota_timer_thread = std::thread(&reactor_backend_epoll::task_quota_timer_thread_fn, this);
@@ -1444,6 +1452,9 @@ public:
     }
     ~reactor_backend_uring() {
         ::io_uring_queue_exit(&_uring);
+    }
+    virtual std::string_view get_backend_name() const override {
+        return "io_uring";
     }
     virtual bool reap_kernel_completions() override {
         return do_process_kernel_completions();

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -171,6 +171,7 @@ public:
 class reactor_backend {
 public:
     virtual ~reactor_backend() {};
+    virtual std::string_view get_backend_name() const = 0;
     // The methods below are used to communicate with the kernel.
     // reap_kernel_completions() will complete any previous async
     // work that is ready to consume.
@@ -252,6 +253,7 @@ public:
     explicit reactor_backend_epoll(reactor& r);
     virtual ~reactor_backend_epoll() override;
 
+    virtual std::string_view get_backend_name() const override;
     virtual bool reap_kernel_completions() override;
     virtual bool kernel_submit_work() override;
     virtual bool kernel_events_can_sleep() const override;
@@ -302,6 +304,7 @@ class reactor_backend_aio : public reactor_backend {
 public:
     explicit reactor_backend_aio(reactor& r);
 
+    virtual std::string_view get_backend_name() const override;
     virtual bool reap_kernel_completions() override;
     virtual bool kernel_submit_work() override;
     virtual bool kernel_events_can_sleep() const override;


### PR DESCRIPTION
```
reactor_backend_selector determines which reactor backends are
available on the system. The selected backend is stored in reactor::_backend,
but there is currently no way to query the selected backend type at runtime.

Add reactor::get_backend_name(), which exposes the backend name
via engine().get_backend_name().

Note: While smp::configure() does log the selected backend using reactor_opts,
a runtime getter is useful for user visibility.
```