### PR TITLE
http: Improve writing of response_line() into the output

### DIFF
--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -125,7 +125,7 @@ void reply::write_body(const sstring& content_type, sstring content) {
 }
 
 future<> reply::write_reply(output_stream<char>& out) {
-    return out.write(response_line().data(), response_line().size()).then([this, &out] {
+    return out.write(response_line()).then([this, &out] {
         if (_body_writer) {
             add_header("Transfer-Encoding", "chunked");
         } else {


### PR DESCRIPTION
The reply::write_reply() constructs response_line() twice and gets data() and size() out of both instances to pass to output_stream::write().

This is overkill, constructing the response line can happen once, and there's output_stream::write(std::string) overload that does buffered write of the provided string.