### PR TITLE
vla.hh: add missing includes

### DIFF
--- a/src/core/vla.hh
+++ b/src/core/vla.hh
@@ -24,6 +24,8 @@
 #include <seastar/core/aligned_buffer.hh>
 #include <seastar/util/assert.hh>
 #include <memory>
+#include <cstdint>
+#include <cstdlib>
 
 namespace seastar {
 


### PR DESCRIPTION
vla.hh uses malloc() and uintptr_t, but doesn't include their respective headers. Fix this.