### PR TITLE
perf_tests: add --no-perf-counters option

### DIFF
--- a/include/seastar/testing/linux_perf_event.hh
+++ b/include/seastar/testing/linux_perf_event.hh
@@ -35,6 +35,7 @@ struct perf_event_attr; // from <linux/perf_event.h>
 
 class linux_perf_event {
     int _fd = -1;
+    linux_perf_event() = default;
 public:
     linux_perf_event(const struct ::perf_event_attr& attr, pid_t pid, int cpu, int group_fd, unsigned long flags);
     linux_perf_event(linux_perf_event&& x) noexcept : _fd(std::exchange(x._fd, -1)) {}
@@ -44,6 +45,8 @@ public:
     void enable();
     void disable();
 public:
+    /// Returns a no-op event that always reads as zero.
+    static linux_perf_event always_zero() { return linux_perf_event(); }
     static linux_perf_event user_instructions_retired();
     static linux_perf_event user_cpu_cycles_retired();
 };

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <boost/program_options/value_semantic.hpp>
 #include <cmath>
+#include <optional>
 #include <ranges>
 #include <seastar/testing/perf_tests.hh>
 
@@ -145,8 +146,8 @@ class time_measurement {
     perf_stats _start_stats;
     perf_stats _total_stats;
 
-    linux_perf_event _instructions_retired_counter = linux_perf_event::user_instructions_retired();
-    linux_perf_event _cpu_cycles_retired_counter = linux_perf_event::user_cpu_cycles_retired();
+    linux_perf_event _instructions_retired_counter;
+    linux_perf_event _cpu_cycles_retired_counter;
 
     uint64_t _start_stop_count = 0;
 
@@ -155,6 +156,11 @@ class time_measurement {
     clock_type::duration _start_stop_overhead_external{0}; // external clock measurement (for comparison)
 
 public:
+    explicit time_measurement(bool perf_counters)
+        : _instructions_retired_counter(perf_counters ? linux_perf_event::user_instructions_retired() : linux_perf_event::always_zero())
+        , _cpu_cycles_retired_counter(perf_counters ? linux_perf_event::user_cpu_cycles_retired() : linux_perf_event::always_zero())
+    {}
+
     void enable_counters() {
         _instructions_retired_counter.enable();
         _cpu_cycles_retired_counter.enable();
@@ -199,8 +205,7 @@ public:
     void stop_iteration() {
         auto t = clock_type::now();
         _total_time += t - _start_time;
-        perf_stats stats;
-        stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
+        perf_stats stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
         _total_stats += stats - _start_stats;
     }
 
@@ -240,25 +245,25 @@ public:
     }
 };
 
-static time_measurement measure_time;
+static std::optional<time_measurement> measure_time;
 
 void performance_test::start_run() {
-    measure_time.enable_counters();
-    measure_time.start_run();
+    measure_time->enable_counters();
+    measure_time->start_run();
 }
 
 performance_test::run_result performance_test::stop_run() {
-    auto ret = measure_time.stop_run();
-    measure_time.disable_counters();
+    auto ret = measure_time->stop_run();
+    measure_time->disable_counters();
     return ret;
 }
 
 void time_measurement_start_iteration() {
-    measure_time.start_iteration();
+    measure_time->start_iteration();
 }
 
 void time_measurement_stop_iteration() {
-    measure_time.stop_iteration();
+    measure_time->stop_iteration();
 }
 
 struct config;
@@ -696,8 +701,8 @@ struct stdout_printer : text_printer {
                 "number of runs:", c.number_of_runs,
                 "number of cores:", smp::count,
                 "random seed:", c.random_seed,
-                "start/stop overhead:", duration { measure_time.start_stop_overhead() },
-                duration { measure_time.start_stop_overhead_external() });
+                "start/stop overhead:", duration { measure_time->start_stop_overhead() },
+                duration { measure_time->start_stop_overhead_external() });
 
         print_header_row();
     }
@@ -818,7 +823,7 @@ void performance_test::do_run(const config& conf)
                 add(r.cycles, rr.stats.cpu_cycles_retired);
 
                 // Calculate overhead ratio from start/stop timing calls
-                auto overhead = rr.start_stop_count * measure_time.start_stop_overhead();
+                auto overhead = rr.start_stop_count * measure_time->start_stop_overhead();
                 double overhead_ratio = dt.count() ? (1.0 * overhead / dt) : 0.;
                 r.overhead.add(overhead_ratio, 1.0);  // already per-run, not per-iteration
             });
@@ -928,12 +933,15 @@ int main(int ac, char** av)
         ("overhead-threshold", bpo::value<double>()->default_value(0.1),
             "warn if overhead exceeds this ratio (default: 0.1 = 10%)")
         ("fail-on-high-overhead", "fail the test run if any test exceeds the overhead threshold")
+        ("no-perf-counters", "disable hardware perf counters (inst/cycles)")
         ;
 
     return app.run(ac, av, [&] {
         return async([&] {
             signal_timer::init();
-            measure_time.calibrate_overhead();
+            bool use_counters = !app.configuration().count("no-perf-counters");
+            measure_time.emplace(use_counters);
+            measure_time->calibrate_overhead();
 
             config conf;
             conf.single_run_iterations = app.configuration()["iterations"].as<size_t>();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -321,6 +321,10 @@ seastar_add_test (chunked_fifo
   KIND BOOST
   SOURCES chunked_fifo_test.cc)
 
+seastar_add_test (linux_perf_event
+  KIND BOOST
+  SOURCES linux_perf_event_test.cc ../perf/linux_perf_event.cc)
+
 seastar_add_test (chunk_parsers
   SOURCES chunk_parsers_test.cc)
 

--- a/tests/unit/linux_perf_event_test.cc
+++ b/tests/unit/linux_perf_event_test.cc
@@ -1,0 +1,46 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define BOOST_TEST_MODULE linux_perf_event
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/testing/linux_perf_event.hh>
+
+BOOST_AUTO_TEST_CASE(test_always_zero_reads_zero) {
+    auto event = linux_perf_event::always_zero();
+    BOOST_CHECK_EQUAL(event.read(), 0u);
+    BOOST_CHECK_EQUAL(event.read(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_always_zero_enable_disable) {
+    auto event = linux_perf_event::always_zero();
+    // These should be no-ops and not crash
+    event.enable();
+    event.disable();
+    BOOST_CHECK_EQUAL(event.read(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_always_zero_move) {
+    auto event = linux_perf_event::always_zero();
+    auto event2 = std::move(event);
+    BOOST_CHECK_EQUAL(event2.read(), 0u);
+
+    linux_perf_event event3 = linux_perf_event::always_zero();
+    event3 = std::move(event2);
+    BOOST_CHECK_EQUAL(event3.read(), 0u);
+}


### PR DESCRIPTION
Hardware perf counters (inst/cycles) require perf_event_open which may
be unavailable in containers or restricted environments. Enable them by
default but allow disabling via --no-perf-counters.

Reasons to disable perf counters:

- They add measurable overhead to start/stop timing calls, and for some
  benchmarks it isn't possible to structure the test to amortize this
  cost, so time-only measurement is preferred.
- Some environments don't support perf_event_open, but you may want
  apples-to-apples comparisons with environments that do, so disabling
  in both ensures consistent measurement methodology.
- Active perf events interfere with collecting perf data from outside
  the process, e.g., using perf record to profile a benchmark.

Add `linux_perf_event::always_zero()` factory method that returns a no-op
event which reads as zero, allowing disabled counters to be handled
without conditional logic throughout the measurement code.

Defer construction of the `time_measurement` object until after command
line parsing so the perf counter state is known at construction time.