### PR TITLE
Introduce asymmetric io_uring backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1140,7 +1140,8 @@ endif ()
 
 set_option_if_package_is_found (Seastar_IO_URING LibUring)
 if (Seastar_IO_URING)
-  list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_URING)
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_HAVE_URING)
   target_link_libraries (seastar
     PRIVATE URING::uring)
 endif ()

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -93,6 +93,7 @@ public:
     friend class reactor;
     friend class pollable_fd;
     friend class reactor_backend_uring;
+    friend class reactor_backend_uring_base;
 
     future<size_t> read_some(char* buffer, size_t size);
     future<size_t> read_some(uint8_t* buffer, size_t size);

--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -94,6 +94,7 @@ public:
     friend class pollable_fd;
     friend class reactor_backend_uring;
     friend class reactor_backend_uring_base;
+    friend class reactor_backend_asymmetric_uring;
 
     future<size_t> read_some(char* buffer, size_t size);
     future<size_t> read_some(uint8_t* buffer, size_t size);

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -109,6 +109,11 @@ class smp;
 
 class reactor_backend_selector;
 
+struct async_worker_allocation {
+    resource::cpuset async_workers_cpuset;
+    resource::cpuset reactor_cpuset;
+};
+
 class reactor_backend;
 struct pollfn;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -175,6 +175,7 @@ private:
     friend class reactor_backend_epoll;
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;
+    friend class reactor_backend_uring_base;
     friend class reactor_backend_selector;
     friend struct reactor_options;
     friend class aio_storage_context;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -176,6 +176,7 @@ private:
     friend class reactor_backend_aio;
     friend class reactor_backend_uring;
     friend class reactor_backend_uring_base;
+    friend class reactor_backend_asymmetric_uring;
     friend class reactor_backend_selector;
     friend struct reactor_options;
     friend class aio_storage_context;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -163,6 +163,7 @@ struct reactor_options : public program_options::option_group {
     /// * \p linux-aio
     /// * \p epoll
     /// * \p io_uring
+    /// * \p asymmetric_io_uring
     ///
     /// Default: \p linux-aio (if available).
     program_options::selection_value<reactor_backend_selector> reactor_backend;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -25,6 +25,10 @@
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/core/scheduling.hh>
 
+#ifdef SEASTAR_HAVE_URING
+#include <liburing.h>
+#endif
+
 namespace seastar {
 
 /// \cond internal
@@ -43,6 +47,9 @@ struct reactor_config {
     bool no_poll_aio = false;
     std::optional<bool> aio_nowait_works = false;
     bool abort_on_too_long_task_queue = false;
+#ifdef SEASTAR_HAVE_URING
+    std::variant<std::monostate, int, ::io_uring> asymmetric_uring;
+#endif
 };
 /// \endcond
 

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -24,6 +24,7 @@
 #include <seastar/util/program-options.hh>
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/core/scheduling.hh>
+#include <seastar/core/resource.hh>
 
 #ifdef SEASTAR_HAVE_URING
 #include <liburing.h>
@@ -174,6 +175,10 @@ struct reactor_options : public program_options::option_group {
     ///
     /// Default: \p linux-aio (if available).
     program_options::selection_value<reactor_backend_selector> reactor_backend;
+    /// \brief CPUs to use (in cpuset(7) format) for backend's async workers. Used for asymmetric_io_uring.
+    ///
+    /// \note This option is only valid when the \p reactor_backend is set to \p asymmetric_io_uring.
+    program_options::value<resource::cpuset> async_workers_cpuset;
     /// \brief Use Linux aio for fsync() calls.
     ///
     /// This reduces latency. Requires Linux 4.18 or later.

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -19,6 +19,10 @@
  * Copyright 2014 Cloudius Systems
  */
 
+#ifdef SEASTAR_HAVE_URING
+#include <liburing.h>
+#endif
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -32,6 +36,7 @@
 #include <thread>
 #include <unordered_set>
 #include <barrier>
+#include <memory>
 
 #include <grp.h>
 #include <spawn.h>
@@ -167,6 +172,7 @@
 #include <seastar/util/internal/iovec_utils.hh>
 #include <seastar/util/internal/magic.hh>
 #include <seastar/util/internal/build_id.hh>
+#include <seastar/core/reactor_config.hh>
 #include "core/crypto.hh"
 #include "core/reactor_backend.hh"
 #include "core/syscall_result.hh"
@@ -4054,6 +4060,10 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                  " Note that if the seastar_memory logger is set to debug or trace level, the diagnostics will be logged irrespective of this setting.")
     , reactor_backend(*this, "reactor-backend", backend_selector_candidates(), reactor_backend_selector::default_backend().name(),
                 fmt::format("Internal reactor implementation ({})", reactor_backend_selector::available()))
+    , async_workers_cpuset(*this, "async-workers-cpuset", resource::cpuset{},
+                "CPUs to use (in cpuset(7) format) for backend's async workers."
+                " Only applicable to, and required by, the asymmetric_io_uring reactor backend (see --reactor-backend)."
+                " Note that if the --cpuset is not set, using --async-workers-cpuset will restrict the CPUs available to the SMP shards.")
     , aio_fsync(*this, "aio-fsync", kernel_supports_aio_fsync(),
                 "Use Linux aio for fsync() calls. This reduces latency; requires Linux 4.18 or later.")
     , max_networking_io_control_blocks(*this, "max-networking-io-control-blocks", 10000,
@@ -4460,6 +4470,17 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         cpu_set = opts_cpuset;
     }
 
+    // Let the backend selector allocate async worker cores if needed
+    auto backend_selector = reactor_opts.reactor_backend.get_selected_candidate();
+    std::shared_ptr<reactor_backend_configurator> backend_configurator;
+    try {
+        backend_configurator = backend_selector.configurator(cpu_set, reactor_opts, smp_opts);
+        cpu_set = backend_configurator->configured_cpuset();
+    } catch (const std::exception& e) {
+        seastar_logger.error("{}", e.what());
+        exit(1);
+    }
+
     if (smp_opts.smp) {
         _shard_count = smp_opts.smp.get_value();
     } else {
@@ -4560,6 +4581,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         memory::configure_minimal();
     }
 
+    backend_configurator->verify_allocations(allocations);
+
     _shard_to_numa_node_mapping.reserve(_shard_count);
     for (unsigned i = 0; i < _shard_count; i++) {
         _shard_to_numa_node_mapping.push_back(allocations[i].mem.size() > 0 ? allocations[i].mem[0].nodeid : 0);
@@ -4642,6 +4665,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 #endif
 
+    std::barrier backend_configuration_initialized(_shard_count);
     // Better to put it into the smp class, but at smp construction time
     // correct _shard_count is not known.
     std::barrier reactors_registered(_shard_count);
@@ -4702,7 +4726,6 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
     _all_event_loops_done.emplace(_shard_count);
 
-    auto backend_selector = reactor_opts.reactor_backend.get_selected_candidate();
     seastar_logger.info("Reactor backend: {}", backend_selector);
 
     _qs_owner = decltype(smp::_qs_owner){new smp_message_queue* [_shard_count], qs_deleter{}};
@@ -4724,12 +4747,17 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         }
     };
 
+    auto master_uring_fds = std::make_shared<std::vector<int>>(_shard_count, -1);
+
+    const shard_id first_shard_id = 0;
+    backend_configurator->initialize_shard_configuration(first_shard_id);
+
     unsigned i;
     auto smp_tmain = smp::_tmain;
     smp::_this_smp = this;
     for (i = 1; i < _shard_count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages, allocate_qs_owner, allocate_smp_queues] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages, allocate_qs_owner, allocate_smp_queues, backend_configurator, &backend_configuration_initialized] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4759,7 +4787,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
             throw_pthread_error(r);
             init_default_smp_service_group(i);
             lowres_clock::update();
-            allocate_reactor(i, backend_selector, reactor_cfg);
+
+            backend_configurator->initialize_shard_configuration(i);
+            backend_configuration_initialized.arrive_and_wait();
+            auto reactor_config = backend_configurator->finalize_apply_shard_configuration(i, reactor_cfg);
+
+            allocate_reactor(i, backend_selector, reactor_config);
             reactors[i] = &engine();
             alloc_io_queues(i);
             allocate_qs_owner(i);
@@ -4781,8 +4814,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
     init_default_smp_service_group(0);
     lowres_clock::update();
+
+    backend_configuration_initialized.arrive_and_wait();
+    auto reactor_config = backend_configurator->finalize_apply_shard_configuration(first_shard_id, reactor_cfg);
+
     try {
-        allocate_reactor(0, backend_selector, reactor_cfg);
+        allocate_reactor(0, backend_selector, reactor_config);
     } catch (const std::exception& e) {
         seastar_logger.error("{}", e.what());
         _exit(1);

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1307,9 +1307,12 @@ detect_io_uring() {
     return bool(ring_opt);
 }
 
-class reactor_backend_uring final : public reactor_backend {
+// Base class for uring backends not to duplicate common logic.
+class reactor_backend_uring_base : public reactor_backend {
+protected:
     reactor& _r;
     ::io_uring _uring;
+private:
     bool _did_work_while_getting_sqe = false;
     bool _has_pending_submissions = false;
     file_desc _hrtimer_timerfd;
@@ -1351,7 +1354,7 @@ class reactor_backend_uring final : public reactor_backend {
             SEASTAR_ASSERT(!ret || *ret == 8);
             _armed = false;
         }
-        void maybe_rearm(reactor_backend_uring& be) {
+        void maybe_rearm(reactor_backend_uring_base& be) {
             if (_armed) {
                 return;
             }
@@ -1390,7 +1393,7 @@ private:
     ::io_uring_sqe* try_get_sqe() {
         return ::io_uring_get_sqe(&_uring);
     }
-
+protected:
     bool do_flush_submission_ring() {
         if (_has_pending_submissions) {
             _has_pending_submissions = false;
@@ -1540,10 +1543,10 @@ private:
         return fut;
     }
 public:
-    explicit reactor_backend_uring(reactor& r)
+    explicit reactor_backend_uring_base(reactor& r, ::io_uring uring)
             : reactor_backend(uses_blocking_io::yes, supports_aio_fdatasync::yes)
             , _r(r)
-            , _uring(try_create_uring(uring::QUEUE_LEN, true).value())
+            , _uring(uring)
             , _hrtimer_timerfd(make_timerfd())
             , _preempt_io_context(_r, _r._task_quota_timer, _hrtimer_timerfd)
             , _hrtimer_completion(_r, _hrtimer_timerfd)
@@ -1553,11 +1556,8 @@ public:
         auto tfd = _r._task_quota_timer.get();
         ::fcntl(tfd, F_SETFL, ::fcntl(tfd, F_GETFL) | O_NONBLOCK);
     }
-    ~reactor_backend_uring() {
+    ~reactor_backend_uring_base() override {
         ::io_uring_queue_exit(&_uring);
-    }
-    virtual std::string_view get_backend_name() const override {
-        return "io_uring";
     }
     virtual bool reap_kernel_completions() override {
         return do_process_kernel_completions();
@@ -1615,6 +1615,43 @@ public:
         auto* pfd = static_cast<uring_pollable_fd_state*>(&fd);
         delete pfd;
     }
+
+    virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override {
+        _r._signals.action(signo, siginfo, ignore);
+    }
+    virtual void start_tick() override {
+        _preempt_io_context.start_tick();
+    }
+    virtual void stop_tick() override {
+        _preempt_io_context.stop_tick();
+    }
+    virtual void arm_highres_timer(const ::itimerspec& its) override {
+        _hrtimer_timerfd.timerfd_settime(TFD_TIMER_ABSTIME, its);
+    }
+    virtual void reset_preemption_monitor() override {
+        _preempt_io_context.reset_preemption_monitor();
+    }
+    virtual void request_preemption() override {
+        _preempt_io_context.request_preemption();
+    }
+    virtual void start_handling_signal() override {
+        // We don't have anything special wrt. signals
+    }
+    virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override {
+        return pollable_fd_state_ptr(new uring_pollable_fd_state(std::move(fd), std::move(speculate)));
+    }
+};
+
+class reactor_backend_uring final : public reactor_backend_uring_base {
+public:
+    explicit reactor_backend_uring(reactor& r)
+        : reactor_backend_uring_base(r, try_create_uring(uring::QUEUE_LEN, true).value()) {
+    }
+
+    virtual std::string_view get_backend_name() const override {
+        return "io_uring";
+    }
+
     virtual future<std::tuple<pollable_fd, socket_address>> accept(pollable_fd_state& listenfd) override {
         if (listenfd.take_speculation(POLLIN)) {
             try {
@@ -1956,31 +1993,6 @@ public:
         auto desc = std::make_unique<recv_completion>(fd, ba->allocate_buffer());
         auto req = internal::io_request::make_recv(fd.fd.get(), desc->get_write(), desc->get_size(), 0);
         return submit_request(std::move(desc), std::move(req));
-    }
-
-    virtual void signal_received(int signo, siginfo_t* siginfo, void* ignore) override {
-        _r._signals.action(signo, siginfo, ignore);
-    }
-    virtual void start_tick() override {
-        _preempt_io_context.start_tick();
-    }
-    virtual void stop_tick() override {
-        _preempt_io_context.stop_tick();
-    }
-    virtual void arm_highres_timer(const ::itimerspec& its) override {
-        _hrtimer_timerfd.timerfd_settime(TFD_TIMER_ABSTIME, its);
-    }
-    virtual void reset_preemption_monitor() override {
-        _preempt_io_context.reset_preemption_monitor();
-    }
-    virtual void request_preemption() override {
-        _preempt_io_context.request_preemption();
-    }
-    virtual void start_handling_signal() override {
-        // We don't have anything special wrt. signals
-    }
-    virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override {
-        return pollable_fd_state_ptr(new uring_pollable_fd_state(std::move(fd), std::move(speculate)));
     }
 };
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1308,10 +1308,6 @@ detect_io_uring() {
 }
 
 class reactor_backend_uring final : public reactor_backend {
-    // s_queue_len is more or less arbitrary. Too low and we'll be
-    // issuing too small batches, too high and we require too much locked
-    // memory, but otherwise it doesn't matter.
-    static constexpr unsigned s_queue_len = 200;
     reactor& _r;
     ::io_uring _uring;
     bool _did_work_while_getting_sqe = false;
@@ -1521,8 +1517,8 @@ private:
 
     // Returns true if completions were processed
     bool do_process_kernel_completions_step() {
-        struct ::io_uring_cqe* buf[s_queue_len];
-        auto n = ::io_uring_peek_batch_cqe(&_uring, buf, s_queue_len);
+        struct ::io_uring_cqe* buf[uring::QUEUE_LEN];
+        auto n = ::io_uring_peek_batch_cqe(&_uring, buf, uring::QUEUE_LEN);
         do_process_ready_kernel_completions(buf, n);
         ::io_uring_cq_advance(&_uring, n);
         return n != 0;
@@ -1547,7 +1543,7 @@ public:
     explicit reactor_backend_uring(reactor& r)
             : reactor_backend(uses_blocking_io::yes, supports_aio_fdatasync::yes)
             , _r(r)
-            , _uring(try_create_uring(s_queue_len, true).value())
+            , _uring(try_create_uring(uring::QUEUE_LEN, true).value())
             , _hrtimer_timerfd(make_timerfd())
             , _preempt_io_context(_r, _r._task_quota_timer, _hrtimer_timerfd)
             , _hrtimer_completion(_r, _hrtimer_timerfd)

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -2019,6 +2019,87 @@ public:
     }
 };
 
+class reactor_backend_asymmetric_uring final : public reactor_backend_uring_base {
+public:
+    explicit reactor_backend_asymmetric_uring(reactor& r)
+        : reactor_backend_uring_base(r, try_create_uring(uring::QUEUE_LEN, true).value()) {
+    }
+
+    virtual std::string_view get_backend_name() const override {
+        return "asymmetric_io_uring";
+    }
+
+    virtual future<std::tuple<pollable_fd, socket_address>> accept(pollable_fd_state& listenfd) override {
+        class accept_completion final : public accept_completion_base {
+        public:
+            accept_completion(pollable_fd_state& listenfd)
+                : accept_completion_base(listenfd) {}
+            void complete(size_t fd) noexcept final {
+                pollable_fd pfd(file_desc::from_fd(fd));
+                _result.emplace_value(std::move(pfd), std::move(_sa));
+                delete this;
+            }
+        };
+        auto desc = std::make_unique<accept_completion>(listenfd);
+        auto req = internal::io_request::make_accept(listenfd.fd.get(), desc->posix_sockaddr(), desc->socklen_ptr(), SOCK_NONBLOCK | SOCK_CLOEXEC);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override {
+        auto desc = std::make_unique<connect_completion_base>(sa);
+        auto req = internal::io_request::make_connect(fd.fd.get(), desc->posix_sockaddr(), desc->socklen());
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<size_t> read(pollable_fd_state& fd, void* buffer, size_t len) override {
+        auto desc = std::make_unique<sized_promise_completion_base>();
+        const uint64_t position_file_offset = -1;
+        auto req = internal::io_request::make_read(fd.fd.get(), position_file_offset, buffer, len, false);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<size_t> recvmsg(pollable_fd_state& fd, const std::vector<iovec>& iov) override {
+        auto desc = std::make_unique<recvmsg_completion_base>(iov);
+        auto req = internal::io_request::make_recvmsg(fd.fd.get(), desc->msghdr(), 0);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<temporary_buffer<char>> read_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override {
+        auto desc = std::make_unique<read_completion_base>(ba->allocate_buffer());
+        const uint64_t position_file_offset = -1;
+        auto req = internal::io_request::make_read(fd.fd.get(), position_file_offset, desc->get_write(), desc->get_size(), false);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<size_t> sendmsg(pollable_fd_state& fd, std::span<iovec> iovs, size_t len) final {
+        auto desc = std::make_unique<sendmsg_completion_base>(iovs, len);
+        auto req = internal::io_request::make_sendmsg(fd.fd.get(), desc->msghdr(), MSG_NOSIGNAL);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+#if SEASTAR_API_LEVEL < 9
+    virtual future<size_t> send(pollable_fd_state& fd, const void* buffer, size_t len) override {
+        auto desc = std::make_unique<send_completion_base>(len);
+        auto req = internal::io_request::make_send(fd.fd.get(), buffer, len, MSG_NOSIGNAL);
+        return submit_request(std::move(desc), std::move(req));
+    }
+#endif
+
+    virtual future<temporary_buffer<char>> recv_some(pollable_fd_state& fd, internal::buffer_allocator* ba) override {
+        auto desc = std::make_unique<read_completion_base>(ba->allocate_buffer());
+        auto req = internal::io_request::make_recv(fd.fd.get(), desc->get_write(), desc->get_size(), 0);
+        return submit_request(std::move(desc), std::move(req));
+    }
+
+    virtual future<size_t> writev(pollable_fd_state& fd, std::span<iovec> iovs) override {
+        auto desc = std::make_unique<sized_promise_completion_base>();
+        const uint64_t position_file_offset = -1;
+        std::vector<iovec> iov(iovs.begin(), iovs.end());
+        auto req = internal::io_request::make_writev(fd.fd.get(), position_file_offset, iov, false);
+        return submit_request(std::move(desc), std::move(req));
+    }
+};
+
 #endif
 
 static bool detect_aio_poll() {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -22,8 +22,11 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <memory>
+#include <optional>
 #include <thread>
 #include <utility>
+#include <vector>
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/epoll.h>
@@ -49,8 +52,10 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor_config.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/core/shard_id.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
+#include <seastar/core/resource.hh>
 
 namespace seastar {
 
@@ -2145,6 +2150,127 @@ try_create_asymmetric_uring(const std::variant<std::monostate, int, ::io_uring>&
     }
 }
 
+unsigned
+select_worker_cpu(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) {
+    SEASTAR_ASSERT(!worker_cpus.empty());
+    const size_t selected_cpu_rank = get_uring_group_id(shard_id, worker_cpus);
+    return *std::next(worker_cpus.cbegin(), selected_cpu_rank);
+}
+
+bool is_master_shard(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept {
+    return shard_id < worker_cpus.size();
+}
+
+unsigned get_uring_group_id(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept {
+    return shard_id % worker_cpus.size();
+}
+
+class asymmetric_uring_reactor_backend_configurator : public reactor_backend_configurator {
+    resource::cpuset _cpu_set, _async_workers_cpuset;
+    std::vector<int> _master_uring_fds;
+
+    struct uring_groups_init_result {
+        std::optional<::io_uring> ring;
+        unsigned group_id;
+    };
+    std::vector<uring_groups_init_result> _init_data;
+
+    /// @brief If async worker CPUs are allocated and neither --smp nor --cpuset is specified, remove async worker CPUs from the main cpuset to avoid overcommitment by default.
+    /// @param reactor_opts The reactor options, used to check if overprovisioned mode is enabled.
+    /// @param smp_opts The SMP options, used to check if --smp or --cpuset is specified.
+    /// @throws std::invalid_argument if running in overprovisioned mode with async workers allocated and neither --smp nor --cpuset is specified, since this combination might be unintentional.
+    void maybe_remove_overlapping_cpus(const reactor_options& reactor_opts, const smp_options& smp_opts) {
+        if (_async_workers_cpuset.size() == 0) {
+            return;
+        }
+
+        if (smp_opts.smp || smp_opts.cpuset) {
+            // User did it explicitly, we won't mess with their choices.
+            return;
+        }
+
+        if (reactor_opts.overprovisioned) {
+            // If running in overprovisioned mode, we shouldn't remove async worker CPUs from the main cpuset, since overprovisioned mode is meant to allow running with more threads than CPUs.
+            // However, this might unintentionally lead to having async workers and multiple shards running on the same CPU. We decide not to allow this.
+            // If user would like to run in overprovisioned mode with async workers, they should explicitly specify the cpuset or smp count.
+            throw std::invalid_argument("Cannot run in overprovisioned mode when async workers are allocated and neither --smp nor --cpuset is specified");
+        }
+
+        seastar_logger.info("Removing async worker CPUs from main cpuset by default (neither --smp nor --cpuset specified)");
+        for (auto cpu_id : _async_workers_cpuset) {
+            _cpu_set.erase(cpu_id);
+        }
+    }
+
+    /// Assigns set of cpus for backends that need dedicated async workers.
+    /// Throws if async_workers_cpu_set is empty
+    void allocate_async_workers(const reactor_options& reactor_opts, const smp_options& smp_opts) {
+        if (_async_workers_cpuset.empty()) {
+            throw std::runtime_error("No CPUs specified for asymmetric_io_uring workers. Please see --async-workers-cpuset option.");
+        }
+
+        maybe_remove_overlapping_cpus(reactor_opts, smp_opts);
+    }
+
+public:
+    asymmetric_uring_reactor_backend_configurator(resource::cpuset cpu_set, const reactor_options& reactor_opts, const smp_options& smp_opts)
+        : _cpu_set(std::move(cpu_set))
+        , _async_workers_cpuset(reactor_opts.async_workers_cpuset.get_value())
+        , _master_uring_fds(_async_workers_cpuset.size(), -1)
+        , _init_data(smp_opts.smp ? smp_opts.smp.get_value() : _cpu_set.size(), uring_groups_init_result{})
+    {
+        allocate_async_workers(reactor_opts, smp_opts);
+
+        seastar_logger.debug("Backend async workers allocated: {} potential app cores [{}], {} worker cores [{}]",
+                _cpu_set.size(), fmt::join(_cpu_set, ","),
+                _async_workers_cpuset.size(), fmt::join(_async_workers_cpuset, ","));
+    }
+
+    virtual const resource::cpuset& configured_cpuset() const override {
+        return _cpu_set;
+    }
+
+    virtual void verify_allocations(const std::vector<resource::cpu>& allocations) const override {
+        std::set<unsigned> overlapping_cpus;
+        for (auto cpu : allocations) {
+            if (_async_workers_cpuset.contains(cpu.cpu_id)) {
+                overlapping_cpus.insert(cpu.cpu_id);
+            }
+        }
+
+        if (!overlapping_cpus.empty()) {
+            seastar_logger.warn("The following CPUs assigned to shards overlap with the async workers cpuset: {}."
+                                " This may lead to performance degradation. It is recommended to keep the main"
+                                " cpuset and async workers cpuset disjoint.", fmt::join(overlapping_cpus, ","));
+        }
+    }
+
+    virtual void initialize_shard_configuration(shard_id shard) override {
+        const bool is_master = is_master_shard(shard, _async_workers_cpuset);
+        const unsigned uring_group_id = get_uring_group_id(shard, _async_workers_cpuset);
+
+        if (is_master) {
+            auto created_uring = try_create_base_asymmetric_uring(select_worker_cpu(shard, _async_workers_cpuset), true).value();
+            _master_uring_fds.at(uring_group_id) = created_uring.ring_fd;
+            _init_data[shard] = {created_uring, uring_group_id};
+        } else {
+            _init_data[shard] = {std::nullopt, uring_group_id};
+        }
+    }
+
+    virtual reactor_config finalize_apply_shard_configuration(shard_id shard, reactor_config cfg) override {
+        auto& init_result = _init_data[shard];
+
+        if (init_result.ring.has_value()) { // The shard is a master.
+            cfg.asymmetric_uring = init_result.ring.value();
+        } else {
+            cfg.asymmetric_uring = _master_uring_fds.at(init_result.group_id);
+        }
+
+        return cfg;
+    }
+};
+
 } // namespace uring
 
 class reactor_backend_asymmetric_uring final : public reactor_backend_uring_base {
@@ -2254,6 +2380,30 @@ static bool detect_aio_poll() {
     return r == 1;
 }
 
+class noop_reactor_backend_configurator : public reactor_backend_configurator {
+    resource::cpuset _cpu_set;
+public:
+    noop_reactor_backend_configurator(resource::cpuset cpu_set)
+        : _cpu_set(cpu_set) {}
+
+    virtual const resource::cpuset& configured_cpuset() const override {
+        return _cpu_set;
+    }
+
+    virtual void verify_allocations(const std::vector<resource::cpu>&) const override {
+
+    }
+
+
+    virtual void initialize_shard_configuration(shard_id id) override {
+
+    }
+
+    virtual reactor_config finalize_apply_shard_configuration(shard_id id, reactor_config cfg) override {
+        return cfg;
+    }
+};
+
 bool reactor_backend_selector::has_enough_aio_nr() {
     auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
     auto aio_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-nr");
@@ -2315,4 +2465,12 @@ std::vector<reactor_backend_selector> reactor_backend_selector::available() {
     return ret;
 }
 
+std::shared_ptr<reactor_backend_configurator> reactor_backend_selector::configurator(resource::cpuset cpu_set, const reactor_options& reactor_opts, const smp_options& smp_opts) const {
+#ifdef SEASTAR_HAVE_URING
+    if (name() == "asymmetric_io_uring") {
+        return std::make_shared<uring::asymmetric_uring_reactor_backend_configurator>(cpu_set, reactor_opts, smp_opts);
+    }
+#endif
+    return std::make_shared<noop_reactor_backend_configurator>(cpu_set);
+}
 }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -47,6 +47,7 @@
 #include <seastar/core/print.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/reactor_config.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
@@ -2019,10 +2020,137 @@ public:
     }
 };
 
+/// Helper functions that manage the lifecycle and configuration of asymmetric io_uring backend
+/// Handles CPU allocation, worker thread management, and backend creation
+namespace uring {
+
+std::optional<::io_uring>
+try_create_asymmetric_uring_impl(::io_uring_params params, bool throw_on_error) {
+    auto required_features =
+            IORING_FEAT_SUBMIT_STABLE
+            | IORING_FEAT_NODROP
+            | IORING_FEAT_SQPOLL_NONFIXED
+            | IORING_FEAT_FAST_POLL;
+    auto required_ops = {
+            IORING_OP_POLL_ADD, // linux 5.1
+            IORING_OP_READV,
+            IORING_OP_WRITEV,
+            IORING_OP_FSYNC,
+            IORING_OP_SENDMSG,  // linux 5.3
+            IORING_OP_RECVMSG,
+            IORING_OP_ACCEPT,
+            IORING_OP_CONNECT,
+            IORING_OP_READ,     // linux 5.6
+            IORING_OP_WRITE,
+            IORING_OP_SEND,
+            IORING_OP_RECV,
+            };
+    auto maybe_throw = [&] (auto exception) {
+        if (throw_on_error) {
+            throw exception;
+        }
+    };
+
+    ::io_uring ring;
+    auto err = ::io_uring_queue_init_params(uring::QUEUE_LEN, &ring, &params);
+    if (err != 0) {
+        maybe_throw(std::system_error(std::error_code(-err, std::system_category()), "trying to create io_uring"));
+        return std::nullopt;
+    }
+    auto free_ring = defer([&] () noexcept { ::io_uring_queue_exit(&ring); });
+    ::io_uring_ring_dontfork(&ring);
+    if (~ring.features & required_features) {
+        maybe_throw(std::runtime_error(fmt::format("missing required io_ring features, required 0x{:x} available 0x{:x}", required_features, ring.features)));
+        return std::nullopt;
+    }
+
+    auto probe = ::io_uring_get_probe_ring(&ring);
+    if (!probe) {
+        maybe_throw(std::runtime_error("unable to create io_uring probe"));
+        return std::nullopt;
+    }
+    auto free_probe = defer([&] () noexcept { ::io_uring_free_probe(probe); });
+
+    for (auto op : required_ops) {
+        if (!io_uring_opcode_supported(probe, op)) {
+            maybe_throw(std::runtime_error(fmt::format("required io_uring opcode {} not supported", static_cast<int>(op))));
+            return std::nullopt;
+        }
+    }
+
+    free_ring.cancel();
+    return ring;
+}
+
+std::optional<::io_uring>
+try_create_attached_asymmetric_uring(int uring_fd, bool throw_on_error) {
+    auto params = ::io_uring_params{};
+    params.flags |= IORING_SETUP_ATTACH_WQ | IORING_SETUP_SQPOLL;
+    params.wq_fd = uring_fd;
+    return try_create_asymmetric_uring_impl(params, throw_on_error);
+}
+
+std::optional<::io_uring>
+try_create_base_asymmetric_uring(unsigned worker_cpu, bool throw_on_error) {
+    auto maybe_throw = [&] (auto exception) {
+        if (throw_on_error) {
+            throw exception;
+        }
+    };
+
+    auto params = ::io_uring_params{};
+    params.flags |= IORING_SETUP_SQPOLL | IORING_SETUP_SQ_AFF;
+    params.sq_thread_cpu = worker_cpu;
+    params.sq_thread_idle = std::chrono::duration_cast<std::chrono::milliseconds>(POLLER_SLEEP_TIMEOUT).count();
+
+    auto maybe_uring = try_create_asymmetric_uring_impl(params, throw_on_error);
+
+    if (!maybe_uring.has_value()) {
+        return std::nullopt;
+    }
+
+    auto ring = maybe_uring.value();
+
+    auto free_ring = defer([&] () noexcept { ::io_uring_queue_exit(&ring); });
+
+    ::cpu_set_t* worker_cpu_set = CPU_ALLOC(worker_cpu + 1);
+    if (worker_cpu_set == nullptr) {
+        maybe_throw(std::bad_alloc{});
+        return std::nullopt;
+    }
+
+    auto setsize = CPU_ALLOC_SIZE(worker_cpu + 1);
+    CPU_ZERO_S(setsize, worker_cpu_set);
+    CPU_SET_S(worker_cpu, setsize, worker_cpu_set);
+    int err = ::io_uring_register_iowq_aff(&ring, setsize, worker_cpu_set);
+    CPU_FREE(worker_cpu_set);
+    if (err != 0) {
+        maybe_throw(std::system_error(std::error_code(-err, std::system_category()), "trying to set io_uring worker affinity"));
+        return std::nullopt;
+    }
+
+    free_ring.cancel();
+    return ring;
+}
+
+static
+std::optional<::io_uring>
+try_create_asymmetric_uring(const std::variant<std::monostate, int, ::io_uring>& variant, bool throw_on_error) {
+    if (std::holds_alternative<int>(variant)) {
+        return try_create_attached_asymmetric_uring(std::get<int>(variant), throw_on_error);
+    } else if (std::holds_alternative<::io_uring>(variant)) {
+        return std::get<::io_uring>(variant);
+    } else {
+        return std::nullopt;
+    }
+}
+
+} // namespace uring
+
 class reactor_backend_asymmetric_uring final : public reactor_backend_uring_base {
 public:
     explicit reactor_backend_asymmetric_uring(reactor& r)
-        : reactor_backend_uring_base(r, try_create_uring(uring::QUEUE_LEN, true).value()) {
+        : reactor_backend_uring_base(r, uring::try_create_asymmetric_uring(r._cfg.asymmetric_uring, true).value()) {
     }
 
     virtual std::string_view get_backend_name() const override {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1307,6 +1307,78 @@ detect_io_uring() {
     return bool(ring_opt);
 }
 
+static
+void
+prepare_sqe(io_uring_sqe* sqe, const internal::io_request& req, io_completion* completion) {
+    using o = internal::io_request::operation;
+    switch (req.opcode()) {
+        case o::read: {
+            const auto& op = req.as<io_request::operation::read>();
+            ::io_uring_prep_read(sqe, op.fd, op.addr, op.size, op.pos);
+            break;
+        }
+        case o::write: {
+            const auto& op = req.as<io_request::operation::write>();
+            ::io_uring_prep_write(sqe, op.fd, op.addr, op.size, op.pos);
+            break;
+        }
+        case o::readv: {
+            const auto& op = req.as<io_request::operation::readv>();
+            ::io_uring_prep_readv(sqe, op.fd, op.iovec, op.iov_len, op.pos);
+            break;
+        }
+        case o::writev: {
+            const auto& op = req.as<io_request::operation::writev>();
+            ::io_uring_prep_writev(sqe, op.fd, op.iovec, op.iov_len, op.pos);
+            break;
+        }
+        case o::fdatasync: {
+            const auto& op = req.as<io_request::operation::fdatasync>();
+            ::io_uring_prep_fsync(sqe, op.fd, IORING_FSYNC_DATASYNC);
+            break;
+        }
+        case o::recv: {
+            const auto& op = req.as<io_request::operation::recv>();
+            ::io_uring_prep_recv(sqe, op.fd, op.addr, op.size, op.flags);
+            break;
+        }
+        case o::recvmsg: {
+            const auto& op = req.as<io_request::operation::recvmsg>();
+            ::io_uring_prep_recvmsg(sqe, op.fd, op.msghdr, op.flags);
+            break;
+        }
+        case o::send: {
+            const auto& op = req.as<io_request::operation::send>();
+            ::io_uring_prep_send(sqe, op.fd, op.addr, op.size, op.flags);
+            break;
+        }
+        case o::sendmsg: {
+            const auto& op = req.as<io_request::operation::sendmsg>();
+            ::io_uring_prep_sendmsg(sqe, op.fd, op.msghdr, op.flags);
+            break;
+        }
+        case o::accept: {
+            const auto& op = req.as<io_request::operation::accept>();
+            ::io_uring_prep_accept(sqe, op.fd, op.sockaddr, op.socklen_ptr, op.flags);
+            break;
+        }
+        case o::connect: {
+            const auto& op = req.as<io_request::operation::connect>();
+            ::io_uring_prep_connect(sqe, op.fd, op.sockaddr, op.socklen);
+            break;
+        }
+        case o::poll_add:
+        case o::poll_remove:
+        case o::cancel:
+            // The reactor does not generate these types of I/O requests yet, so
+            // this path is unreachable. As more features of io_uring are exploited,
+            // we'll utilize more of these opcodes.
+            seastar_logger.error("Invalid operation for iocb: {}", req.opname());
+            abort();
+    }
+    ::io_uring_sqe_set_data(sqe, completion);
+}
+
 // Base class for uring backends not to duplicate common logic.
 class reactor_backend_uring_base : public reactor_backend {
 protected:
@@ -1427,75 +1499,7 @@ protected:
     }
 
     void submit_io_request(const internal::io_request& req, io_completion* completion) {
-        auto sqe = get_sqe();
-        using o = internal::io_request::operation;
-        switch (req.opcode()) {
-            case o::read: {
-                const auto& op = req.as<io_request::operation::read>();
-                ::io_uring_prep_read(sqe, op.fd, op.addr, op.size, op.pos);
-                break;
-            }
-            case o::write: {
-                const auto& op = req.as<io_request::operation::write>();
-                ::io_uring_prep_write(sqe, op.fd, op.addr, op.size, op.pos);
-                break;
-            }
-            case o::readv: {
-                const auto& op = req.as<io_request::operation::readv>();
-                ::io_uring_prep_readv(sqe, op.fd, op.iovec, op.iov_len, op.pos);
-                break;
-            }
-            case o::writev: {
-                const auto& op = req.as<io_request::operation::writev>();
-                ::io_uring_prep_writev(sqe, op.fd, op.iovec, op.iov_len, op.pos);
-                break;
-            }
-            case o::fdatasync: {
-                const auto& op = req.as<io_request::operation::fdatasync>();
-                ::io_uring_prep_fsync(sqe, op.fd, IORING_FSYNC_DATASYNC);
-                break;
-            }
-            case o::recv: {
-                const auto& op = req.as<io_request::operation::recv>();
-                ::io_uring_prep_recv(sqe, op.fd, op.addr, op.size, op.flags);
-                break;
-            }
-            case o::recvmsg: {
-                const auto& op = req.as<io_request::operation::recvmsg>();
-                ::io_uring_prep_recvmsg(sqe, op.fd, op.msghdr, op.flags);
-                break;
-            }
-            case o::send: {
-                const auto& op = req.as<io_request::operation::send>();
-                ::io_uring_prep_send(sqe, op.fd, op.addr, op.size, op.flags);
-                break;
-            }
-            case o::sendmsg: {
-                const auto& op = req.as<io_request::operation::sendmsg>();
-                ::io_uring_prep_sendmsg(sqe, op.fd, op.msghdr, op.flags);
-                break;
-            }
-            case o::accept: {
-                const auto& op = req.as<io_request::operation::accept>();
-                ::io_uring_prep_accept(sqe, op.fd, op.sockaddr, op.socklen_ptr, op.flags);
-                break;
-            }
-            case o::connect: {
-                const auto& op = req.as<io_request::operation::connect>();
-                ::io_uring_prep_connect(sqe, op.fd, op.sockaddr, op.socklen);
-                break;
-            }
-            case o::poll_add:
-            case o::poll_remove:
-            case o::cancel:
-                // The reactor does not generate these types of I/O requests yet, so
-                // this path is unreachable. As more features of io_uring are exploited,
-                // we'll utilize more of these opcodes.
-                seastar_logger.error("Invalid operation for iocb: {}", req.opname());
-                abort();
-        }
-        ::io_uring_sqe_set_data(sqe, completion);
-
+        prepare_sqe(get_sqe(), req, completion);
         _has_pending_submissions = true;
     }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1466,6 +1466,141 @@ private:
         return ::io_uring_get_sqe(&_uring);
     }
 protected:
+    template <typename T>
+    class promise_completion_base : public io_completion {
+    protected:
+        promise<T> _result;
+    public:
+        virtual ~promise_completion_base() = default;
+        void set_exception(std::exception_ptr eptr) noexcept override {
+            _result.set_exception(std::move(eptr));
+            delete this;
+        }
+        future<T> get_future() {
+            return _result.get_future();
+        }
+    };
+
+    class sized_promise_completion_base : public promise_completion_base<size_t> {
+    public:
+        void complete(size_t bytes) noexcept override {
+            _result.set_value(bytes);
+            delete this;
+        }
+    };
+
+    class accept_completion_base : public promise_completion_base<std::tuple<pollable_fd, socket_address>> {
+    protected:
+        pollable_fd_state& _listenfd;
+        socket_address _sa;
+    public:
+        explicit accept_completion_base(pollable_fd_state& listenfd)
+            : _listenfd(listenfd) {}
+        void set_exception(std::exception_ptr eptr) noexcept override {
+            try {
+                std::rethrow_exception(eptr);
+            } catch (const std::system_error& e) {
+                if (e.code() == std::errc::invalid_argument) {
+                    try {
+                        // The chances are that we are shutting down the connection.
+                        _listenfd.maybe_no_more_recv();
+                    } catch (...) {
+                        eptr = std::current_exception();
+                    }
+                }
+            } catch (...) {}
+            _result.set_exception(std::move(eptr));
+            delete this;
+        }
+        ::sockaddr* posix_sockaddr() {
+            return &_sa.as_posix_sockaddr();
+        }
+        socklen_t* socklen_ptr() {
+            return &_sa.addr_length;
+        }
+    };
+
+    class connect_completion_base : public promise_completion_base<void> {
+    protected:
+        socket_address _sa;
+    public:
+        explicit connect_completion_base(const socket_address& sa)
+            : _sa(sa) {}
+        void complete(size_t) noexcept override {
+            _result.set_value();
+            delete this;
+        }
+        ::sockaddr* posix_sockaddr() {
+            return &_sa.as_posix_sockaddr();
+        }
+        socklen_t socklen() const {
+            return _sa.addr_length;
+        }
+    };
+
+    class recvmsg_completion_base : public sized_promise_completion_base {
+    protected:
+        std::vector<iovec> _iov;
+        ::msghdr _mh = {};
+    public:
+        explicit recvmsg_completion_base(const std::vector<iovec>& iov)
+            : _iov(iov) {
+            _mh.msg_iov = const_cast<iovec*>(_iov.data());
+            _mh.msg_iovlen = _iov.size();
+        }
+        ::msghdr* msghdr() {
+            return &_mh;
+        }
+    };
+
+    class read_completion_base : public promise_completion_base<temporary_buffer<char>> {
+    protected:
+        temporary_buffer<char> _buffer;
+    public:
+        explicit read_completion_base(temporary_buffer<char> buffer)
+            : _buffer(std::move(buffer)) {}
+        void complete(size_t bytes) noexcept override {
+            _buffer.trim(bytes);
+            _result.set_value(std::move(_buffer));
+            delete this;
+        }
+        char* get_write() {
+            return _buffer.get_write();
+        }
+        size_t get_size() {
+            return _buffer.size();
+        }
+    };
+
+    class sendmsg_completion_base : public sized_promise_completion_base {
+    protected:
+        ::msghdr _mh = {};
+        const size_t _to_write;
+    public:
+        sendmsg_completion_base(std::span<iovec> iovs, size_t to_write)
+            : _to_write(to_write) {
+            _mh.msg_iov = iovs.data();
+            _mh.msg_iovlen = std::min<size_t>(iovs.size(), IOV_MAX);
+        }
+        ::msghdr* msghdr() {
+            return &_mh;
+        }
+        size_t to_write() const noexcept {
+            return _to_write;
+        }
+    };
+
+    class send_completion_base : public sized_promise_completion_base {
+    protected:
+        const size_t _to_write;
+    public:
+        explicit send_completion_base(size_t to_write)
+            : _to_write(to_write) {}
+        size_t to_write() const noexcept {
+            return _to_write;
+        }
+    };
+
     bool do_flush_submission_ring() {
         if (_has_pending_submissions) {
             _has_pending_submissions = false;
@@ -1671,43 +1806,15 @@ public:
                 return current_exception_as_future<std::tuple<pollable_fd, socket_address>>();
             }
         }
-        class accept_completion final : public io_completion {
-            pollable_fd_state& _listenfd;
-            socket_address _sa;
-            promise<std::tuple<pollable_fd, socket_address>> _result;
+        class accept_completion final : public accept_completion_base {
         public:
             accept_completion(pollable_fd_state& listenfd)
-                : _listenfd(listenfd) {}
+                : accept_completion_base(listenfd) {}
             void complete(size_t fd) noexcept final {
                 _listenfd.speculate_epoll(EPOLLIN);
                 pollable_fd pfd(file_desc::from_fd(fd), pollable_fd::speculation(EPOLLOUT));
                 _result.emplace_value(std::move(pfd), std::move(_sa));
                 delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                try {
-                    std::rethrow_exception(eptr);
-                } catch (const std::system_error& e) {
-                    if (e.code() == std::errc::invalid_argument) {
-                        try {
-                            // The chances are that we shutting down the connection.
-                            _listenfd.maybe_no_more_recv();
-                        } catch (...) {
-                            eptr = std::current_exception();
-                        }
-                    }
-                } catch (...) {}
-                _result.set_exception(eptr);
-                delete this;
-            }
-            future<std::tuple<pollable_fd, socket_address>> get_future() {
-                return _result.get_future();
-            }
-            ::sockaddr* posix_sockaddr() {
-                return &_sa.as_posix_sockaddr();
-            }
-            socklen_t* socklen_ptr() {
-                return &_sa.addr_length;
             }
         };
         return readable_or_writeable(listenfd).then([this, &listenfd] {
@@ -1717,30 +1824,15 @@ public:
         });
     }
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) override {
-        class connect_completion final : public io_completion {
+        class connect_completion final : public connect_completion_base {
             pollable_fd_state& _fd;
-            socket_address _sa;
-            promise<> _result;
         public:
             connect_completion(pollable_fd_state& fd, const socket_address& sa)
-                : _fd(fd), _sa(sa) {}
+                : connect_completion_base(sa)
+                , _fd(fd) {}
             void complete(size_t fd) noexcept final {
                 _fd.speculate_epoll(POLLOUT);
-                _result.set_value();
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            future<> get_future() {
-                return _result.get_future();
-            }
-            ::sockaddr* posix_sockaddr() {
-                return &_sa.as_posix_sockaddr();
-            }
-            socklen_t socklen() const {
-                return _sa.addr_length;
+                connect_completion_base::complete(fd);
             }
         };
         auto desc = std::make_unique<connect_completion>(fd, sa);
@@ -1767,36 +1859,20 @@ public:
                 return current_exception_as_future<size_t>();
             }
         }
-        class read_completion final : public io_completion {
+        class recvmsg_completion final : public recvmsg_completion_base {
             pollable_fd_state& _fd;
-            std::vector<iovec> _iov;
-            ::msghdr _mh = {};
-            promise<size_t> _result;
         public:
-            read_completion(pollable_fd_state& fd, const std::vector<iovec>& iov)
-                : _fd(fd), _iov(iov) {
-                _mh.msg_iov = const_cast<iovec*>(_iov.data());
-                _mh.msg_iovlen = _iov.size();
-            }
+            recvmsg_completion(pollable_fd_state& fd, const std::vector<iovec>& iov)
+                : recvmsg_completion_base(iov)
+                , _fd(fd) {}
             void complete(size_t bytes) noexcept final {
                 if (bytes == internal::iovec_len(_iov)) {
                     _fd.speculate_epoll(EPOLLIN);
                 }
-                _result.set_value(bytes);
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            ::msghdr* msghdr() {
-                return &_mh;
-            }
-            future<size_t> get_future() {
-                return _result.get_future();
+                recvmsg_completion_base::complete(bytes);
             }
         };
-        auto desc = std::make_unique<read_completion>(fd, iov);
+        auto desc = std::make_unique<recvmsg_completion>(fd, iov);
         auto req = internal::io_request::make_recvmsg(fd.fd.get(), desc->msghdr(), 0);
         return submit_request(std::move(desc), std::move(req));
     }
@@ -1817,36 +1893,20 @@ public:
             }
         }
         return readable(fd).then([this, &fd, ba] {
-            class read_completion final : public io_completion {
+            class read_some_completion final : public read_completion_base {
                 pollable_fd_state& _fd;
-                temporary_buffer<char> _buffer;
-                promise<temporary_buffer<char>> _result;
             public:
-                read_completion(pollable_fd_state& fd, temporary_buffer<char> buffer)
-                    : _fd(fd), _buffer(std::move(buffer)) {}
+                read_some_completion(pollable_fd_state& fd, temporary_buffer<char> buffer)
+                    : read_completion_base(std::move(buffer))
+                    , _fd(fd) {}
                 void complete(size_t bytes) noexcept final {
                     if (bytes == _buffer.size()) {
                         _fd.speculate_epoll(EPOLLIN);
                     }
-                    _buffer.trim(bytes);
-                    _result.set_value(std::move(_buffer));
-                    delete this;
-                }
-                void set_exception(std::exception_ptr eptr) noexcept final {
-                    _result.set_exception(eptr);
-                    delete this;
-                }
-                future<temporary_buffer<char>> get_future() {
-                    return _result.get_future();
-                }
-                char* get_write() {
-                    return _buffer.get_write();
-                }
-                size_t get_size() {
-                    return _buffer.size();
+                    read_completion_base::complete(bytes);
                 }
             };
-            auto desc = std::make_unique<read_completion>(fd, ba->allocate_buffer());
+            auto desc = std::make_unique<read_some_completion>(fd, ba->allocate_buffer());
             auto req = internal::io_request::make_read(fd.fd.get(), -1, desc->get_write(), desc->get_size(), false);
             return submit_request(std::move(desc), std::move(req));
         });
@@ -1868,36 +1928,20 @@ public:
                 return current_exception_as_future<size_t>();
             }
         }
-        class write_completion final : public io_completion {
+        class sendmsg_completion final : public sendmsg_completion_base {
             pollable_fd_state& _fd;
-            ::msghdr _mh = {};
-            const size_t _to_write;
-            promise<size_t> _result;
         public:
-            write_completion(pollable_fd_state& fd, std::span<iovec> iovs, size_t len)
-                : _fd(fd), _to_write(len) {
-                _mh.msg_iov = iovs.data();
-                _mh.msg_iovlen = std::min<size_t>(iovs.size(), IOV_MAX);
-            }
+            sendmsg_completion(pollable_fd_state& fd, std::span<iovec> iovs, size_t len)
+                : sendmsg_completion_base(iovs, len)
+                , _fd(fd) {}
             void complete(size_t bytes) noexcept final {
-                if (bytes == _to_write) {
+                if (bytes == to_write()) {
                     _fd.speculate_epoll(EPOLLOUT);
                 }
-                _result.set_value(bytes);
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            ::msghdr* msghdr() {
-                return &_mh;
-            }
-            future<size_t> get_future() {
-                return _result.get_future();
+                sendmsg_completion_base::complete(bytes);
             }
         };
-        auto desc = std::make_unique<write_completion>(fd, iovs, len);
+        auto desc = std::make_unique<sendmsg_completion>(fd, iovs, len);
         auto req = internal::io_request::make_sendmsg(fd.fd.get(), desc->msghdr(), MSG_NOSIGNAL);
         return submit_request(std::move(desc), std::move(req));
     }
@@ -1921,29 +1965,20 @@ public:
                 return current_exception_as_future<size_t>();
             }
         }
-        class write_completion final : public io_completion {
+        class send_completion final : public send_completion_base {
             pollable_fd_state& _fd;
-            const size_t _to_write;
-            promise<size_t> _result;
         public:
-            write_completion(pollable_fd_state& fd, size_t to_write)
-                : _fd(fd), _to_write(to_write) {}
+            send_completion(pollable_fd_state& fd, size_t to_write)
+                : send_completion_base(to_write)
+                , _fd(fd) {}
             void complete(size_t bytes) noexcept final {
-                if (bytes == _to_write) {
+                if (bytes == to_write()) {
                     _fd.speculate_epoll(EPOLLOUT);
                 }
-                _result.set_value(bytes);
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            future<size_t> get_future() {
-                return _result.get_future();
+                send_completion_base::complete(bytes);
             }
         };
-        auto desc = std::make_unique<write_completion>(fd, len);
+        auto desc = std::make_unique<send_completion>(fd, len);
         auto req = internal::io_request::make_send(fd.fd.get(), buffer, len, MSG_NOSIGNAL);
         return submit_request(std::move(desc), std::move(req));
     }
@@ -1965,36 +2000,20 @@ public:
                 return current_exception_as_future<temporary_buffer<char>>();
             }
         }
-        class recv_completion final : public io_completion {
+        class recv_some_completion final : public read_completion_base {
             pollable_fd_state& _fd;
-            temporary_buffer<char> _buffer;
-            promise<temporary_buffer<char>> _result;
         public:
-            recv_completion(pollable_fd_state& fd, temporary_buffer<char> buffer)
-                : _fd(fd), _buffer(std::move(buffer)) {}
+            recv_some_completion(pollable_fd_state& fd, temporary_buffer<char> buffer)
+                : read_completion_base(std::move(buffer))
+                , _fd(fd) {}
             void complete(size_t bytes) noexcept final {
                 if (bytes == _buffer.size()) {
                     _fd.speculate_epoll(EPOLLIN);
                 }
-                _buffer.trim(bytes);
-                _result.set_value(std::move(_buffer));
-                delete this;
-            }
-            void set_exception(std::exception_ptr eptr) noexcept final {
-                _result.set_exception(eptr);
-                delete this;
-            }
-            future<temporary_buffer<char>> get_future() {
-                return _result.get_future();
-            }
-            char* get_write() {
-                return _buffer.get_write();
-            }
-            size_t get_size() {
-                return _buffer.size();
+                read_completion_base::complete(bytes);
             }
         };
-        auto desc = std::make_unique<recv_completion>(fd, ba->allocate_buffer());
+        auto desc = std::make_unique<recv_some_completion>(fd, ba->allocate_buffer());
         auto req = internal::io_request::make_recv(fd.fd.get(), desc->get_write(), desc->get_size(), 0);
         return submit_request(std::move(desc), std::move(req));
     }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1314,6 +1314,30 @@ detect_io_uring() {
 }
 
 static
+bool
+detect_asymmetric_io_uring() {
+    if (!kernel_uname().whitelisted({"5.17"}) && have_md_devices()) {
+        // Older kernels fall back to workqueues for RAID devices
+        return false;
+    }
+    if (!kernel_uname().whitelisted({"5.12"}) && mlock_limit() < (8 << 20)) {
+        // Older kernels lock about 32k/vcpu for the ring itself. Require 8MB of
+        // locked memory to be safe (8MB is what newer kernels and newer systemd provide)
+        return false;
+    }
+    auto base_ring_opt = uring::try_create_base_asymmetric_uring(sched_getcpu(), false);
+    if (!base_ring_opt) {
+        return false;
+    }
+    auto attached_ring_opt = uring::try_create_attached_asymmetric_uring(base_ring_opt.value().ring_fd, false);
+    if (attached_ring_opt) {
+        ::io_uring_queue_exit(&attached_ring_opt.value());
+    }
+    ::io_uring_queue_exit(&base_ring_opt.value());
+    return bool(attached_ring_opt);
+}
+
+static
 void
 prepare_sqe(io_uring_sqe* sqe, const internal::io_request& req, io_completion* completion) {
     using o = internal::io_request::operation;
@@ -2455,6 +2479,8 @@ std::vector<reactor_backend_selector> reactor_backend_selector::available() {
 #ifdef SEASTAR_HAVE_URING
     if (detect_io_uring()) {
         ret.push_back(reactor_backend_selector("io_uring"));
+    }
+    if (detect_asymmetric_io_uring()) {
         ret.push_back(reactor_backend_selector("asymmetric_io_uring"));
     }
 #endif

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -2153,6 +2153,13 @@ std::unique_ptr<reactor_backend> reactor_backend_selector::create(reactor& r) {
         throw std::runtime_error("io_uring backend not compiled in");
 #endif
     }
+    if (_name == "asymmetric_io_uring") {
+#ifdef SEASTAR_HAVE_URING
+        return std::make_unique<reactor_backend_asymmetric_uring>(r);
+#else
+        throw std::runtime_error("asymmetric_io_uring backend not compiled in");
+#endif
+    }
     if (_name == "linux-aio") {
         return std::make_unique<reactor_backend_aio>(r);
     } else if (_name == "epoll") {
@@ -2170,6 +2177,7 @@ std::vector<reactor_backend_selector> reactor_backend_selector::available() {
 #ifdef SEASTAR_HAVE_URING
     if (detect_io_uring()) {
         ret.push_back(reactor_backend_selector("io_uring"));
+        ret.push_back(reactor_backend_selector("asymmetric_io_uring"));
     }
 #endif
     if (has_enough_aio_nr() && detect_aio_poll()) {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -391,6 +391,19 @@ public:
     }
 };
 
+#ifdef SEASTAR_HAVE_URING
+
+namespace uring {
+
+// QUEUE_LEN is more or less arbitrary. Too low and we'll be
+// issuing too small batches, too high and we require too much locked
+// memory, but otherwise it doesn't matter.
+inline constexpr unsigned QUEUE_LEN = 200;
+
+} // namespace uring
+
+#endif // SEASTAR_HAVE_URING
+
 }
 
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -29,13 +29,20 @@
 #include <seastar/core/internal/poll.hh>
 #include <seastar/core/internal/linux-aio.hh>
 #include <seastar/core/cacheline.hh>
+#include <seastar/core/reactor_config.hh>
+#include <seastar/core/smp_options.hh>
 #include <seastar/util/bool_class.hh>
+#include <seastar/core/shard_id.hh>
+#include <seastar/core/resource.hh>
 
 #include <fmt/ostream.h>
 #include <sys/time.h>
 #include <bitset>
 #include <thread>
 #include <stack>
+#include <memory>
+#include <vector>
+#include <optional>
 #include <boost/any.hpp>
 #include <boost/program_options.hpp>
 #include <boost/container/static_vector.hpp>
@@ -52,7 +59,6 @@
 namespace seastar {
 
 class reactor;
-
 // FIXME: merge it with storage context below. At this point the
 // main thing to do is unify the iocb list
 struct aio_general_context {
@@ -380,6 +386,7 @@ public:
 
 class reactor_backend_uring;
 class reactor_backend_asymmetric_uring;
+class reactor_backend_configurator;
 
 class reactor_backend_selector {
     std::string _name;
@@ -394,6 +401,16 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const reactor_backend_selector& rbs) {
         return os << rbs._name;
     }
+    std::shared_ptr<reactor_backend_configurator> configurator(resource::cpuset cpu_set, const reactor_options& reactor_opts, const smp_options& smp_opts) const;
+};
+
+class reactor_backend_configurator {
+public:
+    virtual const resource::cpuset& configured_cpuset() const = 0;
+    virtual void verify_allocations(const std::vector<resource::cpu>& allocations) const = 0;
+    virtual void initialize_shard_configuration(shard_id id) = 0;
+    virtual reactor_config finalize_apply_shard_configuration(shard_id id, reactor_config cfg) = 0;
+    virtual ~reactor_backend_configurator() = default;
 };
 
 #ifdef SEASTAR_HAVE_URING
@@ -407,6 +424,12 @@ try_create_attached_asymmetric_uring(int uring_fd, bool throw_on_error);
 
 std::optional<::io_uring>
 try_create_base_asymmetric_uring(unsigned worker_cpu, bool throw_on_error);
+
+unsigned select_worker_cpu(seastar::shard_id shard_id, const resource::cpuset& worker_cpus);
+
+bool is_master_shard(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept;
+
+unsigned get_uring_group_id(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept;
 
 // QUEUE_LEN is more or less arbitrary. Too low and we'll be
 // issuing too small batches, too high and we require too much locked

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -375,6 +375,7 @@ public:
 };
 
 class reactor_backend_uring;
+class reactor_backend_asymmetric_uring;
 
 class reactor_backend_selector {
     std::string _name;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -45,6 +45,10 @@
 #define SEASTAR_IOCB_POOL_DEBUG
 #endif
 
+#ifdef SEASTAR_HAVE_URING
+#include <liburing.h>
+#endif
+
 namespace seastar {
 
 class reactor;
@@ -394,12 +398,21 @@ public:
 
 #ifdef SEASTAR_HAVE_URING
 
+/// Helper functions that manage the lifecycle and configuration of asymmetric io_uring backend
+/// Handles CPU allocation, worker thread management, and backend creation
 namespace uring {
+
+std::optional<::io_uring>
+try_create_attached_asymmetric_uring(int uring_fd, bool throw_on_error);
+
+std::optional<::io_uring>
+try_create_base_asymmetric_uring(unsigned worker_cpu, bool throw_on_error);
 
 // QUEUE_LEN is more or less arbitrary. Too low and we'll be
 // issuing too small batches, too high and we require too much locked
 // memory, but otherwise it doesn't matter.
 inline constexpr unsigned QUEUE_LEN = 200;
+inline constexpr std::chrono::milliseconds POLLER_SLEEP_TIMEOUT(5);
 
 } // namespace uring
 


### PR DESCRIPTION
This PR introduces a new reactor backend - `asymmetric_io_uring`.

The new backend is mostly simillar to the existing `io_uring` backend. However, the threads performing the actual I/O for `io_uring` instances, live on separate vCPUs, called worker cores, whose set should be disjoint from the "normal" app cpuset. The purpose of this change is to improve efficiency and isolation of the I/O. Most importantly, these workers poll the `io_uring`'s submission queue, so that frequenly shards don't have to perform syscalls to submit the I/O requests.

The single worker core might (and usually is) shared between multiple shards.
This is done by using the `IORING_SETUP_ATTACH_WQ` flag when setting up `io_uring` instances.

Additionally, the backend doesn't use speculation. In difference to
other backends it always uses the "backend mechanism" - submit the operation
to the `io_uring` without speculating whether to or not perform a syscall
instead.

## Usage

To select this backend, use `--reactor-backend=asymmetric_io_uring` command line option. Note, that similarly to the `io_uring` backend, it needs to be compiled in by passing `--enable-io_uring` to `configure.py`.

The new option `--async-workers-cpuset` is used to specify which cores are the worker cores. It must be used if the new backend is selected. The worker cores are reponsible for processing the networking I/O requests submitted by shards. `io_uring` worker/poller threads are pinned to those worker cores, and those worker cores shouldn't be included in cpuset - see the table below for details of how this interacts with various options. Those worker/poller threads are shared between shards that were assigned the same networking core. The algorithm to assign worker cores to shards is as follows:

1. Let: `n` be the number of worker cores, `x` be the ID of the shard for worker core assignment.
2. Calculate `k = x % n`.
3. Select the `k`-th core from the `async-workers-cpuset` - shard `x` will be assgned this worker core.

For example, if `cpuset` is `0-13` and `async-workers-cpuset` is `14-15`, then cores `0, 2, 4, 6, 8, 10, 12` will have their worker pinned to cpu `14`, and the remaining cores `1, 3, 5, 7, 9, 11, 13` will have their worker pinned to cpu `15`.

It is recommended to specify `cpuset` explicitly when using this backend, instead of using `--smp` option.

The table below specifies the behaviour for specific combination of options used for cores configuration:

| async-workers-cpuset | smp | cpuset | taskset | overprovisioned | Resulting Behavior |
| --- | --- | --- | --- | --- | --- |
| None | Any | Any | Any | Any | **Fail** - Mandatory parameter missing |
| X | None | None | None | True | **Fail** - Overprovisioned without explicit CPU config |
| X | None | None | X | False | **Fail** - All available CPUs assigned to workers, none for shards |
| X | None | Y | N/A | False | **Success** - Shards on Y, workers on X. Warning if X ∩ Y ≠ ∅ |
| X ⊆ taskset | n | None | taskset | False | **Success** - n shards on taskset, workers on X, async-workers-cpuset don't affect cpuset for shards |
| X ⊂ taskset | None | None | taskset | False | **Success** - Shards on (taskset - X), workers on X |
| X | n | None | taskset | True | **Success** - n shards created despite contention |
| X | None | Y ⊆ taskset | taskset | True | **Success** - \|Y\| shards created regardless of X |

- `taskset` is the CPU affinity of the process, see [taskset](https://man7.org/linux/man-pages/man1/taskset.1.html). We've used it to simulate
various scenarios if number of CPUS on the system.

## Performance

The main advantage of the new backend comes from properly utilizing the *networking cores* - pinning io_uring workers/pollers to *networking cores* makes it possible to move the networking I/O away from the app cores without reducing the number of cores available to the application.

- *networking cores* - cores that are handling NIC IRQs, set by the
`perftune.py` script. Usually no shards are pinned to those cores, and
that's why we want to take advantage of them by pinning `io_uring` workers/pollers there.

The backend in some cases can yield better performance than the
existing backends, but in other cases it can be worse. It's
not a silver bullet, but rather a tool that can be used
in specific scenarios. For the biggest limitation, please see [this part](#payload-1kb-parallelism-2000)

### Networking I/O

- rpc_tester with rpc::write job, config:
    - \*P\* is replaced with the payload size, e.g. `1kB`:

    ```yaml
    jobs:
    - name: rpc_write_*P*B_parallelism_2000
      parallelism: 2000
      payload: *P*B
      type: rpc
      verb: write
      nodelay: true
    ```

- **metrics are outputted by the client**, so that’s why you always see 7/8 shards;
    - when running with 4 server shards, we run 8 client shards, so that the
    load can be evenly distributed between server shards, as `4 divides 8`
    - in other cases, we've run 7 client shards, as it's closer
    to the desired 7+1 ratio.
    - you may distinct the number of client shards just by looking at the bottom axis of the charts;

- Instance type: [c8gn.4xlarge](https://aws.amazon.com/ec2/instance-types/c8g/).
- perftune was configured with:
    > sudo ./seastar/scripts/perftune.py --tune net --nic ens34 --irq-core-auto-detection-ratio 8
- more info can be found in the [linked discussion](https://github.com/zpp-2025-io-uring/seastar/discussions/10)

#### 1 server shard

- payload size: `1kB`

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/9a2474cc-89dc-497c-8be3-ffe739a33296" />

[full results](https://github.com/zpp-2025-io-uring/seastar/discussions/10#discussioncomment-16718734)

#### 4 server shards

##### Payload 450B

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/8b01b0c3-675d-49c3-8188-09bfce27c9a4" />

##### Payload 100B

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/ec9b68e1-b347-4e65-bc8e-d55a5e2a5097" />

After investigating the reason with `perf` we’ve identified that the networking vCPU seems to be spending around 50% time on copying memory (kernel’s `__copy_to_user`). For more details, please see the [discussion thread](https://github.com/zpp-2025-io-uring/seastar/discussions/10#discussioncomment-16733544).

This stems from moving the I/O from each shard to a single vCPU, which becomes a bottleneck. This is especially visible with the increasing ratio of shards per networking vCPU.

##### adding compute-time

If we switch the scenario and simulate some artificial processing on the server side, then `asymmetric_io_uring`, in some cases, starts to be better than the `linux-aio`. In the `rpc_tester` we’ve added an artificial busy loop, spinning for X microseconds before responding to the client’s request:
[full results](https://github.com/zpp-2025-io-uring/seastar/discussions/10#discussioncomment-16881903).

- X=2 microseconds
- payload size: `1kB`

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/7219190d-a8a4-453c-b7a8-9d77870d0107" />

#### 7 server shards

This is a desired configuration as usually there is one networking core
per 8 cores.

- X=1 microseconds
- payload size: `1kB`

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/c8926009-1972-41b7-9b5f-2e284c52478f" />

Although `asymmetric_io_uring` yields lower raw performance than `linux-aio`, it offloads the shard vCPUs by dedicating a single vCPU to handle I/O for every 7 shards. This, consequently, gives more headroom for performing computation.

### File I/O

Benchmarks were run with io_tester. Tests were performed on a `i4i.4xlarge` instance, on the instance store nvme disk with the xfs filesystem. All benchmarks were run with the io-properties file generated by iotune.

Perftune was configured with
> sudo ./perftune.py --tune net --nic ens5 --irq-core-auto-detection-ratio 8

In our tests, the `asymmetric_io_uring` backend performed similarly to `linux-aio`. This applies both when testing only writes, as well as large writes mixed with small reads with high priority, but a limited number of requests per second.
<img width="700" height="500" alt="io_throughput_writes_throughput" src="https://github.com/user-attachments/assets/ed3a2490-560f-412b-aa8d-f5ea35a9085c" />

More results can be found in the [discussion](https://github.com/zpp-2025-io-uring/seastar/discussions/13).

## Next steps:

- #3315
- #3316

Co-authored by:
@mikolajbilski
@MrD4rkne
@witek-formanski
@pixelkubek