### PR TITLE
reactor_backend: replace virtual bool methods with const bool_class m…

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -512,7 +512,8 @@ void reactor_backend_aio::signal_received(int signo, siginfo_t* siginfo, void* i
 }
 
 reactor_backend_aio::reactor_backend_aio(reactor& r)
-    : _r(r)
+    : reactor_backend(uses_blocking_io::no, supports_aio_fdatasync::yes)
+    , _r(r)
     , _hrtimer_timerfd(make_timerfd())
     , _storage_context(_r)
     , _preempting_io(_r, _r._task_quota_timer, _hrtimer_timerfd)
@@ -717,7 +718,8 @@ reactor_backend_aio::make_pollable_fd_state(file_desc fd, pollable_fd::speculati
 }
 
 reactor_backend_epoll::reactor_backend_epoll(reactor& r)
-        : _r(r)
+        : reactor_backend(uses_blocking_io::no, supports_aio_fdatasync::yes)
+        , _r(r)
         , _steady_clock_timer_reactor_thread(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC))
         , _steady_clock_timer_timer_thread(file_desc::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC))
         , _epollfd(file_desc::epoll_create(EPOLL_CLOEXEC))
@@ -1439,7 +1441,8 @@ private:
     }
 public:
     explicit reactor_backend_uring(reactor& r)
-            : _r(r)
+            : reactor_backend(uses_blocking_io::yes, supports_aio_fdatasync::yes)
+            , _r(r)
             , _uring(try_create_uring(s_queue_len, true).value())
             , _hrtimer_timerfd(make_timerfd())
             , _preempt_io_context(_r, _r._task_quota_timer, _hrtimer_timerfd)
@@ -1849,10 +1852,6 @@ public:
         auto desc = std::make_unique<recv_completion>(fd, ba->allocate_buffer());
         auto req = internal::io_request::make_recv(fd.fd.get(), desc->get_write(), desc->get_size(), 0);
         return submit_request(std::move(desc), std::move(req));
-    }
-
-    virtual bool do_blocking_io() const override {
-        return true;
     }
 
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/internal/poll.hh>
 #include <seastar/core/internal/linux-aio.hh>
 #include <seastar/core/cacheline.hh>
+#include <seastar/util/bool_class.hh>
 
 #include <fmt/ostream.h>
 #include <sys/time.h>
@@ -169,6 +170,14 @@ public:
 // file-descriptors (reactor_backend_epoll), one implementation based on
 // linux aio, and one implementation based on io_uring.
 class reactor_backend {
+protected:
+    using uses_blocking_io = bool_class<struct uses_blocking_io_tag>;
+    using supports_aio_fdatasync = bool_class<struct supports_aio_fdatasync_tag>;
+
+private:
+    const uses_blocking_io _blocking_io;
+    const supports_aio_fdatasync _aio_fdatasync;
+
 public:
     virtual ~reactor_backend() {};
     virtual std::string_view get_backend_name() const = 0;
@@ -206,11 +215,11 @@ public:
 #endif
     virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) = 0;
 
-    virtual bool do_blocking_io() const {
-        return false;
+    bool do_blocking_io() const noexcept {
+        return bool(_blocking_io);
     }
-    virtual bool have_aio_fdatasync() const {
-        return true;
+    bool have_aio_fdatasync() const noexcept {
+        return bool(_aio_fdatasync);
     }
     virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) = 0;
     virtual void start_tick() = 0;
@@ -221,6 +230,12 @@ public:
     virtual void start_handling_signal() = 0;
 
     virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) = 0;
+
+protected:
+    reactor_backend(uses_blocking_io blocking_io, supports_aio_fdatasync aio_fdatasync)
+        : _blocking_io(blocking_io)
+        , _aio_fdatasync(aio_fdatasync)
+    {}
 };
 
 // reactor backend using file-descriptor & epoll, suitable for running on


### PR DESCRIPTION
…embers

Replace the virtual methods do_blocking_io() and have_aio_fdatasync() with const bool_class member variables on the reactor_backend base class. These values are fixed per backend and never change at runtime, so virtual dispatch is unnecessary.

Introduce uses_blocking_io and supports_aio_fdatasync bool_class types for type safety. Each derived backend now explicitly passes both values to the base constructor with no defaults.