### PR TITLE
rpc: Fix uint64 wraparound of expired timeout in send_entry()

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -163,15 +163,21 @@ future<> connection::send_buffer(snd_buf buf) {
 
 future<> connection::send_entry(outgoing_entry& d) noexcept {
     return futurize_invoke([this, &d] {
+        auto expire = d.t.get_timeout();
+        // left_ms is 0 when no timer is set (server treats 0 as "no timeout").
+        // When a timer is set, drop the entry if already expired; otherwise send
+        // the remaining time so the server can honour the deadline too.
+        uint64_t left_ms = 0;
+        if (expire != typename timer<rpc_clock_type>::time_point()) {
+            left_ms = std::chrono::duration_cast<std::chrono::milliseconds>(expire - timer<rpc_clock_type>::clock::now()).count();
+            if (int64_t(left_ms) <= 0) {
+                return make_ready_future<>();
+            }
+        }
         if (d.buf.size && _propagate_timeout) {
             static_assert(snd_buf::chunk_size >= sizeof(uint64_t), "send buffer chunk size is too small");
             if (_timeout_negotiated) {
-                auto expire = d.t.get_timeout();
-                uint64_t left = 0;
-                if (expire != typename timer<rpc_clock_type>::time_point()) {
-                    left = std::chrono::duration_cast<std::chrono::milliseconds>(expire - timer<rpc_clock_type>::clock::now()).count();
-                }
-                write_le<uint64_t>(d.buf.front().get_write(), left);
+                write_le<uint64_t>(d.buf.front().get_write(), left_ms);
             } else {
                 d.buf.front().trim_front(sizeof(uint64_t));
                 d.buf.size -= sizeof(uint64_t);


### PR DESCRIPTION
When a request entry sits at the front of the outgoing queue and its
timeout deadline expires before send_entry() is called, the timer
callback fires but does nothing -- withdrawal is guarded by
'it != _outgoing_queue.begin()'.  The entry stays in the queue with
a stale _expiry.  send_entry() then computes
    
        expire - timer<rpc_clock_type>::clock::now()
    
which is a negative duration.  Assigning the negative int64_t result
to uint64_t left wraps around to a near-infinite value (~2^63), which
the server receives and interprets as a timeout far in the future,
causing the server to sleep for an effectively infinite period waiting
for a deadline that already passed on the client.
    
Fix: in send_entry(), if the timer was set and the deadline has already
passed, drop the entry without sending -- equivalent to the timer
callback having arrived just a little later than it did.  The server
never receives the corrupted timeout, and the client-side reply handler
times out normally and delivers timeout_error to the caller.
    
The expiration check is placed outside the 'buf.size && _propagate_timeout'
block intentionally: whether a timed-out entry should be dropped is a
client-side liveness decision, independent of whether the timeout value
is encoded into the wire frame.  Even when timeout propagation is
disabled, sending an already-expired request only makes the server do
work for a caller that will receive timeout_error regardless.
    
For the bug to surface two rare events must coincide:
      1. The future returned by the previous entry's send completes in a
         way that schedules the next entry's continuation as a new task
         rather than calling it immediately (i.e. it is not a ready future
         at the .then() site).
      2. That scheduling happens at a preemption point, so the reactor
         runs a poll cycle -- advancing the lowres clock and firing pending
         timer callbacks -- before the continuation calls uncancellable()
         and send_entry().

The bug cannot be deterministically reproduced without modifying the
production code-flow, because the .then() continuation on a ready
future is called inline in the current implementation (condition 1 is
never met in practice without an artificial yield).  To surface it
in a test one would need to inject a force_poll()+yield() step into
connection::send() between the two continuations, and run a
CPU-hogging scheduling group that busy-spins long enough to advance
the lowres clock past the request deadline.  That approach requires
modifying production code for test purposes, so no automated test is
added here; the fix is a straightforward defensive check.
    
Fixes #672