### PR TITLE
reactor: add get_all_io_queues() method

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -487,19 +487,8 @@ public:
         return now() - _start_time;
     }
 
-    io_queue& get_io_queue(dev_t devid = 0) {
-        auto queue = _io_queues.find(devid);
-        if (queue == _io_queues.end()) {
-            return *_io_queues.at(0);
-        } else {
-            return *(queue->second);
-        }
-    }
-
-    io_queue* try_get_io_queue(dev_t devid) noexcept {
-        auto queue = _io_queues.find(devid);
-        return queue != _io_queues.end() ? queue->second.get() : nullptr;
-    }
+    io_queue& get_io_queue(dev_t devid = 0);
+    io_queue* try_get_io_queue(dev_t devid) noexcept;
 
     std::string_view get_backend_name() const;
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -490,6 +490,9 @@ public:
     io_queue& get_io_queue(dev_t devid = 0);
     io_queue* try_get_io_queue(dev_t devid) noexcept;
 
+    /// Returns pointers to all io_queues on this shard.
+    std::vector<io_queue*> get_all_io_queues();
+
     std::string_view get_backend_name() const;
 
 private:

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -19,6 +19,7 @@
  * Copyright 2014 Cloudius Systems
  */
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cmath>
@@ -245,6 +246,18 @@ io_queue& reactor::get_io_queue(dev_t devid) {
 io_queue* reactor::try_get_io_queue(dev_t devid) noexcept {
     auto queue = _io_queues.find(devid);
     return queue != _io_queues.end() ? queue->second.get() : nullptr;
+}
+
+std::vector<io_queue*> reactor::get_all_io_queues() {
+    std::vector<io_queue*> queues;
+    queues.reserve(_io_queues.size());
+    for (auto& [_, q] : _io_queues) {
+        auto* p = q.get();
+        if (std::find(queues.begin(), queues.end(), p) == queues.end()) {
+            queues.push_back(p);
+        }
+    }
+    return queues;
 }
 
 future<std::tuple<pollable_fd, socket_address>>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -233,6 +233,20 @@ void reactor::rename_queues(internal::priority_class pc, sstring new_name) {
     }
 }
 
+io_queue& reactor::get_io_queue(dev_t devid) {
+    auto queue = _io_queues.find(devid);
+    if (queue == _io_queues.end()) {
+        return *_io_queues.at(0);
+    } else {
+        return *(queue->second);
+    }
+}
+
+io_queue* reactor::try_get_io_queue(dev_t devid) noexcept {
+    auto queue = _io_queues.find(devid);
+    return queue != _io_queues.end() ? queue->second.get() : nullptr;
+}
+
 future<std::tuple<pollable_fd, socket_address>>
 reactor::do_accept(pollable_fd_state& listenfd) {
     return readable_or_writeable(listenfd).then([this, &listenfd] () mutable {

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -20,6 +20,7 @@
  * Copyright (C) 2021 ScyllaDB
  */
 
+#include <algorithm>
 #include <chrono>
 #include <ratio>
 #include <seastar/core/thread.hh>
@@ -972,4 +973,24 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
     destroy_scheduling_group(sg1).get();
     destroy_scheduling_group(sg0).get();
     destroy_scheduling_supergroup(ssg).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_get_all_io_queues) {
+    auto queues = engine().get_all_io_queues();
+    // The test environment should have at least one io_queue configured
+    BOOST_CHECK(!queues.empty());
+    // Verify no duplicates (io_queues can be shared between devices)
+    std::sort(queues.begin(), queues.end());
+    auto it = std::unique(queues.begin(), queues.end());
+    BOOST_CHECK(it == queues.end());
+    // The default io_queue (device 0) should be in the returned set
+    auto& default_queue = engine().get_io_queue(0);
+    BOOST_CHECK(std::find(queues.begin(), queues.end(), &default_queue) != queues.end());
+    // Every queue reachable via try_get_io_queue for known devices
+    // should appear in the result. Stat the current directory to
+    // discover its device and verify the queue for that device is present.
+    auto sd = file_stat(".").get();
+    if (auto* q = engine().try_get_io_queue(sd.device_id)) {
+        BOOST_CHECK(std::find(queues.begin(), queues.end(), q) != queues.end());
+    }
 }


### PR DESCRIPTION
## Summary
- Move `get_io_queue` and `try_get_io_queue` out of the header into reactor.cc — no reason for these to be inline
- Add `get_all_io_queues()` returning `std::vector<io_queue*>` for all io_queues on the current shard

This method doesn't expose any additional info beyond what is already exposed, but prevents the need of trying arbitrary devid to extract it.