### PR TITLE
net: posix: close abandoned proxy protocol connection early

### DIFF
--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -708,6 +708,7 @@ posix_server_socket_impl::accept() {
         if (_proxy_protocol) {
             addr_data_opt = co_await read_proxy_data(fd);
             if (!addr_data_opt) {
+                fd.close();
                 continue; // drop the connection
             }
             sa = addr_data_opt->remote_address;


### PR DESCRIPTION
If we fail to parse a proxy protocol header, we abandon the connection with `continue`. However, the connection won't be closed until we assign to `fd` after we accept a new connection. This can take some time.

Fix by closing the connection eagerly.

This manifests in a memory leak in the proxy protocol tests, but in production, will have minimal effect.