### PR TITLE
backtrace: print the build_id along with the backtrace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .cproject
 .project
 .settings
-build*
+build/
 build.ninja
 cscope.*
 __pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ add_library (seastar
   src/util/read_first_line.cc
   src/util/tmp_file.cc
   src/util/short_streams.cc
+  src/util/build_id.cc
   src/websocket/parser.cc
   src/websocket/common.cc
   src/websocket/client.cc

--- a/include/seastar/util/internal/build_id.hh
+++ b/include/seastar/util/internal/build_id.hh
@@ -1,0 +1,32 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2019-present ScyllaDB
+ */
+
+#pragma once
+
+namespace seastar::internal {
+
+/// Returns the build ID of the currently running executable, if available.
+/// The build ID is a unique identifier for a specific build of the executable,
+/// often used for debugging and profiling purposes.
+/// If the build ID is not available, this function returns "unknown".
+const char* get_build_id();
+
+} // namespace seastar::internal

--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -240,6 +240,7 @@ class BacktraceResolver:
             addr = "0x[0-9a-f]+"
             path = r"\S+"
             token = fr"(?:{path}\+)?{addr}"
+            build_id = r"\(BuildId: [0-9a-fA-F]+\)"
             full_addr_match = fr"(?:(?P<path>{path})\s*\+\s*)?(?P<addr>{addr})"
             ignore_addr_match = fr"(?:(?P<path>{path})\s*\+\s*)?(?:{addr})"
 
@@ -249,7 +250,7 @@ class BacktraceResolver:
             # All of the below except for separator_re must only match lines containing 0x in them
             # as we use that as a quick first filter
             self.oneline_re = re.compile(
-                fr"^((?:.*(?:(?:at|backtrace):?|:))?(?:\s+))?({token}(?:\s+{token})*)(?:\).*|\s*)$",
+                fr"^((?:.*(?:(?:at|backtrace):?|:))?(?:\s+))?({token}(?:\s+{token})*)(\s+{build_id})?(?:\).*|\s*)$",
                 flags=re.IGNORECASE,
             )
             self.address_re = re.compile(full_addr_match, flags=re.IGNORECASE)
@@ -259,7 +260,7 @@ class BacktraceResolver:
             )
             self.kernel_re = re.compile(fr'^.*kernel callstack: (?P<addrs>(?:{addr}\s*)+)$')
             self.asan_re = re.compile(
-                fr"^(?:.*\s+)\({full_addr_match}\)(\s+\(BuildId: [0-9a-fA-F]+\))?$",
+                fr"^(?:.*\s+)\({full_addr_match}\)(\s+{build_id})?$",
                 flags=re.IGNORECASE,
             )
             self.generic_re = re.compile(fr"^(?:.*\s+){full_addr_match}\s*$", flags=re.IGNORECASE)

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -146,7 +146,7 @@ class TestStringMethods(unittest.TestCase):
     def test_reactor_stall_reports(self):
         data: TestList = [
             (
-                'Reactor stalled on shard 1. Backtrace: 0x12f34',
+                'Reactor stalled on shard 1. Backtrace: 0x12f34 (BuildId: 2d4295e82afee91a64c6dffbb1935537e002df2d)',
                 {
                     'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                     'prefix': 'Reactor stalled on shard 1. Backtrace:',
@@ -154,7 +154,7 @@ class TestStringMethods(unittest.TestCase):
                 },
             ),
             (
-                'Reactor stalled on shard 1. Backtrace: 0xa1234 0xb5678',
+                'Reactor stalled on shard 1. Backtrace: 0xa1234 0xb5678 (BuildId: 2d4295e82afee91a64c6dffbb1935537e002df2d)',
                 {
                     'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                     'prefix': 'Reactor stalled on shard 1. Backtrace:',
@@ -165,7 +165,7 @@ class TestStringMethods(unittest.TestCase):
                 },
             ),
             (
-                'Reactor stalled on shard 1. Backtrace: /my/path+0xabcd',
+                'Reactor stalled on shard 1. Backtrace: /my/path+0xabcd (BuildId: 2d4295e82afee91a64c6dffbb1935537e002df2d)',
                 {
                     'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                     'prefix': 'Reactor stalled on shard 1. Backtrace:',
@@ -191,7 +191,7 @@ class TestStringMethods(unittest.TestCase):
     def test_boost_failure(self):
         data: TestList = [
             (
-                'Expected partition_end(), but got end of stream, at 0xa1234 0xb5678 /my/path+0xabcd',
+                'Expected partition_end(), but got end of stream, at 0xa1234 0xb5678 /my/path+0xabcd (BuildId: 2d4295e82afee91a64c6dffbb1935537e002df2d)',
                 {
                     'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                     'prefix': 'Expected partition_end(), but got end of stream, at',

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -165,6 +165,7 @@
 #include <seastar/util/spinlock.hh>
 #include <seastar/util/internal/iovec_utils.hh>
 #include <seastar/util/internal/magic.hh>
+#include <seastar/util/internal/build_id.hh>
 #include "core/crypto.hh"
 #include "core/reactor_backend.hh"
 #include "core/syscall_result.hh"
@@ -882,6 +883,9 @@ public:
             append("0x");
             append_hex(f.addr);
         }, _immediate);
+        append(" (BuildId: ");
+        append(internal::get_build_id());
+        append(")");
     }
 };
 

--- a/src/testing/test_runner.cc
+++ b/src/testing/test_runner.cc
@@ -27,6 +27,7 @@
 #include <seastar/testing/random.hh>
 #include <seastar/testing/test_runner.hh>
 #include <seastar/util/assert.hh>
+#include <seastar/util/internal/build_id.hh>
 
 namespace seastar {
 
@@ -86,6 +87,7 @@ bool test_runner::start_thread(int ac, char** av) {
                 });
             };
 
+            std::cout << fmt::format("build_id={}", internal::get_build_id()) << std::endl;
             return init().then([this] {
               return do_until([this] { return _done; }, [this] {
                 // this will block the reactor briefly, but we don't care

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -35,6 +35,7 @@
 #include <fmt/ranges.h>
 
 #include <seastar/util/backtrace.hh>
+#include <seastar/util/internal/build_id.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
@@ -191,7 +192,7 @@ auto formatter<seastar::frame>::format(const seastar::frame& f, format_context& 
 
 auto formatter<seastar::simple_backtrace>::format(const seastar::simple_backtrace& b, format_context& ctx) const
     -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{}", fmt::join(b._frames, " "));
+    return fmt::format_to(ctx.out(), "{} (BuildId: {})", fmt::join(b._frames, " "), seastar::internal::get_build_id());
 }
 
 auto formatter<seastar::tasktrace>::format(const seastar::tasktrace& b, format_context& ctx) const

--- a/src/util/build_id.cc
+++ b/src/util/build_id.cc
@@ -1,0 +1,138 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2019-present ScyllaDB
+ */
+
+#include <cstring>
+#include <ostream>
+
+#include <seastar/util/internal/build_id.hh>
+
+#if __has_include(<elf.h>)
+#include <elf.h>
+#include <link.h>
+#define HAS_ELF
+
+#include <stddef.h>
+#include <fmt/format.h>
+
+#include <seastar/core/align.hh>
+#endif
+
+namespace seastar::internal {
+
+#ifdef HAS_ELF
+
+constexpr size_t max_size = 32; // // SHA-256 (32 bytes) is the largest hash algorithm supported by ld --build-id.
+
+static const Elf64_Nhdr* get_nt_build_id(dl_phdr_info* info) {
+    auto base = info->dlpi_addr;
+    const auto* h = info->dlpi_phdr;
+    auto num_headers = info->dlpi_phnum;
+    for (int i = 0; i != num_headers; ++i, ++h) {
+        if (h->p_type != PT_NOTE) {
+            continue;
+        }
+
+        auto* p = reinterpret_cast<const char*>(base + h->p_vaddr);
+        auto* e = p + h->p_memsz;
+        while (p + sizeof(Elf64_Nhdr) <= e) {
+            const auto* n = reinterpret_cast<const Elf64_Nhdr*>(p);
+            if (n->n_type == NT_GNU_BUILD_ID) {
+                return n;
+            }
+
+            p += sizeof(Elf64_Nhdr);
+
+            p += n->n_namesz;
+            p = align_up(p, 4);
+
+            p += n->n_descsz;
+            p = align_up(p, 4);
+        }
+    }
+
+    return nullptr;
+}
+
+static int callback(dl_phdr_info* info, size_t size, void* data) {
+    // size is the size of the dl_phdr_info struct passed by dl_iterate_phdr.
+    if (size < offsetof(dl_phdr_info, dlpi_phnum) + sizeof(info->dlpi_phnum)) {
+        fmt::print(stderr, "warning: build_id: dl_iterate_phdr callback size {} is too small\n", size);
+        return -1;
+    }
+
+    char* buf = static_cast<char*>(data);
+
+    auto* n = get_nt_build_id(info);
+    if (!n) {
+        fmt::print(stderr, "warning: build_id: no NT_GNU_BUILD_ID note\n");
+        return -1;
+    }
+
+    if (n->n_descsz > max_size) {
+        fmt::print(stderr, "warning: build_id: n_descsz {} exceeds max {}\n",
+                   n->n_descsz, max_size);
+        return -1;
+    }
+
+    auto* p = reinterpret_cast<const unsigned char*>(n);
+
+    p += sizeof(Elf64_Nhdr);
+
+    p += n->n_namesz;
+    p = align_up(p, 4);
+
+    for (size_t i = 0; i < n->n_descsz; ++i) {
+        fmt::format_to(buf + 2 * i, "{:02x}", p[i]);
+    }
+    buf[2 * n->n_descsz] = '\0';
+    return n->n_descsz;
+}
+
+struct build_id {
+    char buf[2 * max_size + 1];
+
+    build_id() {
+        if (dl_iterate_phdr(callback, &buf) < 0) {
+            std::strcpy(buf, "unknown");
+        }
+    }
+
+    const char* get() const {
+        return buf;
+    }
+};
+
+#else // HAS_ELF
+
+struct build_id {
+    const char* get() const {
+        return "unknown";
+    }
+};
+
+#endif // HAS_ELF
+
+const char* get_build_id() {
+    static internal::build_id cache;
+    return cache.get();
+}
+
+} // namespace seastar::internal

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -32,6 +32,18 @@
 
 using namespace seastar;
 
+#ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
+static void check_regex_match(const std::string& msg, const std::string& regex_str) {
+    std::regex re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
+    if (!std::regex_search(msg, re)) {
+        BOOST_TEST_MESSAGE("Regex mismatch");
+        BOOST_TEST_MESSAGE("  msg:   " + msg);
+        BOOST_TEST_MESSAGE("  regex: " + regex_str);
+    }
+    BOOST_REQUIRE(std::regex_search(msg, re));
+}
+#endif
+
 // a class which is not derived from std::exception
 // to play the part of the unknown object in the logging
 // function.
@@ -210,9 +222,8 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)";
-    std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
-    BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+    auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+    check_regex_match(log_msg.str(), regex_str);
 #endif
 }
 
@@ -229,9 +240,8 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "std::_Nested_exception<unknown_obj>.*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)";
-    std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
-    BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+    auto regex_str = "std::_Nested_exception<unknown_obj>.*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+    check_regex_match(log_msg.str(), regex_str);
 #endif
 }
 
@@ -254,10 +264,9 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)"
+    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
             " \\(while cleaning up after unknown_obj\\)";
-    std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
-    BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+    check_regex_match(log_msg.str(), regex_str);
 #endif
 }
 
@@ -278,11 +287,11 @@ BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_loggin
             }
         }
     }
+    BOOST_TEST_MESSAGE(log_msg.str());
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)"
-            " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+\\)\\)";
-    std::regex expected_msg_re(regex_str, std::regex_constants::ECMAScript | std::regex_constants::icase);
-    BOOST_REQUIRE(std::regex_search(log_msg.str(), expected_msg_re));
+    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
+            " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)\\)";
+    check_regex_match(log_msg.str(), regex_str);
 #endif
 }


### PR DESCRIPTION
To decode a backtrace using the binary that produced it one typically
uses the binary's unique build_id to locate the binary.

However, this build_id may not be readily available along with the
backtrace, e.g. when it is printed to the system log when the binary
starts and the log is rotated.

To make backtraces self-descriptive, print the build_id along with the
backtrace similar to the AddressSanitzer format as a
`(BuildId: <sha>)` suffix.

The build_id is cached in a statically allocated buffer, avoiding
dynamic allocation. It is statically initialized at program start
via init_build_id(), ensuring it is available in all contexts without
requiring an explicit initialization call from the reactor.

Use `#if __has_include(<elf.h>)` to detect ELF support at compile
time. On platforms without ELF headers, get_build_id() returns an
empty string and the `(BuildId: ...)` suffix is omitted from
backtraces, maintaining backward compatibility.

Relax the dl_phdr_info size check in the dl_iterate_phdr callback:
older library implementations may pass a smaller struct since some
members were added later. Verify the size covers at least up to
dlpi_phnum rather than requiring the full struct size.

Remove the assertion that dlpi_name is empty since the callback may
be invoked for shared libraries, not just the main program.

Fixes #3352

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

