### PR TITLE
future: fix forwarding of reference types

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1305,7 +1305,7 @@ template <typename Func, typename T>
 using future_result_t = typename future_result<Func, T>::type;
 
 template <typename Func, typename T>
-auto future_invoke(Func&& func, T&& v) {
+decltype(auto) future_invoke(Func&& func, T&& v) {
     if constexpr (std::is_same_v<T, monostate>) {
         return std::invoke(std::forward<Func>(func));
     } else {
@@ -1624,7 +1624,7 @@ private:
             if (state.failed()) {
                 pr.set_exception(static_cast<future_state_base&&>(std::move(state)));
             } else {
-                futurator::satisfy_with_result_of(std::move(pr), [&func, &state] {
+                futurator::satisfy_with_result_of(std::move(pr), [&func, &state]() -> decltype(auto) {
                     // clang thinks that "state" is not used, below, for future<>.
                     // Make it think it is used to avoid an unused-lambda-capture warning.
                     (void)state;
@@ -2077,11 +2077,7 @@ struct futurize : public internal::futurize_base<T> {
 
     /// Convert the tuple representation into a future
     static type from_tuple(value_type&& value) {
-        return type(set_ready_future_marker(), std::move(value));
-    }
-    /// Convert the tuple representation into a future
-    static type from_tuple(const value_type& value) {
-        return type(set_ready_future_marker(), value);
+        return type(set_ready_future_marker(), std::forward<value_type>(value));
     }
 private:
     /// Forwards the result of, or exception thrown by, func() to the

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -1575,6 +1575,39 @@ SEASTAR_TEST_CASE(test_futurize_from_tuple) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_futurize_from_tuple_const_ref) {
+    // Regression test for `from_tuple(const value_type&)` conflicting with
+    // `from_tuple(value_type&&)`.
+    //
+    // In addition, when returning an lvalue reference, the type should not
+    // be moved with `std::move` somewhere deep in the implementation.
+    //
+    // The point of declaring move and copy operations is to assert that
+    // even if an object is movable and copyable, it is not moved or copied
+    // when returned as an lvalue reference from a `then` callback.
+    struct unmovable_object {
+        int v;
+        explicit unmovable_object(int v) : v(v) {}
+        unmovable_object(const unmovable_object&) { BOOST_FAIL("unmovable_object should not be copied"); }
+        unmovable_object& operator=(const unmovable_object&) { BOOST_FAIL("unmovable_object should not be copied"); return *this; }
+        unmovable_object(unmovable_object&&) { BOOST_FAIL("unmovable_object should not be moved"); }
+        unmovable_object& operator=(unmovable_object&&) { BOOST_FAIL("unmovable_object should not be moved"); return *this; }
+        ~unmovable_object() { BOOST_REQUIRE_EQUAL(v, 5); }
+    };
+    unmovable_object n{5};
+
+    // Ensure the support through `make_ready_future` as well.
+    BOOST_REQUIRE_EQUAL(make_ready_future<unmovable_object&>(n).get().v, 5);
+
+    auto f = make_ready_future<>();
+    f = std::move(f).then([&]() -> unmovable_object& { return n; }).then([](unmovable_object& x) { BOOST_REQUIRE_EQUAL(x.v, 5); });
+    f = std::move(f).then([&]() -> const unmovable_object& { return n; }).then([](const unmovable_object& x) { BOOST_REQUIRE_EQUAL(x.v, 5); });
+    // Without the annotation, it would be pass-by-value or moved
+    f = std::move(f).then([]() { int x = 1; return x; }).then([](int x) { BOOST_REQUIRE_EQUAL(x, 1); });
+    f = std::move(f).then([x = n.v] { return x; }).then([](int x) { BOOST_REQUIRE_EQUAL(x, 5); });
+    co_await std::move(f);
+}
+
 SEASTAR_TEST_CASE(test_repeat_until_value) {
     return do_with(int(), [] (int& counter) {
         return repeat_until_value([&counter] () -> future<std::optional<int>> {


### PR DESCRIPTION
Turns out, perfect forwarding is sufficient to support both rvalue and
lvalue references without needing a separate overload for `const value_type&`. 

Additionally, it fixes accidental copies or moves when returning references 
from continuations by properly propagating the return type using `decltype(auto)`.

It would previously fail to compile with the following error:

```
seastar/core/future.hh:1906:17: error: multiple overloads of 'from_tuple' instantiate to the same signature 'type (int &)' (aka 'future<int &> (int &)')
 1906 |     static type from_tuple(const value_type& value) {
      |                 ^
seastar/core/future.hh:1061:1: note: in instantiation of template class 'seastar::futurize<int &>' requested here
 1061 | using futurize_t = typename futurize<T>::type;
      | ^
seastar/core/future.hh:1128:25: note: in instantiation of template type alias 'futurize_t' requested here
 1128 |     using future_type = futurize_t<type>;
      |                         ^
seastar/core/future.hh:1384:67: note: in instantiation of template class 'seastar::internal::future_result<(lambda at seastar/tests/unit/futures_test.cc:2689:57), int &>' requested here
 1384 |     template <typename Func, typename Result = typename internal::future_result<Func, T>::future_type>
      |                                                                   ^
seastar/core/future.hh:1388:5: note: in instantiation of default argument for 'then<(lambda at seastar/tests/unit/futures_test.cc:2689:57)>' required here
 1388 |     then(Func&& func, std::source_location sl = std::source_location::current()) noexcept {
  ... |
 1403 |             });
      |             ~~~
seastar/tests/unit/futures_test.cc:2689:52: note: while substituting deduced template arguments into function template 'then' [with Func = (lambda at seastar/tests/unit/futures_test.cc:2689:57), Result = (no value)]
 2689 |     future<int&> lfut_cont = std::move(lfut_ready).then([&] (int& x) -> int& {
      |                                                    ^
seastar/core/future.hh:1902:17: note: previous declaration is here
 1902 |     static type from_tuple(value_type&& value) {
      |                 ^
seastar/tests/unit/futures_test.cc:2689:52: error: no matching member function for call to 'then'
 2689 |     future<int&> lfut_cont = std::move(lfut_ready).then([&] (int& x) -> int& {
      |                              ~~~~~~~~~~~~~~~~~~~~~~^~~~
seastar/core/future.hh:1388:5: note: candidate template ignored: substitution failure [with Func = (lambda at seastar/tests/unit/futures_test.cc:2689:57)]
 1388 |     then(Func&& func, std::source_location sl = std::source_location::current()) noexcept {
      |     ^
```

See also: https://github.com/crackcomm/seastar/actions/runs/25039053092/job/73337497042