### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             docker/dev/Dockerfile
             install-dependencies.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/dev/Dockerfile

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,8 +6,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -7,10 +7,10 @@ jobs:
     name: Enforce python format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: psf/black@24.8.0
+      - uses: actions/checkout@v6
+      - uses: psf/black@26.3.1
         with:
-            version: "24.8.0"
+            version: "26.3.1"
             src: ./scripts
             # override options so that we can specify only specific files for now
             options: "--check --diff --include=.*addr2line.*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Setup ccache
         if: ${{ inputs.enable-ccache }}
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ inputs.compiler }}-${{ inputs.standard }}-${{ inputs.mode }}-${{ inputs.enables }}
 


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2nd, 2026, with Node.js 20 removed from runners on September 16th, 2026. Update all actions to their latest major versions that support Node.js 24.

Actions updated across all workflow files:
- actions/checkout: v4 -> v6
- actions/setup-python: v5 -> v6
- hendrikmuhs/ccache-action: v1 -> v1.2
- docker/setup-buildx-action: v3 -> v4
- docker/build-push-action: v6 -> v7
- psf/black: 24.8.0 -> 26.3.1

Note: pre-commit/action@v3.0.1 internally uses actions/cache@v4 which still runs on Node.js 20. This is an upstream issue -- v3.0.1 is the latest release of pre-commit/action.