### PR TITLE
Use util::memory_data_source in tests

### DIFF
--- a/tests/unit/content_source_test.cc
+++ b/tests/unit/content_source_test.cc
@@ -25,30 +25,15 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/http/internal/content_source.hh>
 #include <seastar/testing/test_case.hh>
+#include <seastar/util/memory-data-source.hh>
 #include <tuple>
 
 using namespace seastar;
 
-class buf_source_impl : public data_source_impl {
-    temporary_buffer<char> _tmp;
-public:
-    buf_source_impl(sstring str) : _tmp(str.c_str(), str.size()) {};
-    virtual future<temporary_buffer<char>> get() override {
-        if (_tmp.empty()) {
-            return make_ready_future<temporary_buffer<char>>();
-        }
-        return make_ready_future<temporary_buffer<char>>(std::move(_tmp));
-    }
-    virtual future<temporary_buffer<char>> skip(uint64_t n) override {
-        _tmp.trim_front(std::min(_tmp.size(), n));
-        return make_ready_future<temporary_buffer<char>>();
-    }
-};
-
 SEASTAR_TEST_CASE(test_incomplete_content) {
     return seastar::async([] {
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("asdfghjkl;"));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
         auto content1 = content_strm.read().get();
@@ -60,7 +45,7 @@ SEASTAR_TEST_CASE(test_incomplete_content) {
       }
 
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("4\r\n132"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("4\r\n132"));
         std::unordered_map<sstring, sstring> tmp, tmp2;
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 
@@ -76,7 +61,7 @@ SEASTAR_TEST_CASE(test_incomplete_content) {
 SEASTAR_TEST_CASE(test_complete_content) {
     return seastar::async([] {
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;1234567890"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("asdfghjkl;1234567890"));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
         auto content1 = content_strm.read().get();
@@ -87,7 +72,7 @@ SEASTAR_TEST_CASE(test_complete_content) {
       }
 
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("4\r\n1324\r\n0\r\n\r\n"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("4\r\n1324\r\n0\r\n\r\n"));
         std::unordered_map<sstring, sstring> tmp, tmp2;
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 
@@ -103,7 +88,7 @@ SEASTAR_TEST_CASE(test_complete_content) {
 SEASTAR_TEST_CASE(test_more_than_requests_content) {
     return seastar::async([] {
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("asdfghjkl;1234567890xyz"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("asdfghjkl;1234567890xyz"));
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::content_length_source_impl>(inp, 20)));
 
         auto content1 = content_strm.read().get();
@@ -116,7 +101,7 @@ SEASTAR_TEST_CASE(test_more_than_requests_content) {
       }
 
       {
-        auto inp = input_stream<char>(data_source(std::make_unique<buf_source_impl>(sstring("4\r\n1324\r\n0\r\n\r\nxyz"))));
+        auto inp = util::as_input_stream(temporary_buffer<char>::copy_of("4\r\n1324\r\n0\r\n\r\nxyz"));
         std::unordered_map<sstring, sstring> tmp, tmp2;
         auto content_strm = input_stream<char>(data_source(std::make_unique<httpd::internal::chunked_source_impl>(inp, tmp, tmp2)));
 

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -9,6 +9,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/http/response_parser.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/memory-data-source.hh>
 #include "loopback_socket.hh"
 
 using namespace seastar;
@@ -184,21 +185,6 @@ SEASTAR_TEST_CASE(test_websocket_handler_registration_no_subprotocol) {
 }
 
 // Simple wrapper to help create a testable input_stream.
-class test_source_impl : public data_source_impl {
-    std::vector<temporary_buffer<char>> _bufs{};
-    size_t _idx = 0;
-public:
-    void push_back(std::string s) {
-        auto buf = temporary_buffer<char>::copy_of(s);
-        _bufs.emplace_back(std::move(buf));
-    }
-    virtual future<temporary_buffer<char>> get() override {
-        if (_idx < _bufs.size()) {
-            return make_ready_future<temporary_buffer<char>>(_bufs[_idx++].share());
-        }
-        return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>{});
-    }
-};
 
 SEASTAR_TEST_CASE(test_websocket_parser_split) {
     return seastar::async([] {
@@ -217,16 +203,16 @@ SEASTAR_TEST_CASE(test_websocket_parser_split) {
         for (unsigned split_i = 0; split_i < ws_frames.size() - 1; ++split_i) {
             websocket::websocket_parser parser;
 
-            auto source = std::make_unique<test_source_impl>();
+            auto bufs = std::vector<temporary_buffer<char>>{};
 
             if (split_i == 0) {
-                source->push_back(ws_frames);
+                bufs.push_back(temporary_buffer<char>::copy_of(ws_frames));
             } else {
-                source->push_back(ws_frames.substr(0, split_i));
-                source->push_back(ws_frames.substr(split_i));
+                bufs.push_back(temporary_buffer<char>::copy_of(ws_frames.substr(0, split_i)));
+                bufs.push_back(temporary_buffer<char>::copy_of(ws_frames.substr(split_i)));
             }
 
-            input_stream<char> in{data_source{std::move(source)}};
+            input_stream<char> in = util::as_input_stream(std::move(bufs));
 
             std::vector<sstring> results;
 


### PR DESCRIPTION
Tests actively use in-memory data sources to simulate data that comes from e.g. sockets. Some of those were replaced with "standard" one in util::, here are few more.