### PR TITLE
reactor: Deprecate add_task/add_urgent_task/add_high_priority_task

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -613,8 +613,12 @@ template <typename Func>
 public:
     task* current_task() const { return _current_task; }
 
+    [[deprecated("Use seastar::schedule(t) instead")]]
     void add_task(task* t) noexcept;
+    [[deprecated("Use seastar::schedule_urgent(t) instead")]]
     void add_urgent_task(task* t) noexcept;
+    [[deprecated("Use seastar::schedule(t) or seastar::schedule_urgent(t) instead")]]
+    void add_high_priority_task(task*) noexcept;
 
     /// Pass a future to "run" in the background.
     ///
@@ -652,8 +656,6 @@ public:
         _idle_cpu_handler = std::move(handler);
     }
     void force_poll();
-
-    void add_high_priority_task(task*) noexcept;
 
     network_stack& net() { return *_network_stack; }
 
@@ -780,6 +782,7 @@ public:
         static future<> restore_long_task_queue_state(const long_task_queue_state& state) noexcept;
         static void set_abort_on_too_long_task_queue(bool value) noexcept;
         static void set_max_task_backlog(unsigned value) noexcept;
+        static void add_high_priority_task(task*) noexcept;
     };
 };
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1115,9 +1115,12 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     auto r = ::pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
     SEASTAR_ASSERT(r == 0);
     memory::set_reclaim_hook([this] (std::function<void ()> reclaim_fn) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         add_high_priority_task(make_task(default_scheduling_group(), [fn = std::move(reclaim_fn)] {
             fn();
         }));
+#pragma GCC diagnostic pop
     });
 
     _loads.reserve(loads_size);
@@ -1585,6 +1588,13 @@ void reactor::test::set_abort_on_too_long_task_queue(bool value) noexcept {
 void reactor::test::set_max_task_backlog(unsigned value) noexcept {
     auto& r = engine();
     r._cfg.max_task_backlog = value;
+}
+
+void reactor::test::add_high_priority_task(task* t) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    engine().add_high_priority_task(t);
+#pragma GCC diagnostic pop
 }
 
 void
@@ -3553,7 +3563,10 @@ poller::do_register() noexcept {
     // iterating reactor::_pollers itself.  So we schedule a task to add
     // the poller instead.
     auto task = new registration_task(this);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     engine().add_task(task);
+#pragma GCC diagnostic pop
     _registration_task = task;
 }
 
@@ -3577,7 +3590,10 @@ poller::~poller() {
             auto dummy = make_pollfn([] { return false; });
             auto dummy_p = dummy.get();
             auto task = new deregistration_task(std::move(dummy));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             engine().add_task(task);
+#pragma GCC diagnostic pop
             engine().replace_poller(_pollfn.get(), dummy_p);
         }
     }
@@ -3836,7 +3852,10 @@ future<size_t> readable_eventfd::wait() {
 }
 
 void schedule(task* t) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     engine().add_task(t);
+#pragma GCC diagnostic pop
 }
 
 void schedule_checked(task* t) noexcept {
@@ -3844,11 +3863,17 @@ void schedule_checked(task* t) noexcept {
         // trying to schedule a task in at_destroy. Not allowed
         on_internal_error(seastar_logger, "Cannot schedule tasks in at_destroy queue. Use reactor::at_destroy.");
     }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     engine().add_task(t);
+#pragma GCC diagnostic pop
 }
 
 void schedule_urgent(task* t) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     engine().add_urgent_task(t);
+#pragma GCC diagnostic pop
 }
 
 }
@@ -4849,7 +4874,10 @@ net::datagram_channel make_bound_datagram_channel(const socket_address& local) {
 }
 
 void reactor::add_high_priority_task(task* t) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     add_urgent_task(t);
+#pragma GCC diagnostic pop
     // break .then() chains
     request_preemption();
 }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1157,7 +1157,7 @@ SEASTAR_TEST_CASE(test_high_priority_task_runs_in_the_middle_of_loops) {
             BOOST_REQUIRE(*flag);
             return stop_iteration::yes;
         }
-        engine().add_high_priority_task(make_task([flag] {
+        reactor::test::add_high_priority_task(make_task([flag] {
             *flag = true;
         }));
         ++(*counter);


### PR DESCRIPTION
These methods may have out-of-tree users and cannot be simply removed, but they should not be part of the public reactor API going forward. Deprecate them in favor of the seastar::schedule() and seastar::schedule_urgent() free functions.

Internal call sites in reactor.cc are wrapped with diagnostic pragmas to suppress the deprecation warnings. add_high_priority_task() is additionally exposed via reactor::test::add_high_priority_task() to prepare for the eventual privatization of the method, with the pragma applied there so test code remains clean.