### PR TITLE
fair_queue: remove notify_request_finished()

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -301,9 +301,6 @@ public:
     void plug_class_group(unsigned index) noexcept;
     void unplug_class_group(unsigned index) noexcept;
 
-    /// Notifies that ont request finished
-    /// \param desc an instance of \c fair_queue_ticket structure describing the request that just finished.
-    void notify_request_finished(fair_queue_entry::capacity_t cap) noexcept;
     void notify_request_cancelled(fair_queue_entry& ent) noexcept;
 
     fair_queue_entry* top();

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -262,9 +262,6 @@ void fair_queue::queue(class_id id, fair_queue_entry& ent) noexcept {
     _queued_capacity += ent.capacity();
 }
 
-void fair_queue::notify_request_finished(fair_queue_entry::capacity_t cap) noexcept {
-}
-
 void fair_queue::notify_request_cancelled(fair_queue_entry& ent) noexcept {
     _queued_capacity -= ent._capacity;
     ent._capacity = 0;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -628,7 +628,6 @@ void
 io_queue::complete_request(io_desc_read_write& desc, std::chrono::duration<double> delay) noexcept {
     _requests_executing--;
     _requests_completed++;
-    _streams[desc.stream()].fq.notify_request_finished(desc.capacity());
 
     if (delay > _stall_threshold) {
         _stall_threshold *= 2;
@@ -1179,7 +1178,6 @@ void io_queue::cancel_request(queued_io_request& req) noexcept {
 }
 
 void io_queue::complete_cancelled_request(queued_io_request& req) noexcept {
-    _streams[req.stream()].fq.notify_request_finished(req.queue_entry().capacity());
 }
 
 io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -85,9 +85,8 @@ future<> perf_fair_queue::test(bool loc) {
     auto invokers = local_fq.invoke_on_all([loc] (local_fq_and_class& local) {
         return parallel_for_each(std::views::iota(0u, requests_to_dispatch), [&local, loc] (unsigned dummy) {
             auto cap = fair_queue_entry::capacity_t(1);
-            auto req = std::make_unique<local_fq_entry>(cap, [&local, loc, cap] {
+            auto req = std::make_unique<local_fq_entry>(cap, [&local] {
                 local.executed++;
-                local.queue(loc).notify_request_finished(cap);
             });
             local.queue(loc).queue(cid, req->ent);
             req.release();

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -109,7 +109,6 @@ public:
             for (auto& req : curr) {
                 processed++;
                 _results[req.index]++;
-                _fq.notify_request_finished(req.fqent.capacity());
             }
         }
         return processed;
@@ -143,7 +142,6 @@ public:
             } catch (...) {
                 auto eptr = std::current_exception();
                 _exceptions[index].push_back(eptr);
-                _fq.notify_request_finished(req.fqent.capacity());
             }
         });
 


### PR DESCRIPTION
The function's sole purpose was releasing tokens back to the token bucket (`_group.release_capacity(cap)`), implementing the dispatch -> completion backlink that rate-limited dispatch to the observed completion rate. Commit 557017fe removed that call when the 2-bucket backlink was replaced by the flow-rate monitor in io_queue, leaving the function permanently empty with an ignored parameter.

In this change, we

* Remove the declaration, the out-of-line definition in fair_queue.cc,
* Remove all call sites in io_queue.cc and the tests,
* Remove the now-unused lambda captures in fair_queue_perf.cc.