### PR TITLE
smp: make smp::count non-static

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -202,7 +202,7 @@ class shard_config {
     std::unordered_set<unsigned> _shards;
 public:
     shard_config()
-        : _shards(boost::copy_range<std::unordered_set<unsigned>>(boost::irange(0u, smp::count))) {}
+        : _shards(boost::copy_range<std::unordered_set<unsigned>>(boost::irange(0u, this_smp_shard_count()))) {}
     shard_config(std::unordered_set<unsigned> s) : _shards(std::move(s)) {}
 
     bool is_set(unsigned cpu) const {
@@ -647,7 +647,7 @@ private:
         return open_file_dma(name, flags).then([this] (auto f) {
             _file = std::move(f);
             return _file.size().then([this] (uint64_t size) {
-                auto shard_area_size = align_down<uint64_t>(size / smp::count, 1 << 20);
+                auto shard_area_size = align_down<uint64_t>(size / this_smp_shard_count(), 1 << 20);
                 if (_config.offset_in_bdev + _config.file_size > shard_area_size) {
                     throw std::runtime_error("Data doesn't fit the blockdevice");
                 }
@@ -897,7 +897,7 @@ private:
     uint64_t max_concurrency() const {
         // When we have many files it is easy to exceed the limit of open file descriptors.
         // To avoid that the limit is divided between shards (leaving some room for other jobs).
-        return static_cast<uint64_t>((1024u / smp::count) * 0.8);
+        return static_cast<uint64_t>((1024u / this_smp_shard_count()) * 0.8);
     }
 
     bool all_files_removed() const {
@@ -1159,7 +1159,7 @@ struct convert<job_config> {
         // constant) disk space between workloads. Each shard inside the
         // workload thus uses its portion of the assigned space.
         if (node["data_size"]) {
-            const uint64_t per_shard_bytes = node["data_size"].as<byte_size>().size / smp::count;
+            const uint64_t per_shard_bytes = node["data_size"].as<byte_size>().size / this_smp_shard_count();
             cl.file_size = align_up<uint64_t>(per_shard_bytes, extent_size_hint_alignment);
         } else if (cl.type == request_type::append) {
             cl.file_size = 0;
@@ -1261,7 +1261,7 @@ static void show_results(sharded<context>& ctx) {
     YAML::Emitter out;
     out << YAML::BeginDoc;
     out << YAML::BeginSeq;
-    for (unsigned i = 0; i < smp::count; ++i) {
+    for (unsigned i = 0; i < this_smp_shard_count(); ++i) {
         out << YAML::BeginMap;
         out << YAML::Key << "shard" << YAML::Value << i;
         ctx.invoke_on(i, [&out] (auto& c) {

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -574,8 +574,8 @@ class iotune_multi_shard_context {
     uint64_t _random_read_io_buffer_size;
 
     unsigned per_shard_io_depth() const {
-        auto iodepth = _test_directory.max_iodepth() / smp::count;
-        if (this_shard_id() < _test_directory.max_iodepth() % smp::count) {
+        auto iodepth = _test_directory.max_iodepth() / this_smp_shard_count();
+        if (this_shard_id() < _test_directory.max_iodepth() % this_smp_shard_count()) {
             iodepth++;
         }
         return std::min(iodepth, 128u);
@@ -591,7 +591,7 @@ public:
     }
 
     future<> start() {
-       const auto maximum_size = (_test_directory.available_space() / (2 * smp::count));
+       const auto maximum_size = (_test_directory.available_space() / (2 * this_smp_shard_count()));
        return _iotune_test_file.start(_test_directory, maximum_size, _random_write_io_buffer_size, _random_read_io_buffer_size).then([this] {
            return sharded_rates.start();
        });
@@ -971,10 +971,10 @@ int main(int ac, char** av) {
                 iotune_logger.info("Disk parameters: max_iodepth={} disks_per_array={} minimum_io_size={}",
                         test_directory.max_iodepth(), test_directory.disks_per_array(), test_directory.minimum_io_size());
 
-                if (test_directory.max_iodepth() < smp::count) {
-                    iotune_logger.warn("smp::count={} is greater than max_iodepth={} - shards above max_io_depth "
+                if (test_directory.max_iodepth() < this_smp_shard_count()) {
+                    iotune_logger.warn("shard_count={} is greater than max_iodepth={} - shards above max_io_depth "
                                        "will be ignored during random read and random write measurements",
-                                       smp::count, test_directory.max_iodepth());
+                                       this_smp_shard_count(), test_directory.max_iodepth());
                 }
 
                 if (random_write_io_buffer_size != 0u) {
@@ -1010,10 +1010,10 @@ int main(int ac, char** av) {
                 fmt::print("Measuring sequential write bandwidth: ");
                 std::cout.flush();
                 io_rates write_bw;
-                for (unsigned shard = 0; shard < smp::count; ++shard) {
-                    write_bw += iotune_tests.write_sequential_data(shard, sequential_write_buffer_size, duration * 0.70 / smp::count).get();
+                for (unsigned shard = 0; shard < this_smp_shard_count(); ++shard) {
+                    write_bw += iotune_tests.write_sequential_data(shard, sequential_write_buffer_size, duration * 0.70 / this_smp_shard_count()).get();
                 }
-                write_bw.bytes_per_sec /= smp::count;
+                write_bw.bytes_per_sec /= this_smp_shard_count();
                 rates = iotune_tests.get_serial_rates().get();
                 fmt::print("{} MiB/s{}\n", uint64_t(write_bw.bytes_per_sec / (1024 * 1024)), accuracy_msg());
 

--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -741,7 +741,7 @@ private:
 
     inline
     unsigned get_cpu(const item_key& key) {
-        return std::hash<item_key>()(key) % smp::count;
+        return std::hash<item_key>()(key) % this_smp_shard_count();
     }
 public:
     sharded_cache(sharded<cache>& peers) : _peers(peers) {}
@@ -1019,7 +1019,7 @@ private:
                         }).then([&out] {
                             return print_stat(out, "auth_errors", 0);
                         }).then([&out] {
-                            return print_stat(out, "threads", smp::count);
+                            return print_stat(out, "threads", this_smp_shard_count());
                         }).then([&out, v = all_cache_stats._size] {
                             return print_stat(out, "curr_items", v);
                         }).then([&out, v = total_items] {

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -955,7 +955,7 @@ int main(int ac, char** av) {
             YAML::Emitter out;
             out << YAML::BeginDoc;
             out << YAML::BeginSeq;
-            for (unsigned i = 0; i < smp::count; i++) {
+            for (unsigned i = 0; i < this_smp_shard_count(); i++) {
                 out << YAML::BeginMap;
                 out << YAML::Key << "shard" << YAML::Value << i;
                 ctx.invoke_on(i, [&out] (auto& c) {

--- a/apps/seawreck/seawreck.cc
+++ b/apps/seawreck/seawreck.cc
@@ -52,7 +52,7 @@ private:
 public:
     http_client(unsigned duration, unsigned total_conn, unsigned reqs_per_conn)
         : _duration(duration)
-        , _conn_per_core(total_conn / smp::count)
+        , _conn_per_core(total_conn / this_smp_shard_count())
         , _reqs_per_conn(reqs_per_conn)
         , _run_timer([this] { _timer_done = true; })
         , _timer_based(reqs_per_conn == 0) {
@@ -189,7 +189,7 @@ int main(int ac, char** av) {
         auto total_conn= config["conn"].as<unsigned>();
         auto duration = config["duration"].as<unsigned>();
 
-        if (total_conn % smp::count != 0) {
+        if (total_conn % this_smp_shard_count() != 0) {
             fmt::print("Error: conn needs to be n * cpu_nr\n");
             return make_ready_future<int>(-1);
         }
@@ -213,7 +213,7 @@ int main(int ac, char** av) {
            auto finished = steady_clock_type::now();
            auto elapsed = finished - started;
            auto secs = static_cast<double>(elapsed.count() / 1000000000.0);
-           fmt::print("Total cpus: {:d}\n", smp::count);
+           fmt::print("Total cpus: {:d}\n", this_smp_shard_count());
            fmt::print("Total requests: {:d}\n", total_reqs);
            fmt::print("Total time: {:f}\n", secs);
            fmt::print("Requests/sec: {:f}\n", static_cast<double>(total_reqs) / secs);

--- a/demos/tcp_sctp_client_demo.cc
+++ b/demos/tcp_sctp_client_demo.cc
@@ -205,7 +205,7 @@ public:
 
     future<> start(ipv4_addr server_addr, std::string test, unsigned ncon) {
         _server_addr = server_addr;
-        _concurrent_connections = ncon * smp::count;
+        _concurrent_connections = ncon * this_smp_shard_count();
         _total_pings = _pings_per_connection * _concurrent_connections;
         _test = test;
 

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -451,7 +451,7 @@ public:
                 return std::invoke(map, *inst);
             });
         };
-        return ::seastar::map_reduce(smp::all_cpus().begin(), smp::all_cpus().end(),
+        return ::seastar::map_reduce(this_smp_all_shards().begin(), this_smp_all_shards().end(),
                             std::move(wrapped_map),
                             std::move(initial),
                             std::move(reduce));
@@ -467,7 +467,7 @@ public:
                 return std::invoke(map, *inst);
             });
         };
-        return ::seastar::map_reduce(smp::all_cpus().begin(), smp::all_cpus().end(),
+        return ::seastar::map_reduce(this_smp_all_shards().begin(), this_smp_all_shards().end(),
                             std::move(wrapped_map),
                             std::move(initial),
                             std::move(reduce));
@@ -615,7 +615,7 @@ template <typename... Args>
 future<>
 sharded<Service>::start(Args&&... args) noexcept {
   try {
-    _instances.resize(smp::count);
+    _instances.resize(this_smp_shard_count());
     return sharded_parallel_for_each(
         [this, args = std::make_tuple(std::forward<Args>(args)...)] (unsigned c) mutable {
             return smp::submit_to(c, [this, args] () mutable {
@@ -849,8 +849,8 @@ sharded<Service>::invoke_on(R range, smp_submit_to_options options, Func func, A
             return futurize_apply(func, std::tuple_cat(std::forward_as_tuple(service), std::tuple(internal::unwrap_sharded_arg(std::forward<Args>(args))...)));
         });
         return parallel_for_each(range, [this, options, func = std::move(func_futurized)] (unsigned s) {
-            if (s > smp::count - 1) {
-                throw std::invalid_argument(format("Invalid shard id in range: {}. Must be in range [0,{})", s, smp::count));
+            if (s > this_smp_shard_count() - 1) {
+                throw std::invalid_argument(format("Invalid shard id in range: {}. Must be in range [0,{})", s, this_smp_shard_count()));
             }
             return smp::submit_to(s, options, [this, func] {
                 return func(*get_local_service());

--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -89,7 +89,7 @@ struct smp_service_group_config {
 /// smp::submit_to() and similar calls. While it's easy to limit
 /// the caller's concurrency (for example, by using a semaphore),
 /// the concurrency at the remote end can be multiplied by a factor
-/// of smp::count-1, which can be large.
+/// of smp::shard_count()-1, which can be large.
 ///
 /// The class is called a service _group_ because it can be used
 /// to group similar calls that share resource usage characteristics,
@@ -302,8 +302,18 @@ class smp_message_queue;
 struct reactor_options;
 struct smp_options;
 
+/// A set of cooperating reactor threads.
+///
+/// An smp instance manages a set of reactor threads, sharing memory and
+/// communicating via messages. The number of threads is determined
+/// at construction time and does not change over the lifetime of the smp
+/// instance.
+///
+/// Multiple smp instances may exist in the same process, typically for
+/// testing purposes.
 class smp : public std::enable_shared_from_this<smp> {
     alien::instance& _alien;
+    unsigned _shard_count = 0;
     std::vector<posix_thread> _threads;
     std::vector<std::function<void ()>> _thread_loops; // for dpdk
     std::optional<std::barrier<>> _all_event_loops_done;
@@ -314,6 +324,7 @@ class smp : public std::enable_shared_from_this<smp> {
     std::unique_ptr<smp_message_queue*[], qs_deleter> _qs_owner;
     static thread_local smp_message_queue**_qs;
     static thread_local std::thread::id _tmain;
+    static inline thread_local smp* _this_smp = nullptr;
     bool _using_dpdk = false;
     std::vector<unsigned> _shard_to_numa_node_mapping;
 
@@ -323,13 +334,17 @@ public:
     explicit smp(alien::instance& alien);
     ~smp();
     void configure(const smp_options& smp_opts, const reactor_options& reactor_opts);
+
+    /// The number of shards available in this `smp` instance. Does not change over the lifetime of the instance.
+    unsigned shard_count() const { return _shard_count; }
+
     void cleanup() noexcept;
     void cleanup_cpu();
     void arrive_at_event_loop_end();
     void join_all();
     static bool main_thread() { return std::this_thread::get_id() == _tmain; }
 
-    /// \returns A integer span of size smp::count, with nth integer being the ID of nth shard's NUMA node.
+    /// \returns A integer span of size smp::shard_count(), with nth integer being the ID of nth shard's NUMA node.
     std::span<const unsigned> shard_to_numa_node_mapping() const noexcept;
 
     /// Runs a function on a remote core.
@@ -390,8 +405,22 @@ public:
     }
     static bool poll_queues();
     static bool pure_poll_queues();
+
+    /// Returns a range of all shard IDs.
+    ///
+    /// Returns a range of all shard IDs (a range with a value_type
+    /// of some unspecified unsigned type) in this `smp` instance.
+    /// Order is unspecified. Does not change over the lifetime of the instance.
+    std::ranges::range auto all_shards() const noexcept {
+        return std::views::iota(0u, _shard_count);
+    }
+
+    [[deprecated("use smp::all_shards instead")]]
     static std::ranges::range auto all_cpus() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         return std::views::iota(0u, count);
+#pragma GCC diagnostic pop
     }
 private:
     template <typename Func>
@@ -423,7 +452,7 @@ public:
     static future<> invoke_on_all(smp_submit_to_options options, Func&& func) noexcept {
         static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
-        return parallel_for_each(all_cpus(), [options, &func] (unsigned id) {
+        return parallel_for_each(this_smp().all_shards(), [options, &func] (unsigned id) {
             return smp::copy_and_submit_to(id, options, func);
         });
     }
@@ -454,7 +483,7 @@ public:
     static future<> invoke_on_others(unsigned cpu_id, smp_submit_to_options options, Func func) noexcept {
         static_assert(std::is_same_v<future<>, typename futurize<std::invoke_result_t<Func>>::type>, "bad Func signature");
         static_assert(std::is_nothrow_move_constructible_v<Func>);
-        return parallel_for_each(all_cpus(), [cpu_id, options, func = std::move(func)] (unsigned id) {
+        return parallel_for_each(this_smp().all_shards(), [cpu_id, options, func = std::move(func)] (unsigned id) {
             return id != cpu_id ? smp::copy_and_submit_to(id, options, func) : make_ready_future<>();
         });
     }
@@ -484,16 +513,45 @@ public:
     static future<> invoke_on_others(Func func) noexcept {
         return invoke_on_others(this_shard_id(), std::move(func));
     }
+    static smp& this_smp() noexcept {
+        return *_this_smp;
+    }
 private:
     void start_all_queues();
     void pin(unsigned cpu_id);
     void allocate_reactor(unsigned id, reactor_backend_selector rbs, reactor_config cfg);
     void create_thread(std::function<void ()> thread_loop);
     unsigned adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs, unsigned reserve_iocbs);
-    static void log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network, unsigned reserve);
+    void log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network, unsigned reserve);
 public:
+    [[deprecated("use smp::shard_count() instead")]]
     static unsigned count;
 };
+
+
+/// Returns the smp object used for cross-shard communications.
+/// May only be called from a reactor thread.
+inline
+smp&
+this_smp() noexcept {
+    return smp::this_smp();
+}
+
+/// Returns the number of shards in the current smp instance.
+/// May only be called from a reactor thread.
+inline
+unsigned
+this_smp_shard_count() noexcept {
+    return this_smp().shard_count();
+}
+
+/// Returns a range of all shard ids in the current smp instance.
+/// May only be called from a reactor thread.
+inline
+std::ranges::range auto
+this_smp_all_shards() noexcept {
+    return this_smp().all_shards();
+}
 
 
 }

--- a/include/seastar/net/net.hh
+++ b/include/seastar/net/net.hh
@@ -268,7 +268,7 @@ protected:
     size_t _rss_table_bits = 0;
 public:
     device() {
-        _queues = std::make_unique<qp*[]>(smp::count);
+        _queues = std::make_unique<qp*[]>(this_smp_shard_count());
     }
     virtual ~device() {};
     qp& queue_for_cpu(unsigned cpu) { return *_queues[cpu]; }

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -61,7 +61,7 @@ class conntrack {
     class load_balancer {
         std::vector<unsigned> _cpu_load;
     public:
-        load_balancer() : _cpu_load(size_t(smp::count), 0) {}
+        load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}
         void closed_cpu(shard_id cpu) {
             _cpu_load[cpu]--;
         }

--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -833,7 +833,7 @@ auto tcp<InetTraits>::connect(socket_address sa) -> connection {
     auto dst_ip = ipv4_address(sa);
     auto dst_port = net::ntoh(sa.u.in.sin_port);
 
-    if (smp::count > 1) {
+    if (this_smp_shard_count() > 1) {
         do {
             id = connid{src_ip, dst_ip, _port_dist(_e), dst_port};
         } while (_inet._inet.netif()->hash2cpu(id.hash(_inet._inet.netif()->rss_key())) != this_shard_id()

--- a/src/core/disk_params.cc
+++ b/src/core/disk_params.cc
@@ -79,7 +79,11 @@ extern logger seastar_logger;
 namespace internal {
 
 void disk_config_params::parse_config(const smp_options& smp_opts, const reactor_options& reactor_opts) {
-    seastar_logger.debug("smp::count: {}", smp::count);
+    // FIXME: parse_config() is called from smp::configure() before _this_smp
+    // is set, so the shard count is not available via this_smp(). The old code
+    // read smp::count which was already set at this point, but that global is
+    // being removed. For now this debug log just prints 0.
+    seastar_logger.debug("shard_count: {}", 0);
     _latency_goal = std::chrono::duration_cast<std::chrono::duration<double>>(latency_goal_opt(reactor_opts) * 1ms);
     seastar_logger.debug("latency_goal: {}", latency_goal().count());
     _flow_ratio_backpressure_threshold = reactor_opts.io_flow_ratio_threshold.get_value();

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -563,8 +563,8 @@ public:
 
 static future<metrics_families_per_shard> get_map_value() {
     metrics_families_per_shard vec;
-    vec.resize(smp::count);
-    co_await parallel_for_each(std::views::iota(0u, smp::count), [&vec] (auto cpu) {
+    vec.resize(this_smp_shard_count());
+    co_await parallel_for_each(std::views::iota(0u, this_smp_shard_count()), [&vec] (auto cpu) {
         return smp::submit_to(cpu, [] {
             return mi::get_values();
         }).then([&vec, cpu] (auto res) {
@@ -757,7 +757,7 @@ class metric_family_range {
     metric_family_iterator _begin;
     metric_family_iterator _end;
 public:
-    metric_family_range(const metrics_families_per_shard& families) : _begin(families, smp::count),
+    metric_family_range(const metrics_families_per_shard& families) : _begin(families, this_smp_shard_count()),
         _end(metric_family_iterator(families, 0))
     {
     }
@@ -777,7 +777,7 @@ public:
 
 metric_family_iterator metrics_families_per_shard::find_bound(const sstring& family_name, comp_function comp) const {
     std::vector<size_t> positions;
-    positions.reserve(smp::count);
+    positions.reserve(this_smp_shard_count());
 
     for (auto& shard_info : _data) {
         std::vector<mi::metric_family_metadata>& metadata = *(shard_info->metadata);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4065,11 +4065,12 @@ thread_local std::unique_ptr<reactor, reactor_deleter> reactor_holder;
 
 thread_local smp_message_queue** smp::_qs;
 thread_local std::thread::id smp::_tmain;
+
 unsigned smp::count = 0;
 
 void smp::start_all_queues()
 {
-    for (unsigned c = 0; c < count; c++) {
+    for (unsigned c = 0; c < _shard_count; c++) {
         if (c != this_shard_id()) {
             _qs[c][this_shard_id()].start(c);
         }
@@ -4139,7 +4140,7 @@ void smp::cleanup_cpu() {
     size_t cpuid = this_shard_id();
 
     if (_qs) {
-        for(unsigned i = 0; i < smp::count; i++) {
+        for(unsigned i = 0; i < _shard_count; i++) {
             _qs[i][cpuid].stop();
         }
     }
@@ -4258,8 +4259,8 @@ void install_oneshot_signal_handler<SIGSEGV, sigsegv_action>() {
 #endif
 
 void smp::qs_deleter::operator()(smp_message_queue** qs) const {
-    for (unsigned i = 0; i < smp::count; i++) {
-        for (unsigned j = 0; j < smp::count; j++) {
+    for (unsigned i = 0; i < this_smp_shard_count(); i++) {
+        for (unsigned j = 0; j < this_smp_shard_count(); j++) {
             qs[i][j].~smp_message_queue();
         }
         ::operator delete[](qs[i], std::align_val_t(alignof(smp_message_queue))
@@ -4268,15 +4269,17 @@ void smp::qs_deleter::operator()(smp_message_queue** qs) const {
     delete[](qs);
 }
 
+
+
 void smp::log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsigned network, unsigned reserve) {
     // Each cell in the table should be
     // - as wide as the grand total,
     // - as wide as its containing column's header,
     // whichever is wider.
     std::string percpu_hdr = format("per cpu");
-    std::string allcpus_hdr = format("all {} cpus", smp::count);
+    std::string allcpus_hdr = format("all {} cpus", _shard_count);
     unsigned percpu_total = storage + preempt + network;
-    unsigned allcpus_total = reserve + percpu_total * smp::count;
+    unsigned allcpus_total = reserve + percpu_total * _shard_count;
     size_t num_width = format("{}", allcpus_total).length();
     size_t percpu_width = std::max(num_width, percpu_hdr.length());
     size_t allcpus_width = std::max(num_width, allcpus_hdr.length());
@@ -4284,9 +4287,9 @@ void smp::log_aiocbs(log_level level, unsigned storage, unsigned preempt, unsign
     seastar_logger.log(level, "purpose  {:{}}  {:{}}",     percpu_hdr,   percpu_width, allcpus_hdr,          allcpus_width);
     seastar_logger.log(level, "-------  {:-<{}}  {:-<{}}", "",           percpu_width, "",                   allcpus_width);
     seastar_logger.log(level, "reserve  {:{}}  {:{}}",     "",           percpu_width, reserve,              allcpus_width);
-    seastar_logger.log(level, "storage  {:{}}  {:{}}",     storage,      percpu_width, storage * smp::count, allcpus_width);
-    seastar_logger.log(level, "preempt  {:{}}  {:{}}",     preempt,      percpu_width, preempt * smp::count, allcpus_width);
-    seastar_logger.log(level, "network  {:{}}  {:{}}",     network,      percpu_width, network * smp::count, allcpus_width);
+    seastar_logger.log(level, "storage  {:{}}  {:{}}",     storage,      percpu_width, storage * _shard_count, allcpus_width);
+    seastar_logger.log(level, "preempt  {:{}}  {:{}}",     preempt,      percpu_width, preempt * _shard_count, allcpus_width);
+    seastar_logger.log(level, "network  {:{}}  {:{}}",     network,      percpu_width, network * _shard_count, allcpus_width);
     seastar_logger.log(level, "-------  {:-<{}}  {:-<{}}", "",           percpu_width, "",                   allcpus_width);
     seastar_logger.log(level, "total    {:{}}  {:{}}",     percpu_total, percpu_width, allcpus_total,        allcpus_width);
 }
@@ -4299,8 +4302,8 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
     auto aio_max_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-max-nr");
     auto aio_nr = read_first_line_as<unsigned>("/proc/sys/fs/aio-nr");
     auto available_aio = aio_max_nr - aio_nr;
-    auto requested_aio_network = network_iocbs * smp::count;
-    auto requested_aio_other = reserve_iocbs + (storage_iocbs + preempt_iocbs) * smp::count;
+    auto requested_aio_network = network_iocbs * _shard_count;
+    auto requested_aio_other = reserve_iocbs + (storage_iocbs + preempt_iocbs) * _shard_count;
     auto requested_aio = requested_aio_network + requested_aio_other;
 
     seastar_logger.debug("Intended AIO control block usage:");
@@ -4310,8 +4313,8 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
     seastar_logger.debug("Available AIO control blocks = aio-max-nr - aio-nr = {} - {} = {}", aio_max_nr, aio_nr, available_aio);
 
     if (available_aio < requested_aio) {
-        if (available_aio >= requested_aio_other + smp::count) { // at least one queue for each shard
-            network_iocbs = (available_aio - requested_aio_other) / smp::count;
+        if (available_aio >= requested_aio_other + _shard_count) { // at least one queue for each shard
+            network_iocbs = (available_aio - requested_aio_other) / _shard_count;
             seastar_logger.warn("Your system does not have enough AIO capacity for optimal network performance; reducing `max-networking-io-control-blocks'.");
             seastar_logger.warn("Resultant AIO control block usage:");
             seastar_logger.warn("");
@@ -4322,7 +4325,7 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
             throw std::runtime_error(
                 format("Your system does not satisfy minimum AIO requirements. "
                        "Set /proc/sys/fs/aio-max-nr to at least {} (minimum) or {} (recommended for networking performance).",
-                       aio_nr + (requested_aio_other + smp::count), aio_nr + requested_aio));
+                       aio_nr + (requested_aio_other + _shard_count), aio_nr + requested_aio));
         }
     }
 
@@ -4409,11 +4412,17 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 
     if (smp_opts.smp) {
-        smp::count = smp_opts.smp.get_value();
+        _shard_count = smp_opts.smp.get_value();
     } else {
-        smp::count = cpu_set.size();
+        _shard_count = cpu_set.size();
     }
-    std::vector<reactor*> reactors(smp::count);
+
+    // For compatiblity, set smp::count, but don't warn about it.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    smp::count = _shard_count;
+#pragma GCC diagnostic pop
+    std::vector<reactor*> reactors(_shard_count);
     if (smp_opts.memory) {
 #ifdef SEASTAR_DEFAULT_ALLOCATOR
         seastar_logger.warn("Seastar compiled with default allocator, --memory option won't take effect");
@@ -4423,7 +4432,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         if (smp_opts.hugepages &&
             !reactor_opts.network_stack.get_selected_candidate_name().compare("native") &&
             _using_dpdk) {
-            size_t dpdk_memory = dpdk::eal::mem_size(smp::count);
+            size_t dpdk_memory = dpdk::eal::mem_size(_shard_count);
 
             if (dpdk_memory >= rc.total_memory) {
                 seastar_logger.error("Can't run with the given amount of memory: {}. "
@@ -4470,7 +4479,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         }
     }
 
-    rc.cpus = smp::count;
+    rc.cpus = _shard_count;
     rc.cpu_set = std::move(cpu_set);
 
     internal::disk_config_params disk_config(reactor::max_queues);
@@ -4487,7 +4496,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 #endif
 
     auto resources = resource::allocate(rc);
-    logger::set_shard_field_width(std::ceil(std::log10(smp::count)));
+    logger::set_shard_field_width(std::ceil(std::log10(_shard_count)));
     std::vector<resource::cpu> allocations = std::move(resources.cpus);
     if (thread_affinity) {
         smp::pin(allocations[0].cpu_id);
@@ -4502,8 +4511,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         memory::configure_minimal();
     }
 
-    _shard_to_numa_node_mapping.reserve(smp::count);
-    for (unsigned i = 0; i < smp::count; i++) {
+    _shard_to_numa_node_mapping.reserve(_shard_count);
+    for (unsigned i = 0; i < _shard_count; i++) {
         _shard_to_numa_node_mapping.push_back(allocations[i].mem.size() > 0 ? allocations[i].mem[0].nodeid : 0);
     }
 
@@ -4585,11 +4594,11 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 #endif
 
     // Better to put it into the smp class, but at smp construction time
-    // correct smp::count is not known.
-    std::barrier reactors_registered(smp::count);
-    std::barrier smp_queues_constructed(smp::count);
+    // correct _shard_count is not known.
+    std::barrier reactors_registered(_shard_count);
+    std::barrier smp_queues_constructed(_shard_count);
     // We use shared_ptr since this thread can exit while other threads are still unlocking
-    auto inited = std::make_shared<std::barrier<>>(smp::count);
+    auto inited = std::make_shared<std::barrier<>>(_shard_count);
 
     auto ioq_topology = std::move(resources.ioq_topology);
 
@@ -4642,12 +4651,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         }
     };
 
-    _all_event_loops_done.emplace(smp::count);
+    _all_event_loops_done.emplace(_shard_count);
 
     auto backend_selector = reactor_opts.reactor_backend.get_selected_candidate();
     seastar_logger.info("Reactor backend: {}", backend_selector);
 
-    _qs_owner = decltype(smp::_qs_owner){new smp_message_queue* [smp::count], qs_deleter{}};
+    _qs_owner = decltype(smp::_qs_owner){new smp_message_queue* [_shard_count], qs_deleter{}};
 
     auto allocate_qs_owner = [this] (unsigned i) {
         // smp_message_queue has members with hefty alignment requirements.
@@ -4655,25 +4664,27 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         // new default aligned seemingly works, as does reordering
         // dlinit dependencies (ugh). But we should enforce calling out to
         // aligned_alloc, instead of pure malloc, if possible.
-        smp::_qs_owner[i] = reinterpret_cast<smp_message_queue*>(operator new[] (sizeof(smp_message_queue) * smp::count
+        smp::_qs_owner[i] = reinterpret_cast<smp_message_queue*>(operator new[] (sizeof(smp_message_queue) * _shard_count
             , std::align_val_t(alignof(smp_message_queue))
         ));
     };
 
     auto allocate_smp_queues = [this, &reactors] (unsigned i) {
-        for (unsigned j = 0; j < smp::count; ++j) {
+        for (unsigned j = 0; j < _shard_count; ++j) {
             new (&smp::_qs_owner[i][j]) smp_message_queue(reactors[j], reactors[i]);
         }
     };
 
     unsigned i;
     auto smp_tmain = smp::_tmain;
-    for (i = 1; i < smp::count; i++) {
+    smp::_this_smp = this;
+    for (i = 1; i < _shard_count; i++) {
         auto allocation = allocations[i];
         create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages, allocate_qs_owner, allocate_smp_queues] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
+            smp::_this_smp = this;
             auto thread_name = fmt::format("reactor-{}", i);
             pthread_setname_np(pthread_self(), thread_name.c_str());
             if (thread_affinity) {
@@ -4759,7 +4770,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
 bool smp::poll_queues() {
     size_t got = 0;
-    for (unsigned i = 0; i < count; i++) {
+    for (unsigned i = 0; i < this_smp_shard_count(); i++) {
         if (this_shard_id() != i) {
             auto& rxq = _qs[this_shard_id()][i];
             rxq.flush_response_batch();
@@ -4774,7 +4785,7 @@ bool smp::poll_queues() {
 }
 
 bool smp::pure_poll_queues() {
-    for (unsigned i = 0; i < count; i++) {
+    for (unsigned i = 0; i < this_smp_shard_count(); i++) {
         if (this_shard_id() != i) {
             auto& rxq = _qs[this_shard_id()][i];
             rxq.flush_response_batch();

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1937,7 +1937,12 @@ bool reactor_backend_selector::has_enough_aio_nr() {
      * So this method calculates:
      *  Available AIO on the system - (request AIO per-cpu * ncpus)
      */
-    if (aio_max_nr - aio_nr < reactor::max_aio * smp::count) {
+    // FIXME: available() is called during app_template construction, before
+    // smp::configure() runs, so the shard count is not yet known. The old code
+    // read smp::count which was 0 at this point, making this check a no-op.
+    // Pass 0 to preserve that (broken) behavior until the initialization order
+    // is fixed.
+    if (aio_max_nr - aio_nr < reactor::max_aio * 0) {
         return false;
     }
     return true;

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -555,7 +555,7 @@ void configure(const options& opts) {
             : sstring(opts.collectd_hostname.get_value());
 
     // Now create send loops on each cpu
-    for (unsigned c = 0; c < smp::count; c++) {
+    for (unsigned c = 0; c < this_smp_shard_count(); c++) {
         // FIXME: future is discarded
         (void)smp::submit_to(c, [=] () {
             get_impl().start(host, addr, period);

--- a/src/core/smp.cc
+++ b/src/core/smp.cc
@@ -80,19 +80,19 @@ static_assert(std::is_nothrow_copy_constructible_v<smp_submit_to_options>);
 static_assert(std::is_nothrow_move_constructible_v<smp_submit_to_options>);
 
 future<smp_service_group> create_smp_service_group(smp_service_group_config ssgc) noexcept {
-    ssgc.max_nonlocal_requests = std::max(ssgc.max_nonlocal_requests, smp::count - 1);
+    ssgc.max_nonlocal_requests = std::max(ssgc.max_nonlocal_requests, this_smp_shard_count() - 1);
     return smp::submit_to(0, [ssgc] {
         return with_semaphore(smp_service_group_management_sem, 1, [ssgc] {
             auto it = boost::range::find_if(smp_service_groups, [&] (smp_service_group_impl& ssgi) { return ssgi.clients.empty(); });
             size_t id = it - smp_service_groups.begin();
-            return parallel_for_each(smp::all_cpus(), [ssgc, id] (unsigned cpu) {
+            return parallel_for_each(this_smp_all_shards(), [ssgc, id] (unsigned cpu) {
               return smp::submit_to(cpu, [ssgc, id, cpu] {
                 if (id >= smp_service_groups.size()) {
                     smp_service_groups.resize(id + 1); // may throw
                 }
-                smp_service_groups[id].clients.reserve(smp::count); // may throw
-                auto per_client = smp::count > 1 ? ssgc.max_nonlocal_requests / (smp::count - 1) : 0u;
-                for (unsigned i = 0; i != smp::count; ++i) {
+                smp_service_groups[id].clients.reserve(this_smp_shard_count()); // may throw
+                auto per_client = this_smp_shard_count() > 1 ? ssgc.max_nonlocal_requests / (this_smp_shard_count() - 1) : 0u;
+                for (unsigned i = 0; i != this_smp_shard_count(); ++i) {
                     smp_service_groups[id].clients.emplace_back(per_client, make_service_group_semaphore_exception_factory(id, i, cpu, ssgc.group_name));
                 }
               });
@@ -148,8 +148,8 @@ void init_default_smp_service_group(shard_id cpu) {
     smp_service_groups.clear();
     smp_service_groups.emplace_back();
     auto& ssg0 = smp_service_groups.back();
-    ssg0.clients.reserve(smp::count);
-    for (unsigned i = 0; i != smp::count; ++i) {
+    ssg0.clients.reserve(this_smp_shard_count());
+    for (unsigned i = 0; i != this_smp_shard_count(); ++i) {
         ssg0.clients.emplace_back(smp_service_group_semaphore::max_counter(), make_service_group_semaphore_exception_factory(0, i, cpu, {"default"}));
     }
 }

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -1509,7 +1509,7 @@ int dpdk_device::init_port_start()
     // Set RSS mode: enable RSS if seastar is configured with more than 1 CPU.
     // Even if port has a single queue we still want the RSS feature to be
     // available in order to make HW calculate RSS hash for us.
-    if (smp::count > 1) {
+    if (this_smp_shard_count() > 1) {
         if (_dev_info.hash_key_size == 40) {
             _rss_key = default_rsskey_40bytes;
         } else if (_dev_info.hash_key_size == 52) {
@@ -2284,7 +2284,7 @@ std::unique_ptr<net::device> create_dpdk_net_device(
 std::unique_ptr<net::device> create_dpdk_net_device(
                                     const hw_config& hw_cfg)
 {
-    return create_dpdk_net_device(*hw_cfg.port_index, smp::count, hw_cfg.lro, hw_cfg.hw_fc);
+    return create_dpdk_net_device(*hw_cfg.port_index, this_smp_shard_count(), hw_cfg.lro, hw_cfg.hw_fc);
 }
 
 }

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -185,7 +185,7 @@ ipv4::handle_received_packet(packet p, ethernet_address from) {
             auto cpu_id = this_shard_id();
             auto l4 = _l4[h.ip_proto];
             if (l4) {
-                if (smp::count == 1) {
+                if (this_smp_shard_count() == 1) {
                     l4->received(std::move(ip_data), h.src_ip, h.dst_ip);
                 } else {
                     size_t l4_offset = 0;

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -76,7 +76,7 @@ void create_native_net_device(const native_stack_options& opts) {
     if ( deprecated_config_used) {
 #ifdef SEASTAR_HAVE_DPDK
         if ( opts.dpdk_pmd) {
-             dev = create_dpdk_net_device(opts.dpdk_opts.dpdk_port_index.get_value(), smp::count,
+             dev = create_dpdk_net_device(opts.dpdk_opts.dpdk_port_index.get_value(), this_smp_shard_count(),
                 !(opts.lro && opts.lro.get_value() == "off"),
                 !(opts.dpdk_opts.hw_fc && opts.dpdk_opts.hw_fc.get_value() == "off"));
        } else
@@ -109,13 +109,13 @@ void create_native_net_device(const native_stack_options& opts) {
     // set_local_queue on all shard in the background,
     // signal when done.
     // FIXME: handle exceptions
-    for (unsigned i = 0; i < smp::count; i++) {
+    for (unsigned i = 0; i < this_smp_shard_count(); i++) {
         (void)smp::submit_to(i, [&opts, sdev] {
             uint16_t qid = this_shard_id();
             if (qid < sdev->hw_queues_count()) {
                 auto qp = sdev->init_local_queue(opts, qid);
                 std::map<unsigned, float> cpu_weights;
-                for (unsigned i = sdev->hw_queues_count() + qid % sdev->hw_queues_count(); i < smp::count; i+= sdev->hw_queues_count()) {
+                for (unsigned i = sdev->hw_queues_count() + qid % sdev->hw_queues_count(); i < this_smp_shard_count(); i+= sdev->hw_queues_count()) {
                     cpu_weights[i] = 1;
                 }
                 cpu_weights[qid] = opts.hw_queue_weight.get_value();
@@ -132,10 +132,10 @@ void create_native_net_device(const native_stack_options& opts) {
     // wait for all shards to set their local queue,
     // then when link is ready, communicate the native_stack to the caller
     // via `create_native_stack` (that sets the ready_promise value)
-    (void)sem->wait(smp::count).then([&opts, sdev] {
+    (void)sem->wait(this_smp_shard_count()).then([&opts, sdev] {
         // FIXME: future is discarded
         (void)sdev->link_ready().then([&opts, sdev] {
-            for (unsigned i = 0; i < smp::count; i++) {
+            for (unsigned i = 0; i < this_smp_shard_count(); i++) {
                 // FIXME: future is discarded
                 (void)smp::submit_to(i, [&opts, sdev] {
                     create_native_stack(opts, sdev);
@@ -280,7 +280,7 @@ void native_network_stack::on_dhcp(std::optional<dhcp::lease> lease, bool is_ren
     if (this_shard_id() == 0) {
         // And the other cpus, which, in the case of initial discovery,
         // will be waiting for us.
-        for (unsigned i = 1; i < smp::count; i++) {
+        for (unsigned i = 1; i < this_smp_shard_count(); i++) {
             (void)smp::submit_to(i, [lease, is_renew]() {
                 auto & ns = static_cast<native_network_stack&>(engine().net());
                 ns.on_dhcp(lease, is_renew);

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -473,7 +473,7 @@ class posix_socket_impl final : public socket_impl {
 
     future<> find_port_and_connect(socket_address sa, socket_address local, transport proto = transport::TCP) {
         static thread_local std::default_random_engine random_engine{std::random_device{}()};
-        static thread_local std::uniform_int_distribution<uint16_t> u(49152/smp::count + 1, 65535/smp::count - 1);
+        static thread_local std::uniform_int_distribution<uint16_t> u(49152/this_smp_shard_count() + 1, 65535/this_smp_shard_count() - 1);
         // If no explicit local address, set to dest address family wildcard.
         if (local.is_unspecified()) {
             local = net::inet_address(sa.addr().in_family());
@@ -482,7 +482,7 @@ class posix_socket_impl final : public socket_impl {
         return repeat([this, sa, local, proto, attempts = 0, requested_port = ntoh(local.as_posix_sockaddr_in().sin_port)] () mutable {
             _fd = file_desc::socket(sa.u.sa.sa_family, _sock_flags, int(proto));
             _fd.get_file_desc().setsockopt(SOL_SOCKET, SO_REUSEADDR, int(_reuseaddr));
-            uint16_t port = attempts++ < 5 && requested_port == 0 && proto == transport::TCP ? u(random_engine) * smp::count + this_shard_id() : requested_port;
+            uint16_t port = attempts++ < 5 && requested_port == 0 && proto == transport::TCP ? u(random_engine) * this_smp_shard_count() + this_shard_id() : requested_port;
             local.as_posix_sockaddr_in().sin_port = hton(port);
             return internal::posix_connect(_fd, sa, local).then_wrapped([port, requested_port] (future<> f) {
                 try {
@@ -719,7 +719,7 @@ posix_server_socket_impl::accept() {
             cth = _conntrack.get_handle();
             break;
         case server_socket::load_balancing_algorithm::port:
-            cth = _conntrack.get_handle(get_port_or_counter(sa) % smp::count);
+            cth = _conntrack.get_handle(get_port_or_counter(sa) % this_smp_shard_count());
             break;
         case server_socket::load_balancing_algorithm::fixed:
             cth = _conntrack.get_handle(_fixed_cpu);

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -246,6 +246,9 @@ using seastar::reactor;
 using seastar::engine;
 using seastar::local_engine;
 using seastar::smp;
+using seastar::this_smp;
+using seastar::this_smp_shard_count;
+using seastar::this_smp_all_shards;
 using seastar::shard_id;
 using seastar::this_shard_id;
 

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -700,7 +700,7 @@ struct stdout_printer : text_printer {
                 "single run iterations:", c.single_run_iterations,
                 "single run duration:", duration { double(c.single_run_duration.count()) },
                 "number of runs:", c.number_of_runs,
-                "number of cores:", smp::count,
+                "number of cores:", this_smp_shard_count(),
                 "random seed:", c.random_seed,
                 "start/stop overhead:", duration { measure_time->start_stop_overhead() },
                 duration { measure_time->start_stop_overhead_external() });

--- a/tests/perf/smp_submit_to_perf.cc
+++ b/tests/perf/smp_submit_to_perf.cc
@@ -110,7 +110,7 @@ class worker {
     future<> _done;
 
     static unsigned my_target(unsigned targets) noexcept {
-        unsigned group_size = (smp::count + (targets - 1)) / targets;
+        unsigned group_size = (this_smp_shard_count() + (targets - 1)) / targets;
         unsigned group_no = this_shard_id() / group_size;
         return group_size * group_no;
     }
@@ -231,7 +231,7 @@ int main(int ac, char** av) {
             auto real_duration = duration_cast<seconds>(steady_clock::now() - start);
             fmt::print("took {}s (expected {}s)\n", real_duration.count(), duration.count());
             stats st(real_duration.count()), st_targets(real_duration.count());
-            for (unsigned i = 0; i < smp::count; i++) {
+            for (unsigned i = 0; i < this_smp_shard_count(); i++) {
                 workers.invoke_on(i, [&st, &st_targets] (worker& w) {
                     if (w.is_target()) {
                         st_targets.append(w.total());

--- a/tests/perf/thread_context_switch_test.cc
+++ b/tests/perf/thread_context_switch_test.cc
@@ -84,7 +84,7 @@ int main(int ac, char** av) {
         }).then([&dcst] {
             return dcst.map_reduce0(std::mem_fn(&context_switch_tester::measure), uint64_t(), std::plus<uint64_t>());
         }).then([] (uint64_t switches) {
-            switches /= smp::count;
+            switches /= this_smp_shard_count();
             fmt::print("context switch time: {:5.1f} ns\n",
                   double(std::chrono::duration_cast<std::chrono::nanoseconds>(test_time).count()) / switches);
         }).then([&dcst] {

--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     app.run(argc, argv, [&] {
         return seastar::now().then([engine_ready_fd, &shard_count] {
             // engine ready!
-            shard_count = smp::count;
+            shard_count = this_smp_shard_count();
             ::eventfd_write(engine_ready_fd, ENGINE_READY);
             return seastar::now();
         }).then([alien_done = std::move(alien_done), &result]() mutable {

--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -49,9 +49,11 @@ int main(int argc, char** argv)
     auto alien_done = file_desc::eventfd(0, 0);
     seastar::app_template app;
 
+    unsigned shard_count = 0;
+
     // use the raw fd, because seastar engine want to take over the fds, if it
     // polls on them.
-    auto zim = std::async([&app, engine_ready_fd,
+    auto zim = std::async([&app, &shard_count, engine_ready_fd,
                            alien_done=alien_done.get()] {
         eventfd_t result = 0;
         // wait until the seastar engine is ready
@@ -70,7 +72,7 @@ int main(int argc, char** argv)
         });
         // test for alien::submit_to(), which returns a std::future<int>
         std::vector<std::future<int>> counts;
-        for (auto i : std::views::iota(0u, smp::count)) {
+        for (auto i : std::views::iota(0u, shard_count)) {
             // send messages from alien.
             counts.push_back(alien::submit_to(app.alien(), i, [i] {
                 return seastar::make_ready_future<int>(i);
@@ -91,8 +93,9 @@ int main(int argc, char** argv)
 
     eventfd_t result = 0;
     app.run(argc, argv, [&] {
-        return seastar::now().then([engine_ready_fd] {
+        return seastar::now().then([engine_ready_fd, &shard_count] {
             // engine ready!
+            shard_count = smp::count;
             ::eventfd_write(engine_ready_fd, ENGINE_READY);
             return seastar::now();
         }).then([alien_done = std::move(alien_done), &result]() mutable {
@@ -122,7 +125,7 @@ int main(int argc, char** argv)
         std::cerr << "Bad everything: " << everything << " != " << expected << std::endl;
         return 1;
     }
-    const auto shards = std::views::iota(0u, smp::count);
+    const auto shards = std::views::iota(0u, shard_count);
     auto expected = std::accumulate(std::begin(shards), std::end(shards), 0);
     if (total != expected) {
         std::cerr << "Bad total: " << total << " != " << expected << std::endl;

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -168,7 +168,7 @@ SEASTAR_THREAD_TEST_CASE(test_cross_thread_realloc) {
         BOOST_TEST_CONTEXT("cross_shard=" << cross_shard << ", initial="
                 << initial_size << ", realloc_size=" << realloc_size) {
 
-            auto other_shard = (this_shard_id() + cross_shard) % smp::count;
+            auto other_shard = (this_shard_id() + cross_shard) % this_smp_shard_count();
 
             char *p = static_cast<char *>(malloc(initial_size));
 

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -125,7 +125,7 @@ SEASTAR_TEST_CASE(test_map_reduce) {
             return x.map_reduce0(std::mem_fn(&X::cpu_id_squared),
                                  0,
                                  std::plus<int>()).then([] (int result) {
-                int n = smp::count - 1;
+                int n = this_smp_shard_count() - 1;
                 if (result != (n * (n + 1) * (2*n + 1)) / 6) {
                     throw std::runtime_error("map_reduce failed");
                 }
@@ -169,7 +169,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
         return x.start().then([&x] {
             return do_with(0L, [&x] (auto& result) {
                 return x.map_reduce(reduce{result}, map{}).then([&result] {
-                    long n = smp::count - 1;
+                    long n = this_smp_shard_count() - 1;
                     long expected = (n * (n + 1) * (2*n + 1)) / 6;
                     BOOST_REQUIRE_EQUAL(result, expected);
                 });
@@ -208,7 +208,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     return do_with_distributed<X>([] (sharded<X>& x) {
         return x.start().then([&x] {
             return x.map_reduce0(map{}, 0L, reduce{}).then([] (long result) {
-                long n = smp::count - 1;
+                long n = this_smp_shard_count() - 1;
                 long expected = (n * (n + 1) * (2*n + 1)) / 6;
                 BOOST_REQUIRE_EQUAL(result, expected);
             });
@@ -234,8 +234,8 @@ SEASTAR_TEST_CASE(test_map_lifetime) {
     return do_with_distributed<X>([] (sharded<X>& x) {
         return x.start().then([&x] {
             return x.map(map{}).then([] (std::vector<int> result) {
-                BOOST_REQUIRE_EQUAL(result.size(), smp::count);
-                for (size_t i = 0; i < (size_t)smp::count; i++) {
+                BOOST_REQUIRE_EQUAL(result.size(), this_smp_shard_count());
+                for (size_t i = 0; i < (size_t)this_smp_shard_count(); i++) {
                     BOOST_REQUIRE_EQUAL(result[i], i * i);
                 }
             });
@@ -249,7 +249,7 @@ SEASTAR_TEST_CASE(test_async) {
             return x.invoke_on_all(&async_service::run);
         });
     }).then([] {
-        return sleep(std::chrono::milliseconds(100 * (smp::count + 1)));
+        return sleep(std::chrono::milliseconds(100 * (this_smp_shard_count() + 1)));
     });
 }
 
@@ -260,7 +260,7 @@ SEASTAR_TEST_CASE(test_invoke_on_others) {
             void up() { ++counter; }
             future<> stop() { return make_ready_future<>(); }
         };
-        for (unsigned c = 0; c < smp::count; ++c) {
+        for (unsigned c = 0; c < this_smp_shard_count(); ++c) {
             smp::submit_to(c, [c] {
                 return seastar::async([c] {
                     sharded<my_service> s;
@@ -286,10 +286,10 @@ SEASTAR_TEST_CASE(test_invoke_on_others) {
 SEASTAR_TEST_CASE(test_smp_invoke_on_others) {
     return seastar::async([] {
         std::vector<std::vector<int>> calls;
-        calls.reserve(smp::count);
-        for (unsigned i = 0; i < smp::count; i++) {
+        calls.reserve(this_smp_shard_count());
+        for (unsigned i = 0; i < this_smp_shard_count(); i++) {
             auto& sv = calls.emplace_back();
-            sv.reserve(smp::count);
+            sv.reserve(this_smp_shard_count());
         }
 
         smp::invoke_on_all([&calls] {
@@ -298,9 +298,9 @@ SEASTAR_TEST_CASE(test_smp_invoke_on_others) {
             });
         }).get();
 
-        for (unsigned i = 0; i < smp::count; i++) {
-            BOOST_REQUIRE_EQUAL(calls[i].size(), smp::count - 1);
-            for (unsigned f = 0; f < smp::count; f++) {
+        for (unsigned i = 0; i < this_smp_shard_count(); i++) {
+            BOOST_REQUIRE_EQUAL(calls[i].size(), this_smp_shard_count() - 1);
+            for (unsigned f = 0; f < this_smp_shard_count(); f++) {
                 auto r = std::find(calls[i].begin(), calls[i].end(), f);
                 BOOST_REQUIRE_EQUAL(r == calls[i].end(), i == f);
             }
@@ -344,14 +344,14 @@ SEASTAR_TEST_CASE(test_smp_service_groups) {
         smp_service_group_config ssgc2;
         ssgc2.max_nonlocal_requests = 1000;
         auto ssg2 = create_smp_service_group(ssgc2).get();
-        shard_id other_shard = smp::count - 1;
+        shard_id other_shard = this_smp_shard_count() - 1;
         remote_worker rm1(1);
         remote_worker rm2(1000);
         auto bunch1 = parallel_for_each(std::views::iota(0, 20), [&] (int ignore) { return rm1.do_remote_work(other_shard, ssg1); });
         auto bunch2 = parallel_for_each(std::views::iota(0, 2000), [&] (int ignore) { return rm2.do_remote_work(other_shard, ssg2); });
         bunch1.get();
         bunch2.get();
-        if (smp::count > 1) {
+        if (this_smp_shard_count() > 1) {
             SEASTAR_ASSERT(rm1.max_concurrent_observed == 1);
             SEASTAR_ASSERT(rm2.max_concurrent_observed == 1000);
         }
@@ -384,7 +384,7 @@ SEASTAR_TEST_CASE(test_smp_timeout) {
             destroy_smp_service_group(ssg1).get();
         });
 
-        const shard_id other_shard = smp::count - 1;
+        const shard_id other_shard = this_smp_shard_count() - 1;
 
         // Ugly but beats using sleeps.
         std::mutex mut;

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -118,7 +118,7 @@ SEASTAR_TEST_CASE(file_access_test) {
 // that a file obtained from the handle is the same one, as it was
 // when the file was opened.
 SEASTAR_TEST_CASE(file_ro_dup_test) {
-    if (seastar::smp::count < 2) {
+    if (seastar::this_smp_shard_count() < 2) {
         fmt::print("This test needs at least 2 shards to run\n");
         return make_ready_future<>();
     }

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -98,7 +98,7 @@ public:
 };
 
 SEASTAR_TEST_CASE(foreign_ptr_cpu_test) {
-    if (smp::count == 1) {
+    if (this_smp_shard_count() == 1) {
         std::cerr << "Skipping multi-cpu foreign_ptr tests. Run with --smp=2 to test multi-cpu delete and reset.";
         return make_ready_future<>();
     }
@@ -118,7 +118,7 @@ SEASTAR_TEST_CASE(foreign_ptr_cpu_test) {
 }
 
 SEASTAR_TEST_CASE(foreign_ptr_move_assignment_test) {
-    if (smp::count == 1) {
+    if (this_smp_shard_count() == 1) {
         std::cerr << "Skipping multi-cpu foreign_ptr tests. Run with --smp=2 to test multi-cpu delete and reset.";
         return make_ready_future<>();
     }
@@ -138,7 +138,7 @@ SEASTAR_TEST_CASE(foreign_ptr_move_assignment_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
-    if (smp::count == 1) {
+    if (this_smp_shard_count() == 1) {
         std::cerr << "Skipping multi-cpu foreign_ptr tests. Run with --smp=2 to test multi-cpu delete and reset.";
         return;
     }
@@ -146,7 +146,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
     using namespace std::chrono_literals;
 
     std::vector<promise<bool>> done;
-    done.resize(smp::count);
+    done.resize(this_smp_shard_count());
 
     struct deferred {
         std::vector<promise<bool>>& done;
@@ -175,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_foreign_ptr_use_count) {
-    shard_id shard = (this_shard_id() + 1) % smp::count;
+    shard_id shard = (this_shard_id() + 1) % this_smp_shard_count();
     auto p0 = smp::submit_to(shard, [] {
         return make_foreign(make_lw_shared<sstring>("foo"));
     }).get();

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -367,7 +367,7 @@ SEASTAR_TEST_CASE(file_handle_test) {
             buf[i] = i;
         }
         f.dma_write(0, buf, 4096).get();
-        auto bad = std::vector<unsigned>(smp::count); // std::vector<bool> is special and unsuitable because it uses bitfields
+        auto bad = std::vector<unsigned>(this_smp_shard_count()); // std::vector<bool> is special and unsuitable because it uses bitfields
         close_f.close_now();
         f = open_file_dma(filename, open_flags::ro).get();
         close_f = deferred_close(f);

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -2258,12 +2258,12 @@ SEASTAR_THREAD_TEST_CASE(test_manual_clock_advance) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_ready_future_across_shards) {
-    if (smp::count == 1) {
+    if (this_smp_shard_count() == 1) {
         seastar_logger.info("test_ready_future_across_shards requires at least 2 shards");
         return;
     }
 
-    auto other_shard = (this_shard_id() + 1) % smp::count;
+    auto other_shard = (this_shard_id() + 1) % this_smp_shard_count();
     auto f1 = make_ready_future<int>(42);
     smp::submit_to(other_shard, [f1 = std::move(f1)] () mutable {
         BOOST_REQUIRE_EQUAL(f1.get(), 42);
@@ -2623,13 +2623,13 @@ SEASTAR_THREAD_TEST_CASE(test_lifetimes_and_copies_finally_void) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_foreign_promise_set_value) {
-    if (smp::count == 1) {
+    if (this_smp_shard_count() == 1) {
         seastar_logger.info("test_foreign_promise_set_value requires at least 2 shards");
         return;
     }
 
     promise<int> pr;
-    auto other_shard = (this_shard_id() + 1) % smp::count;
+    auto other_shard = (this_shard_id() + 1) % this_smp_shard_count();
 
     auto getter = pr.get_future();
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1904,14 +1904,14 @@ SEASTAR_TEST_CASE(case_insensitive_header_reply) {
 }
 
 SEASTAR_THREAD_TEST_CASE(multiple_connections) {
-    loopback_connection_factory lcf = loopback_connection_factory::with_pending_capacity(smp::count + 1, 1);
+    loopback_connection_factory lcf = loopback_connection_factory::with_pending_capacity(this_smp_shard_count() + 1, 1);
     http_server server("test");
     httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
     socket_address addr{ipv4_addr()};
 
     std::vector<connected_socket> socks;
     // Make sure one shard has two connections pending.
-    for (unsigned i = 0; i <= smp::count; ++i) {
+    for (unsigned i = 0; i <= this_smp_shard_count(); ++i) {
         socks.push_back(loopback_socket_impl(lcf).connect(addr, addr).get());
     }
 

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -268,13 +268,13 @@ class loopback_connection_factory {
     unsigned _pending_capacity = 10;
     std::vector<lw_shared_ptr<queue<connected_socket>>> _pending;
 public:
-    explicit loopback_connection_factory(unsigned shards_count = smp::count)
+    explicit loopback_connection_factory(unsigned shards_count = this_smp_shard_count())
             : _shards_count(shards_count)
     {
         _pending.resize(shards_count);
     }
 
-    static loopback_connection_factory with_pending_capacity(unsigned pending_capacity, unsigned shards_count = smp::count) {
+    static loopback_connection_factory with_pending_capacity(unsigned pending_capacity, unsigned shards_count = this_smp_shard_count()) {
         auto lcf = loopback_connection_factory(shards_count);
         lcf._pending_capacity = pending_capacity;
         return lcf;

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -415,7 +415,7 @@ test_load_balancing_algorithm_port(socket_address listen_addr, bool proxy_protoc
     };
     auto server = sharded<shard_number_server>();
     server.start(listen_addr, lo).get();
-    auto smp_count = smp::count;
+    auto smp_count = this_smp_shard_count();
     promise<> client_done;
     auto client = std::async(std::launch::async, [&] {
         auto r = client_results{};


### PR DESCRIPTION
smp::count is now a static variable as a convenience - it can be accessed from
anywhere without requiring any object to access it. But that means we can only
have one smp::count per process. This stands in the way for running multiple
Seastar instances in a single process, which is desirable for testing (cluster-in-a-box).

Remove this limitation by making smp::count a private non-static member named
_shard_count. smp::count is kept for compatibility, but deprecated. Similarly smp::all_cpus()
gains a non-static equivalent smp::all_shards().

To simplify access from within reactor threads, which is the vast majority of accesses,
we add convenience this_smp(), this_smp_shard_count(), and this_smp_all_shards().

Two uses of smp::count before it is initialized are converted to FIXMEs.

The tree is converted to use the new accessors.