### PR TITLE
net: posix: fix pollable_fd_state leak on cross-shard connection forwarding

### DIFF
--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -759,7 +759,9 @@ posix_ap_server_socket_impl::posix_ap_server_socket_impl(int protocol, socket_ad
 }
 
 posix_ap_server_socket_impl::~posix_ap_server_socket_impl() {
-    ports.erase(std::make_tuple(_protocol, _sa));
+    auto t_sa = std::make_tuple(_protocol, _sa);
+    conn_q.erase(t_sa);
+    ports.erase(t_sa);
 }
 
 future<accept_result> posix_ap_server_socket_impl::accept() {
@@ -830,8 +832,11 @@ posix_ap_server_socket_impl::move_connected_socket(int protocol, socket_address 
             i->second.set_exception(std::current_exception());
         }
         sockets.erase(i);
-    } else {
+    } else if (ports.contains(t_sa)) {
         conn_q.emplace(std::piecewise_construct, std::make_tuple(t_sa), std::make_tuple(std::move(fd), std::move(addr), std::move(cth), std::move(addr_data_opt)));
+    } else {
+        // No one is listening anymore; drop the connection to avoid leaking it.
+        fd.close();
     }
 }
 


### PR DESCRIPTION
Fix a memory leak of pollable_fd_state objects during cross-shard
connection forwarding.

The leak has two contributing factors, all in the cross-shard
connection forwarding path of posix_server_socket_impl::accept():

1. posix_ap_server_socket_impl::move_connected_socket() unconditionally
   queues connections into the static conn_q when no acceptor is
   waiting. If the server_socket has already been destroyed (entry
   removed from ports), these queued connections are never consumed.
   Fix by checking ports.contains() before queuing, and closing the
   fd otherwise.

2. posix_ap_server_socket_impl's destructor only removed from ports
   but did not drain conn_q entries for its address. Connections
   queued between abort_accept() (which drains conn_q) and the
   destructor would be leaked. Fix by also erasing from conn_q in
   the destructor.