### PR TITLE
perf_tests: add total runtime to json output

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -269,6 +269,7 @@ struct result_printer {
 
     virtual void print_configuration(const config&) = 0;
     virtual void print_result(const result&) = 0;
+    virtual void print_summary(clock_type::duration /*total_duration*/) { }
 
     void update_name_column_length(size_t length) {
         _name_column_length = std::max(1ul, length);
@@ -708,12 +709,14 @@ class json_printer final : public result_printer {
     std::unordered_map<std::string,
                        std::unordered_map<std::string,
                                           std::unordered_map<std::string, double>>> _root;
+    std::unordered_map<std::string, double> _summary;
 public:
     explicit json_printer(const std::string& file) : _output_file(file) { }
 
     ~json_printer() {
         std::ofstream out(_output_file);
-        out << json::formatter::to_json(_root);
+        out << "{\"results\":" << json::formatter::to_json(_root["results"])
+            << ",\"summary\":"  << json::formatter::to_json(_summary) << "}";
     }
 
     virtual void print_configuration(const config&) override { }
@@ -726,6 +729,10 @@ public:
         for (auto& c : json_columns) {
             result[c.header] = c.to_double(r);
         }
+    }
+
+    virtual void print_summary(clock_type::duration total_duration) override {
+        _summary["total_runtime_s"] = std::chrono::duration<double>(total_duration).count();
     }
 };
 
@@ -892,10 +899,15 @@ void run_all(const std::vector<std::string>& test_patterns, config& conf) {
         rp->update_name_column_length(max_name_column_length);
         rp->print_configuration(conf);
     }
+    auto run_start = clock_type::now();
     for (auto& t : all_tests()) {
         if (match(t.get())) {
             t->run(conf);
         }
+    }
+    auto total_duration = clock_type::now() - run_start;
+    for (auto& rp : conf.printers) {
+        rp->print_summary(total_duration);
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a `print_summary()` virtual hook to `result_printer`, called after all tests complete with the total wall-clock duration
- `json_printer` implements it to emit a top-level `summary` section containing `total_runtime_s` (floating-point seconds)
- JSON output changes from `{"results": {...}}` to `{"results": {...}, "summary": {"total_runtime_s": ...}}`

This makes it easy for downstream tooling to extract overall benchmark duration from the JSON output.

## Test plan

- Ran `coroutine_perf` with `--json-output` and `--runs 5`, verified `total_runtime_s` is present and consistent with wall-clock time reported by `time`