### PR TITLE
http: deprecate reply::done(), remove _response_line dead field

### DIFF
--- a/include/seastar/http/api_docs.hh
+++ b/include/seastar/http/api_docs.hh
@@ -128,7 +128,7 @@ public:
     future<std::unique_ptr<http::reply>> handle(const sstring& path,
             std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         rep->_content = json::formatter::to_json(_docs);
-        rep->done("json");
+        rep->set_content_type("json");
         return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 

--- a/include/seastar/http/function_handlers.hh
+++ b/include/seastar/http/function_handlers.hh
@@ -110,7 +110,7 @@ public:
             std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) override {
         return _f_handle(std::move(req), std::move(rep)).then(
                 [this](std::unique_ptr<http::reply> rep) {
-                    rep->done(_type);
+                    rep->set_content_type(_type);
                     return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
                 });
     }

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -157,7 +157,6 @@ struct reply {
     size_t left_content_length = std::numeric_limits<size_t>::max();
     bool _skip_body = false;
 
-    sstring _response_line;
     std::unordered_map<sstring, sstring> trailing_headers;
     std::unordered_map<sstring, sstring> chunk_extensions;
 
@@ -230,15 +229,15 @@ struct reply {
         return *this;
     }
 
+    [[deprecated("Use set_content_type() or write_body() instead")]]
     reply& done(const sstring& content_type) {
-        return set_content_type(content_type).done();
+        return set_content_type(content_type);
     }
     /**
-     * Done should be called before using the reply.
-     * It would set the response line
+     * \deprecated done() is no longer required; remove the call.
      */
+    [[deprecated("done() is no longer required; remove the call")]]
     reply& done() {
-        _response_line = response_line();
         return *this;
     }
     sstring response_line() const;

--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -56,7 +56,7 @@ future<std::unique_ptr<http::reply>> directory_handler::handle(const sstring& pa
                     }
                     return h->read(full_path, std::move(req), std::move(rep));
                 }
-                rep->set_status(http::reply::status_type::not_found).done();
+                rep->set_status(http::reply::status_type::not_found);
                 return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
 
             });
@@ -112,7 +112,6 @@ bool file_interaction_handler::redirect_if_needed(const http::request& req,
     if (req._url.length() == 0 || req._url.back() != '/') {
         rep.set_status(http::reply::status_type::moved_permanently);
         rep._headers["Location"] = req.get_url() + "/";
-        rep.done();
         return true;
     }
     return false;

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -194,7 +194,6 @@ void connection::generate_error_reply_and_close(std::unique_ptr<http::request> r
     resp->set_version(req->_version);
     resp->set_status(status, msg);
     set_header_connection(*resp, false);
-    resp->done();
     _done = true;
     _replies.push(std::move(resp));
 }
@@ -247,7 +246,7 @@ future<> connection::read_one() {
                     auto continue_reply = std::make_unique<http::reply>();
                     set_headers(*continue_reply);
                     continue_reply->set_version(req->_version);
-                    continue_reply->set_status(http::reply::status_type::continue_).done();
+                    continue_reply->set_status(http::reply::status_type::continue_);
                     this->_replies.push(std::move(continue_reply));
                     return make_ready_future<std::unique_ptr<http::request>>(std::move(req));
                 });
@@ -347,7 +346,7 @@ future<bool> connection::generate_reply(std::unique_ptr<http::request> req) {
     return _server._routes.handle(url, std::move(req), std::move(resp)).
     // Caller guarantees enough room
     then([this, keep_alive , version = std::move(version)](std::unique_ptr<http::reply> rep) {
-        rep->set_version(version).done();
+        rep->set_version(version);
         this->_replies.push(std::move(rep));
         return make_ready_future<bool>(!keep_alive);
     });

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -120,8 +120,8 @@ void reply::write_body(const sstring& content_type, body_writer_type&& body_writ
 }
 
 void reply::write_body(const sstring& content_type, sstring content) {
+    set_content_type(content_type);
     _content = std::move(content);
-    done(content_type);
 }
 
 future<> reply::write_reply(output_stream<char>& out) {

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -84,7 +84,7 @@ std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
                 internal::to_json(std::current_exception()));
     }
 
-    rep->done("json");
+    rep->set_content_type("json");
     return rep;
 }
 
@@ -101,7 +101,7 @@ future<std::unique_ptr<http::reply> > routes::handle(const sstring& path, std::u
         }
     } else {
         rep.reset(new http::reply());
-        rep->set_status(http::reply::status_type::not_found, internal::to_json(not_found_exception("Not found"))).done(
+        rep->set_status(http::reply::status_type::not_found, internal::to_json(not_found_exception("Not found"))).set_content_type(
                 "json");
     }
     return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -43,7 +43,7 @@ class handl : public httpd::handler_base {
 public:
     virtual future<std::unique_ptr<http::reply> > handle(const sstring& path,
             std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
-        rep->done("html");
+        rep->set_content_type("html");
         return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
     }
 };
@@ -2358,6 +2358,61 @@ SEASTAR_THREAD_TEST_CASE(test_content_length_data_sink) {
     do_check(2, "1", true);
     do_check(2, "12", true);
     do_check(2, "123", true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_write_reply_content) {
+    // Tests write_reply() for the sstring body path:
+    // - response line is correctly formatted
+    // - Content-Type header reflects set_content_type()
+    // - Content-Length header matches the body
+    // - body is written verbatim
+    http::reply reply;
+    reply.set_version("1.1");
+    reply.set_status(http::reply::status_type::ok);
+    reply.write_body("txt", sstring("hello"));
+
+    std::stringstream ss;
+    auto os = output_stream<char>(data_sink(std::make_unique<testing::memory_data_sink_impl>(ss)));
+    auto close_os = deferred_close(os);
+
+    reply.write_reply(os).get();
+    os.flush().get();
+
+    auto s = ss.str();
+    BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
+    BOOST_REQUIRE_NE(s.find("Content-Type: text/plain\r\n"), std::string::npos);
+    BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
+    BOOST_REQUIRE(s.ends_with("hello"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_write_reply_body_writer) {
+    // Tests write_reply() for the body_writer (chunked) path:
+    // - response line is correctly formatted
+    // - Content-Type header reflects set_content_type()
+    // - Transfer-Encoding: chunked is set (not Content-Length)
+    // - body is wrapped in chunked framing
+    http::reply reply;
+    reply.set_version("1.1");
+    reply.set_status(http::reply::status_type::ok);
+    reply.write_body("json", [] (output_stream<char>& out) -> future<> {
+        return out.write(sstring("{}"));
+    });
+
+    std::stringstream ss;
+    auto os = output_stream<char>(data_sink(std::make_unique<testing::memory_data_sink_impl>(ss)));
+    auto close_os = deferred_close(os);
+
+    reply.write_reply(os).get();
+    os.flush().get();
+
+    auto s = ss.str();
+    BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
+    BOOST_REQUIRE_NE(s.find("Content-Type: application/json\r\n"), std::string::npos);
+    BOOST_REQUIRE_NE(s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
+    BOOST_REQUIRE_EQUAL(s.find("Content-Length:"), std::string::npos);
+    // chunk: "2\r\n{}\r\n" followed by terminal "0\r\n\r\n"
+    BOOST_REQUIRE_NE(s.find("2\r\n{}\r\n"), std::string::npos);
+    BOOST_REQUIRE(s.ends_with("0\r\n\r\n"));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_reply_cookies) {


### PR DESCRIPTION
reply::done() was originally intended as a required finalisation step that cached the response line into _response_line. However _response_line was never read back — write_reply() always called response_line() directly. The done(content_type) overload was likewise redundant, doing nothing beyond set_content_type() internally.

- Remove the _response_line field entirely
- Make done() a no-op and mark it [[deprecated]]
- Make done(content_type) delegate to set_content_type() and mark it [[deprecated]]
- Fix write_body(content_type, sstring) in reply.cc which was calling done(content_type) instead of set_content_type() directly
- Replace all in-tree callers of done() / done(content_type) with set_content_type() or plain removal (routes.cc, httpd.cc, file_handler.cc, api_docs.hh, function_handlers.hh, httpd_test.cc)
- Add tests test_write_reply_content and test_write_reply_body_writer covering the full write_reply() output: response line, Content-Type, Content-Length / Transfer-Encoding, and body framing