### PR TITLE
memory: expose cumulative allocated bytes statistic

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -296,6 +296,7 @@ class statistics {
     uint64_t _cross_cpu_frees;
     size_t _total_memory;
     size_t _free_memory;
+    uint64_t _total_bytes_allocated;
     uint64_t _reclaims;
     uint64_t _large_allocs;
     uint64_t _failed_allocs;
@@ -305,11 +306,11 @@ class statistics {
     uint64_t _foreign_cross_frees;
 private:
     statistics(uint64_t mallocs, uint64_t frees, uint64_t cross_cpu_frees,
-            uint64_t total_memory, uint64_t free_memory, uint64_t reclaims,
+            uint64_t total_memory, uint64_t free_memory, uint64_t total_bytes_allocated, uint64_t reclaims,
             uint64_t large_allocs, uint64_t failed_allocs,
             uint64_t foreign_mallocs, uint64_t foreign_frees, uint64_t foreign_cross_frees)
         : _mallocs(mallocs), _frees(frees), _cross_cpu_frees(cross_cpu_frees)
-        , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims)
+        , _total_memory(total_memory), _free_memory(free_memory), _total_bytes_allocated(total_bytes_allocated), _reclaims(reclaims)
         , _large_allocs(large_allocs), _failed_allocs(failed_allocs)
         , _foreign_mallocs(foreign_mallocs), _foreign_frees(foreign_frees)
         , _foreign_cross_frees(foreign_cross_frees) {}
@@ -329,6 +330,8 @@ public:
     size_t allocated_memory() const { return _total_memory - _free_memory; }
     /// Total memory (in bytes)
     size_t total_memory() const { return _total_memory; }
+    /// Total number of bytes allocated since the system was started.
+    uint64_t total_bytes_allocated() const { return _total_bytes_allocated; }
     /// Number of reclaims performed due to low memory
     uint64_t reclaims() const { return _reclaims; }
     /// Number of allocations which violated the large allocation threshold

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -237,7 +237,7 @@ std::atomic<bool> use_transparent_hugepages = true;
 
 namespace alloc_stats {
 
-enum class types { allocs, frees, cross_cpu_frees, reclaims, large_allocs, failed_allocs,
+enum class types { allocs, frees, cross_cpu_frees, total_bytes_allocated, reclaims, large_allocs, failed_allocs,
     foreign_mallocs, foreign_frees, foreign_cross_frees, enum_size };
 
 using stats_array = std::array<uint64_t, static_cast<std::size_t>(types::enum_size)>;
@@ -1647,6 +1647,7 @@ static inline void* finish_allocation(void* ptr, size_t size) {
     if (__builtin_expect(!ptr, false)) {
         on_allocation_failure(size);
     } else {
+        alloc_stats::increment_local(alloc_stats::types::total_bytes_allocated, size);
 #ifdef SEASTAR_DEBUG_ALLOCATIONS
         std::memset(ptr, debug_allocation_pattern, size);
 #endif
@@ -1946,7 +1947,7 @@ configure(std::vector<resource::memory> m, bool mbind,
 
 statistics stats() {
     return statistics{alloc_stats::get(alloc_stats::types::allocs), alloc_stats::get(alloc_stats::types::frees), alloc_stats::get(alloc_stats::types::cross_cpu_frees),
-        cpu_mem.nr_pages * page_size, cpu_mem.nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
+        cpu_mem.nr_pages * page_size, cpu_mem.nr_free_pages * page_size, alloc_stats::get(alloc_stats::types::total_bytes_allocated), alloc_stats::get(alloc_stats::types::reclaims), alloc_stats::get(alloc_stats::types::large_allocs),
         alloc_stats::get(alloc_stats::types::failed_allocs), alloc_stats::get(alloc_stats::types::foreign_mallocs), alloc_stats::get(alloc_stats::types::foreign_frees),
         alloc_stats::get(alloc_stats::types::foreign_cross_frees)};
 }
@@ -2709,7 +2710,7 @@ void configure_minimal()
 {}
 
 statistics stats() {
-    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0, 0};
+    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0, 0, 0};
 }
 
 size_t free_memory() {

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -409,6 +409,25 @@ SEASTAR_TEST_CASE(test_diagnostics_allocation) {
     return seastar::make_ready_future();
 }
 
+SEASTAR_TEST_CASE(test_two_allocations_increase_total_bytes_allocated) {
+    auto before = seastar::memory::stats();
+
+    constexpr size_t size1 = 128;
+    constexpr size_t size2 = 256;
+
+    void* volatile p1 = operator new(size1);
+    void* volatile p2 = operator new(size2);
+
+    auto after = seastar::memory::stats();
+
+    BOOST_REQUIRE_EQUAL(after.total_bytes_allocated() - before.total_bytes_allocated(), size1 + size2);
+
+    operator delete(p2);
+    operator delete(p1);
+
+    return seastar::make_ready_future();
+}
+
 #ifdef SEASTAR_HEAPPROF
 
 // small wrapper to disincentivize gcc from unrolling the loop


### PR DESCRIPTION
Add total_bytes_allocated() to memory::statistics and update it on each successful allocation.

The counter is useful, for example, for estimating the memory usage of non-yielding code blocks.