### PR TITLE
reactor: reduce steady_clock::now() calls per scheduling quantum

### DIFF
--- a/include/seastar/core/internal/stall_detector.hh
+++ b/include/seastar/core/internal/stall_detector.hh
@@ -84,7 +84,7 @@ public:
     virtual ~cpu_stall_detector() = default;
     static int signal_number() { return SIGRTMIN + 1; }
     void start_task_run(sched_clock::time_point now);
-    void end_task_run(sched_clock::time_point now);
+    void end_task_run();
     void generate_trace();
     void update_config(cpu_stall_detector_config cfg);
     cpu_stall_detector_config get_config() const;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -323,6 +323,7 @@ private:
         bool active() const noexcept;
         void activate(sched_entity*);
     private:
+        bool run_tasks_impl(sched_clock::time_point t_initial);
         void insert_active_entity(sched_entity*);
         sched_entity* pop_active_entity(sched_clock::time_point now);
         void insert_activating_entities();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1348,7 +1348,7 @@ void cpu_stall_detector::start_task_run(sched_clock::time_point now) {
     std::atomic_signal_fence(std::memory_order_release); // Don't delay this write, so the signal handler can see it
 }
 
-void cpu_stall_detector::end_task_run(sched_clock::time_point now) {
+void cpu_stall_detector::end_task_run() {
     std::atomic_signal_fence(std::memory_order_acquire); // Don't hoist this write, so the signal handler can see it
     _last_tasks_processed_seen.store(0, std::memory_order_relaxed);
 }
@@ -3217,19 +3217,21 @@ reactor::task_queue_group::run_some_tasks() {
     lowres_clock::update();
 
     STAP_PROBE(seastar, reactor_run_tasks_start);
-    r._cpu_stall_detector->start_task_run(now());
-
-    run_tasks();
-
-    r._cpu_stall_detector->end_task_run(now());
+    auto t = now();
+    r._cpu_stall_detector->start_task_run(t);
+    run_tasks_impl(t);
+    r._cpu_stall_detector->end_task_run();
     STAP_PROBE(seastar, reactor_run_tasks_end);
     *internal::current_scheduling_group_ptr() = default_scheduling_group(); // Prevent inheritance from last group run
 }
 
 bool reactor::task_queue_group::run_tasks() {
+    return run_tasks_impl(now());
+}
+
+bool reactor::task_queue_group::run_tasks_impl(sched_clock::time_point t_run_completed) {
     reactor& r = engine();
 
-    sched_clock::time_point t_run_completed = now();
     while (active()) {
         auto t_run_started = t_run_completed;
         insert_activating_entities();


### PR DESCRIPTION
Two redundant clock reads were removed from the hot scheduling path.

###  end_task_run() drop unused parameter

`cpu_stall_detector::end_task_run()` accepted a `sched_clock::time_point` argument that its body never used -- only the signal fence and the _last_tasks_processed_seen store are there.  The caller in `run_some_tasks()` was therefore evaluating `now()` (one vDSO RDTSCP + multiply/shift) and discarding the result.  Remove the parameter. Note: the compiler already eliminated the dead `clock_gettime` call within the same TU at -O2, so this is a correctness/API fix rather than a runtime win -- future callers in other TUs could not rely on that optimisation.

### Thread the quantum-start timestamp into run_tasks_impl()

`run_some_tasks()` called now() for start_task_run(), then `run_tasks()` called now() again as its first action to initialise t_run_completed.  These two reads were back-to-back with no task execution between them, so they measured the same instant twice.

Introduce a private run_tasks_impl(`sched_clock::time_point t_initial`) that accepts the already-computed timestamp instead of calling `now()` again.  `run_some_tasks()` shares one now() value across both `start_task_run()` and `run_tasks_impl()`.  The public virtual `run_tasks()` keeps its zero-argument signature (required by the `sched_entity` interface) and simply calls `run_tasks_impl(now()`).

On Linux with clocksource=tsc, `steady_clock::now()` resolves to a vDSO fast path: RDTSCP + multiply/shift in userspace with no syscall. The cost is ~20-40 cycles per call.  This change eliminates one such call per scheduling quantum from the `run_some_tasks()` entry point.