### PR TITLE
net: add set_listen_backlog() to update backlog on a live server socket

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -203,6 +203,7 @@ public:
     future<> listen(socket_address addr, listen_options lo, server_credentials_ptr credentials);
     future<> listen(socket_address addr, listen_options lo);
     future<> listen(socket_address addr);
+    void set_listen_backlog(int backlog);
     future<> stop();
 
     future<> do_accepts(int which);

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -397,6 +397,18 @@ public:
     /// \see listen(socket_address sa, listen_options opts)
     socket_address local_address() const noexcept;
 
+    /// Update the listen backlog on an already-listening socket.
+    ///
+    /// On Linux, this re-invokes the listen() syscall on the underlying
+    /// file descriptor to change the backlog value.
+    /// \throws std::system_error (EOPNOTSUPP) if the socket implementation
+    ///         does not support runtime backlog changes.
+    void set_listen_backlog(int backlog);
+
+    /// Get the currently configured listen backlog.
+    /// Returns -1 if the socket implementation does not track the backlog value.
+    int get_listen_backlog() const;
+
     /// Check whether the \c server_socket is listening on any address.
     ///
     /// \return true if this \c socket_address is bound to an address,

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -201,6 +201,7 @@ class posix_server_socket_impl : public server_socket_impl {
     socket_address _sa;
     int _protocol;
     pollable_fd _lfd;
+    int _listen_backlog;
     conntrack _conntrack;
     server_socket::load_balancing_algorithm _lba;
     shard_id _fixed_cpu;
@@ -210,23 +211,30 @@ public:
     explicit posix_server_socket_impl(int protocol, socket_address sa, pollable_fd lfd,
         server_socket::load_balancing_algorithm lba, shard_id fixed_cpu,
         bool proxy_protocol,
-        std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) : _sa(sa), _protocol(protocol), _lfd(std::move(lfd)), _lba(lba), _fixed_cpu(fixed_cpu), _proxy_protocol(proxy_protocol), _allocator(allocator) {}
+        int listen_backlog,
+        std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) : _sa(sa), _protocol(protocol), _lfd(std::move(lfd)), _listen_backlog(listen_backlog), _lba(lba), _fixed_cpu(fixed_cpu), _proxy_protocol(proxy_protocol), _allocator(allocator) {}
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     virtual socket_address local_address() const override;
+    virtual void set_listen_backlog(int backlog) override;
+    virtual int get_listen_backlog() const override;
 };
 
 class posix_reuseport_server_socket_impl : public server_socket_impl {
     socket_address _sa;
     int _protocol;
     pollable_fd _lfd;
+    int _listen_backlog;
     std::pmr::polymorphic_allocator<char>* _allocator;
 public:
     explicit posix_reuseport_server_socket_impl(int protocol, socket_address sa, pollable_fd lfd,
-        std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) : _sa(sa), _protocol(protocol), _lfd(std::move(lfd)), _allocator(allocator) {}
+        int listen_backlog,
+        std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) : _sa(sa), _protocol(protocol), _lfd(std::move(lfd)), _listen_backlog(listen_backlog), _allocator(allocator) {}
     virtual future<accept_result> accept() override;
     virtual void abort_accept() override;
     virtual socket_address local_address() const override;
+    virtual void set_listen_backlog(int backlog) override;
+    virtual int get_listen_backlog() const override;
 };
 
 class posix_network_stack : public network_stack {

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -70,6 +70,13 @@ public:
     virtual future<accept_result> accept() = 0;
     virtual void abort_accept() = 0;
     virtual socket_address local_address() const = 0;
+    /// Update the listen backlog on an already-listening socket.
+    /// Throws std::system_error (EOPNOTSUPP) if the implementation
+    /// does not support runtime backlog changes.
+    virtual void set_listen_backlog(int backlog);
+    /// Get the currently configured listen backlog.
+    /// Returns -1 if the implementation does not track the backlog value.
+    virtual int get_listen_backlog() const;
 };
 
 class datagram_channel_impl {

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -427,6 +427,13 @@ future<> http_server::listen(socket_address addr) {
     lo.reuse_address = true;
     return listen(addr, lo);
 }
+
+void http_server::set_listen_backlog(int backlog) {
+    for (auto& listener : _listeners) {
+        listener.set_listen_backlog(backlog);
+    }
+}
+
 future<> http_server::stop() {
     future<> tasks_done = _task_gate.close();
     for (auto&& l : _listeners) {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -755,6 +755,15 @@ socket_address posix_server_socket_impl::local_address() const {
     return _lfd.get_file_desc().get_address();
 }
 
+void posix_server_socket_impl::set_listen_backlog(int backlog) {
+    _lfd.get_file_desc().listen(backlog);
+    _listen_backlog = backlog;
+}
+
+int posix_server_socket_impl::get_listen_backlog() const {
+    return _listen_backlog;
+}
+
 posix_ap_server_socket_impl::posix_ap_server_socket_impl(int protocol, socket_address sa, std::pmr::polymorphic_allocator<char>* allocator)
         : _protocol(protocol), _sa(sa), _allocator(allocator)
 {
@@ -820,6 +829,15 @@ posix_reuseport_server_socket_impl::abort_accept() {
 
 socket_address posix_reuseport_server_socket_impl::local_address() const {
     return _lfd.get_file_desc().get_address();
+}
+
+void posix_reuseport_server_socket_impl::set_listen_backlog(int backlog) {
+    _lfd.get_file_desc().listen(backlog);
+    _listen_backlog = backlog;
+}
+
+int posix_reuseport_server_socket_impl::get_listen_backlog() const {
+    return _listen_backlog;
 }
 
 void
@@ -921,13 +939,13 @@ posix_network_stack::listen(socket_address sa, listen_options opt) {
         sa = inet_address(inet_address::family::INET);
     }
     if (sa.is_af_unix()) {
-        return server_socket(std::make_unique<posix_server_socket_impl>(0, sa, internal::posix_listen(sa, opt), opt.lba, opt.fixed_cpu, opt.proxy_protocol, _allocator));
+        return server_socket(std::make_unique<posix_server_socket_impl>(0, sa, internal::posix_listen(sa, opt), opt.lba, opt.fixed_cpu, opt.proxy_protocol, opt.listen_backlog, _allocator));
     }
     auto protocol = static_cast<int>(opt.proto);
     return _reuseport ?
-        server_socket(std::make_unique<posix_reuseport_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), _allocator))
+        server_socket(std::make_unique<posix_reuseport_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), opt.listen_backlog, _allocator))
         :
-        server_socket(std::make_unique<posix_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), opt.lba, opt.fixed_cpu, opt.proxy_protocol, _allocator));
+        server_socket(std::make_unique<posix_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), opt.lba, opt.fixed_cpu, opt.proxy_protocol, opt.listen_backlog, _allocator));
 }
 
 ::seastar::socket posix_network_stack::socket() {
@@ -951,7 +969,7 @@ posix_ap_network_stack::listen(socket_address sa, listen_options opt) {
     }
     auto protocol = static_cast<int>(opt.proto);
     return posix_network_stack::_reuseport ?
-        server_socket(std::make_unique<posix_reuseport_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), _allocator))
+        server_socket(std::make_unique<posix_reuseport_server_socket_impl>(protocol, sa, internal::posix_listen(sa, opt), opt.listen_backlog, _allocator))
         :
         server_socket(std::make_unique<posix_ap_server_socket_impl>(protocol, sa, _allocator));
 }

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -227,6 +227,22 @@ socket_address server_socket::local_address() const noexcept {
     return _ssi->local_address();
 }
 
+void server_socket::set_listen_backlog(int backlog) {
+    _ssi->set_listen_backlog(backlog);
+}
+
+int server_socket::get_listen_backlog() const {
+    return _ssi->get_listen_backlog();
+}
+
+void net::server_socket_impl::set_listen_backlog(int backlog) {
+    throw std::system_error(EOPNOTSUPP, std::system_category(), "set_listen_backlog");
+}
+
+int net::server_socket_impl::get_listen_backlog() const {
+    return -1; // -1 signals that the implementation does not track the backlog value
+}
+
 network_interface::network_interface(shared_ptr<net::network_interface_impl> impl) noexcept
     : _impl(std::move(impl))
 {}

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -367,6 +367,12 @@ public:
     socket_address local_address() const override {
         return _sock.local_address();
     }
+    void set_listen_backlog(int backlog) override {
+        _sock.set_listen_backlog(backlog);
+    }
+    int get_listen_backlog() const override {
+        return _sock.get_listen_backlog();
+    }
 private:
 
     shared_ptr<server_credentials> _creds;

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -364,6 +364,19 @@ SEASTAR_THREAD_TEST_CASE(socket_bufsize) {
     BOOST_CHECK_LT(recv_default, 20'000'000);
 }
 
+SEASTAR_THREAD_TEST_CASE(socket_listen_backlog_runtime_update_test) {
+    listen_options lo;
+    lo.reuse_address = true;
+    lo.listen_backlog = 1111;
+
+    server_socket ss = seastar::listen(ipv4_addr("127.0.0.1", 0), lo);
+
+    BOOST_REQUIRE_EQUAL(ss.get_listen_backlog(), 1111);
+
+    ss.set_listen_backlog(1888);
+    BOOST_REQUIRE_EQUAL(ss.get_listen_backlog(), 1888);
+}
+
 static
 void
 test_load_balancing_algorithm_port(socket_address listen_addr, bool proxy_protocol) {


### PR DESCRIPTION
- Add `set_listen_backlog(int)` to the `server_socket` class hierarchy, allowing the listen backlog to be changed on an already-listening socket
- On Linux, this re-invokes the `listen()` syscall on the underlying file descriptor, which is supported for bound sockets
- Also add `set_listen_backlog()` to `http_server`, which iterates all active listeners and updates their backlog