### PR TITLE
net/tls: improve OpenSSL error queue hygiene

### DIFF
--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -961,6 +961,7 @@ public:
         // This do_until runs until either a renegotiation occurs or the packet is empty
         while (!eof() && size > 0) {
             size_t bytes_written = 0;
+            verify_clean_error_queue("SSL_write_ex");
             auto write_rc = SSL_write_ex(_ssl.get(), ptr, size, &bytes_written);
             tls_log.trace("{} do_put: SSL_write_ex: {}", *this, write_rc);
             if (write_rc != 1) {
@@ -1053,6 +1054,7 @@ public:
             [this] { return connected() || eof(); },
             [this] {
                 try {
+                    verify_clean_error_queue("SSL_do_handshake");
                     auto n = SSL_do_handshake(_ssl.get());
                     tls_log.trace("{} do_handshake: SSL_do_handshake: {}", *this, n);
                     if (n <= 0) {
@@ -1175,6 +1177,7 @@ public:
             tls_log.trace("{} do_get: available: {}", *this, avail);
             buf_type buf(avail);
             size_t bytes_read = 0;
+            verify_clean_error_queue("SSL_read_ex");
             auto read_result = SSL_read_ex(
               _ssl.get(), buf.get_write(), avail, &bytes_read);
             tls_log.trace("{} do_get: SSL_read_ex: {}", *this, read_result);
@@ -1271,6 +1274,7 @@ public:
             return make_ready_future();
         }
 
+        verify_clean_error_queue("SSL_shutdown");
         auto res = SSL_shutdown(_ssl.get());
         tls_log.trace("{} do_shutdown: SSL_shutdown: {}", *this, res);
         if (res == 1) {
@@ -1632,6 +1636,21 @@ private:
         }
         auto errors = get_all_openssl_errors();
         tls_log.debug("{} {}: ignoring stale errors on queue: {}", *this, operation, errors);
+    }
+
+    // Checks that the OpenSSL per-thread error queue is clean before
+    // calling an SSL function.  A dirty queue can cause SSL_get_error
+    // to misclassify results (e.g. reporting SSL_ERROR_SYSCALL instead
+    // of SSL_ERROR_SSL), which can affect unrelated sessions that share
+    // the same thread.
+    void verify_clean_error_queue(const char* operation) {
+        auto err = ERR_peek_error();
+        if (err == 0) [[likely]] {
+            return;
+        }
+        char buf[256];
+        ERR_error_string_n(err, buf, sizeof(buf));
+        tls_log.warn("{} stale error on queue before {}: {}", *this, operation, buf);
     }
 
     std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -171,6 +171,10 @@ std::system_error make_openssl_error(const std::string & msg) {
     return make_openssl_error(msg, get_all_openssl_errors());
 }
 
+std::runtime_error make_unknown_openssl_error(const std::string & msg) {
+    return std::runtime_error(fmt::format("{}: {}", msg, get_all_openssl_errors()));
+}
+
 bool contains_openssl_error(const std::vector<openssl_errc> & error_codes, int lib, int reason) {
     return std::any_of(error_codes.cbegin(), error_codes.cend(), [lib, reason](const openssl_errc & code) {
         return ERR_GET_LIB(static_cast<unsigned long>(code)) == lib &&
@@ -917,7 +921,7 @@ public:
         default:
         {
             // Some other unhandled situation
-            auto err = std::runtime_error(
+            auto err = make_unknown_openssl_error(
                 "Unknown error encountered during SSL write");
             return handle_output_error(std::move(err)).then([] {
                 return stop_iteration::yes;
@@ -1102,7 +1106,7 @@ public:
                             return handle_output_error(std::move(err));
                         }
                         default:
-                            auto err = std::runtime_error(
+                            auto err = make_unknown_openssl_error(
                             "Unknown error encountered during handshake");
                             return handle_output_error(std::move(err));
                         }
@@ -1227,7 +1231,7 @@ public:
                         return make_exception_future<buf_type>(_error);
                     }
                 default:
-                    _error = std::make_exception_ptr(std::runtime_error(
+                    _error = std::make_exception_ptr(make_unknown_openssl_error(
                       "Unexpected error condition during SSL read"));
                     return make_exception_future<buf_type>(_error);
                 }
@@ -1312,7 +1316,7 @@ public:
             }
             default:
             {
-                auto err = std::runtime_error(
+                auto err = make_unknown_openssl_error(
                   "Unknown error occurred during SSL shutdown");
                 return handle_output_error(std::move(err));
             }

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -1618,6 +1618,17 @@ public:
     }
 
 private:
+    // Some SSL operations return success while leaving stale errors on the
+    // queue (e.g. from internal BIO write failures that OpenSSL absorbed).
+    // Drain them so they don't poison the next operation on this shard.
+    void clear_stale_ssl_errors(const char* operation) {
+        if (ERR_peek_error() == 0) [[likely]] {
+            return;
+        }
+        auto errors = get_all_openssl_errors();
+        tls_log.debug("{} {}: ignoring stale errors on queue: {}", *this, operation, errors);
+    }
+
     std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,
                                                               const std::unordered_set<subject_alt_name_type> &types) const {
         int ext_idx = X509_get_ext_by_NID(
@@ -1786,6 +1797,11 @@ private:
             throw make_openssl_error(
               "Failed to initialize SSL context");
         }
+        // SSL_CTX_new can return a valid context while leaving errors on the
+        // error queue from partially-failed system config parsing (e.g. an
+        // invalid Ciphersuites value in the system openssl.cnf).
+        // See https://github.com/openssl/openssl/issues/30760
+        clear_stale_ssl_errors("SSL_CTX_new");
         const auto& ck_pair = _creds->get_certkey_pair();
         if (type == session_type::SERVER) {
             if (!ck_pair) {

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -789,7 +789,7 @@ public:
         bio_ptr in_bio(BIO_new(get_method()));
         bio_ptr out_bio(BIO_new(get_method()));
         if (!in_bio || !out_bio) {
-            throw std::runtime_error("Failed to create BIOs");
+            throw make_openssl_error("Failed to create BIOs");
         }
         if (1 != BIO_ctrl(in_bio.get(), BIO_C_SET_POINTER, 0, this)) {
             throw make_openssl_error("Failed to set bio ptr to in bio");

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -971,6 +971,7 @@ public:
                     co_return;
                 }
             } else {
+                clear_stale_ssl_errors("SSL_write_ex");
                 SEASTAR_ASSERT(bytes_written <= size);
                 tls_log.trace("{} do_put: bytes_written: {}", *this, bytes_written);
                 ptr += bytes_written;
@@ -1111,6 +1112,7 @@ public:
                             return handle_output_error(std::move(err));
                         }
                     } else {
+                        clear_stale_ssl_errors("SSL_do_handshake");
                         if (_type == session_type::CLIENT
                             || _creds->get_client_auth() != client_auth::NONE) {
                             verify();
@@ -1236,6 +1238,7 @@ public:
                     return make_exception_future<buf_type>(_error);
                 }
             } else {
+                clear_stale_ssl_errors("SSL_read_ex");
                 buf.trim(bytes_read);
                 return make_ready_future<buf_type>(std::move(buf));
             }
@@ -1271,8 +1274,10 @@ public:
         auto res = SSL_shutdown(_ssl.get());
         tls_log.trace("{} do_shutdown: SSL_shutdown: {}", *this, res);
         if (res == 1) {
+            clear_stale_ssl_errors("SSL_shutdown");
             return wait_for_output();
         } else if (res == 0) {
+            clear_stale_ssl_errors("SSL_shutdown");
             return yield().then([this] { return do_shutdown(); });
         } else {
             auto ssl_err = SSL_get_error(_ssl.get(), res);


### PR DESCRIPTION
OpenSSL uses a per-thread error queue to communicate failure details. In
seastar's cooperative scheduling model multiple TLS sessions share the
same thread, so if stale errors are left on the queue across a
scheduling point, `SSL_get_error` on an unrelated session can
misclassify the result (e.g. reporting `SSL_ERROR_SYSCALL` instead of
`SSL_ERROR_SSL`) because it peeks at the oldest error on the queue to
decide the classification.

We have hit this in practice at redpanda and it resulted in
hard-to-debug customer issues. This PR hardens the OpenSSL error queue
handling. See the individual commit messages for the details.

**Drain stale errors on error paths**
- `net/tls: use make_openssl_error for BIO creation failure`. Aligns
  the `BIO_new` failure with every other error path in the session
  constructor.
- `net/tls: drain error queue on unexpected error codes`. Ensures the
  default switch cases in error handlers drain the queue rather than
  silently discarding errors.

**Drain stale errors after successful operations**
- `net/tls: clear error queue after successful SSL_CTX_new`.
  `SSL_CTX_new` can return success while leaving errors from
  partially-failed system config parsing (e.g. an invalid
  `Ciphersuites` value in `openssl.cnf`).
- `net/tls: clear error queue after successful SSL operations`.
  `SSL_shutdown`, `SSL_do_handshake`, `SSL_write_ex`, and `SSL_read_ex`
  can return success while leaving errors from internal BIO write
  failures that OpenSSL absorbed. Root cause is a return-value
  translation gap in `bio_write_intern` where our `bwrite` callback's
  0-means-failure is misclassified as success by
  `tls_retry_write_records`. See the commit message for detailed call
  chains.

**Assert the queue is clean**
- `net/tls: assert clean error queue before SSL operations`. Adds
  `verify_clean_error_queue` checks before every `SSL_do_handshake`,
  `SSL_write_ex`, `SSL_read_ex`, and `SSL_shutdown` call as a safety
  net to surface regressions in tests and to make issues easier to debug in production.