### PR TITLE
reactor: Allow offline cpus in cpuset

### DIFF
--- a/include/seastar/core/resource.hh
+++ b/include/seastar/core/resource.hh
@@ -49,6 +49,7 @@ using cpuset = std::set<unsigned>;
 
 /// \cond internal
 std::optional<cpuset> parse_cpuset(std::string value);
+cpuset get_offline_cpus();
 /// \endcond
 
 namespace hwloc::internal {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4331,20 +4331,51 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
     if (smp_opts.cpuset) {
         auto opts_cpuset = smp_opts.cpuset.get_value();
-        // CPUs that are not available are those pinned by
-        // --cpuset but not present in current task set
+
+        // CPUs that are not available are those in --cpuset
+        // but not in the current task's affinity set
         std::set<unsigned int> not_available_cpus;
         std::set_difference(opts_cpuset.begin(), opts_cpuset.end(),
                             cpu_set.begin(), cpu_set.end(),
                             std::inserter(not_available_cpus, not_available_cpus.end()));
 
         if (!not_available_cpus.empty()) {
-            std::ostringstream not_available_cpus_list;
+            auto known_offline_cpus = resource::get_offline_cpus();
+
+            // Distinguish between offline CPUs (e.g. SMT disabled)
+            // and CPUs restricted by taskset/cgroup cpuset
+            std::set<unsigned int> offline_cpus;
+            std::set<unsigned int> restricted_cpus;
             for (auto cpu_id : not_available_cpus) {
-                not_available_cpus_list << " " << cpu_id;
+                if (known_offline_cpus.count(cpu_id)) {
+                    offline_cpus.insert(cpu_id);
+                } else {
+                    restricted_cpus.insert(cpu_id);
+                }
             }
-            seastar_logger.error("Bad value for --cpuset:{} not allowed. Shutting down.", not_available_cpus_list.str());
-            exit(1);
+
+            if (!offline_cpus.empty()) {
+                std::ostringstream offline_cpus_list;
+                for (auto cpu_id : offline_cpus) {
+                    offline_cpus_list << " " << cpu_id;
+                    opts_cpuset.erase(cpu_id);
+                }
+                seastar_logger.warn("Ignoring offline CPUs from --cpuset:{}", offline_cpus_list.str());
+            }
+
+            if (!restricted_cpus.empty()) {
+                std::ostringstream restricted_cpus_list;
+                for (auto cpu_id : restricted_cpus) {
+                    restricted_cpus_list << " " << cpu_id;
+                }
+                seastar_logger.error("Bad value for --cpuset:{} not allowed by taskset/cgroup. Shutting down.", restricted_cpus_list.str());
+                exit(1);
+            }
+
+            if (opts_cpuset.empty()) {
+                seastar_logger.error("No available CPUs in --cpuset. Shutting down.");
+                exit(1);
+            }
         }
         cpu_set = opts_cpuset;
     }

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -91,6 +91,18 @@ std::optional<cpuset> parse_cpuset(std::string value) {
     return std::nullopt;
 }
 
+cpuset get_offline_cpus() {
+    try {
+        auto line = read_first_line(std::filesystem::path("/sys/devices/system/cpu/offline"));
+        if (auto parsed = parse_cpuset(std::string(line))) {
+            return *parsed;
+        }
+    } catch (...) {
+        seastar_logger.warn("Unable to read offline CPUs from /sys/devices/system/cpu/offline. Ignoring.");
+    }
+    return {};
+}
+
 }
 
 namespace cgroup {


### PR DESCRIPTION
When running on SMT systems CPU sibling threads are numbered either:
 - N and N + CORES / 2
 - N and N + 1

When offlining SMT cores (or any cores for any reason really) the latter mode can become cumbersome to use with seastar's `--cpuset` arg.

It currently checks that all cores in the specified cpuset can be run on by comparing it to the allowed taskset as returned by `pthread_getaffinity_np`. This function however doesn't include offlined CPUs (taskset itself seems undisturbed by a specifying a cpuset with offline CPUs).

Hence seastar applications fail to start up when run with `--cpuset=X-Y` if any of the CPUs are offline. In this case one has to manually build the cpuset to exclude all offline cpus.

This patch changes seastar logic such that it detects offlined CPUs and doesn't count them as strictly unavailable. For those it only emits a warning. CPUs excluded by the taskset/cgroup are still a harderror. If offline cpus are not readable we just fall back to the current behaviour.

```
stephan@rp:/build/seastar/build/release$ cat /sys/devices/system/cpu/online
0,2,4,6,8,10,12,14,16-31
```

Before:

```
stephan@rp:/build/seastar/build/release$ ./demos/file_demo --cpuset 0-7
ERROR 2026-03-09 09:41:24,319 seastar - Bad value for --cpuset: 1 3 5 7 not allowed. Shutting down.
```

After:

```
stephan@rp:/build/seastar/build/release$ ./demos/file_demo --cpuset 0-7
WARN  2026-03-09 10:35:59,781 seastar - Ignoring offline CPUs from --cpuset: 1 3 5 7
INFO  2026-03-09 10:35:59,829 seastar - Reactor backend: io_uring
...
stephan@rp:/build/seastar/build/release$ taskset -c 0-3 ./demos/file_demo --cpuset 0-7
WARN  2026-03-09 10:36:13,257 seastar - Ignoring offline CPUs from --cpuset: 1 3 5 7
ERROR 2026-03-09 10:36:13,257 seastar - Bad value for --cpuset: 4 6 not allowed by taskset/cgroup. Shutting down.
```