### PR TITLE
loop: use small_vector for parallel_for_each_state incomplete futures

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -28,7 +28,7 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
-#include <vector>
+#include <boost/container/small_vector.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/task.hh>
 #include <seastar/util/assert.hh>
@@ -531,7 +531,7 @@ iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end) {
 /// \cond internal
 
 class parallel_for_each_state final : private continuation_base<> {
-    std::vector<future<>> _incomplete;
+    boost::container::small_vector<future<>, 5> _incomplete;
     promise<> _result;
     std::exception_ptr _ex;
 private:


### PR DESCRIPTION
parallel_for_each_state holds pending futures in a `std::vector<future<>>`, so we pay a heap allocation for the buffer even when the range has just one element.  coroutine::parallel_for_each already sidesteps this with an inline-capacity `small_vector`; do the same here.

With `boost::container::small_vector<future<>, 5>`, ranges of up to 5 elements keep their pending futures inline on the state object -- no separate heap allocation for the vector.  Larger ranges still spill to the heap, so n > 5 looks the same as before.

Quick numbers from parallel_for_each_perf:

| Test | Time before | MAD | Time after | MAD | Δ time | Allocs before | Allocs after | Δ allocs |                          
|---|---:|---:|---:|---:|---:|---:|---:|---:|                                                                                                                                                                         
| `immediate_1` | 5.54 ns | ±0.40% | 5.38 ns | ±0.06% | -0.16 | 0 | 0 | 0 |                                                 
| `immediate_2` | 3.56 ns | ±0.87% | 3.55 ns | ±0.04% | -0.01 | 0 | 0 | 0 |                                                                                                                                           
| `immediate_10` | 1.59 ns | ±0.15% | 1.64 ns | ±0.22% | +0.05 | 0 | 0 | 0 |                                                                                                                                          
| `immediate_100` | 1.08 ns | ±0.16% | 1.10 ns | ±0.75% | +0.02 | 0 | 0 | 0 |                                                                                                                                         
| **`suspend_1`** | **50.39 ns** | **±0.09%** | **50.87 ns** | **±0.04%** | **+0.48** | **4.000** | **3.000** | **−1.000** |                                                                                          
| **`suspend_2`** | **32.65 ns** | **±0.88%** | **30.57 ns** | **±0.66%** | **−2.08** | **2.500** | **2.000** | **−0.500** |                                                                                          
| `suspend_10` | 15.99 ns | ±0.19% | 16.15 ns | ±0.41% | +0.16 | 1.300 | 1.300 | 0 |                                                                                                                                  
| `suspend_100` | 11.52 ns | ±0.30% | 11.52 ns | ±0.04% | 0.00 | 1.030 | 1.030 | 0 |

Release build, single shard, 5 runs averaged.