### PR TITLE
Zero-copy http chunked data sink

### DIFF
--- a/src/http/common.cc
+++ b/src/http/common.cc
@@ -116,8 +116,26 @@ public:
     }
 #if SEASTAR_API_LEVEL >= 9
     future<> put(std::span<temporary_buffer<char>> data) override {
-        return data_sink_impl::fallback_put(data, [this] (temporary_buffer<char>&& buf) {
-            return do_put(std::move(buf));
+        size_t size = std::accumulate(data.begin(), data.end(), size_t(0),
+                [] (size_t s, const auto& b) { return s + b.size(); });
+        if (size == 0) {
+            // size 0 chunk should be ignored, some server
+            // may consider it an end of message
+            return make_ready_future<>();
+        }
+        // The span is only valid synchronously, so move the buffers into
+        // an owning vector before any suspension. The chunk size header and
+        // trailing CRLF go through small buffered writes, while the user's
+        // payload is forwarded as a span over the owned vector so the
+        // underlying output_stream can splice it into its zero-copy queue
+        // without copying user data.
+        auto buffers = std::vector<temporary_buffer<char>>(
+                std::make_move_iterator(data.begin()),
+                std::make_move_iterator(data.end()));
+        return write_size(size).then([this, buffers = std::move(buffers)] () mutable {
+            return _out.write(std::span<temporary_buffer<char>>(buffers));
+        }).then([this] {
+            return _out.write("\r\n", 2);
         });
     }
 #else

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -762,32 +762,32 @@ SEASTAR_TEST_CASE(content_length_limit) {
         loopback_connection_factory lcf(1);
         http_server server("test");
         server.set_content_length_limit(11);
-        loopback_socket_impl lsi(lcf);
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
 
-        future<> client = seastar::async([&lsi] {
-            connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
-            input_stream<char> input(c_socket.input());
-            output_stream<char> output(c_socket.output());
+        future<> client = seastar::async([&lcf] {
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
+            auto check_status = [&cln] (sstring body, http::reply::status_type expected) {
+                auto req = http::request::make("GET", "test", "/test");
+                if (!body.empty()) {
+                    req.write_body("txt", std::move(body));
+                }
+                std::optional<http::reply::status_type> status;
+                cln.make_request(std::move(req), [&status] (const http::reply& rep, input_stream<char>&& in) {
+                    status = rep._status;
+                    return seastar::async([in = std::move(in)] () mutable {
+                        util::skip_entire_stream(in).get();
+                        in.close().get();
+                    });
+                }).get();
+                BOOST_REQUIRE(status.has_value());
+                BOOST_REQUIRE_EQUAL(status.value(), expected);
+            };
 
-            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\n\r\n")).get();
-            output.flush().get();
-            auto resp = input.read().get();
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("200 OK"), std::string::npos);
+            check_status("",                    http::reply::status_type::ok);
+            check_status("xxxxxxxxxxx",         http::reply::status_type::ok);                // 11 bytes, at limit
+            check_status("xxxxxxxxxxxxxxxxx",   http::reply::status_type::payload_too_large); // 17 bytes, over limit
 
-            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\nContent-Length: 11\r\n\r\nxxxxxxxxxxx")).get();
-            output.flush().get();
-            resp = input.read().get();
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("200 OK"), std::string::npos);
-
-            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\nContent-Length: 17\r\n\r\nxxxxxxxxxxxxxxxx")).get();
-            output.flush().get();
-            resp = input.read().get();
-            BOOST_REQUIRE_EQUAL(std::string(resp.get(), resp.size()).find("200 OK"), std::string::npos);
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Payload Too Large"), std::string::npos);
-
-            input.close().get();
-            output.close().get();
+            cln.close().get();
         });
 
         auto handler = new json_test_handler(json::stream_object("hello"));

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -5,6 +5,8 @@
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/handlers.hh>
+#include <seastar/http/common.hh>
+#include <seastar/util/memory-data-sink.hh>
 #include <seastar/http/matcher.hh>
 #include <seastar/http/matchrules.hh>
 #include <seastar/http/reply.hh>
@@ -654,6 +656,48 @@ SEASTAR_TEST_CASE(test_simple_chunked) {
         std::make_tuple(true, 100)};
     return test_client_server::run(tests);
 }
+
+#if SEASTAR_API_LEVEL >= 9
+// Verify that http_chunked_data_sink_impl emits one chunk per put() call
+// even when the put receives multiple buffers, and that the chunk size
+// header and trailing CRLF frame the output correctly. Each chunked.write()
+// hands in a span of two buffers of differing sizes, and flush() forces it
+// down to the chunked sink as a single put() call. With a fallback
+// (per-buffer) implementation this would produce four chunks instead of
+// two, and the equality check below would fail.
+SEASTAR_TEST_CASE(test_chunked_sink_two_chunks_two_bufs) {
+    return seastar::async([] {
+        std::stringstream ss;
+        output_stream<char> raw_out(testing::memory_data_sink(ss), 4096);
+        auto chunked = http::internal::make_http_chunked_output_stream(raw_out);
+
+        const std::string A = "AAAAAAA";
+        const std::string B = "BBBBBBBBBBBBBBBBBBBBBBBB";
+        const std::string C = "C";
+        const std::string D = "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+
+        std::array<temporary_buffer<char>, 2> chunk1{
+                temporary_buffer<char>::copy_of(A),
+                temporary_buffer<char>::copy_of(B)};
+        chunked.write(std::span<temporary_buffer<char>>(chunk1)).get();
+        chunked.flush().get();
+
+        std::array<temporary_buffer<char>, 2> chunk2{
+                temporary_buffer<char>::copy_of(C),
+                temporary_buffer<char>::copy_of(D)};
+        chunked.write(std::span<temporary_buffer<char>>(chunk2)).get();
+        chunked.flush().get();
+
+        chunked.close().get();
+        raw_out.close().get();
+
+        const std::string expected =
+                  format("{:x}", A.size() + B.size()) + "\r\n" + A + B + "\r\n"
+                + format("{:x}", C.size() + D.size()) + "\r\n" + C + D + "\r\n";
+        BOOST_REQUIRE_EQUAL(ss.str(), expected);
+    });
+}
+#endif
 
 SEASTAR_TEST_CASE(test_http_client_server_full) {
     std::vector<std::tuple<bool, size_t>> tests = {

--- a/tests/unit/prometheus_http_test.cc
+++ b/tests/unit/prometheus_http_test.cc
@@ -23,10 +23,13 @@
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/prometheus.hh>
+#include <seastar/http/client.hh>
 #include <seastar/http/common.hh>
+#include <seastar/http/request.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/util/short_streams.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 
@@ -35,6 +38,31 @@ using namespace httpd;
 using namespace std::literals;
 
 namespace {
+
+class loopback_http_factory : public http::connection_factory {
+    loopback_socket_impl lsi;
+public:
+    explicit loopback_http_factory(loopback_connection_factory& f) : lsi(f) {}
+    virtual future<connected_socket> make(abort_source*) override {
+        return lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr()));
+    }
+};
+
+// Issue a GET to `path` and return the full response body as a string.
+std::string get_metrics_body(loopback_connection_factory& lcf, const sstring& path) {
+    auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
+    std::string body;
+    cln.make_request(http::request::make("GET", "test", path),
+        [&body] (const http::reply& rep, input_stream<char>&& in) {
+            BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::ok);
+            return seastar::async([&body, in = std::move(in)] () mutable {
+                body = util::read_entire_stream_contiguous(in).get();
+                in.close().get();
+            });
+        }, http::reply::status_type::ok).get();
+    cln.close().get();
+    return body;
+}
 
 struct test_metrics {
     metrics::metric_groups _metrics;
@@ -66,7 +94,6 @@ future<> test_prometheus_metrics_body(test_case tc) {
     co_await seastar::async([tc] {
         loopback_connection_factory lcf(1);
         http_server server("test");
-        loopback_socket_impl lsi(lcf);
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
 
         prometheus::config ctx;
@@ -75,18 +102,8 @@ future<> test_prometheus_metrics_body(test_case tc) {
         }
         add_prometheus_routes(server, ctx).get();
 
-        future<> client = seastar::async([&lsi, tc] {
-            connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
-            input_stream<char> input(c_socket.input());
-            auto close_input = deferred_close(input);
-            output_stream<char> output(c_socket.output());
-            auto close_output = deferred_close(output);
-
-            output.write(sstring("GET /metrics HTTP/1.1\r\nHost: test\r\n\r\n")).get();
-            output.flush().get();
-            auto resp = input.read().get();
-            auto resp_str = std::string(resp.get(), resp.size());
-            BOOST_REQUIRE(std::ranges::search(resp_str, "200 OK"sv));
+        future<> client = seastar::async([&lcf, tc] {
+            auto resp_str = get_metrics_body(lcf, "/metrics");
 
             auto global_label_str = tc.use_global_label ? fmt::format("{}=\"{}\",", global_label.key(), global_label.value()) : std::string{};
 
@@ -133,25 +150,14 @@ SEASTAR_TEST_CASE(test_prometheus_multiple_name_filters) {
     co_await seastar::async([] {
         loopback_connection_factory lcf(1);
         http_server server("test");
-        loopback_socket_impl lsi(lcf);
         httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
 
         prometheus::config ctx;
         add_prometheus_routes(server, ctx).get();
 
-        future<> client = seastar::async([&lsi] {
-            connected_socket c_socket = lsi.connect(socket_address(ipv4_addr()), socket_address(ipv4_addr())).get();
-            input_stream<char> input(c_socket.input());
-            auto close_input = deferred_close(input);
-            output_stream<char> output(c_socket.output());
-            auto close_output = deferred_close(output);
-
+        future<> client = seastar::async([&lcf] {
             // Request only metric_alpha and metric_gamma using multiple __name__ parameters
-            output.write(sstring("GET /metrics?__name__=test_metric_alpha&__name__=test_metric_gamma HTTP/1.1\r\nHost: test\r\n\r\n")).get();
-            output.flush().get();
-            auto resp = input.read().get();
-            auto resp_str = std::string(resp.get(), resp.size());
-            BOOST_REQUIRE(std::ranges::search(resp_str, "200 OK"sv));
+            auto resp_str = get_metrics_body(lcf, "/metrics?__name__=test_metric_alpha&__name__=test_metric_gamma");
 
             // Should contain alpha and gamma
             BOOST_REQUIRE_MESSAGE(std::ranges::search(resp_str, "seastar_test_metric_alpha"sv),


### PR DESCRIPTION
Make http_chunked_data_sink_impl (API ≥ 9) splice user buffers into the underlying output_stream's zero-copy queue instead of memcpy'ing them through its small buffer. Chunk-size header and trailing CRLF still go through the buffered write, piggy-backing on output_stream's mixed-mode facility.

First it rewrites httpd/content_length_limit and prometheus tests on top of http::client to fix a latent fragility (single input.read() per response) that the new sink would otherwise expose. The second commit is the sink change itself, plus a unit test.

Fixes #2916
