### PR TITLE
Use exception parameter in log_timer_callback_exception()

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5370,7 +5370,7 @@ run_in_background(future<> f) {
 }
 
 void log_timer_callback_exception(std::exception_ptr ex) noexcept {
-    seastar_logger.error("Timer callback failed: {}", std::current_exception());
+    seastar_logger.error("Timer callback failed: {}", ex);
 }
 
 void set_current_task(task* t) {


### PR DESCRIPTION
The function receives an std::exception_ptr argument but prints std::current_exception() to the logger instead. It's benign as it's called fron inside catch block and the same std::current_exception is passed as the argument, but the intenti was to print the argument exception anyway.