### PR TITLE
Fix _shard_to_numa_node_mapping double population

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4435,7 +4435,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         memory::configure_minimal();
     }
 
-    _shard_to_numa_node_mapping.resize(smp::count);
+    _shard_to_numa_node_mapping.reserve(smp::count);
     for (unsigned i = 0; i < smp::count; i++) {
         _shard_to_numa_node_mapping.push_back(allocations[i].mem.size() > 0 ? allocations[i].mem[0].nodeid : 0);
     }


### PR DESCRIPTION
The _shard_to_numa_node_mapping is first resize()-d to smp::count elements and is thus filled with zeros. Then the subsequent loop push_back()-s the same number more entries, resulting in a two times larger vector than needed, having wrong first half.

Presumably, the intent was to _reserve_ the vector, then populate.