### PR TITLE
net: Introduce round-robin connection balancing policy

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -360,6 +360,9 @@ public:
         port,
         // This algorithm distributes all new connections to listen_options::fixed_cpu shard only.
         fixed,
+        // This algorithm distributes new connections to shards in a round-robin fashion,
+        // cycling through shards 0, 1, ..., N-1, 0, 1, ... regardless of current load.
+        round_robin,
         default_ = connection_distribution
     };
     /// Constructs a \c server_socket without being bound to any address

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -60,6 +60,7 @@ using namespace seastar;
 class conntrack {
     class load_balancer {
         std::vector<unsigned> _cpu_load;
+        unsigned _rr_counter = 0;
     public:
         load_balancer() : _cpu_load(size_t(smp::count), 0) {}
         void closed_cpu(shard_id cpu) {
@@ -71,6 +72,12 @@ class conntrack {
             // and use that information.
             auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
             auto cpu = shard_id(std::distance(_cpu_load.begin(), min_el));
+            _cpu_load[cpu]++;
+            return cpu;
+        }
+        shard_id next_cpu_rr() {
+            auto cpu = shard_id(_rr_counter % smp::count);
+            _rr_counter++;
             _cpu_load[cpu]++;
             return cpu;
         }
@@ -118,6 +125,9 @@ public:
     conntrack() : _lb(make_lw_shared<load_balancer>()) {}
     handle get_handle() {
         return handle(_lb->next_cpu(), _lb);
+    }
+    handle get_handle_rr() {
+        return handle(_lb->next_cpu_rr(), _lb);
     }
     handle get_handle(shard_id cpu) {
         return handle(_lb->force_cpu(cpu), _lb);

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -724,6 +724,9 @@ posix_server_socket_impl::accept() {
         case server_socket::load_balancing_algorithm::fixed:
             cth = _conntrack.get_handle(_fixed_cpu);
             break;
+        case server_socket::load_balancing_algorithm::round_robin:
+            cth = _conntrack.get_handle_rr();
+            break;
         default: abort();
         }
 


### PR DESCRIPTION
Useful for some protocols which assume this policy, like shard-aware CQL protocol, which keeps opening connections until it hits the desired shard. With the current default load balancing strategy, which picks the least-loaded shard, that is not guaranteed to converge and can live-lock if there is connection imbalance.