### PR TITLE
build: fix cmake missing ninja on Ubuntu 26.04

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -309,6 +309,9 @@ def configure_mode(mode):
         tr(args.debug_shared_ptr, 'DEBUG_SHARED_PTR', value_when_none='default'),
     ]
 
+    if not which('ninja-build') and which('ninja'):
+        TRANSLATED_ARGS.append('-DCMAKE_MAKE_PROGRAM=ninja')
+
     ingredients_to_cook = set(args.cook)
 
     if ingredients_to_cook:


### PR DESCRIPTION
Apparently, the ninja-build package on Ubuntu 26.04 provides a ninja command but not ninja-build. On the other hand cmake apparently looks for ninja-build. Detect this situation and steer cmake in the right direction when it happens.