### PR TITLE
io_tester: fix bad optional access from missing metric during startup

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -594,8 +594,12 @@ public:
 
 private:
     void update_queue_length() {
-        unsigned qlen = get_one_metrics("io_queue_disk_queue_length").value();
-        _disk_queue_lengths(qlen);
+        // The metric may not exist yet: io_queue lazily registers per-class
+        // metrics on the first I/O request from a scheduling group, but this
+        // timer is armed during file setup before any I/O is issued.
+        if (auto val = get_one_metrics("io_queue_disk_queue_length")) {
+            _disk_queue_lengths(static_cast<unsigned>(*val));
+        }
     }
 
     future<> do_start_path(sstring path, directory_entry_type type) {


### PR DESCRIPTION
The queue length sampling timer in `io_class_data` is armed during file
setup (`do_start`), before any I/O requests are issued under the job's
scheduling group. Since `io_queue` lazily registers per-class metrics on the
first I/O request from each scheduling group, `get_one_metrics()` can return
`nullopt` when the timer fires before any I/O has been dispatched.

The unconditional `.value()` call on the returned optional then throws
`std::bad_optional_access`, surfacing as:
```
ERROR seastar - Timer callback failed: std::bad_optional_access (bad optional access)
```

This is easiest to reproduce with short durations (`--duration 1`) and many
shards, but can occur in any run depending on timing.

Fix by skipping the sample when the metric is not yet available.