### PR TITLE
Move some chunked_source_impl test from httpd set to content_source one

### DIFF
--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -226,3 +226,22 @@ SEASTAR_TEST_CASE(test_chunk_extension_parser_fail) {
             });
     });
 }
+
+SEASTAR_TEST_CASE(test_trailer_part_parser_fail) {
+    return seastar::async([] {
+        // Valid data chunk followed by a trailer with invalid syntax (= instead of :)
+        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring(
+            "8\r\nparsable\r\n0\r\ngood:header\r\nbad=header\r\n\r\n"))));
+        std::unordered_map<sstring, sstring> chunk_extensions;
+        std::unordered_map<sstring, sstring> trailing_headers;
+        auto content_stream = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, chunk_extensions, trailing_headers)));
+        // Read the data chunk successfully first
+        auto buf = content_stream.read().get();
+        BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), sstring("parsable"));
+        // Next read triggers trailer parsing and must throw
+        BOOST_REQUIRE_EXCEPTION(content_stream.read().get(), httpd::bad_request_exception,
+            [] (const httpd::bad_request_exception& e) {
+                return sstring(e.what()).find("Can't parse chunked request trailer") != sstring::npos;
+            });
+    });
+}

--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -184,3 +184,30 @@ SEASTAR_TEST_CASE(test_fragmented_chunks) {
         BOOST_REQUIRE(trailing_headers[sstring("trailer")] == sstring("part"));
     });
 }
+
+SEASTAR_TEST_CASE(test_full_chunk_format) {
+    return seastar::async([] {
+        // Two data chunks with complex extensions and trailing headers
+        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring(
+            "a;abc-def;hello=world;aaaa\r\n1234567890\r\n"
+            "a;a0-!#$%&'*+.^_`|~=\"quoted string obstext\x80\x81\xff quoted_pair: \\a\"\r\n1234521345\r\n"
+            "0\r\na:b\r\n~|`_^.+*'&%$#!-0a:  ~!@#$%^&*()_+\x80\x81\xff\r\n  obs fold  \r\n\r\n"))));
+        std::unordered_map<sstring, sstring> chunk_extensions;
+        std::unordered_map<sstring, sstring> trailing_headers;
+        auto content_stream = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, chunk_extensions, trailing_headers)));
+
+        sstring decoded_body;
+        content_stream.consume([&decoded_body] (temporary_buffer<char> buf) {
+            decoded_body += sstring(buf.get(), buf.size());
+            return make_ready_future<consumption_result<char>>(continue_consuming{});
+        }).get();
+
+        BOOST_REQUIRE_EQUAL(decoded_body, sstring("12345678901234521345"));
+        BOOST_REQUIRE_EQUAL(chunk_extensions[sstring("abc-def")], sstring(""));
+        BOOST_REQUIRE_EQUAL(chunk_extensions[sstring("hello")], sstring("world"));
+        BOOST_REQUIRE_EQUAL(chunk_extensions[sstring("aaaa")], sstring(""));
+        BOOST_REQUIRE_EQUAL(chunk_extensions[sstring("a0-!#$%&'*+.^_`|~")], sstring("quoted string obstext\x80\x81\xff quoted_pair: a"));
+        BOOST_REQUIRE_EQUAL(trailing_headers[sstring("a")], sstring("b"));
+        BOOST_REQUIRE_EQUAL(trailing_headers[sstring("~|`_^.+*'&%$#!-0a")], sstring("~!@#$%^&*()_+\x80\x81\xff obs fold"));
+    });
+}

--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/http/internal/content_source.hh>
+#include <seastar/http/exception.hh>
 #include <seastar/testing/test_case.hh>
 #include <tuple>
 
@@ -209,5 +210,19 @@ SEASTAR_TEST_CASE(test_full_chunk_format) {
         BOOST_REQUIRE_EQUAL(chunk_extensions[sstring("a0-!#$%&'*+.^_`|~")], sstring("quoted string obstext\x80\x81\xff quoted_pair: a"));
         BOOST_REQUIRE_EQUAL(trailing_headers[sstring("a")], sstring("b"));
         BOOST_REQUIRE_EQUAL(trailing_headers[sstring("~|`_^.+*'&%$#!-0a")], sstring("~!@#$%^&*()_+\x80\x81\xff obs fold"));
+    });
+}
+
+SEASTAR_TEST_CASE(test_chunk_extension_parser_fail) {
+    return seastar::async([] {
+        // Space after semicolon with no extension name is invalid
+        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("7; \r\nnoparse\r\n0\r\n\r\n"))));
+        std::unordered_map<sstring, sstring> chunk_extensions;
+        std::unordered_map<sstring, sstring> trailing_headers;
+        auto content_stream = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, chunk_extensions, trailing_headers)));
+        BOOST_REQUIRE_EXCEPTION(content_stream.read().get(), httpd::bad_request_exception,
+            [] (const httpd::bad_request_exception& e) {
+                return sstring(e.what()).find("Can't parse chunk size and extensions") != sstring::npos;
+            });
     });
 }

--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -245,3 +245,22 @@ SEASTAR_TEST_CASE(test_trailer_part_parser_fail) {
             });
     });
 }
+
+SEASTAR_TEST_CASE(test_too_long_chunk) {
+    return seastar::async([] {
+        // Second chunk declares 10 bytes but has an extra 'X' after them
+        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring(
+            "a\r\n1234567890\r\na\r\n1234521345X\r\n0\r\n\r\n"))));
+        std::unordered_map<sstring, sstring> chunk_extensions;
+        std::unordered_map<sstring, sstring> trailing_headers;
+        auto content_stream = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, chunk_extensions, trailing_headers)));
+        // Read both chunk bodies in one call
+        auto buf = content_stream.read_exactly(20).get();
+        BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), sstring("12345678901234521345"));
+        // Next read finds 'X' where '\r' is expected and must throw
+        BOOST_REQUIRE_EXCEPTION(content_stream.read().get(), httpd::bad_chunk_exception,
+            [] (const httpd::bad_chunk_exception& e) {
+                return sstring(e.what()).find("The actual chunk length exceeds the specified length") != sstring::npos;
+            });
+    });
+}

--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -264,3 +264,22 @@ SEASTAR_TEST_CASE(test_too_long_chunk) {
             });
     });
 }
+
+SEASTAR_TEST_CASE(test_bad_chunk_length) {
+    return seastar::async([] {
+        // Second chunk size contains an invalid hex character 'X'
+        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring(
+            "a\r\n1234567890\r\naX\r\n1234521345\r\n0\r\n\r\n"))));
+        std::unordered_map<sstring, sstring> chunk_extensions;
+        std::unordered_map<sstring, sstring> trailing_headers;
+        auto content_stream = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, chunk_extensions, trailing_headers)));
+        // Read first chunk successfully
+        auto buf = content_stream.read_exactly(10).get();
+        BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), sstring("1234567890"));
+        // Next read tries to parse 'aX' as chunk size and must throw
+        BOOST_REQUIRE_EXCEPTION(content_stream.read().get(), httpd::bad_request_exception,
+            [] (const httpd::bad_request_exception& e) {
+                return sstring(e.what()).find("Can't parse chunk size and extensions") != sstring::npos;
+            });
+    });
+}

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1772,14 +1772,6 @@ SEASTAR_TEST_CASE(test_not_implemented_encoding) {
 }
 
 
-SEASTAR_TEST_CASE(test_trailer_part_parser_fail) {
-    return check_http_reply({
-        "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",
-        "8\r\nparsable\r\n",
-        "0\r\ngood:header\r\nbad=header\r\n\r\n"
-    }, {"400 Bad Request", "Can't parse chunked request trailer"}, false, new echo_string_handler());
-}
-
 SEASTAR_TEST_CASE(test_too_long_chunk) {
     return check_http_reply({
         "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1771,16 +1771,6 @@ SEASTAR_TEST_CASE(test_not_implemented_encoding) {
     }, {"501 Not Implemented", "Encodings other than \"chunked\" are not implemented (received encoding: \"gzip, chunked\")"}, false, new echo_string_handler());
 }
 
-SEASTAR_TEST_CASE(test_full_chunk_format) {
-    return check_http_reply({
-        "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",
-        "a;abc-def;hello=world;aaaa\r\n1234567890\r\n",
-        "a;a0-!#$%&'*+.^_`|~=\"quoted string obstext\x80\x81\xff quoted_pair: \\a\"\r\n1234521345\r\n",
-        "0\r\na:b\r\n~|`_^.+*'&%$#!-0a:  ~!@#$%^&*()_+\x80\x81\xff\r\n  obs fold  \r\n\r\n"
-    }, {"12345678901234521345", "abc-def", "hello=world", "aaaa", "a0-!#$%&'*+.^_`|~=quoted string obstext\x80\x81\xff quoted_pair: a",
-        "a: b", "~|`_^.+*'&%$#!-0a: ~!@#$%^&*()_+\x80\x81\xff obs fold"
-    }, false, new echo_string_handler());
-}
 
 SEASTAR_TEST_CASE(test_chunk_extension_parser_fail) {
     return check_http_reply({

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1772,15 +1772,6 @@ SEASTAR_TEST_CASE(test_not_implemented_encoding) {
 }
 
 
-SEASTAR_TEST_CASE(test_too_long_chunk) {
-    return check_http_reply({
-        "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",
-        "a\r\n1234567890\r\n",
-        "a\r\n1234521345X\r\n",
-        "0\r\n\r\n"
-    }, {"400 Bad Request", "The actual chunk length exceeds the specified length"}, true, new echo_stream_handler());
-}
-
 SEASTAR_TEST_CASE(test_bad_chunk_length) {
     return check_http_reply({
         "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1772,14 +1772,6 @@ SEASTAR_TEST_CASE(test_not_implemented_encoding) {
 }
 
 
-SEASTAR_TEST_CASE(test_chunk_extension_parser_fail) {
-    return check_http_reply({
-        "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",
-        "7; \r\nnoparse\r\n",
-        "0\r\n\r\n"
-    }, {"400 Bad Request", "Can't parse chunk size and extensions"}, false, new echo_string_handler());
-}
-
 SEASTAR_TEST_CASE(test_trailer_part_parser_fail) {
     return check_http_reply({
         "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1772,15 +1772,6 @@ SEASTAR_TEST_CASE(test_not_implemented_encoding) {
 }
 
 
-SEASTAR_TEST_CASE(test_bad_chunk_length) {
-    return check_http_reply({
-        "GET /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\n\r\n",
-        "a\r\n1234567890\r\n",
-        "aX\r\n1234521345\r\n",
-        "0\r\n\r\n"
-    }, {"400 Bad Request", "Can't parse chunk size and extensions"}, true, new echo_stream_handler());
-}
-
 SEASTAR_TEST_CASE(test_close_response) {
     return check_http_reply({
         "GET /test HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"


### PR DESCRIPTION
There are several tests in httpd set that feed server with hard-coded request containing chunked-encoded body, make it respond with the echo handler and validate the received string with silly string.find() matchers. These tests effectively validate chunked_source_impl parsing, not the server itself. For such tests there's another file. In it the validation can be made explicit, but checking that conent_source_impl correctly identified and parsed all the relevant parts of the input.