### PR TITLE
task_profiler: add sampling profiler for suspended coroutine chains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,7 @@ add_library (seastar
   src/core/fsqual.cc
   src/core/fstream.cc
   src/core/future.cc
+  src/core/task_profiler.cc
   src/core/future-util.cc
   src/core/linux-aio.cc
   src/core/memory.cc

--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -198,6 +198,7 @@ public:
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {
+            task_profiler::mark_completion(hndl.promise());
             schedule(&hndl.promise());
         }
     }
@@ -224,6 +225,7 @@ public:
         if (!CheckPreempt || !_future.available()) {
             _future.set_coroutine(hndl.promise());
         } else {
+            task_profiler::mark_completion(hndl.promise());
             schedule(&hndl.promise());
         }
     }

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -33,6 +33,7 @@
 #include <source_location>
 
 #include <seastar/core/task.hh>
+#include <seastar/core/task_profiler.hh>
 #include <seastar/core/thread_impl.hh>
 #include <seastar/core/function_traits.hh>
 #include <seastar/core/shard_id.hh>
@@ -776,11 +777,13 @@ protected:
     void set_task(task* task) noexcept {
         _task = task;
         _task_shard = this_shard_id();
+        task_profiler::on_task_suspend(*task);
     }
     void assert_task_shard() const noexcept;
 #else
     void set_task(task* task) noexcept {
         _task = task;
+        task_profiler::on_task_suspend(*task);
     }
     void assert_task_shard() const noexcept { }
 #endif

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -24,21 +24,29 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/backtrace.hh>
 
+#include <cstdint>
 #include <utility>
 #include <source_location>
 
 namespace seastar {
+
+class task_profiler;
 
 class task {
     std::source_location _resume_point = {};
 
 protected:
     scheduling_group _sg;
+    // Index into task_profiler's entries vector. UINT32_MAX means the
+    // task is not tracked. Placed right after _sg (both 4 bytes) to
+    // fill the padding gap — zero per-task memory overhead.
+    uint32_t _prof_idx = UINT32_MAX;
 
 private:
 #ifdef SEASTAR_TASK_BACKTRACE
     shared_backtrace _bt;
 #endif
+
 protected:
     // Task destruction is performed by run_and_dispose() via a concrete type,
     // so no need for a virtual destructor here. Derived classes that implement
@@ -64,6 +72,8 @@ public:
     void make_backtrace() noexcept {}
     shared_backtrace get_backtrace() const { return {}; }
 #endif
+
+    friend class task_profiler;
 };
 
 

--- a/include/seastar/core/task_profiler.hh
+++ b/include/seastar/core/task_profiler.hh
@@ -1,0 +1,120 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+#pragma once
+
+#include <seastar/core/task.hh>
+
+#include <chrono>
+#include <cstdint>
+
+namespace seastar {
+
+template <typename CharType> class output_stream;
+
+/// \brief Per-shard async coroutine profiler.
+///
+/// Tracks suspended tasks via a vector of task entries indexed by
+/// task::_prof_idx. A periodic timer samples the entries, walks
+/// waiting_task() chains, and accumulates per-stack counts in a
+/// pmr unordered_map backed by a monotonic arena. On stop(), the
+/// accumulated data is formatted and written to the given streams.
+///
+/// Two complementary views of the same data are emitted by stop():
+///
+///  - raw stream: each stack's count is the total number of leaf
+///    observations across all ticks. A stack with many concurrent
+///    fibers blocked at the same place accumulates a proportionally
+///    larger count, even if those fibers were only blocked briefly.
+///
+///  - normalized stream: each stack's count is the number of distinct
+///    ticks during which the stack appeared on at least one fiber.
+///    This count is comparable across stacks regardless of fiber
+///    multiplicity, and is a better proxy for "fraction of wall-clock
+///    time this code path was blocked anywhere on the shard".
+///
+/// All methods operate on the current shard only. Use smp::invoke_on_all()
+/// to orchestrate across shards.
+class task_profiler {
+public:
+    struct session;
+
+    /// Start profiling session on this shard.
+    /// \param sampling_interval  Time between samples. Typical: 10-100ms.
+    static void start(std::chrono::steady_clock::duration sampling_interval);
+
+    /// Stop the profiling session, dump the accumulated samples, and
+    /// reset internal state. Writes folded-stack output to two streams:
+    /// \param raw_out         per-leaf sample counts (raw view)
+    /// \param normalized_out  per-tick presence counts (normalized view)
+    /// Both streams receive identical frame strings; only the trailing
+    /// count value differs. Each stream is independently consumable by
+    /// flamegraph.pl.
+    static future<> stop(output_stream<char>& raw_out,
+                         output_stream<char>& normalized_out);
+
+    /// Called from set_task() when a task becomes dormant (suspended on
+    /// a non-ready future). Fast path: single TLS pointer check,
+    /// predicted not-taken.
+    [[gnu::always_inline]]
+    static void on_task_suspend(task& t) noexcept {
+        if (auto* const session = _session; session != nullptr) [[unlikely]] {
+            do_suspend_task(*session, t);
+        }
+    }
+
+    /// Called from make_ready()/clear() when a suspended task is about
+    /// to be scheduled for execution. Fast path: single field check
+    /// on the task itself — no TLS access when profiler is off.
+    [[gnu::always_inline]]
+    static void on_task_resume(task& t) noexcept {
+        if (t._prof_idx != UINT32_MAX) [[unlikely]] {
+            do_resume_task(t);
+        }
+    }
+
+    /// Called when a task's awaited future is already available (e.g.
+    /// preemption path in co_await) — the task was never tracked, but
+    /// its parent should record the completion location so it doesn't
+    /// appear as a bare leaf. Fast path: single TLS pointer check.
+    [[gnu::always_inline]]
+    static void mark_completion(task& t) noexcept {
+        if (auto* const session = _session; session != nullptr) [[unlikely]] {
+            do_mark_completion(*session, t);
+        }
+    }
+
+private:
+    static void do_suspend_task(session& session, task& t) noexcept;
+    static void do_resume_task(task& t) noexcept;
+    static void do_mark_completion(session& session, task& t) noexcept;
+    static void sample_once(session& session) noexcept;
+
+    // Raw pointer (POD) rather than unique_ptr so that the TLS access on the
+    // suspend/resume hot paths compiles to a single direct load (initial-exec
+    // / local-exec TLS model). A non-trivially-destructible thread_local
+    // would force the compiler to route accesses through a guarded init
+    // wrapper, defeating that. Ownership/exception safety is handled
+    // locally in start() and stop().
+    inline static thread_local session* _session = nullptr;
+};
+
+} // namespace seastar

--- a/include/seastar/coroutine/try_future.hh
+++ b/include/seastar/coroutine/try_future.hh
@@ -45,7 +45,6 @@ class [[nodiscard]] try_future_awaiter : public seastar::task {
     seastar::future<T> _future;
     void (*_resume_or_destroy)(seastar::future<T>&, seastar::task&){};
     seastar::task* _coroutine_task{};
-    seastar::task* _waiting_task{};
 
 public:
     explicit try_future_awaiter(seastar::future<T>&& f) noexcept : _future(std::move(f)) {}
@@ -59,10 +58,11 @@ public:
     }
 
     template<typename U>
-    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl SEASTAR_COROUTINE_LOC_PARAM) noexcept {
+        // Capture co_await site so task_profiler shows the right function/line.
+        SEASTAR_COROUTINE_LOC_STORE(*this);
         _resume_or_destroy = try_future_resume_or_destroy_coroutine<T, U>;
         _coroutine_task = &hndl.promise();
-        _waiting_task = hndl.promise().waiting_task();
 
         if (_future.available()) {
             execute_involving_handle_destruction_in_await_suspend(this);
@@ -83,8 +83,14 @@ public:
         _resume_or_destroy(_future, *_coroutine_task);
     }
 
+    // Must delegate dynamically — not return a snapshot captured in
+    // await_suspend.  At await_suspend time, nobody has co_await'ed
+    // the enclosing coroutine's return future yet, so the coroutine
+    // promise's waiting_task is still nullptr.  By the time anyone
+    // reads this (e.g. task_profiler sampling), the caller's co_await
+    // has completed the chain.
     virtual task* waiting_task() noexcept override {
-        return _waiting_task;
+        return _coroutine_task->waiting_task();
     }
 };
 

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -84,6 +84,7 @@ void promise_base::clear() noexcept {
     if (__builtin_expect(bool(_task), false)) {
         SEASTAR_ASSERT(_state && !_state->available());
         set_to_broken_promise(*_state);
+        task_profiler::on_task_resume(*_task);
         ::seastar::schedule(std::exchange(_task, nullptr));
     }
     if (_future) {
@@ -119,6 +120,7 @@ template <promise_base::urgent Urgent>
 void promise_base::make_ready() noexcept {
     if (_task) {
         assert_task_shard();
+        task_profiler::on_task_resume(*_task);
         if (Urgent == urgent::yes) {
             ::seastar::schedule_urgent(std::exchange(_task, nullptr));
         } else {

--- a/src/core/task_profiler.cc
+++ b/src/core/task_profiler.cc
@@ -1,0 +1,375 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+#include <seastar/core/task_profiler.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/all.hh>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <memory_resource>
+#include <unordered_map>
+#include <vector>
+#include <fmt/format.h>
+
+namespace seastar {
+
+// The profiler tracks suspended tasks via a dense vector of task entries,
+// indexed by task::_prof_idx. Freed slots are removed by swapping
+// with the last entry and popping, keeping the vector dense — sample_once()
+// iterates only live entries with no holes to skip.
+//
+// Two concerns are separated:
+//
+// 1. Task entries (vector<task_entry>): tracks currently-suspended tasks.
+//    Managed by do_suspend_task (appends entry, sets _prof_idx)
+//    and do_resume_task (saves child_last_completion_loc in parent, swaps
+//    out entry). Ephemeral — entries come and go as tasks suspend/resume.
+//
+// 2. Folded stacks map (pmr unordered_map<stack_key, stack_stats>):
+//    accumulates sampling history. Populated during sample_once().
+//    Persistent — survives task resume/re-suspend cycles. Released only
+//    on stop() (via the arena that backs the map).
+//
+// On each timer tick, sample_once() first marks ancestor entries via
+// waiting_task() chains (Phase 1), then iterates remaining leaves to
+// build stack keys and increment map entries (Phase 2). Entries with
+// child_last_completion_loc record recently-completed children whose
+// entries were already freed — these appear as [completed] frames in
+// the output.
+//
+// Two counters are accumulated per unique stack:
+//
+//  - leaf_samples: incremented once for every leaf observation. Sums
+//    across all fibers and ticks. Stacks with high fiber multiplicity
+//    (many concurrent fibers blocked at the same place) accumulate
+//    proportionally larger values, which can mislead a reader trying
+//    to compare wall-clock time spent in different code paths.
+//
+//  - tick_presence: incremented at most once per tick per stack.
+//    Counts the number of ticks during which this stack appeared on
+//    at least one fiber. Comparable across stacks regardless of fiber
+//    multiplicity, so it is a better proxy for "fraction of wall-clock
+//    time this code path was blocked anywhere on the shard".
+//
+// Both views are emitted by stop() to separate output streams.
+
+namespace {
+
+constexpr size_t max_depth = 32;
+
+// std::source_location holds a single pointer to compiler-emitted
+// metadata. A default-constructed instance has a null pointer, which
+// observers expose as line()==0. Locations populated by
+// __builtin_source_location() (the only producer used here, via
+// std::source_location::current() and coroutine awaiter contexts)
+// always have line() >= 1, so line()==0 reliably means "unset". Using
+// this sentinel avoids the 16-byte overhead of std::optional<std::source_location>
+// and the engaged-bit write on the suspend hot path.
+inline bool is_set(const std::source_location& sl) noexcept {
+    return sl.line() != 0;
+}
+
+struct stack_key {
+    std::source_location frames[max_depth];
+    uint8_t depth = 0;
+    bool leaf_is_completed = false;
+
+    bool operator==(const stack_key& o) const noexcept {
+        return depth == o.depth
+            && leaf_is_completed == o.leaf_is_completed
+            && std::memcmp(frames, o.frames, depth * sizeof(std::source_location)) == 0;
+    }
+};
+
+struct stack_key_hash {
+    size_t operator()(const stack_key& k) const noexcept {
+        size_t h = k.depth | (size_t(k.leaf_is_completed) << 8);
+        for (uint8_t i = 0; i < k.depth; ++i) {
+            size_t v;
+            static_assert(sizeof(std::source_location) == sizeof(size_t));
+            std::memcpy(&v, &k.frames[i], sizeof(v));
+            // boost::hash_combine style mix
+            h ^= v * 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
+
+} // anonymous namespace
+
+struct task_profiler::session {
+    struct task_entry {
+        task* t;
+        // Default-constructed (null impl, line()==0) means "no recently-
+        // completed child recorded". Set by mark_completion when a child
+        // task resumes, so the parent leaf can show the [completed] frame.
+        std::source_location child_last_completion_loc;
+    };
+
+    // Per-stack accumulators, 16 bytes each (no padding):
+    //  - leaf_samples: total leaf observations across all ticks
+    //  - tick_presence: number of distinct ticks in which the stack appeared
+    //  - last_tick_seen: sentinel used by sample_once() to dedupe within a
+    //    tick. Compared against session::tick_counter; equality means
+    //    "already counted this tick".
+    //
+    // tick_presence and last_tick_seen are uint32_t. tick_counter wraps
+    // after ~2^32 ticks; at the typical 100 ms sampling interval that's
+    // ~13.6 years per session, so wraparound is not a practical concern.
+    // leaf_samples stays uint64_t to avoid overflow on long sessions with
+    // many concurrent fibers piling up on the same stack.
+    struct stack_stats {
+        uint64_t leaf_samples;
+        uint32_t tick_presence;
+        uint32_t last_tick_seen;
+    };
+
+    std::vector<task_entry> suspended_tasks;
+    // Parallel to suspended_tasks: a packed bit vector for the
+    // has_descendant flag used during sample_once(). Kept separate
+    // from task_entry so Phase 1 can clear it with a single word-fill
+    // and Phase 2 can read it sequentially, instead of strided
+    // writes/reads through the larger task_entry struct. vector<bool>
+    // packs 8 flags per byte for minimal cache footprint.
+    std::vector<bool> has_descendant;
+    timer<> sampling_timer;
+
+    // Monotonic arena that backs folded_stacks. Allocations are bump-
+    // pointer; deallocate() is a no-op. All memory is released at once
+    // when the arena is destroyed (i.e. when the session ends). This
+    // matches our access pattern: the map only grows during a session,
+    // and is freed in bulk afterwards. Initial chunk is 16 KiB; the
+    // resource grows geometrically when exhausted.
+    std::pmr::monotonic_buffer_resource arena{16 * 1024};
+    std::pmr::unordered_map<stack_key, stack_stats, stack_key_hash> folded_stacks{&arena};
+
+    // Monotonically incremented at the start of each sample_once() call.
+    // Starts at 1 so the default-initialized last_tick_seen == 0 in any
+    // newly inserted stack_stats correctly indicates "never seen".
+    uint32_t tick_counter = 0;
+};
+
+void task_profiler::sample_once(session& session) noexcept {
+    auto& suspended = session.suspended_tasks;
+    auto& has_descendant = session.has_descendant;
+
+    // Increment first so the value is always > 0 (matches "never seen" == 0
+    // sentinel in stack_stats::last_tick_seen).
+    const uint32_t tick = ++session.tick_counter;
+
+    // Phase 1: Find leaf tasks — tasks with no tracked descendant.
+    // Only leaves are sampled: an ancestor's suspension time is already
+    // accounted for by the leaves below it, so counting it again would
+    // overcount. Walk each entry's waiting_task() chain and flag every
+    // tracked ancestor as has_descendant. Early-break on already-
+    // flagged ancestors — their chains were already walked, so
+    // everything above is flagged too. O(N) amortised per tick.
+    //
+    // It would be nice to keep leaves and ancestors in separate vectors
+    // so that Phase 2 only iterates leaves. But when a task resumes
+    // between ticks, its parent may become a new leaf — and we can't
+    // tell, because the parent-child topology is only fully known at
+    // sampling time (waiting_task() links are set one at a time as
+    // each coroutine in the chain suspends). So we'd still need to
+    // re-classify everything each tick, gaining nothing.
+    has_descendant.assign(suspended.size(), false);
+    for (const auto& e : suspended) {
+        for (auto* p = e.t->waiting_task(); p && p->_prof_idx != UINT32_MAX; p = p->waiting_task()) {
+            if (has_descendant[p->_prof_idx]) {
+                break;
+            }
+            has_descendant[p->_prof_idx] = true;
+        }
+    }
+
+    // Phase 2: Sample leaves — entries that have no live descendant.
+    stack_key key;
+    for (size_t i = 0; i < suspended.size(); ++i) {
+        if (has_descendant[i]) {
+            continue;
+        }
+        const auto& e = suspended[i];
+
+        key.depth = 0;
+        key.leaf_is_completed = is_set(e.child_last_completion_loc);
+
+        // If this leaf has a recently-completed child, include its
+        // resume point as the innermost frame with [completed] annotation.
+        if (key.leaf_is_completed) {
+            key.frames[key.depth++] = e.child_last_completion_loc;
+        }
+
+        // Walk the task chain from leaf to root.
+        for (auto* p = e.t; p && key.depth < max_depth; p = p->waiting_task()) {
+            key.frames[key.depth++] = p->get_resume_point();
+        }
+
+        if (key.depth > 0) {
+            auto& stats = session.folded_stacks[key];
+            ++stats.leaf_samples;
+            // Bump tick_presence at most once per tick per stack.
+            if (stats.last_tick_seen != tick) {
+                stats.last_tick_seen = tick;
+                ++stats.tick_presence;
+            }
+        }
+    }
+}
+
+void task_profiler::do_suspend_task(session& session, task& t) noexcept {
+    // Append a new entry at the end of the dense vector.
+    const auto idx = static_cast<uint32_t>(session.suspended_tasks.size());
+    session.suspended_tasks.push_back({
+        .t = &t,
+    });
+    t._prof_idx = idx;
+}
+
+void task_profiler::do_mark_completion(session& session, task& t) noexcept {
+    auto* const parent = t.waiting_task();
+    if (parent && parent->_prof_idx != UINT32_MAX) {
+        auto& parent_entry = session.suspended_tasks[parent->_prof_idx];
+        parent_entry.child_last_completion_loc = t.get_resume_point();
+    }
+}
+
+void task_profiler::do_resume_task(task& t) noexcept {
+    auto* const session = _session;
+    if (!session) {
+        return;
+    }
+
+    const auto idx = t._prof_idx;
+    t._prof_idx = UINT32_MAX;
+
+    // When this child task resumes, its entry is about to be removed
+    // from the vector. Record the child's resume point in the parent's
+    // entry so that if the parent ends up as a leaf at sampling time
+    // (because no other descendant is currently tracked), the profiler
+    // can still show where the most recent child was when it completed.
+    do_mark_completion(*session, t);
+
+    // Remove the entry by swapping with the last and popping.
+    auto& suspended = session->suspended_tasks;
+    const auto last = static_cast<uint32_t>(suspended.size() - 1);
+    if (idx != last) {
+        suspended[idx] = suspended[last];
+        suspended[idx].t->_prof_idx = idx;
+    }
+    suspended.pop_back();
+}
+
+void task_profiler::start(std::chrono::steady_clock::duration sampling_interval) {
+    if (_session) {
+        throw std::runtime_error(format("task_profiler session already started on shard {}", this_shard_id()));
+    }
+    // Hold the session in unique_ptr until fully initialized (timer callback
+    // set, timer armed) so that any exception from those steps frees it
+    // without leaving _session pointing at a half-initialized instance.
+    auto session = std::make_unique<task_profiler::session>();
+    session->sampling_timer.set_callback([s = session.get()] {
+        sample_once(*s);
+    });
+    session->sampling_timer.arm(timer<>::clock::now() + sampling_interval, {sampling_interval});
+    _session = session.release();
+}
+
+future<> task_profiler::stop(output_stream<char>& raw_out,
+                             output_stream<char>& normalized_out) {
+    // Take ownership immediately and clear _session so on_task_suspend
+    // becomes a no-op and do_resume_task handles stale indexes gracefully.
+    // Doing this before any other action ensures that even if a subsequent
+    // step throws, _session won't dangle and a second stop() call won't
+    // double-free.
+    const auto session = std::unique_ptr<task_profiler::session>(std::exchange(_session, nullptr));
+    if (!session) {
+        co_return;
+    }
+
+    session->sampling_timer.cancel();
+
+    // Clear all profiler indexes on tracked tasks.
+    for (const auto& e : session->suspended_tasks) {
+        e.t->_prof_idx = UINT32_MAX;
+    }
+
+    // Dump folded stacks. No task pointers involved — stack_key
+    // contains only source_location values (pointers to static
+    // compiler metadata, always valid).
+    //
+    // The frame portion of the line is identical across the two output
+    // streams; only the trailing count differs (leaf_samples for the raw
+    // stream, tick_presence for the normalized stream). We format the
+    // frame portion once and append the differing count when building
+    // each line.
+    //
+    // The format is:
+    //   <frame>;<frame>;...;<frame> <count>\n
+    // where <frame> is "function_name (file:line)", or "[unknown]" when
+    // function_name is empty. The leaf frame may be prefixed with
+    // "[completed] " to indicate the most recent child completion point
+    // for a stack whose deepest tracked task has no live descendant.
+    auto format_frames = [](const stack_key& key, std::string& out) {
+        out.clear();
+        auto it = std::back_inserter(out);
+        for (size_t i = key.depth; i > 0; --i) {
+            if (i != key.depth) {
+                *it++ = ';';
+            }
+            const bool is_completed_frame = key.leaf_is_completed && (i == 1);
+            if (is_completed_frame) {
+                it = fmt::format_to(it, "[completed] ");
+            }
+            const auto& sl = key.frames[i - 1];
+            const char* const fn = sl.function_name();
+            const char* const file = sl.file_name();
+            const auto line = sl.line();
+            if (fn && fn[0] != '\0') {
+                it = fmt::format_to(it, "{}", fn);
+                if (file && file[0] != '\0' && line > 0) {
+                    it = fmt::format_to(it, " ({}:{})", file, line);
+                }
+            } else {
+                it = fmt::format_to(it, "[unknown]");
+            }
+        }
+    };
+
+    std::string frames;
+    std::string raw_line;
+    std::string norm_line;
+    for (const auto& [key, stats] : session->folded_stacks) {
+        format_frames(key, frames);
+        raw_line.clear();
+        norm_line.clear();
+        fmt::format_to(std::back_inserter(raw_line), "{} {}\n", frames, stats.leaf_samples);
+        fmt::format_to(std::back_inserter(norm_line), "{} {}\n", frames, stats.tick_presence);
+        co_await coroutine::all(
+            [&] { return raw_out.write(raw_line); },
+            [&] { return normalized_out.write(norm_line); });
+    }
+}
+
+} // namespace seastar


### PR DESCRIPTION
While investigating bottlenecks in ScyllaDB's strong consistency path,
we needed a way to see which suspended coroutine chains accumulate the
most samples over a profiling session — i.e., which fibers tend to stay
suspended.

The task_profiler is a per-shard sampling profiler for dormant tasks.
A periodic timer snapshots all currently-suspended task chains, walks
their waiting_task() links to collect source_location frames, and
accumulates per-stack sample counts in an unordered_map.  On stop(),
the map is streamed in folded-stack format consumable by flamegraph.pl.

It hooks into three points in the future/promise machinery:

 - on_task_suspend(): called from promise_base::set_task() when a task
   becomes dormant (suspended on a non-ready future).  Appends a
   task_entry to a dense vector and records the index in task::_prof_idx.

 - on_task_resume(): called from promise_base::make_ready() and clear()
   when a dormant task is about to be scheduled.  Records the child's
   resume_point in the parent entry (so recently-completed children
   appear as [completed] frames), then removes the entry via swap-and-pop.

 - mark_completion(): called from coroutine awaiter preemption paths
   where the awaited future is already available but need_preempt() is
   true.  The child was never tracked (it completed immediately), but
   this records its source_location in the parent entry.

sample_once() works in two phases:

 Phase 1 — identify leaves: walk each entry's waiting_task() chain and
 flag ancestors.  Early-break on already-flagged entries gives O(N)
 amortised cost.  Only leaves are sampled — ancestors' suspension is
 already accounted for by their leaves.

 Phase 2 — build stacks: for each leaf, walk waiting_task() from leaf to
 root collecting source_location frames, and increment the corresponding
 entry in the map.

The task::_prof_idx field (4 bytes) is placed after _sg (also 4 bytes),
filling an existing padding gap — zero per-task memory overhead.  All
three hook functions are [[gnu::always_inline]] with a single branch
(TLS pointer check or _prof_idx != UINT_MAX) predicted not-taken, so the
cost when the profiler is off is a single untaken branch per
suspend/resume.

An example of the flamegraph from a [test run](https://github.com/gusev-p/scylla/commits/async_profiler/):

<img width="1200" height="294" alt="out-333" src="https://github.com/user-attachments/assets/08cc8624-1979-47be-aabe-f98463a27d71" />