### PR TITLE
scheduling_group: expose usage statistics

### DIFF
--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -426,6 +426,13 @@ public:
     friend unsigned internal::scheduling_group_index(scheduling_group sg) noexcept;
     friend scheduling_group internal::scheduling_group_from_index(unsigned index) noexcept;
 
+    struct stats {
+        sched_clock::duration runtime;
+        sched_clock::duration waittime;
+        sched_clock::duration starvetime;
+    };
+    stats get_stats() const noexcept;
+
     template<typename SpecificValType, typename Mapper, typename Reducer, typename Initial>
     requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
         {reducer(initial, mapper(specific_val))} -> std::convertible_to<Initial>;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -5301,6 +5301,16 @@ future<> destroy_scheduling_supergroup(scheduling_supergroup sg) noexcept {
     });
 }
 
+scheduling_group::stats
+scheduling_group::get_stats() const noexcept {
+    const auto * const tq = engine()._task_queues[_id].get();
+    return {
+        .runtime = tq->_runtime,
+        .waittime = tq->_waittime,
+        .starvetime = tq->_starvetime
+    };
+}
+
 future<scheduling_group>
 create_scheduling_group(sstring name, sstring shortname, float shares, scheduling_supergroup parent) noexcept {
     auto sg = co_await smp::submit_to(0, [name, shortname, shares, parent] {


### PR DESCRIPTION
Extends the public interface of `scheduling_group` to expose its task
queue usage statistics — `runtime`, `waittime`, and `starvetime` — via
a new `get_stats()` accessor returning a `scheduling_group::stats`
struct. The underlying counters are already maintained on the per-shard
task queue; this just makes them readable from outside the reactor.

This patch has been carried in the Redpanda fork since 2022. We have
two production uses motivating upstreaming:

1. **Per-scheduling-group Prometheus metric.** Redpanda exports a
   `scheduler_runtime_seconds_total` counter with one series per
   scheduling group, sampled from `get_stats().runtime` in the metric
   callback — visibility into how reactor time is split between SGs,
   useful for capacity planning and noisy-neighbor diagnosis.

2. **Fetch PID controller.** A PID loop samples the Kafka fetch
   scheduling group's `runtime` to compute its utilization fraction
   (delta runtime / delta wallclock), combines it with overall reactor
   busy time, and outputs a per-fetch debounce delay that keeps the
   fetch SG within a configured share of the reactor.

Original: https://github.com/redpanda-data/seastar/commit/a618fe8da390d34609a8debbf6c42df61754602f