### PR TITLE
net: tls: adjust openssl integration to new module support

### DIFF
--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -20,10 +20,6 @@
  * Copyright 2024 Redpanda Data
  */
 
-#ifdef SEASTAR_MODULE
-module;
-#endif
-
 #include <boost/algorithm/string/trim.hpp>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
@@ -54,9 +50,6 @@ module;
 
 #include <netinet/in.h>
 
-#ifdef SEASTAR_MODULE
-module seastar;
-#else
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sstring.hh>
@@ -69,7 +62,6 @@ module seastar;
 
 #include "tls-impl.hh"
 #include "tls_openssl.hh"
-#endif
 
 namespace seastar::tls {
 class openssl_session;


### PR DESCRIPTION
In 719d7880eca70 we changed module integration to be completely outside the regular source files, but tls/openssl integration introduced in efbb1f7bb53 followed the old, non-standards-compliant method. Adjust by removing all the module plumbing.

The TLS implementation is not reachable from the public API, so seastar.cppm does not require adjustment.