### PR TITLE
build: install openssl package on Fedora

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -96,6 +96,7 @@ redhat_packages=(
     make
     meson
     numactl-devel
+    openssl
     openssl-devel
     protobuf-compiler
     protobuf-devel


### PR DESCRIPTION
While the build itself only requires openssl-devel, the tests require the openssl package to generate certificates etc.