### PR TITLE
http: Fix hex_to_byte() to only accept valid hex digits (a-f, A-F)

### DIFF
--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -30,21 +30,23 @@ namespace internal {
 
 namespace {
 
-short hex_to_byte(char c) {
-    if (c >='a' && c <= 'z') {
-        return c - 'a' + 10;
-    } else if (c >='A' && c <= 'Z') {
-        return c - 'A' + 10;
-    }
-    return c - '0';
+// https://url.spec.whatwg.org/#percent-encoded-bytes — a percent-encoded byte is
+// '%' followed by two ASCII hex digits; otherwise the '%' is left in the output.
+
+bool is_ascii_hex_digit(char c) noexcept {
+    return (c >= '0' && c <= '9') ||
+           (c >= 'A' && c <= 'F') ||
+           (c >= 'a' && c <= 'f');
 }
 
-/**
- * Convert a hex encoded 2 bytes substring to char
- */
-char hexstr_to_char(std::string_view in, size_t from) {
-
-    return static_cast<char>(hex_to_byte(in[from]) * 16 + hex_to_byte(in[from + 1]));
+unsigned hex_digit_value(char c) noexcept {
+    if (c <= '9') {
+        return static_cast<unsigned>(c - '0');
+    }
+    if (c <= 'F') {
+        return static_cast<unsigned>(c - 'A' + 10);
+    }
+    return static_cast<unsigned>(c - 'a' + 10);
 }
 
 bool should_encode(char c) {
@@ -65,11 +67,12 @@ bool decode(bool replace_plus, std::string_view in, sstring& out) {
     sstring buff(in.length(), 0);
     for (size_t i = 0; i < in.length(); ++i) {
         if (in[i] == '%') {
-            if (i + 3 <= in.size()) {
-                buff[pos++] = hexstr_to_char(in, i + 1);
+            if (i + 2 < in.size() && is_ascii_hex_digit(in[i + 1]) && is_ascii_hex_digit(in[i + 2])) {
+                buff[pos++] = static_cast<char>(
+                    (hex_digit_value(in[i + 1]) << 4) | hex_digit_value(in[i + 2]));
                 i += 2;
             } else {
-                return false;
+                buff[pos++] = '%';
             }
         } else if (replace_plus && in[i] == '+') {
             buff[pos++] = ' ';

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2132,6 +2132,24 @@ BOOST_AUTO_TEST_CASE(test_path_decode_changed) {
     BOOST_REQUIRE_EQUAL(result, expected_chars);
 }
 
+// https://url.spec.whatwg.org/#percent-encoded-bytes — if '%' is not followed by
+// two ASCII hex digits, emit '%' and continue (see spec example %25%s%1G -> %%s%1G).
+BOOST_AUTO_TEST_CASE(test_path_decode_invalid_percent_sequence) {
+    sstring result;
+    BOOST_REQUIRE(http::internal::path_decode("%25%s%1G", result));
+    BOOST_REQUIRE_EQUAL(result, "%%s%1G");
+    BOOST_REQUIRE(http::internal::path_decode("%2g", result));
+    BOOST_REQUIRE_EQUAL(result, "%2g");
+    BOOST_REQUIRE(http::internal::path_decode("x%", result));
+    BOOST_REQUIRE_EQUAL(result, "x%");
+}
+
+BOOST_AUTO_TEST_CASE(test_url_decode_invalid_percent_sequence) {
+    sstring result;
+    BOOST_REQUIRE(http::internal::url_decode("%25%s%1G", result));
+    BOOST_REQUIRE_EQUAL(result, "%%s%1G");
+}
+
 namespace seastar::http {
 std::ostream& boost_test_print_type(std::ostream& os, reply::status_class sc) {
     constexpr std::string_view status_strings[] {


### PR DESCRIPTION
The previous range check used 'a'-'z' and 'A'-'Z', which incorrectly accepted invalid hex characters like 'g', 'z', etc. and produced wrong results. Restrict to valid hex digit range.

Closes #3303 