### PR TITLE
tests/tls: set 1000-day validity for self-signed CA cert

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -732,7 +732,7 @@ function(seastar_sign_cert name)
     # create a cert if CA is not specified
     add_custom_command(OUTPUT ${cert}
       COMMAND ${OPENSSL} req
-        -new -x509 -sha256
+        -new -x509 -sha256 -days 1000
         -key ${privkey}
         -out ${cert}
         -subj ${subj}


### PR DESCRIPTION
## Summary

The mtls CA cert generated by `seastar_sign_cert` (when no CA is supplied) omits `-days`, which makes `openssl req -new -x509` default to a **30-day** validity. The leaf certs signed by this CA already use `-days 1000`, but the CA itself expires first, so signature verification fails with `certificate has expired` once the build directory is older than 30 days.

Fresh CI builds never hit this because ninja considers the rule satisfied as long as the `.crt` file exists — there is no trigger to regenerate a cert that has expired in place. Persistent dev/build trees are the ones that break, with errors like:

```
fatal error: in "test_dn_name_handling": seastar::tls::verification_error:
  certificate has expired (Issuer=[...CN=redpanda.com], Subject=[...CN=redpanda.com])
```

This sets the CA's validity to 1000 days, matching the leaf certs.

## Test plan

- [x] `./test.py --mode dev --name tls_openssl` passes after regenerating the certs (`rm build/<mode>/tests/unit/mtls_*.{crt,key,csr} && ninja -C build/<mode> mtls_certs`)
- [x] Verified new CA cert validity: `openssl x509 -in build/<mode>/tests/unit/mtls_ca.crt -noout -dates` shows ~1000 days out