### PR TITLE
file: fix `dup()` read-only check in `posix_file_impl::do_dup()`

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -170,7 +170,7 @@ void posix_file_impl::configure_io_lengths() noexcept {
 template <typename FileImpl>
 std::unique_ptr<seastar::file_handle_impl>
 posix_file_impl::do_dup() {
-    if ((_open_flags & open_flags::ro) != open_flags{}) {
+    if ((_open_flags & (open_flags::rw | open_flags::wo)) != open_flags{}) {
         throw std::runtime_error("File is not read-only");
     }
 

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -153,6 +153,18 @@ SEASTAR_TEST_CASE(file_rw_dup_test) {
     });
 }
 
+// Test that the non-append-challenged path (posix_file_impl::do_dup)
+// also rejects non-read-only files
+SEASTAR_TEST_CASE(file_rw_noappend_dup_test) {
+    return tmp_dir::do_with_thread([] (tmp_dir& t) {
+        sstring filename = (t.get_path() / "testfile.tmp").native();
+        file_open_options options;
+        options.append_is_unlikely = true;
+        auto f = open_file_dma(filename, open_flags::rw | open_flags::create, options).get();
+        BOOST_REQUIRE_THROW(f.dup(), std::runtime_error);
+    });
+}
+
 struct file_test {
     file_test(file&& f) : f(std::move(f)) {}
     file f;


### PR DESCRIPTION
The current check `(_open_flags & open_flags::ro) != open_flags{}` is a no-op because `open_flags::ro` is `O_RDONLY`(0). `_open_flags & 0` will always be 0 and the check will never be true.

The test, `file_rw_dup_test`, still passes because the created file is always using the `append_challenged_posix_file_impl` impl. This impl unconditionally throws on `dup()` which is what the test expects.

This PR fixes this by making the mask `(open_flags::rw | open_flags::wo)` instead and adds a new test that should always use the `posix_file_impl` impl.