### PR TITLE
file: add mmap support to file

### DIFF
--- a/include/seastar/core/file-types.hh
+++ b/include/seastar/core/file-types.hh
@@ -22,8 +22,11 @@
 #pragma once
 
 #include <fcntl.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <type_traits>
+
+#include <seastar/util/bool_class.hh>
 
 namespace seastar {
 
@@ -160,6 +163,37 @@ inline constexpr file_permissions operator|(file_permissions a, file_permissions
 inline constexpr file_permissions operator&(file_permissions a, file_permissions b) {
     return file_permissions(std::underlying_type_t<file_permissions>(a) & std::underlying_type_t<file_permissions>(b));
 }
+
+/// \brief Memory protection flags for mmap.
+///
+/// \see file::mmap()
+enum class mmap_prot {
+    none = PROT_NONE,
+    read = PROT_READ,
+    write = PROT_WRITE,
+    execute = PROT_EXEC,
+};
+
+inline constexpr mmap_prot operator|(mmap_prot a, mmap_prot b) {
+    return mmap_prot(std::underlying_type_t<mmap_prot>(a) | std::underlying_type_t<mmap_prot>(b));
+}
+
+inline void operator|=(mmap_prot& a, mmap_prot b) {
+    a = (a | b);
+}
+
+inline constexpr mmap_prot operator&(mmap_prot a, mmap_prot b) {
+    return mmap_prot(std::underlying_type_t<mmap_prot>(a) & std::underlying_type_t<mmap_prot>(b));
+}
+
+inline void operator&=(mmap_prot& a, mmap_prot b) {
+    a = (a & b);
+}
+
+/// \brief Visibility flag for mmap (`MAP_PRIVATE` when true, `MAP_SHARED` when false).
+///
+/// \see file::mmap()
+using mmap_private = bool_class<struct mmap_private_tag>;
 
 /// @}
 

--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -115,6 +115,87 @@ class file_handle;
 class file_data_sink_impl;
 class file_data_source_impl;
 
+/// \brief A memory mapped region of a file.
+///
+/// Represents a memory region created by \ref seastar::file::mmap().
+///
+/// \warning This API is strongly discouraged for general-purpose file I/O.
+/// Accessing file-backed memory mappings relies on the kernel page cache and
+/// can trigger major page faults. These faults will silently block the
+/// Seastar reactor thread, bypassing Seastar's I/O scheduler and severely
+/// degrading overall system performance. Seastar applications should prefer
+/// \c O_DIRECT DMA interfaces (e.g., \ref dma_read) for persistent storage.
+///
+/// This facility is provided specifically for shared memory use cases (e.g.,
+/// mapping files on \c tmpfs or \c shm), where data resides entirely in RAM
+/// and blocking disk I/O is not a concern.
+///
+/// Because \c munmap requires acquiring kernel \c mmap_sem locks, it cannot
+/// be executed synchronously in a destructor without risking blocking the reactor.
+/// Therefore, the user must explicitly await the asynchronous \ref unmap()
+/// method before this object is destroyed.
+class file_mapping {
+    void* _addr = nullptr;
+    size_t _length = 0;
+
+    file_mapping(void* addr, size_t length) noexcept
+        : _addr(addr), _length(length) {}
+
+    friend class posix_file_impl;
+
+public:
+    /// Constructs an uninitialized file mapping.
+    file_mapping() noexcept = default;
+    file_mapping(const file_mapping&) = delete;
+    file_mapping& operator=(const file_mapping&) = delete;
+
+    file_mapping(file_mapping&& other) noexcept
+        : _addr(std::exchange(other._addr, nullptr))
+        , _length(std::exchange(other._length, 0)) {}
+
+    file_mapping& operator=(file_mapping&& other) noexcept {
+        if (this != &other) {
+            SEASTAR_ASSERT(!_addr && !_length && "file_mapping assigned to without unmapping");
+            _addr = std::exchange(other._addr, nullptr);
+            _length = std::exchange(other._length, 0);
+        }
+        return *this;
+    }
+
+    ~file_mapping() noexcept;
+
+    /// Returns the address of the memory mapped region.
+    void* get() const noexcept { return _addr; }
+
+    /// Returns the size of the memory mapped region.
+    size_t size() const noexcept { return _length; }
+
+    /// Unmaps the file mapping asynchronously.
+    ///
+    /// This must be called exactly once before the object is destroyed.
+    /// \post The file mapping is unmapped and the object is in an uninitialized
+    /// state (i.e. \ref get() returns nullptr and \ref size() returns 0).
+    future<> unmap() noexcept;
+
+    /// Flushes changes made to the in-core copy of a file that was mapped into
+    /// memory using \c mmap(2) back to the filesystem by calling \c msync(2).
+    ///
+    /// This method is executed asynchronously on the reactor's thread pool, as
+    /// \c msync blocks until the dirty pages are written to the underlying storage.
+    ///
+    /// \note For the primary use case of this class (shared memory via \c tmpfs
+    /// or \c shm), calling \ref flush() is strictly unnecessary as the data resides
+    /// entirely in RAM.
+    ///
+    /// This method is provided primarily for testing or rare edge cases where
+    /// mapped memory access is mixed with Seastar's \c O_DIRECT I/O. Because
+    /// \ref dma_read() bypasses the kernel page cache, dirty mapped pages must
+    /// be explicitly synced to the backing device before a DMA read will see
+    /// the modifications. Doing this on persistent storage in production is
+    /// strongly discouraged.
+    future<> flush() noexcept;
+};
+
 // The directory_entry size is 24 bytes (as the file name is allocated separately)
 // so the circular buffer is tuned to hold 16 entries
 constexpr size_t list_directory_generator_buffer_size = calc_circular_buffer_capacity<directory_entry, 512>();
@@ -159,6 +240,7 @@ public:
     virtual future<int> fcntl(int op, uintptr_t arg) noexcept;
     virtual future<int> fcntl_short(int op, uintptr_t arg) noexcept;
     virtual future<> allocate(uint64_t position, uint64_t length) = 0;
+    virtual future<file_mapping> mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept;
     virtual future<uint64_t> size() = 0;
     virtual future<> close() = 0;
     virtual std::unique_ptr<file_handle_impl> dup();
@@ -420,6 +502,23 @@ public:
     /// The discard operation tells the file system that a range of offsets
     /// (which be aligned) is no longer needed and can be reused.
     future<> discard(uint64_t offset, uint64_t length) noexcept;
+
+    /// Maps a portion of the file into memory.
+    ///
+    /// Asynchronously maps the file into memory using the \c mmap syscall.
+    /// Because \c mmap can block on kernel memory management semaphores,
+    /// the syscall is submitted to the reactor's background thread pool.
+    ///
+    /// \note This method is intended strictly for shared memory applications
+    /// (e.g., \c tmpfs). Using it for standard disk I/O will result in page
+    /// faults that block the reactor thread.
+    ///
+    /// \param length the size of the mapping
+    /// \param prot the memory protection flags (e.g., `PROT_READ | PROT_WRITE`)
+    /// \param priv the visibility of the mapping (`MAP_PRIVATE` when true, `MAP_SHARED` when false)
+    /// \param offset the offset in the file to start mapping from (must be page-aligned)
+    /// \return a future containing a \ref file_mapping object.
+    future<file_mapping> mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept;
 
     /// Generic ioctl syscall support for special file handling.
     ///

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -719,6 +719,7 @@ private:
     future<> run_exit_tasks();
     void stop();
     friend class pollable_fd_state;
+    friend class file_mapping;
     friend class posix_file_impl;
     friend class blockdev_file_impl;
     friend class pipe_data_source_impl;

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -107,6 +107,7 @@ public:
     future<int> fcntl(int op, uintptr_t arg) noexcept override;
     future<int> fcntl_short(int op, uintptr_t arg) noexcept override;
     virtual future<> allocate(uint64_t position, uint64_t length) noexcept override;
+    future<file_mapping> mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept override;
     future<uint64_t> size() noexcept override;
     // close() never fails. It just reports errors and swallows them.
     // The user must call flush() first if they care aout stable storage semantics.

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -369,6 +369,17 @@ posix_file_impl::allocate(uint64_t position, uint64_t length) noexcept {
 #endif
 }
 
+future<file_mapping>
+posix_file_impl::mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<void*>>(
+            internal::thread_pool_submit_reason::file_operation, [fd = _fd, length, prot, priv, offset] {
+        int flags = bool(priv) ? MAP_PRIVATE : MAP_SHARED;
+        return wrap_syscall<void*>(::mmap(nullptr, length, static_cast<int>(prot), flags, fd, offset));
+    });
+    sr.throw_if_error();
+    co_return file_mapping{sr.result, length};
+}
+
 future<uint64_t>
 posix_file_impl::size() noexcept {
     auto r = ::lseek(_fd, 0, SEEK_END);
@@ -1095,6 +1106,36 @@ posix_file_handle_impl<FileImpl>::to_file() && {
     return ret;
 }
 
+file_mapping::~file_mapping() noexcept {
+    if (_addr || _length) {
+        seastar_logger.warn("file_mapping destroyed without unmap(); falling back to blocking ::munmap (reactor stall), contact support");
+        ::munmap(_addr, _length);
+    }
+}
+
+future<> file_mapping::unmap() noexcept {
+    void* addr = std::exchange(_addr, nullptr);
+    size_t length = std::exchange(_length, 0);
+    if (!addr) {
+        seastar_logger.warn("double unmap() detected, contact support");
+        co_return;
+    }
+
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
+            internal::thread_pool_submit_reason::file_operation, [addr, length] {
+        return wrap_syscall<int>(::munmap(addr, length));
+    });
+    sr.throw_if_error();
+}
+
+future<> file_mapping::flush() noexcept {
+    auto sr = co_await engine()._thread_pool->submit<syscall_result<int>>(
+            internal::thread_pool_submit_reason::file_operation, [addr = _addr, length = _length] {
+        return wrap_syscall<int>(::msync(addr, length, MS_SYNC));
+    });
+    sr.throw_if_error();
+}
+
 // Some kernels can append to xfs filesystems, some cannot; determine
 // from kernel version.
 static
@@ -1424,6 +1465,10 @@ future<> file::allocate(uint64_t position, uint64_t length) noexcept {
   }
 }
 
+future<file_mapping> file::mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept {
+    return _file_impl->mmap(length, prot, priv, offset);
+}
+
 future<> file::truncate(uint64_t length) noexcept {
   try {
     return _file_impl->truncate(length);
@@ -1571,6 +1616,10 @@ future<int> file_impl::fcntl_short(int op, uintptr_t arg) noexcept {
 
 future<struct stat> file_impl::statat(std::string_view name, int flags) {
     return make_exception_future<struct stat>(std::runtime_error("this file type does not support statat"));
+}
+
+future<file_mapping> file_impl::mmap(size_t length, mmap_prot prot, mmap_private priv, size_t offset) noexcept {
+    return make_exception_future<file_mapping>(std::runtime_error("this file type does not support mmap"));
 }
 
 future<file> open_file_dma(std::string_view name, open_flags flags) noexcept {

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -153,6 +153,29 @@ SEASTAR_TEST_CASE(file_rw_dup_test) {
     });
 }
 
+SEASTAR_TEST_CASE(file_mmap_test) {
+    return tmp_dir::do_with([] (tmp_dir& t) -> future<> {
+        sstring filename = (t.get_path() / "testfile.tmp").native();
+        auto f = co_await open_file_dma(filename, open_flags::rw | open_flags::create);
+        co_await f.truncate(4096);
+        auto map = co_await f.mmap(4096, mmap_prot::read | mmap_prot::write, mmap_private::no, 0);
+        BOOST_CHECK_EQUAL(map.size(), 4096);
+        // Write null-terminated string to the map.
+        std::string_view str = "Hello, mmap!";
+        std::memcpy(map.get(), str.data(), str.size() + 1);
+        std::string_view map_str{reinterpret_cast<const char*>(map.get()), str.size()};
+        BOOST_CHECK_EQUAL(map_str, str);
+        co_await map.flush();
+        co_await map.unmap();
+        // Read the string back through the file, using dma_read.
+        auto buf = allocate_aligned_buffer<char>(4096, 4096);
+        co_await f.dma_read(0, buf.get(), 4096);
+        std::string_view buf_str{buf.get(), str.size()};
+        BOOST_CHECK_EQUAL(buf_str, str);
+        co_await f.close();
+    });
+}
+
 struct file_test {
     file_test(file&& f) : f(std::move(f)) {}
     file f;


### PR DESCRIPTION
Introduce file::mmap() and a file_mapping class to support memory-mapped files. This is primarily intended for shared memory use cases (e.g., tmpfs) where data resides in RAM.

Both mmap and unmap are performed asynchronously via the reactor's  thread pool to avoid blocking the reactor thread on kernel memory  management locks. file_mapping requires an explicit call to unmap()  to ensure this asynchronous teardown.

A flush() method is included to call msync(), ensuring consistency  between the kernel page cache and Seastar's O_DIRECT DMA operations,  which is particularly useful for testing.

Ref #3361