### PR TITLE
resource: Avoid copying CPU vector to break it into groups

### DIFF
--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -351,7 +351,7 @@ static hwloc_obj_t hwloc_get_ancestor(hwloc_obj_type_t type, hwloc_topology_t to
 }
 
 static std::unordered_map<hwloc_obj_t, std::vector<unsigned>> break_cpus_into_groups(hwloc_topology_t topology,
-        std::vector<unsigned> cpus, hwloc_obj_type_t type) {
+        const std::vector<unsigned>& cpus, hwloc_obj_type_t type) {
     std::unordered_map<hwloc_obj_t, std::vector<unsigned>> groups;
 
     for (auto&& cpu_id : cpus) {


### PR DESCRIPTION
There's a code that collects "orphan" CPUs on the node and spreads them into existing numa nodes in RR manner. The spreading code copies the vector of CPUs, but can go with a const reference on it.