### PR TITLE
file: Fix checks for file being read-only

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -60,6 +60,12 @@ inline void operator&=(open_flags& a, open_flags b) {
     a = (a & b);
 }
 
+// The mask that should be used to extract only open-mode from the flags
+constexpr open_flags open_flags_mode_mask = open_flags(3);
+static_assert((open_flags_mode_mask & open_flags::ro) == open_flags::ro);
+static_assert((open_flags_mode_mask & open_flags::rw) == open_flags::rw);
+static_assert((open_flags_mode_mask & open_flags::wo) == open_flags::wo);
+
 /// Enumeration describing the type of a directory entry being listed.
 ///
 /// \see file::list_directory()

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -168,7 +168,7 @@ void posix_file_impl::configure_io_lengths() noexcept {
 template <typename FileImpl>
 std::unique_ptr<seastar::file_handle_impl>
 posix_file_impl::do_dup() {
-    if ((_open_flags & open_flags::ro) != open_flags{}) {
+    if ((_open_flags & open_flags_mode_mask) != open_flags::ro) {
         throw std::runtime_error("File is not read-only");
     }
 
@@ -343,7 +343,7 @@ posix_file_impl::close() noexcept {
     delete _refcount;
     _refcount = nullptr;
     auto closed = make_ready_future<syscall_result<int>>(0, 0);
-    if ((_open_flags & open_flags::ro) != open_flags{}) {
+    if ((_open_flags & open_flags_mode_mask) == open_flags::ro) {
         closed = futurize_invoke([fd] () noexcept {
             return wrap_syscall<int>(::close(fd));
         });


### PR DESCRIPTION
There are two places that check if a posix_file_impl is RO -- one in close() and another in dup(). The latter was copied from the former. Both checks are wrong, they do `(flags & open_flags::ro) == 0`, to check the bit, but unfortunately open_flags::ro == 0 and 0 == 0 is always true.

Good news is that both bugs are pretty harmless. The one in dup() decides whether or not to thrown an exception, and never thrrows. The one in close() decidew how to call close(), synchronously or via thread-pool, and always chooses thread-pool.

The fix is to check the open mode by directo comparison of the ro/rw/wo part of the open-flags with the expected value.