### PR TITLE
httpd: log do_accepts gate-closed instead of swallowing it

### DIFF
--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -462,7 +462,9 @@ future<> http_server::accept_loop(int which, bool tls) {
 future<> http_server::do_accepts(int which, bool tls) {
     (void)try_with_gate(_task_gate, [this, which, tls] {
         return accept_loop(which, tls);
-    }).handle_exception_type([](const gate_closed_exception&) {});
+    }).handle_exception_type([which, tls] (const gate_closed_exception& e) {
+        hlogger.warn("In http_server::do_accepts(), try_with_gate(which={}, tls={}): {}", which, tls, e.what());
+    });
     return make_ready_future<>();
 }
 


### PR DESCRIPTION
Follow-up to #3359 review.
The handle_exception_type(gate_closed_exception) in do_accepts() is
unreachable under correct use (gate is only closed by stop()). Log
the failure instead of swallowing it silently.