### PR TITLE
test_fixture: Fix SEASTAR_FIXTURE_THREAD_TEST_CASE thread not propagated

### DIFF
--- a/include/seastar/testing/test_fixture.hh
+++ b/include/seastar/testing/test_fixture.hh
@@ -29,6 +29,7 @@
 #include <seastar/util/defer.hh>
 #include <seastar/testing/seastar_test.hh>
 #include <seastar/testing/test_runner.hh>
+#include <seastar/util/defer.hh>
 
 namespace seastar::testing {
 namespace detail {
@@ -176,9 +177,17 @@ inline boost::unit_test::decorator::fixture_t async_func_fixture(F1 setup, F2 te
             namespace td =  seastar::testing::detail;               \
             using type = name ## _fxt;                              \
             type t;                                                 \
-            td::do_fixture_test(                                    \
-                std::mem_fn(&type::run_test_case), t, #F            \
-                ).get();                                            \
+            td::conditional_invoke_setup(t).get();                  \
+            auto def = defer([&t]() noexcept {                      \
+                try {                                               \
+                    td::conditional_invoke_teardown(t).get();       \
+                } catch (...) {                                     \
+                    td::warn_teardown_exception(#name               \
+                        , std::current_exception()                  \
+                    );                                              \
+                }                                                   \
+            });                                                     \
+            t.run_test_case();                                      \
         });                                                         \
     }                                                               \
     void name ## _fxt::run_test_case() const

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -22,6 +22,7 @@
 
 #include <boost/test/execution_monitor.hpp>
 
+#include <seastar/core/sleep.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/test_fixture.hh>
 
@@ -65,6 +66,8 @@ struct SyncTestFixture {
     }
 };
 
+using namespace std::chrono_literals;
+
 SEASTAR_FIXTURE_TEST_CASE(test_single_test_fixture_void_ret, SyncTestFixture) {
     BOOST_REQUIRE(inited);
     return make_ready_future<>();
@@ -72,6 +75,29 @@ SEASTAR_FIXTURE_TEST_CASE(test_single_test_fixture_void_ret, SyncTestFixture) {
 
 SEASTAR_FIXTURE_THREAD_TEST_CASE(test_single_thread_test_fixture_void_ret, SyncTestFixture) {
     BOOST_REQUIRE(inited);
+    seastar::sleep(1ms).get();
+}
+
+struct ThreadTestFixture {
+    bool inited = false;
+    bool destroyed = false;
+
+    ~ThreadTestFixture() {
+        BOOST_REQUIRE(destroyed);
+    }
+    void setup() {
+        seastar::sleep(1ms).get();
+        inited = true;
+    }
+    void teardown() {
+        seastar::sleep(1ms).get();
+        destroyed = true;
+    }
+};
+
+SEASTAR_FIXTURE_THREAD_TEST_CASE(test_single_thread_test_fixture_thread_fixt, ThreadTestFixture) {
+    BOOST_REQUIRE(inited);
+    seastar::sleep(1ms).get();
 }
 
 // having these thread local subtly verifies that the fixture


### PR DESCRIPTION
Fixes #3267

seastar::async(...) (i.e. thread_impl context) is not propagated through nested "then(...)" calls. The impl of SEASTAR_FIXTURE_THREAD_TEST_CASE need to keep the invocation of the actual test code on top level, thus cannot call the helper, but must do stuff manually.

Extended test to verify this.