### PR TITLE
reactor: open_directory(): honor bypass_fsync

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2430,7 +2430,10 @@ reactor::open_directory(std::string_view name_view) noexcept {
         return wrap_syscall(fd, st);
     });
     sr.throw_fs_exception_if_error("open failed", name);
-    shared_ptr<file_impl> file_impl = co_await make_file_impl(sr.result, file_open_options(), oflags, sr.extra);
+    auto options = file_open_options{
+        .durable = !_cfg.bypass_fsync,
+    };
+    shared_ptr<file_impl> file_impl = co_await make_file_impl(sr.result, options, oflags, sr.extra);
     co_return file(std::move(file_impl));
 }
 


### PR DESCRIPTION
Since 613f14d42f72c3 ("reactor,file: Make full use of file_open_options::durable bit") reactor::fdatasync() is no longer responsible for bypassing fsync; instead, its callers are.

However, one of the callers, open_directory(), did not set the durable flags correctly. As a result directories became durable even with --unsafe-bypass-fsync 1.

This manifested in directory-intensive tests running in an overloaded environment on consumer disks timing out, as every directory fsync had to flush all outstanding I/O to disk.

Fix by setting file_open_options::durable according to the configuration.