### PR TITLE
rpc_tester: expose throuput for rpc tester

### DIFF
--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -404,6 +404,8 @@ class job_rpc : public job {
     std::chrono::steady_clock::time_point _stop;
     uint64_t _total_messages = 0;
     accumulator_type _latencies;
+    std::chrono::steady_clock::time_point _start_time{};
+    std::chrono::duration<double> _total_duration{0.0};
 
     future<> call_echo(unsigned dummy) {
         auto cln = _rpc.make_client<uint64_t(uint64_t)>(rpc_verb::ECHO);
@@ -457,6 +459,7 @@ public:
         rpc::client_options co;
         co.tcp_nodelay = _ccfg.nodelay;
         co.isolation_cookie = _cfg.sg_name;
+        _start_time = std::chrono::steady_clock::now();
         _client = std::make_unique<rpc_protocol::client>(_rpc, co, _caddr);
         return parallel_for_each(std::views::iota(0u, _cfg.parallelism), [this] (auto dummy) {
           auto f = make_ready_future<>();
@@ -483,13 +486,17 @@ public:
             });
           });
         }).finally([this] {
+            _total_duration = std::chrono::steady_clock::now() - _start_time;
             return _client->stop();
         });
       });
     }
 
     virtual void emit_result(YAML::Emitter& out) const override {
-        out << YAML::Key << "messages" << YAML::Value << _total_messages;
+        emit_messages(out, _total_messages, _total_duration);
+        if (_cfg.verb == "write") {
+            emit_throughput(out, _total_messages, _cfg.payload, _total_duration);
+        }
         out << YAML::Key << "latencies" << YAML::Comment("usec");
         out << YAML::BeginMap;
         out << YAML::Key << "average" << YAML::Value << (uint64_t)mean(_latencies);

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -517,7 +517,6 @@ class job_rpc_streaming : public job {
     std::function<future<>(unsigned, const payload_t&)> _call;
     std::chrono::steady_clock::time_point _stop;
     uint64_t _total_messages = 0;
-    uint64_t _payload_size_bytes = 0;
     std::chrono::steady_clock::time_point _start_time{};
     std::chrono::duration<double> _total_duration{0.0};
     payload_t _payload;
@@ -529,7 +528,6 @@ public:
             , _ccfg(ccfg)
             , _rpc(rpc)
             , _stop(std::chrono::steady_clock::now() + _cfg.duration)
-            , _payload_size_bytes(_cfg.payload)
             , _payload(_cfg.payload / sizeof(payload_t::value_type), 0) {
         if (_cfg.verb == "bidirectional") {
             _call = [this] (unsigned worker_id, const payload_t& payload) {

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -369,6 +369,29 @@ public:
     virtual ~job() {}
 };
 
+static inline void emit_throughput(YAML::Emitter& out, uint64_t total_messages, uint64_t message_size, std::chrono::duration<double> total_duration) {
+    uint64_t total_bytes = (UINT64_MAX / message_size < total_messages) ? UINT64_MAX : total_messages * message_size;
+    out << YAML::Key << "total bytes" << YAML::Value << total_bytes << YAML::Comment("B");
+    out << YAML::Key << "message size" << YAML::Value << message_size << YAML::Comment("B");
+    if (total_duration.count() > 0) {
+        double throughput = total_bytes / total_duration.count();
+        out << YAML::Key << "throughput" << YAML::Value << throughput << YAML::Comment("B/s");
+    } else {
+        out << YAML::Key << "throughput" << YAML::Value << "inf" << YAML::Comment("B/s");
+    }
+}
+
+static inline void emit_messages(YAML::Emitter& out, uint64_t total_messages, std::chrono::duration<double> total_duration) {
+    out << YAML::Key << "messages" << YAML::Value << total_messages;
+    out << YAML::Key << "total duration" << YAML::Value << total_duration.count() << YAML::Comment("s");
+    if (total_duration.count() > 0) {
+        double messages_per_sec = total_messages / total_duration.count();
+        out << YAML::Key << "messages per second" << YAML::Value << messages_per_sec;
+    } else {
+        out << YAML::Key << "messages per second" << YAML::Value << "inf";
+    }
+}
+
 class job_rpc : public job {
     using accumulator_type = accumulator_set<double, stats<tag::extended_p_square_quantile(quadratic), tag::mean, tag::max>>;
 
@@ -595,19 +618,8 @@ public:
     }
 
     virtual void emit_result(YAML::Emitter& out) const override {
-        out << YAML::Key << "messages" << YAML::Value << _total_messages;
-
-        auto total_bytes = _total_messages * _payload_size_bytes;
-        if (_total_duration.count() > 0) {
-            double throughput = total_bytes / _total_duration.count();
-            out << YAML::Key << "throughput" << YAML::Value << throughput << YAML::Comment("B/s");
-
-            double messages_per_sec = _total_messages / _total_duration.count();
-            out << YAML::Key << "messages per second" << YAML::Value << messages_per_sec;
-        } else {
-            out << YAML::Key << "throughput" << YAML::Value << "inf" << YAML::Comment("kB/s");
-            out << YAML::Key << "messages per second" << YAML::Value << "inf";
-        }
+        emit_throughput(out, _total_messages, _cfg.payload, _total_duration);
+        emit_messages(out, _total_messages, _total_duration);
     }
 
     static future<> process_bi_source(rpc::source<payload_t> source, rpc::sink<payload_t> sink) {


### PR DESCRIPTION
- extract code for printing number of messages / sent payload to helper
- emit number of messages and throughput for `job_rpc`

<table>
  <thead>
    <tr>
      <th>Job</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>job_rpc write</td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_write_1kB:
    messages: 1516970
    latencies:  # usec
      average: 19
      p0.5: 17
      p0.95: 22
      p0.99: 27
      p0.999: 254
      max: 3859
- shard: 1
  rpc_write_1kB:
    messages: 1516881
    latencies:  # usec
      average: 19
      p0.5: 18
      p0.95: 22
      p0.99: 27
      p0.999: 254
      max: 3863
...</pre>
      </td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_write_1kB:
    messages: 1628873
    total duration: 29.999270353  # s
    messages per second: 54297.087256894192
    total bytes: 1667965952  # B
    message size: 1024  # B
    throughput: 55600217.351059653  # B/s
    latencies:  # usec
      average: 17
      p0.5: 16
      p0.95: 20
      p0.99: 24
      p0.999: 303
      max: 3343
- shard: 1
  rpc_write_1kB:
    messages: 1721161
    total duration: 29.999582342  # s
    messages per second: 57372.832074076614
    total bytes: 1762468864  # B
    message size: 1024  # B
    throughput: 58749780.043854453  # B/s
    latencies:  # usec
      average: 16
      p0.5: 16
      p0.95: 19
      p0.99: 21
      p0.999: 31
      max: 237
</pre>
</td>
<tr>
      <td>job_rpc_streaming</td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_throughput_uni_1kB:
    messages: 43419979
    throughput: 1481903189.4080482  # B/s
    messages per second: 1447171.083406297
- shard: 1
  rpc_throughput_uni_1kB:
    messages: 43889450
    throughput: 1497972584.0991342  # B/s
    messages per second: 1462863.8516593107
...</pre>
      </td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_throughput_uni_1kB:
    total bytes: 43407100928  # B
    message size: 1024  # B
    throughput: 1446787357.9627306  # B/s
    messages: 42389747
    total duration: 30.002405459999999  # s
    messages per second: 1412878.2792604791
- shard: 1
  rpc_throughput_uni_1kB:
    total bytes: 33958086656  # B
    message size: 1024  # B
    throughput: 1131940746.648876  # B/s
    messages: 33162194
    total duration: 29.999880079  # s
    messages per second: 1105410.8853992929
</pre>
</td>
</tr>

<tr>
      <td>job_rpc echo</td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_echo:
    messages: 1632562
    latencies:  # usec
      average: 17
      p0.5: 16
      p0.95: 20
      p0.99: 24
      p0.999: 251
      max: 3828
- shard: 1
  rpc_echo:
    messages: 1730217
    latencies:  # usec
      average: 16
      p0.5: 16
      p0.95: 18
      p0.99: 21
      p0.999: 28
      max: 331
...</pre>
      </td>
      <td>
<pre lang="yaml">
- shard: 0
  rpc_echo:
    messages: 1652788
    total duration: 29.999740879000001  # s
    messages per second: 55093.409195309468
    latencies:  # usec
      average: 17
      p0.5: 16
      p0.95: 20
      p0.99: 24
      p0.999: 251
      max: 4789
- shard: 1
  rpc_echo:
    messages: 1749383
    total duration: 29.999801839  # s
    messages per second: 58313.151846416098
    latencies:  # usec
      average: 16
      p0.5: 16
      p0.95: 22
      p0.99: 24
      p0.999: 27
      max: 4007
</pre>
</td>
</tr>
