### PR TITLE
iovec: fix iovec_trim_front infinite loop on zero-length iovecs

### DIFF
--- a/include/seastar/util/internal/iovec_utils.hh
+++ b/include/seastar/util/internal/iovec_utils.hh
@@ -51,7 +51,7 @@ inline size_t iovec_len(std::span<const iovec> iov) {
 // Can update some iovecs in-place
 inline std::span<iovec> iovec_trim_front(std::span<iovec> iov, size_t size) {
     unsigned pos = 0;
-    while (pos < iov.size() && size > 0) {
+    while (pos < iov.size()) {
         if (iov[pos].iov_len > size) {
             iov[pos].iov_base = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(iov[pos].iov_base) + size);
             iov[pos].iov_len -= size;

--- a/tests/unit/temporary_buffer_test.cc
+++ b/tests/unit/temporary_buffer_test.cc
@@ -134,3 +134,43 @@ BOOST_AUTO_TEST_CASE(test_iovec_trim_front) {
         }
     }
 }
+
+// Reproducer for a bug where iovec_trim_front returns a non-empty span
+// when all iovecs have zero length, causing write_all to loop forever
+// since no progress is made.
+BOOST_AUTO_TEST_CASE(test_iovec_trim_front_zero_length) {
+    char dummy;
+
+    // Single zero-length iovec: trimming 0 bytes should skip it
+    {
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_MESSAGE(res.empty(),
+            "trim_front(0) on a single zero-length iovec must return empty span");
+    }
+
+    // Multiple zero-length iovecs
+    {
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ &dummy, 0 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_MESSAGE(res.empty(),
+            "trim_front(0) on all-zero-length iovecs must return empty span");
+    }
+
+    // Zero-length iovecs before a non-zero one: should skip the empty
+    // entries and return a span starting at the non-zero iovec
+    {
+        const char* data = "abc";
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ (void*)data, 3 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_EQUAL(res.size(), 1);
+        BOOST_REQUIRE_EQUAL(res[0].iov_len, 3);
+        BOOST_REQUIRE_EQUAL(*reinterpret_cast<const char*>(res[0].iov_base), 'a');
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `iovec_trim_front` to skip zero-length iovecs instead of looping infinitely when all remaining iovecs have zero length
- Add regression tests for zero-length iovec handling

Without this, some zero length writes could crash due to infinite recursion in `write_all`.

## Test plan

- [x] Unit tests added in `temporary_buffer_test.cc` covering single, multiple, and mixed zero-length iovecs
- [x] Tests pass on both api8 and api9 builds