### PR TITLE
json: formatter: support types with user-defined conversion to sstring

### DIFF
--- a/include/seastar/json/formatter.hh
+++ b/include/seastar/json/formatter.hh
@@ -183,6 +183,18 @@ public:
     static sstring to_json(std::string_view str);
 
     /**
+     * return a json formatted string for types with a user-defined
+     * conversion to sstring but not directly to std::string_view.
+     * Without this, such types would require two user-defined conversions
+     * (T -> sstring -> string_view), which C++ doesn't allow implicitly.
+     */
+    template<typename T>
+    requires (std::convertible_to<const T&, sstring> && !std::convertible_to<const T&, std::string_view>)
+    static sstring to_json(const T& v) {
+        return to_json(std::string_view(sstring(v)));
+    }
+
+    /**
      * return a json formatted int
      * @param n the int to format
      * @return the given int in a json format
@@ -283,6 +295,16 @@ public:
      */
     static future<> write(output_stream<char>& s, std::string_view str) {
         return s.write(to_json(str));
+    }
+
+    /**
+     * write a json formatted string for types with a user-defined
+     * conversion to sstring but not directly to std::string_view.
+     */
+    template<typename T>
+    requires (std::convertible_to<const T&, sstring> && !std::convertible_to<const T&, std::string_view>)
+    static future<> write(output_stream<char>& s, const T& v) {
+        return write(s, std::string_view(sstring(v)));
     }
 
     /**

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -202,3 +202,32 @@ SEASTAR_THREAD_TEST_CASE(formatter_write) {
     });
 #endif
 }
+
+SEASTAR_THREAD_TEST_CASE(formatter_write_strings) {
+    sstring s = "hello, world";
+    const char* expected = "\"hello, world\"";
+    formatter_check_expected(expected, [&s] (auto& out) {
+        json::formatter::write(out, s).get();
+    });
+    formatter_check_expected(expected, [&s] (auto& out) {
+        json::formatter::write(out, std::string(s)).get();
+    });
+    formatter_check_expected(expected, [&s] (auto& out) {
+        json::formatter::write(out, std::string_view(s)).get();
+    });
+    formatter_check_expected(expected, [&s] (auto& out) {
+        json::formatter::write(out, s.c_str()).get();
+    });
+
+    // Test that formatter::write works with a type that has a user-defined
+    // conversion to sstring but not to std::string_view.
+    // See scylladb/seastar#3184.
+    struct sstring_convertible {
+        sstring value;
+        operator sstring() const { return value; }
+    };
+    sstring_convertible sc{s};
+    formatter_check_expected(expected, [&sc] (auto& out) {
+        json::formatter::write(out, sc).get();
+    });
+}

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -82,6 +82,16 @@ SEASTAR_TEST_CASE(test_strings) {
     BOOST_CHECK_EQUAL(expected, formatter::to_json(std::string_view(s)));
     BOOST_CHECK_EQUAL(expected, formatter::to_json(s.c_str()));
 
+    // Test that a type with a user-defined conversion to sstring
+    // (but not to std::string_view) works with to_json via a single
+    // implicit conversion. See scylladb/seastar#3184.
+    struct sstring_convertible {
+        sstring value;
+        operator sstring() const { return value; }
+    };
+    sstring_convertible sc{s};
+    BOOST_CHECK_EQUAL(expected, formatter::to_json(sc));
+
     return make_ready_future();
 }
 


### PR DESCRIPTION
## Summary

- Fixes a regression from #3184 where types with a user-defined conversion to `sstring` (but not to `std::string_view`) can no longer be passed to `formatter::to_json` / `formatter::write`
- The issue is that `to_json(std::string_view)` requires two implicit user-defined conversions (`T → sstring → string_view`), which C++ doesn't allow
- Adds constrained template overloads that accept types convertible to `sstring` but not directly to `std::string_view`, performing the conversion explicitly
- Adds a test case to verify the fix

Reported in https://github.com/scylladb/seastar/pull/3184#issuecomment-4392847668