### PR TITLE
http: fix compilation on clang 22 with c++26

### DIFF
--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -172,7 +172,7 @@ public:
             size_t available = static_cast<size_t>(pe - p);
             size_t context_len = std::min(available, 32ul);
             sstring encountered(p, context_len);
-            _error_message = sstring("Parsing error at offset ") + std::to_string(offset) + ": encountered \"" + encountered +
+            _error_message = sstring("Parsing error at offset ") + to_sstring(offset) + ": encountered \"" + encountered +
                                          "\". Expected valid HTTP response header format (e.g., a complete start line with HTTP version, three-digit status code, header "
                                          "fields, and a terminating CRLF).";
         } else {


### PR DESCRIPTION
Fixes the following compilation error when building with `-std=c++26`:

src/http/response_parser.rl:172:58: error: use of overloaded operator '+' is ambiguous (with operand types 'sstring' (aka 'basic_sstring<char, unsigned int, 15>') and 'string' (aka 'basic_string<char>'))
  172 |                                 _error_message = sstring("Parsing error at offset ") + std::to_string(offset) + "..."