### PR TITLE
core: Deprecate scattered_message

### DIFF
--- a/include/seastar/core/scattered_message.hh
+++ b/include/seastar/core/scattered_message.hh
@@ -30,7 +30,9 @@
 namespace seastar {
 
 template <typename CharType>
-class scattered_message {
+class
+[[deprecated("Use output_stream::write(span<temporary_buffer>) from API level 9")]]
+scattered_message {
 private:
     using fragment = net::fragment;
     using packet = net::packet;


### PR DESCRIPTION
This net::packet wrapper was used for zero-copy output_stream writing. In the latest API level write(span<temporary_buffer>) should be used instead, neither packet nor scattered_message are accepted (#3039)

That said, the scattered_message can be deprecated