### PR TITLE
reactor: always use oneline backtraces in signal handlers and fatal paths

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -913,7 +913,7 @@ static void print_with_backtrace(backtrace_buffer& buf, bool oneline) noexcept {
 // where the backtrace itself may crash at some point down the stack
 // while the latter is more efficient and avoids splitting output
 // in the face of concurrent logging by other shards.
-static void print_with_backtrace(const char* cause, bool oneline = false, bool immediate = false) noexcept {
+static void print_with_backtrace(const char* cause, bool oneline = true, bool immediate = false) noexcept {
     backtrace_buffer buf(immediate);
     buf.append(cause);
     print_with_backtrace(buf, oneline);
@@ -4245,7 +4245,7 @@ static void sigsegv_action(siginfo_t *info, ucontext_t* uc) noexcept {
 
     // print the backtrace in immediate mode, so if we crash
     // during the backtrace we get as much output as possible
-    print_with_backtrace("Segmentation fault", false, true);
+    print_with_backtrace("Segmentation fault", true, true);
     reraise_signal(SIGSEGV);
 }
 


### PR DESCRIPTION
## Summary

- All backtrace output from signal handlers (SIGSEGV, SIGABRT, SIGILL) and the reactor main loop exception handler now unconditionally use the oneline format.
- This aligns signal handler output with reactor stall backtraces which already default to oneline, making log parsing more reliable and avoiding interlaced multi-line output from concurrent shards.

## Approach

Rather than making this configurable (which ran into template issues with `install_oneshot_signal_handler` as discussed in #2052), this simply hardcodes `oneline=true` for all fatal/crash backtrace paths. The rationale:

1. Community consensus from scylladb/scylladb#5464 is that oneline is strictly better for automated parsing
2. Signal handlers fire at most once (fatal) so there is no performance concern
3. The existing `blocked_reactor_report_format_oneline` option already controls stall detector output separately
4. addr2line.py and backtrace tools already support the oneline format

Supersedes #2052.
Fixes: scylladb/scylladb#16922