### PR TITLE
github: update compiler toolchains

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,37 +43,43 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-24.04
+    container:
+      image: docker.io/fedora:44
     steps:
+      - run: |
+          dnf -y upgrade
+
+      - name: Install git
+        run: |
+          dnf install -y git
+
       - uses: actions/checkout@v4
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
 
-      - run: |
-          sudo apt-get update
-
       - name: Install build dependencies
         run: |
-          sudo ./install-dependencies.sh
+          ./install-dependencies.sh
 
       - name: Install clang++
         if: ${{ inputs.compiler == 'clang++' }}
         run: |
-          sudo apt-get -y install clang-20
+          dnf install -y clang
 
       - name: Install clang-scan-deps
         if: ${{ contains(inputs.enables, 'cxx-modules') }}
         run: |
-          sudo apt-get -y install clang-tools-20
+          dnf install -y clang-tools-extra
 
       - name: Install g++
         if: ${{ inputs.compiler == 'g++' }}
         run: |
-          sudo apt-get -y install gcc-14 g++-14
+          dnf install -y gcc gcc-c++
 
       - name: Install ccache
         if: ${{ inputs.enable-ccache }}
         run: |
-          sudo apt-get -y install ccache
+          dnf install -y ccache
 
       - name: Setup ccache
         if: ${{ inputs.enable-ccache }}
@@ -84,11 +90,11 @@ jobs:
       - name: Configure
         run: |
           if [ ${{ inputs.compiler }} = "clang++" ]; then
-            CC=clang-20
-            CPP=clang++-20
+            CC=clang
+            CPP=clang++
           else
-            CC=gcc-14
-            CPP=g++-14
+            CC=gcc
+            CPP=g++
           fi
           if ${{ inputs.enable-ccache }}; then
             MAYBE_CCACHE_OPT="--compiler-cache=ccache"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,10 @@ jobs:
         compiler: [clang++, g++]
         standard: [20, 23]
         mode: [dev, debug, release]
+        exclude:
+          # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=124584
+          - compiler: g++
+            mode: debug
     with:
       compiler: ${{ matrix.compiler }}
       standard: ${{ matrix.standard }}


### PR DESCRIPTION
Switch to Fedora 44 (in a container, as github doesn't support it
directly yet), Clang 22, and gcc 16. This lets us test with modern
toolchains and sets the stage for bumping the standard to C++26.

Since we're running in a container, drop sudo, which isn't provided
by the container and also isn't needed.

Disable the g++ debug mode combination due to
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=124584.