### PR TITLE
websocket: refactor connection lifecycle and harden frame parser

### DIFF
--- a/demos/websocket_client_demo.cc
+++ b/demos/websocket_client_demo.cc
@@ -97,6 +97,11 @@ int main(int argc, char** argv) {
             duration);
         co_await seastar::sleep_abortable(std::chrono::seconds(duration));
         ws_demo_logger.info("Done, closing connection.");
+        // close() drives the CLOSE handshake and tears the streams down,
+        // which unblocks the handler's in.read() via SHUT_RD. shutdown() is
+        // an OOB escape hatch for outbound-stall cases; here it is harmless
+        // belt-and-suspenders.
+        ws_client.shutdown();
         co_await ws_client.close();
     });
 }

--- a/doc/websocket.md
+++ b/doc/websocket.md
@@ -7,7 +7,7 @@ https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocke
 
 ## Handlers
 
-A WebSocket server needs a user-defined handler in order to be functiomal. WebSocket specification defines a concept of subprotocols, and Seastar WebSocket server allows registering a single handler per subprotocol.
+A WebSocket server needs a user-defined handler in order to be functional. WebSocket specification defines a concept of subprotocols, and Seastar WebSocket server allows registering a single handler per subprotocol.
 
 Each subprotocol has a unique name and is expected to be sent by the connecting client during handshake,
 by sending a `Sec-Websocket-Protocol` header with the chosen value.
@@ -34,6 +34,68 @@ ws.register_handler("echo", [] (input_stream<char>& in, output_stream<char>& out
 
 Note: the developers should assume that the input stream provides decoded and unmasked data - so the stream should be treated as if it was backed by a TCP socket. Similarly, responses should be sent to the output stream as is, and the WebSocket server implementation will handle its proper serialization, masking and so on.
 
+## Connection lifecycle
+
+The handler owns the normal WebSocket connection lifecycle. To actively close a
+connection, close the output stream passed to the handler:
+
+```cpp
+ws.register_handler("echo", [] (input_stream<char>& in, output_stream<char>& out) -> future<> {
+    while (true) {
+        auto buf = co_await in.read();
+        if (buf.empty()) {
+            break;
+        }
+        co_await out.write(std::move(buf));
+        co_await out.flush();
+    }
+    co_await out.close();
+});
+```
+
+On EOF or after the connection is torn down, `in.read()` returns an empty
+buffer. If WebSocket frame parsing fails, the current `in.read()` fails with
+`websocket::exception`; after the connection teardown completes, later reads
+return an empty buffer.
+
+The frame parser enforces RFC 6455 control-frame limits: CLOSE, PING and PONG
+frames must not be fragmented and their payload is limited to 125 bytes. Data
+frames are limited to 16 MiB by default to avoid allocating memory from
+untrusted frame lengths; the limit is configurable via
+`connection_options::max_payload_length` passed to the server/client
+constructor. A frame that exceeds either limit fails the active `in.read()`
+with `websocket::exception`.
+
+Outgoing frames are serialized internally. If an output write or close fails,
+the connection's send path is considered failed: later writes fail with the same
+exception until the connection is torn down. Applications should treat any
+failed output operation as terminal for that WebSocket connection.
+
+When the application initiates the close handshake (by closing the output
+stream from inside the handler, or `websocket::client::close()` from outside),
+the implementation waits up to `connection_options::close_timeout` (200 ms by
+default) for the peer's CLOSE response before tearing down the streams.
+
+For `websocket::client`, `close()` initiates a WebSocket CLOSE handshake and
+tears down the connection's streams; the stream teardown shuts down the socket
+read side, so a handler blocked in `in.read()` is unblocked and `close()`
+resolves once the processing task has finished.
+
+`close()` may fail to make progress only when the outbound path itself stalls
+(for example, the peer's TCP receive window is full so the CLOSE frame can
+never be sent). In that case `shutdown()` provides an out-of-band escape hatch
+that synchronously shuts the connection's input down so the handler can return
+and `close()` can complete:
+
+```cpp
+ws_client.shutdown();   // only needed when the outbound is stalled
+co_await ws_client.close();
+```
+
+`websocket::server::stop()` stops accepting new connections and tears down
+active connections. It does not initiate a WebSocket CLOSE handshake for those
+active connections.
+
 ## Error handling
 
 Registered WebSocket handlers can throw arbitrary exceptions during their operation. Currently, exceptions that aren't explicitly handled within the handler will cause the established WebSocket connection to be terminated, and a proper error message will be logged.
@@ -42,4 +104,3 @@ Registered WebSocket handlers can throw arbitrary exceptions during their operat
 
 Implementation of Secure WebSocket standard, based on HTTPS is currently work in advanced progress. Once reviewed and merged, this section will contain documentation for it.
 Ref: https://github.com/scylladb/seastar/pull/1044
-

--- a/include/seastar/websocket/client.hh
+++ b/include/seastar/websocket/client.hh
@@ -54,9 +54,11 @@ public:
      * \param host the Host header value
      * \param subprotocol optional subprotocol name
      * \param handler application handler for incoming/outgoing data
+     * \param options connection tuning options.
      */
     client_connection(connected_socket&& fd, sstring resource, sstring host,
-                      sstring subprotocol, handler_t handler);
+                      sstring subprotocol, handler_t handler,
+                      connection_options options = {});
 
     /*!
      * \brief Run the WebSocket client connection.
@@ -96,9 +98,11 @@ public:
      * \param host the Host header value
      * \param subprotocol optional subprotocol name (empty for none)
      * \param handler application handler
+     * \param options connection tuning options.
      */
     future<> connect(socket_address addr, sstring resource, sstring host,
-                     sstring subprotocol, handler_t handler);
+                     sstring subprotocol, handler_t handler,
+                     connection_options options = {});
 
     /*!
      * \brief Connect to a WebSocket server over TLS.
@@ -108,11 +112,13 @@ public:
      * \param host the Host header value
      * \param subprotocol optional subprotocol name (empty for none)
      * \param handler application handler
+     * \param options connection tuning options.
      */
     future<> connect(socket_address addr,
                      shared_ptr<tls::certificate_credentials> creds,
                      sstring resource, sstring host,
-                     sstring subprotocol, handler_t handler);
+                     sstring subprotocol, handler_t handler,
+                     connection_options options = {});
 
     /*!
      * \brief Close the client and the underlying connection.

--- a/include/seastar/websocket/client.hh
+++ b/include/seastar/websocket/client.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/websocket/common.hh>
 
@@ -65,7 +66,7 @@ public:
      */
     future<> process();
 
-     /*!
+    /*!
      * \brief Perform the WebSocket opening handshake.
      *
      * Sends an HTTP Upgrade request to the server and waits for
@@ -89,7 +90,10 @@ template<bool text_frame = false>
 class client {
     std::unique_ptr<client_connection<text_frame>> _conn;
     gate _task_gate;
-
+    bool _handshake_done = false;
+    future<> connect(connected_socket fd, sstring resource, sstring host,
+                     sstring subprotocol, handler_t handler,
+                     const connection_options& options);
 public:
     /*!
      * \brief Connect to a WebSocket server over plain TCP.
@@ -121,9 +125,43 @@ public:
                      connection_options options = {});
 
     /*!
-     * \brief Close the client and the underlying connection.
+     * \brief Close the connection and wait for the client processing task to
+     *        finish.
+     *
+     * The client handler owns the WebSocket connection lifetime. To close the
+     * connection normally, the handler should call close() on the output stream
+     * passed to it.
+     *
+     * close() initiates a WebSocket CLOSE handshake and tears down the
+     * underlying streams. A handler blocked in input_stream::read() is unblocked
+     * because the stream teardown shuts down the socket read side (SHUT_RD),
+     * causing the pending read to observe EOF.
+     *
+     * The one case where this future may not resolve is when the CLOSE frame
+     * itself cannot be sent (for example, the peer's TCP receive window is full
+     * and the outbound write never yields back). In that case the teardown
+     * path never runs, and shutdown() can be used as an out-of-band escape
+     * hatch: it directly shuts down the connection's input so the handler can
+     * return and the task gate can drain.
+     *
+     * \sa shutdown()
      */
     future<> close();
+    /*!
+     * \brief Shut down the underlying connection input as an out-of-band escape.
+     *
+     * Synchronously shuts down the connection's read side without going through
+     * the CLOSE handshake. Useful when close() cannot make progress because the
+     * outbound path is stalled (peer recv-window full, dead peer holding the
+     * connection open). Calling shutdown() unblocks a handler waiting in
+     * input_stream::read() so close() and the task gate can finish.
+     *
+     * Normal teardown should go through close(); shutdown() is an escape hatch
+     * for outbound-stall scenarios.
+     *
+     * \sa close()
+     */
+    void shutdown();
 };
 
 /// @}

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -34,6 +34,23 @@ using handler_t = std::function<future<>(input_stream<char>&, output_stream<char
 
 class server;
 
+/// RFC 6455 section 1.3 accept-key GUID shared by server and client handshakes.
+constexpr std::string_view websocket_magic_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/*!
+ * \brief Configuration knobs for a WebSocket connection.
+ */
+struct connection_options {
+    /*!
+     * \brief Maximum accepted payload size for incoming data frames.
+     */
+    uint64_t max_payload_length = websocket_parser::default_max_payload_length;
+    /*!
+     * \brief Buffer size of the output_stream wrapping the connection sink.
+     */
+    size_t output_buffer_size = 8192;
+};
+
 /// \defgroup websocket WebSocket
 /// \addtogroup websocket
 /// @{
@@ -147,15 +164,16 @@ public:
      * \param is_client if true, this is a client-side connection (sends masked
      *        frames and expects unmasked frames from server)
      */
-    basic_connection(connected_socket&& fd)
+    basic_connection(connected_socket&& fd,
+            connection_options options = {})
         : _fd(std::move(fd))
         , _read_buf(_fd.input())
         , _write_buf(_fd.output())
-        , _websocket_parser(!is_client)
+        , _websocket_parser(!is_client, options.max_payload_length)
         , _input_buffer{PIPE_SIZE}
         , _input(data_source{std::make_unique<connection_source_impl>(&_input_buffer)})
         , _output_buffer{PIPE_SIZE}
-        , _output(data_sink{std::make_unique<connection_sink_impl>(&_output_buffer)})
+        , _output(data_sink{std::make_unique<connection_sink_impl>(&_output_buffer)}, options.output_buffer_size)
     {
     }
 

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -146,6 +146,7 @@ protected:
     connected_socket _fd;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
+    future<> _send_chain;
     bool _done = false;
     // TODO: implement https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.2
     bool _half_close = false;
@@ -169,6 +170,7 @@ public:
         : _fd(std::move(fd))
         , _read_buf(_fd.input())
         , _write_buf(_fd.output())
+        , _send_chain(make_ready_future())
         , _websocket_parser(!is_client, options.max_payload_length)
         , _input_buffer{PIPE_SIZE}
         , _input(data_source{std::make_unique<connection_source_impl>(&_input_buffer)})
@@ -190,6 +192,8 @@ protected:
      * \brief Packs buff in websocket frame and sends it to the client.
      */
     future<> send_data(opcodes opcode, temporary_buffer<char> buff);
+    future<> do_send(opcodes opcode, temporary_buffer<char> buff);
+    future<> drain_send_chain();
 };
 
 using connection = basic_connection<false, false>;

--- a/include/seastar/websocket/common.hh
+++ b/include/seastar/websocket/common.hh
@@ -21,21 +21,43 @@
 
 #pragma once
 
+#include <chrono>
+#include <optional>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/iostream.hh>
-#include <seastar/core/queue.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/temporary_buffer.hh>
 #include <seastar/net/api.hh>
 #include <seastar/util/log.hh>
 #include <seastar/websocket/parser.hh>
 
 namespace seastar::experimental::websocket {
 
+/*!
+ * \brief Application handler for an established WebSocket connection.
+ *
+ * The input stream yields decoded WebSocket message payloads and returns an
+ * empty buffer on orderly teardown. Protocol parse failures are reported to the
+ * current read as websocket::exception; after teardown, later reads return an
+ * empty buffer.
+ *
+ * The output stream accepts unframed payload data. To actively close the
+ * WebSocket connection normally, the handler should close the output stream.
+ * If an output write or close fails, the connection's send path is no longer
+ * usable and the handler should not attempt more writes.
+ */
 using handler_t = std::function<future<>(input_stream<char>&, output_stream<char>&)>;
 
 class server;
 
-/// RFC 6455 section 1.3 accept-key GUID shared by server and client handshakes.
+/// RFC 6455 §1.3 accept-key GUID shared by server and client handshake paths.
 constexpr std::string_view websocket_magic_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+template <bool is_client, bool text_frame>
+struct basic_connection_test_accessor;
 
 /*!
  * \brief Configuration knobs for a WebSocket connection.
@@ -43,12 +65,29 @@ constexpr std::string_view websocket_magic_guid = "258EAFA5-E914-47DA-95CA-C5AB0
 struct connection_options {
     /*!
      * \brief Maximum accepted payload size for incoming data frames.
+     *
+     * Frames whose payload exceeds this limit cause the parser to stop with an
+     * error, which is reported to the current input_stream::read() as a
+     * websocket::exception. The default is 16 MiB. Does not apply to control
+     * frames, which are fixed to the RFC 6455 maximum of 125 bytes.
      */
     uint64_t max_payload_length = websocket_parser::default_max_payload_length;
     /*!
      * \brief Buffer size of the output_stream wrapping the connection sink.
+     *
+     * Sets the chunking granularity at which the handler's writes are batched
+     * before being serialized as WebSocket frames. Not the size of any
+     * underlying socket buffer.
      */
     size_t output_buffer_size = 8192;
+    /*!
+     * \brief How long to wait for the peer's CLOSE response during a locally
+     *        initiated close handshake.
+     *
+     * On timeout, the connection's input is shut down so teardown can proceed
+     * even if the peer never sends a CLOSE frame.
+     */
+    lowres_clock::duration close_timeout = std::chrono::milliseconds(200);
 };
 
 /// \defgroup websocket WebSocket
@@ -68,35 +107,55 @@ public:
 };
 
 /*!
- * \brief a server WebSocket connection
+ * \brief Base implementation for a WebSocket connection (client- or server-side).
+ *
+ * Whether the connection behaves as a client or server is selected by the
+ * \c is_client template parameter.
  */
 template <bool is_client = false, bool text_frame = false>
 class basic_connection : public boost::intrusive::list_base_hook<> {
+    template <bool test_is_client, bool test_text_frame>
+    friend struct basic_connection_test_accessor;
+
 protected:
     using buff_t = temporary_buffer<char>;
-
+    /*!
+     * \brief Connection close lifecycle.
+     *
+     * A running connection can move to a local close, a peer close, or direct
+     * teardown. All closing states eventually move through tearing_down to
+     * torn_down. Re-entrant close callers share _close_future instead of
+     * starting another handshake or stream teardown.
+     */
+    enum class lifecycle_state {
+        running,
+        closing_local,
+        closing_peer,
+        tearing_down,
+        torn_down,
+    };
     /*!
      * \brief Implementation of connection's data source.
      */
     class connection_source_impl final : public data_source_impl {
-        queue<buff_t>* data;
+        basic_connection<is_client, text_frame>& _conn;
 
     public:
-        connection_source_impl(queue<buff_t>* data) : data(data) {}
+        connection_source_impl(basic_connection<is_client, text_frame>& conn)
+            : _conn(conn) {}
 
         virtual future<buff_t> get() override {
-            return data->pop_eventually().then_wrapped([](future<buff_t> f){
-                try {
-                    return make_ready_future<buff_t>(std::move(f.get()));
-                } catch(...) {
-                    return current_exception_as_future<buff_t>();
-                }
+            return do_until([this] () { return _conn._pending_inbound.has_value(); }, [this] () {
+                return _conn.consume();
+            }).then([this] () {
+                buff_t buff = std::move(*_conn._pending_inbound);
+                _conn._pending_inbound.reset();
+                return make_ready_future<buff_t>(std::move(buff));
             });
         }
 
         virtual future<> close() override {
-            data->push(buff_t(0));
-            return make_ready_future<>();
+            return _conn._read_buf.close();
         }
     };
 
@@ -104,96 +163,164 @@ protected:
      * \brief Implementation of connection's data sink.
      */
     class connection_sink_impl final : public data_sink_impl {
-        queue<buff_t>* data;
+        basic_connection<is_client, text_frame>& _conn;
+
+        opcodes opcode() {
+            return text_frame ? opcodes::TEXT : opcodes::BINARY;
+        }
     public:
-        connection_sink_impl(queue<buff_t>* data) : data(data) {}
+        connection_sink_impl(basic_connection<is_client, text_frame>& conn) : _conn(conn) {}
 
 #if SEASTAR_API_LEVEL >= 9
         future<> put(std::span<temporary_buffer<char>> d) override {
             return data_sink_impl::fallback_put(d, [this] (temporary_buffer<char>&& buf) {
-                return data->push_eventually(std::move(buf));
+                return _conn.send_data(opcode(), std::move(buf));
             });
         }
 #else
         virtual future<> put(net::packet d) override {
             net::fragment f = d.frag(0);
-            return data->push_eventually(temporary_buffer<char>{std::move(f.base), f.size});
+            return _conn.send_data(opcode(), temporary_buffer<char>{std::move(f.base), f.size});
         }
 #endif
-
-        size_t buffer_size() const noexcept override {
-            return data->max_size();
-        }
-
         virtual future<> close() override {
-            data->push(buff_t(0));
-            return make_ready_future<>();
+            // basic_connection::close() owns close idempotency; keep the sink
+            // adapter stateless so source and sink close paths share one
+            // connection-level state machine.
+            return _conn.close();
         }
     };
 
     /*!
-     * \brief This function processess received PING frame.
+     * \brief This function processes received PING frame.
      * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
      */
     future<> handle_ping(temporary_buffer<char>);
     /*!
-     * \brief This function processess received PONG frame.
+     * \brief This function processes received PONG frame.
      * https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3
      */
     future<> handle_pong();
 
-    static const size_t PIPE_SIZE = 512;
     connected_socket _fd;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
+    std::optional<timer<lowres_clock>> _close_timer;
+    lowres_clock::duration _close_timeout;
     future<> _send_chain;
-    bool _done = false;
-    // TODO: implement https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.2
-    bool _half_close = false;
+    lifecycle_state _state;
+    bool _in_consume = false;
+    std::optional<shared_future<>> _close_future;
+    std::optional<shared_future<>> _tear_down_future;
 
     websocket_parser _websocket_parser;
-    queue <temporary_buffer<char>> _input_buffer;
     input_stream<char> _input;
-    queue <temporary_buffer<char>> _output_buffer;
     output_stream<char> _output;
+    std::optional<temporary_buffer<char>> _pending_inbound;
 
     sstring _subprotocol;
     handler_t _handler;
 public:
     /*!
      * \param fd established socket used for communication
-     * \param is_client if true, this is a client-side connection (sends masked
-     *        frames and expects unmasked frames from server)
+     * \param options connection tuning options.
+     *
+     * Whether the connection is client- or server-side is selected by the
+     * \c is_client template parameter. Client-side connections send masked
+     * frames and expect unmasked frames from the server; server-side
+     * connections are the reverse.
      */
     basic_connection(connected_socket&& fd,
             connection_options options = {})
         : _fd(std::move(fd))
         , _read_buf(_fd.input())
         , _write_buf(_fd.output())
+        , _close_timeout(options.close_timeout)
         , _send_chain(make_ready_future())
+        , _state(lifecycle_state::running)
         , _websocket_parser(!is_client, options.max_payload_length)
-        , _input_buffer{PIPE_SIZE}
-        , _input(data_source{std::make_unique<connection_source_impl>(&_input_buffer)})
-        , _output_buffer{PIPE_SIZE}
-        , _output(data_sink{std::make_unique<connection_sink_impl>(&_output_buffer)}, options.output_buffer_size)
+        , _input(data_source{std::make_unique<connection_source_impl>(*this)})
+        , _output(data_sink{std::make_unique<connection_sink_impl>(*this)}, options.output_buffer_size)
     {
     }
 
     /*!
-     * \brief close the socket
+     * \brief Shut down the socket input.
      */
     void shutdown_input();
+    /*!
+     * \brief Close this WebSocket connection.
+     *
+     * \param send_close If true, perform the WebSocket CLOSE handshake (send a
+     *        CLOSE frame and then tear down the streams). If false, tear down
+     *        the underlying streams without sending a CLOSE frame.
+     * \return A future that resolves after the underlying streams have been
+     *         torn down.
+     *
+     * Repeated close calls share the same completion future. When close(true)
+     * is invoked from within input consumption (e.g. by closing the output
+     * stream from inside the handler in response to a peer message), it sends
+     * a CLOSE frame but does not wait for the peer's CLOSE response, to avoid
+     * deadlocking against the in-progress read.
+     */
     future<> close(bool send_close = true);
 
 protected:
-    future<> read_one();
-    future<> response_loop();
     /*!
-     * \brief Packs buff in websocket frame and sends it to the client.
+     * \brief Handle a peer-initiated CLOSE frame.
+     *
+     * Sends the required CLOSE response and then tears down the underlying
+     * streams.
+     */
+    future<> respond_to_peer_close();
+    /*!
+     * \brief Tear down the underlying input and output streams.
+     *
+     * Drains any in-flight sends, then closes both streams. This is the common
+     * terminal cleanup path for both graceful and abortive close flows; the
+     * operation is idempotent.
+     */
+    future<> tear_down_streams();
+    /*!
+     * \brief Start a locally initiated WebSocket CLOSE handshake.
+     *
+     * Sends a CLOSE frame, then waits for the peer's CLOSE response and tears
+     * down the streams. If called from within input consumption, skips the
+     * wait to avoid deadlocking against the in-progress read. A close timer
+     * shuts down input if the peer does not respond within close_timeout.
+     */
+    future<> initiate_close_handshake();
+    /*!
+     * \brief Wait until a peer CLOSE frame, parser stop condition, or EOF is received.
+     */
+    future<> wait_close();
+    /*!
+     * \brief Consume the next WebSocket frame from the input stream.
+     *
+     * Data frames are exposed through the connection input stream. Control
+     * frames are handled internally.
+     */
+    future<> consume();
+    /*!
+     * \brief Wait for any in-flight sends to complete before teardown.
+     *
+     * Ensures pending sends do not outlive the connection object. Exceptions
+     * from the drained sends are logged and swallowed: teardown must proceed
+     * regardless of a prior send failure.
+     */
+    future<> drain_send_chain();
+    /*!
+     * \brief Queue a WebSocket frame for serialized transmission.
+     *
+     * Frames are serialized through a send chain. Once any queued send fails,
+     * the chain remains failed and later sends fail with the same exception
+     * until the chain is explicitly drained during connection teardown.
      */
     future<> send_data(opcodes opcode, temporary_buffer<char> buff);
+    /*!
+     * \brief Pack a WebSocket frame and write it to the underlying stream.
+     */
     future<> do_send(opcodes opcode, temporary_buffer<char> buff);
-    future<> drain_send_chain();
 };
 
 using connection = basic_connection<false, false>;

--- a/include/seastar/websocket/parser.hh
+++ b/include/seastar/websocket/parser.hh
@@ -82,7 +82,7 @@ struct frame_header {
 
     bool is_opcode_known() {
         //https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
-        return opcode < 0xA && !(opcode < 0x8 && opcode > 0x2);
+        return opcode <= 0xA && !(opcode < 0x8 && opcode > 0x2);
     }
 };
 
@@ -108,6 +108,7 @@ class websocket_parser {
     std::unique_ptr<frame_header> _header;
     uint64_t _payload_length = 0;
     uint64_t _consumed_payload_length = 0;
+    uint64_t _max_payload_length;
     bool _require_mask;
     uint32_t _masking_key;
     buff_t _result;
@@ -129,16 +130,35 @@ class websocket_parser {
             payload[i] ^= static_cast<char>(((_masking_key << (j * 8)) >> 24));
         }
     }
+    bool is_control_frame() const {
+        return _header && _header->opcode >= opcodes::CLOSE;
+    }
+    bool valid_payload_length() const {
+        if (is_control_frame()) {
+            return _header->fin && _payload_length <= 125;
+        }
+        return _payload_length <= _max_payload_length;
+    }
 public:
+    static constexpr uint64_t default_max_payload_length = 16 * 1024 * 1024;
+
     /*!
      * \brief Construct a websocket frame parser.
      * \param require_mask if true (default), incoming frames must be masked
      *        (server-side). If false, incoming frames must not be masked
      *        (client-side).
+     * \param max_payload_length maximum accepted payload size for data frames.
+     *        The default is 16 MiB. Control frames are always limited to the
+     *        RFC 6455 maximum of 125 bytes and must not be fragmented. A frame
+     *        violating either limit puts the parser into the error state
+     *        (\ref is_valid returns false) and stops consumption; the caller
+     *        sees this as a websocket::exception on the active read.
      */
-    explicit websocket_parser(bool require_mask = true)
+    explicit websocket_parser(bool require_mask = true,
+            uint64_t max_payload_length = default_max_payload_length)
         : _state(parsing_state::flags_and_payload_data)
         , _cstate(connection_state::valid)
+        , _max_payload_length(max_payload_length)
         , _require_mask(require_mask)
         , _masking_key(0) {}
     future<consumption_result_t> operator()(temporary_buffer<char> data);

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -27,8 +27,6 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/queue.hh>
-#include <seastar/core/when_all.hh>
 #include <seastar/websocket/common.hh>
 
 namespace seastar::experimental::websocket {
@@ -59,12 +57,15 @@ public:
     ~server_connection();
 
     /*!
-     * \brief serve WebSocket protocol on a server_connection
+     * \brief Serve WebSocket protocol on a server_connection.
+     *
+     * Performs the opening handshake and then runs the registered \ref
+     * handler_t for the negotiated subprotocol. See \ref handler_t for the
+     * connection lifecycle contract.
      */
     future<> process();
 
 protected:
-    future<> read_loop();
     future<> read_http_upgrade_request();
     void on_new_connection();
 };
@@ -100,12 +101,25 @@ public:
      * \param lo custom listen options (\ref listen_options)
      */
     void listen(socket_address addr, listen_options lo);
+    /*!
+     * \brief Listen on an already-created server_socket.
+     * \param ss The server socket to accept connections from.
+     */
+    void listen(server_socket ss);
 
     /*!
-     * Stops the server and shuts down all active connections
+     * Stops the server and shuts down all active connections.
+     *
+     * Active connections are torn down without initiating a WebSocket CLOSE
+     * handshake.
      */
     future<> stop();
 
+    /*!
+     * \brief Check whether a handler is registered for the given subprotocol name.
+     * \param name The subprotocol name (may be empty for the no-subprotocol handler).
+     * \return true if a handler is registered, false otherwise.
+     */
     bool is_handler_registered(std::string const& name);
 
     /*!
@@ -122,6 +136,6 @@ protected:
     future<stop_iteration> accept_one(server_socket &listener);
 };
 
-/// }@
+/// @}
 
 }

--- a/include/seastar/websocket/server.hh
+++ b/include/seastar/websocket/server.hh
@@ -48,9 +48,11 @@ public:
     /*!
      * \param server owning \ref server
      * \param fd established socket used for communication
+     * \param options connection tuning options.
      */
-    server_connection(server& server, connected_socket&& fd)
-        : connection(std::move(fd))
+    server_connection(server& server, connected_socket&& fd,
+            connection_options options = {})
+        : connection(std::move(fd), options)
         , _server(server) {
         on_new_connection();
     }
@@ -78,7 +80,15 @@ class server {
     boost::intrusive::list<server_connection> _connections;
     std::map<std::string, handler_t> _handlers;
     gate _task_gate;
+    connection_options _connection_options;
 public:
+    /*!
+     * \param options connection tuning options for accepted connections.
+     */
+    explicit server(connection_options options = {})
+        : _connection_options(options) {
+    }
+
     /*!
      * \brief listen for a WebSocket connection on given address
      * \param addr address to listen on

--- a/src/websocket/client.cc
+++ b/src/websocket/client.cc
@@ -24,13 +24,9 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/http/reply.hh>
+#include <seastar/websocket/common.hh>
 
 namespace seastar::experimental::websocket {
-
-using namespace std::string_view_literals;
-
-// refer https://datatracker.ietf.org/doc/html/rfc6455#section-1.3
-constexpr auto magic_key_suffix_client = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"sv;
 
 static thread_local std::mt19937 rng(std::random_device{}());
 
@@ -46,8 +42,9 @@ static sstring generate_websocket_key() {
 template <bool text_frame>
 client_connection<text_frame>::client_connection(connected_socket&& fd, sstring resource,
                                      sstring host, sstring subprotocol,
-                                     handler_t handler)
-    : basic_connection<true, text_frame>(std::move(fd))
+                                     handler_t handler,
+                                     connection_options options)
+    : basic_connection<true, text_frame>(std::move(fd), options)
     , _resource(std::move(resource))
     , _host(std::move(host))
 {
@@ -98,7 +95,7 @@ future<> client_connection<text_frame>::read_http_upgrade_response() {
 
     // Validate Sec-WebSocket-Accept
     auto expected_accept = sha1_base64(
-        fmt::format("{}{}", _websocket_key, magic_key_suffix_client));
+        fmt::format("{}{}", _websocket_key, websocket_magic_guid));
 
     sstring actual_accept = resp->get_header("Sec-WebSocket-Accept");
     // Trim leading whitespace
@@ -148,11 +145,12 @@ future<> client_connection<text_frame>::process() {
 
 template <bool text_frame>
 future<> client<text_frame>::connect(socket_address addr, sstring resource, sstring host,
-                         sstring subprotocol, handler_t handler) {
+                         sstring subprotocol, handler_t handler,
+                         connection_options options) {
     auto fd = co_await seastar::connect(addr);
     _conn = std::make_unique<client_connection<text_frame>>(std::move(fd),
         std::move(resource), std::move(host),
-        std::move(subprotocol), std::move(handler));
+        std::move(subprotocol), std::move(handler), options);
 
     co_await _conn->handshake();
     (void)try_with_gate(_task_gate, [this] () -> future<> {
@@ -168,11 +166,12 @@ template <bool text_frame>
 future<> client<text_frame>::connect(socket_address addr,
                          shared_ptr<tls::certificate_credentials> creds,
                          sstring resource, sstring host,
-                         sstring subprotocol, handler_t handler) {
+                         sstring subprotocol, handler_t handler,
+                         connection_options options) {
     auto fd = co_await tls::connect(creds, addr, tls::tls_options{.server_name = host});
     this->_conn = std::make_unique<client_connection<text_frame>>(std::move(fd),
         std::move(resource), std::move(host),
-        std::move(subprotocol), std::move(handler));
+        std::move(subprotocol), std::move(handler), options);
 
     co_await _conn->handshake();
     (void)try_with_gate(_task_gate, [this] () -> future<> {

--- a/src/websocket/client.cc
+++ b/src/websocket/client.cc
@@ -19,9 +19,8 @@
 #include <exception>
 #include <random>
 #include <seastar/core/future.hh>
-#include <seastar/coroutine/all.hh>
+#include <seastar/net/api.hh>
 #include <seastar/websocket/client.hh>
-#include <seastar/core/when_all.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/websocket/common.hh>
@@ -125,34 +124,28 @@ future<> client_connection<text_frame>::handshake() {
 
 template <bool text_frame>
 future<> client_connection<text_frame>::process() {
-    co_await coroutine::all(
-        [this] () -> future<> {
-            co_await this->_handler(this->_input, this->_output).handle_exception([this] (std::exception_ptr e) -> future<> {
-                co_await this->_read_buf.close();
-                std::rethrow_exception(e);
-            });
-        },
-        [this] () -> future<> {
-            while (!this->_done) {
-                co_await this->read_one();
-            }
-        },
-        [this] () {
-            return this->response_loop();
-        }
-    );
+    return this->_handler(this->_input, this->_output).handle_exception([this] (std::exception_ptr e){
+        // Preserve the handler failure even if the best-effort output close fails.
+        return this->_output.close().handle_exception([] (std::exception_ptr ex) {
+            websocket_logger.debug("WebSocket client output close failed after handler exception: {}", ex);
+        }).then([e = std::move(e)] () {
+            return make_exception_future(e);
+        });
+    }).finally([this] () {
+        return this->drain_send_chain();
+    });
 }
 
 template <bool text_frame>
-future<> client<text_frame>::connect(socket_address addr, sstring resource, sstring host,
+future<> client<text_frame>::connect(connected_socket fd, sstring resource, sstring host,
                          sstring subprotocol, handler_t handler,
-                         connection_options options) {
-    auto fd = co_await seastar::connect(addr);
-    _conn = std::make_unique<client_connection<text_frame>>(std::move(fd),
+                         const connection_options& options) {
+    this->_conn = std::make_unique<client_connection<text_frame>>(std::move(fd),
         std::move(resource), std::move(host),
         std::move(subprotocol), std::move(handler), options);
 
     co_await _conn->handshake();
+    _handshake_done = true;
     (void)try_with_gate(_task_gate, [this] () -> future<> {
         try {
             co_await _conn->process();
@@ -160,6 +153,15 @@ future<> client<text_frame>::connect(socket_address addr, sstring resource, sstr
             websocket_logger.debug("WebSocket client processing failed: {}", std::current_exception());
         }
     }).handle_exception_type([] (const gate_closed_exception&) {});
+}
+
+template <bool text_frame>
+future<> client<text_frame>::connect(socket_address addr, sstring resource, sstring host,
+                         sstring subprotocol, handler_t handler,
+                         connection_options options) {
+    SEASTAR_ASSERT(!_conn);
+    auto fd = co_await seastar::connect(addr);
+    co_await connect(std::move(fd), std::move(resource), std::move(host), std::move(subprotocol), std::move(handler), options);
 }
 
 template <bool text_frame>
@@ -168,28 +170,28 @@ future<> client<text_frame>::connect(socket_address addr,
                          sstring resource, sstring host,
                          sstring subprotocol, handler_t handler,
                          connection_options options) {
+    SEASTAR_ASSERT(!_conn);
     auto fd = co_await tls::connect(creds, addr, tls::tls_options{.server_name = host});
-    this->_conn = std::make_unique<client_connection<text_frame>>(std::move(fd),
-        std::move(resource), std::move(host),
-        std::move(subprotocol), std::move(handler), options);
-
-    co_await _conn->handshake();
-    (void)try_with_gate(_task_gate, [this] () -> future<> {
-        try {
-            co_await _conn->process();
-        } catch (...) {
-            websocket_logger.debug("WebSocket client processing failed: {}", std::current_exception());
-        }
-    }).handle_exception_type([] (const gate_closed_exception&) {});
+    co_await connect(std::move(fd), std::move(resource), std::move(host), std::move(subprotocol), std::move(handler), options);
 }
 
 template <bool text_frame>
 future<> client<text_frame>::close() {
     if (_conn) {
-        co_await _conn->close(true).handle_exception([] (auto) {});
-        _conn->shutdown_input();
+        co_await _conn->close(_handshake_done).handle_exception([] (auto e) {
+            websocket_logger.debug("close handshake failed: {}", e);
+        });
     }
     co_await _task_gate.close();
+    _conn.reset();
+}
+
+
+template <bool text_frame>
+void client<text_frame>::shutdown() {
+    if (_conn) {
+        _conn->shutdown_input();
+    }
 }
 
 template class client_connection<false>;

--- a/src/websocket/common.cc
+++ b/src/websocket/common.cc
@@ -20,6 +20,10 @@
  */
 
 #include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/websocket/common.hh>
 #include <seastar/core/byteorder.hh>
 #include "../core/crypto.hh"
@@ -28,6 +32,7 @@
 #include <seastar/util/defer.hh>
 #include <random>
 #include <seastar/websocket/parser.hh>
+#include <system_error>
 #include <utility>
 
 namespace seastar::experimental::websocket {
@@ -111,73 +116,127 @@ future<> basic_connection<is_client, text_frame>::do_send(opcodes opcode, tempor
 }
 
 template <bool is_client, bool text_frame>
-future<> basic_connection<is_client, text_frame>::drain_send_chain() {
-    return std::exchange(_send_chain, make_ready_future<>())
-        .handle_exception([] (std::exception_ptr ex) {
-            websocket_logger.debug("Drained websocket send chain failure: {}", ex);
-        });
-}
-
-template <bool is_client, bool text_frame>
-future<> basic_connection<is_client, text_frame>::response_loop() {
-    return do_until([this] {return _done;}, [this] {
-        // FIXME: implement error handling
-        return _output_buffer.pop_eventually().then([this] (
-                temporary_buffer<char> buf) {
-            if (!buf) {
-                return make_ready_future<>();
-            }
-            return send_data(text_frame ? opcodes::TEXT : opcodes::BINARY, std::move(buf));
-        });
-    }).finally([this]() {
-        return _write_buf.close();
-    });
-}
-
-template <bool is_client, bool text_frame>
 void basic_connection<is_client, text_frame>::shutdown_input() {
     _fd.shutdown_input();
 }
 
 template <bool is_client, bool text_frame>
 future<> basic_connection<is_client, text_frame>::close(bool send_close) {
-    if (_half_close) {
+    if (_close_future) {
+        return _close_future->get_future();
+    }
+    if (_state == lifecycle_state::torn_down) {
         return make_ready_future<>();
     }
-    _half_close = true;
-    return [this, send_close]() {
-        if (send_close) {
-            return send_data(opcodes::CLOSE, temporary_buffer<char>(0));
-        } else {
-            return make_ready_future<>();
-        }
-    }().finally([this] {
-        _done = true;
-        return when_all_succeed(_input.close(), _output.close()).discard_result().finally([this] {
-            _fd.shutdown_output();
+
+    if (send_close) {
+        _close_future.emplace(initiate_close_handshake());
+    } else {
+        _close_future.emplace(tear_down_streams());
+    }
+    return _close_future->get_future();
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::respond_to_peer_close() {
+    if (_close_future) {
+        return _close_future->get_future();
+    }
+
+    _state = lifecycle_state::closing_peer;
+    _pending_inbound.emplace();
+    _close_future.emplace(this->send_data(opcodes::CLOSE, temporary_buffer<char>()).handle_exception([] (std::exception_ptr ex) {
+        websocket_logger.debug("Failed to send websocket close response: {}", ex);
+    }).finally([this] () {
+        return this->tear_down_streams();
+    }));
+    return _close_future->get_future();
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::tear_down_streams() {
+    if (_tear_down_future) {
+        return _tear_down_future->get_future();
+    }
+    if (_state == lifecycle_state::torn_down) {
+        return make_ready_future<>();
+    }
+
+    _state = lifecycle_state::tearing_down;
+    _tear_down_future.emplace(drain_send_chain().finally([this] {
+        return when_all(_read_buf.close(), _write_buf.close()).then([] (std::tuple<future<>,future<>> f) {
+            std::get<0>(f).ignore_ready_future();
+            std::get<1>(f).ignore_ready_future();
+        });
+    }).finally([this] {
+        _state = lifecycle_state::torn_down;
+    }));
+    return _tear_down_future->get_future();
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::initiate_close_handshake() {
+    _state = lifecycle_state::closing_local;
+    return this->send_data(opcodes::CLOSE, temporary_buffer<char>())
+        .then_wrapped([this] (future<> f) mutable -> future<> {
+            if (f.failed()) {
+                auto ex = f.get_exception();
+                websocket_logger.debug("Failed to send websocket close frame: {}", ex);
+                return make_exception_future<>(ex);
+            }
+            if (_in_consume) {
+                return make_ready_future<>();
+            }
+            _close_timer.emplace();
+            _close_timer->set_callback([this] () { _fd.shutdown_input(); });
+            _close_timer->arm(_close_timeout);
+            return wait_close();
+        }).finally([this] () {
+            _close_timer.reset();
+            return tear_down_streams();
+        });
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::wait_close() {
+    return repeat([this] () {
+        return _read_buf.consume(_websocket_parser).then([this] () mutable {
+            if (_websocket_parser.eof()
+                || !_websocket_parser.is_valid()
+                || _websocket_parser.opcode() == opcodes::CLOSE) {
+                return make_ready_future<stop_iteration>(stop_iteration::yes);
+            };
+            return make_ready_future<stop_iteration>(stop_iteration::no);
+        }).handle_exception_type([] (const std::system_error& ex) {
+            websocket_logger.debug("Websocket close wait stopped by input shutdown: {}", ex);
+            return make_ready_future<stop_iteration>(stop_iteration::yes);
+        }).handle_exception([] (std::exception_ptr ex) {
+            websocket_logger.debug("Websocket close wait failed: {}", ex);
+            return make_ready_future<stop_iteration>(stop_iteration::yes);
         });
     });
 }
 
 template <bool is_client, bool text_frame>
-future<> basic_connection<is_client, text_frame>::read_one() {
+future<> basic_connection<is_client, text_frame>::consume() {
+    if (_state != lifecycle_state::running) [[unlikely]] {
+        _pending_inbound.emplace();
+        return make_ready_future();
+    }
+    _in_consume = true;
     return _read_buf.consume(_websocket_parser).then([this] () mutable {
         if (_websocket_parser.is_valid()) {
-            if (_half_close) {
-                // When the connection enters _half_closed state, just wait for the close to complete.
-                return make_ready_future();
-            }
-            // FIXME: implement error handling
             switch(_websocket_parser.opcode()) {
             // We do not distinguish between these 3 types.
             case opcodes::CONTINUATION:
             case opcodes::TEXT:
             case opcodes::BINARY:
-                return _input_buffer.push_eventually(_websocket_parser.result());
+                _pending_inbound = _websocket_parser.result();
+                return make_ready_future();
             case opcodes::CLOSE:
                 websocket_logger.debug("Received close frame.");
                 // datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
-                return close(true);
+                return respond_to_peer_close();
             case opcodes::PING:
                 websocket_logger.debug("Received ping frame.");
                 return handle_ping(_websocket_parser.result());
@@ -185,15 +244,32 @@ future<> basic_connection<is_client, text_frame>::read_one() {
                 websocket_logger.debug("Received pong frame.");
                 return handle_pong();
             default:
-                // Invalid - do nothing.
+                SEASTAR_ASSERT(false); // parser guarantees only known opcodes reach here
                 ;
             }
         } else if (_websocket_parser.eof()) {
+            websocket_logger.debug("Websocket parse eof.");
+            _pending_inbound.emplace();
             return close(false);
         }
-        websocket_logger.debug("Reading from socket has failed.");
-        return close(true);
-    });
+
+        websocket_logger.debug("Websocket parse error.");
+        // The parser keeps its error state. Tear the streams down before
+        // reporting the parse failure so a handler that catches this exception
+        // cannot re-enter the same parser error forever.
+        return close(false).then([] {
+            return make_exception_future(websocket::exception("Reading from socket has failed."));
+        });
+    }).finally([this] () { _in_consume = false; });
+}
+
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::drain_send_chain() {
+    return std::exchange(_send_chain, make_ready_future<>())
+        .handle_exception([] (std::exception_ptr ex) {
+            websocket_logger.debug("Drained websocket send chain failure: {}", ex);
+        });
 }
 
 std::string sha1_base64(std::string_view source) {

--- a/src/websocket/common.cc
+++ b/src/websocket/common.cc
@@ -28,6 +28,7 @@
 #include <seastar/util/defer.hh>
 #include <random>
 #include <seastar/websocket/parser.hh>
+#include <utility>
 
 namespace seastar::experimental::websocket {
 
@@ -60,6 +61,24 @@ static void apply_mask(char* data, size_t len, uint32_t masking_key) {
 
 template <bool is_client, bool text_frame>
 future<> basic_connection<is_client, text_frame>::send_data(opcodes opcode, temporary_buffer<char> buff) {
+    promise<> p;
+    return std::exchange(_send_chain, p.get_future())
+        .then([this, opcode, buff = std::move(buff)] () mutable -> future<> {
+            return do_send(opcode, std::move(buff));
+        }).then_wrapped([p = std::move(p)] (future<> f) mutable {
+            if (f.failed()) {
+                auto e = f.get_exception();
+                p.set_exception(e);
+                return make_exception_future(std::move(e));
+            } else {
+                p.set_value();
+                return make_ready_future();
+            }
+        });
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::do_send(opcodes opcode, temporary_buffer<char> buff) {
     char header[14] = {'\x80', 0}; // max: 2 + 8 (extended len) + 4 (mask key)
     size_t header_size = 2;
 
@@ -89,6 +108,14 @@ future<> basic_connection<is_client, text_frame>::send_data(opcodes opcode, temp
     co_await _write_buf.write(header, header_size);
     co_await _write_buf.write(std::move(buff));
     co_await _write_buf.flush();
+}
+
+template <bool is_client, bool text_frame>
+future<> basic_connection<is_client, text_frame>::drain_send_chain() {
+    return std::exchange(_send_chain, make_ready_future<>())
+        .handle_exception([] (std::exception_ptr ex) {
+            websocket_logger.debug("Drained websocket send chain failure: {}", ex);
+        });
 }
 
 template <bool is_client, bool text_frame>

--- a/src/websocket/parser.cc
+++ b/src/websocket/parser.cc
@@ -92,6 +92,10 @@ future<websocket_parser::consumption_result_t> websocket_parser::operator()(
                 _masking_key = consume_be<uint32_t>(input);
             }
             _buffer = {};
+            if (!valid_payload_length()) {
+                _cstate = connection_state::error;
+                return websocket_parser::stop(std::move(data));
+            }
             _state = parsing_state::payload;
         } else {
             _buffer.append(data.get(), data.size());

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -25,12 +25,12 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 #include <seastar/http/request.hh>
+#include <seastar/websocket/common.hh>
 
 namespace seastar::experimental::websocket {
 
 using namespace std::string_view_literals;
 
-constexpr auto magic_key_suffix = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"sv;
 constexpr auto http_upgrade_reply_template =
     "HTTP/1.1 101 Switching Protocols\r\n"
     "Upgrade: websocket\r\n"
@@ -58,7 +58,7 @@ void server::accept(server_socket &listener) {
 
 future<stop_iteration> server::accept_one(server_socket &listener) {
     return listener.accept().then([this](accept_result ar) {
-        auto conn = std::make_unique<server_connection>(*this, std::move(ar.connection));
+        auto conn = std::make_unique<server_connection>(*this, std::move(ar.connection), _connection_options);
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().finally([conn = std::move(conn)] {
                 websocket_logger.debug("Connection is finished");
@@ -138,7 +138,7 @@ future<> server_connection::read_http_upgrade_request() {
     sstring sec_key = req->get_header("Sec-Websocket-Key");
     sstring sec_version = req->get_header("Sec-Websocket-Version");
 
-    auto sha1_input = fmt::format("{}{}", sec_key, magic_key_suffix);
+    auto sha1_input = fmt::format("{}{}", sec_key, websocket_magic_guid);
 
     websocket_logger.debug("Sec-Websocket-Key: {}, Sec-Websocket-Version: {}", sec_key, sec_version);
 

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -19,13 +19,13 @@
  * Copyright 2021 ScyllaDB
  */
 
+#include <exception>
+#include <seastar/core/future.hh>
+#include <seastar/websocket/common.hh>
 #include <seastar/websocket/server.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/util/defer.hh>
-#include <seastar/util/log.hh>
 #include <seastar/http/request.hh>
-#include <seastar/websocket/common.hh>
 
 namespace seastar::experimental::websocket {
 
@@ -46,6 +46,10 @@ void server::listen(socket_address addr) {
     listen_options lo;
     lo.reuse_address = true;
     return listen(addr, lo);
+}
+void server::listen(server_socket ss) {
+    _listeners.push_back(std::move(ss));
+    accept(_listeners.back());
 }
 
 void server::accept(server_socket &listener) {
@@ -79,19 +83,16 @@ future<stop_iteration> server::accept_one(server_socket &listener) {
 }
 
 future<> server::stop() {
+    websocket_logger.info("server close");
     for (auto&& l : _listeners) {
         l.abort_accept();
     }
 
-    for (auto&& c : _connections) {
+    for (auto& c: _connections) {
         c.shutdown_input();
     }
 
-    return _task_gate.close().finally([this] {
-        return parallel_for_each(_connections, [] (server_connection& conn) {
-            return conn.close(true).handle_exception([] (auto ignored) {});
-        });
-    });
+    return _task_gate.close();
 }
 
 server_connection::~server_connection() {
@@ -103,9 +104,14 @@ void server_connection::on_new_connection() {
 }
 
 future<> server_connection::process() {
-    return when_all_succeed(read_loop(), response_loop()).discard_result().handle_exception([] (const std::exception_ptr& e) {
-        websocket_logger.debug("Processing failed: {}", e);
-    });
+    return read_http_upgrade_request()
+        .then([this] () {
+            return _handler(_input, _output);
+        }).handle_exception([this] (std::exception_ptr e) {
+            return close(false).handle_exception([] (auto) {}).then([e = std::move(e)] () {
+                return make_exception_future(e);
+            });
+        });
 }
 
 future<> server_connection::read_http_upgrade_request() {
@@ -113,7 +119,6 @@ future<> server_connection::read_http_upgrade_request() {
     co_await _read_buf.consume(_http_parser);
 
     if (_http_parser.eof()) {
-        _done = true;
         co_return;
     }
     std::unique_ptr<http::request> req = _http_parser.get_parsed_request();
@@ -153,21 +158,6 @@ future<> server_connection::read_http_upgrade_request() {
     }
     co_await _write_buf.write("\r\n\r\n", 4);
     co_await _write_buf.flush();
-}
-
-future<> server_connection::read_loop() {
-    return read_http_upgrade_request().then([this] {
-        return when_all_succeed(
-            _handler(_input, _output).handle_exception([this] (std::exception_ptr e) mutable {
-                return _read_buf.close().then([e = std::move(e)] () mutable {
-                    return make_exception_future<>(std::move(e));
-                });
-            }),
-            do_until([this] {return _done;}, [this] {return read_one();})
-        ).discard_result();
-    }).finally([this] {
-        return _read_buf.close();
-    });
 }
 
 bool server::is_handler_registered(std::string const& name) {

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -2,19 +2,359 @@
  * Copyright 2021 ScyllaDB
  */
 
+#include <chrono>
+#include <limits>
+#include <utility>
 #include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/net/ip.hh>
 #include <seastar/websocket/server.hh>
 #include <seastar/websocket/client.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/http/response_parser.hh>
+#include <seastar/core/byteorder.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/memory-data-source.hh>
+#include <system_error>
+#include <stdexcept>
 #include "loopback_socket.hh"
 
 using namespace seastar;
 using namespace seastar::experimental;
+using namespace std::chrono_literals;
 using namespace std::literals::string_view_literals;
+
+namespace seastar::experimental::websocket {
+
+template <bool is_client, bool text_frame>
+struct basic_connection_test_accessor {
+    using connection_type = basic_connection<is_client, text_frame>;
+
+    static future<> send_data(connection_type& conn, opcodes opcode, temporary_buffer<char> buff) {
+        return conn.send_data(opcode, std::move(buff));
+    }
+
+    static void poison_send_chain(connection_type& conn, std::exception_ptr ex) {
+        conn._send_chain = make_exception_future<>(ex);
+    }
+
+    static future<> drain_send_chain_error(connection_type& conn) {
+        return std::exchange(conn._send_chain, make_ready_future<>()).handle_exception([] (std::exception_ptr) {});
+    }
+
+    static void set_close_timeout(connection_type& conn, lowres_clock::duration timeout) {
+        conn._close_timeout = timeout;
+    }
+
+    static input_stream<char>& input(connection_type& conn) {
+        return conn._input;
+    }
+
+    static output_stream<char>& output(connection_type& conn) {
+        return conn._output;
+    }
+};
+
+}
+
+
+class eof_data_source_impl : public data_source_impl {
+public:
+    future<temporary_buffer<char>> get() override {
+        return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>());
+    }
+};
+
+class counting_data_sink_impl : public data_sink_impl {
+    unsigned& _put_attempts;
+
+public:
+    explicit counting_data_sink_impl(unsigned& put_attempts)
+        : _put_attempts(put_attempts) {
+    }
+
+#if SEASTAR_API_LEVEL >= 9
+    future<> put(std::span<temporary_buffer<char>>) override {
+#else
+    future<> put(net::packet) override {
+#endif
+        ++_put_attempts;
+        return make_ready_future<>();
+    }
+
+    future<> close() override {
+        return make_ready_future<>();
+    }
+};
+
+class close_failing_data_sink_impl : public data_sink_impl {
+public:
+#if SEASTAR_API_LEVEL >= 9
+    future<> put(std::span<temporary_buffer<char>>) override {
+#else
+    future<> put(net::packet) override {
+#endif
+        return make_ready_future<>();
+    }
+
+    future<> close() override {
+        return make_exception_future<>(std::runtime_error("output close failed"));
+    }
+};
+
+class write_failing_data_sink_impl : public data_sink_impl {
+public:
+#if SEASTAR_API_LEVEL >= 9
+    future<> put(std::span<temporary_buffer<char>>) override {
+#else
+    future<> put(net::packet) override {
+#endif
+        return make_exception_future<>(std::runtime_error("write failed"));
+    }
+
+    future<> close() override {
+        return make_ready_future<>();
+    }
+};
+
+// A data source that yields one frame then EOF. Used by Fix K test.
+class close_then_eof_source_impl : public data_source_impl {
+    std::string _frame;
+    bool _sent = false;
+public:
+    explicit close_then_eof_source_impl(std::string frame) : _frame(std::move(frame)) {}
+    future<temporary_buffer<char>> get() override {
+        if (!_sent) {
+            _sent = true;
+            return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>::copy_of(_frame));
+        }
+        return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>());
+    }
+};
+
+// A connected_socket_impl whose source yields a single frame then EOF
+// and whose sink always fails writes (to exercise Fix B).
+class close_source_write_failing_socket_impl : public net::connected_socket_impl {
+    std::string _frame;
+public:
+    explicit close_source_write_failing_socket_impl(std::string frame) : _frame(std::move(frame)) {}
+    data_source source() override {
+        return data_source(std::make_unique<close_then_eof_source_impl>(_frame));
+    }
+    data_sink sink() override {
+        return data_sink(std::make_unique<write_failing_data_sink_impl>());
+    }
+    void shutdown_input() override {}
+    void shutdown_output() override {}
+    void set_nodelay(bool) override {}
+    bool get_nodelay() const override { return true; }
+    void set_keepalive(bool) override {}
+    bool get_keepalive() const override { return false; }
+    void set_keepalive_parameters(const net::keepalive_params&) override {}
+    net::keepalive_params get_keepalive_parameters() const override {
+        return net::tcp_keepalive_params{std::chrono::seconds(0), std::chrono::seconds(0), 0};
+    }
+    void set_sockopt(int, int, const void*, size_t) override {
+        throw std::runtime_error("not supported");
+    }
+    int get_sockopt(int, int, void*, size_t) const override {
+        throw std::runtime_error("not supported");
+    }
+    socket_address local_address() const noexcept override { return {}; }
+    socket_address remote_address() const noexcept override { return {}; }
+    future<> wait_input_shutdown() override { return make_ready_future<>(); }
+};
+
+class counting_connected_socket_impl : public net::connected_socket_impl {
+    unsigned& _put_attempts;
+
+public:
+    explicit counting_connected_socket_impl(unsigned& put_attempts)
+        : _put_attempts(put_attempts) {
+    }
+
+    data_source source() override {
+        return data_source(std::make_unique<eof_data_source_impl>());
+    }
+
+    data_sink sink() override {
+        return data_sink(std::make_unique<counting_data_sink_impl>(_put_attempts));
+    }
+
+    void shutdown_input() override {
+    }
+
+    void shutdown_output() override {
+    }
+
+    void set_nodelay(bool) override {
+    }
+
+    bool get_nodelay() const override {
+        return true;
+    }
+
+    void set_keepalive(bool) override {
+    }
+
+    bool get_keepalive() const override {
+        return false;
+    }
+
+    void set_keepalive_parameters(const net::keepalive_params&) override {
+    }
+
+    net::keepalive_params get_keepalive_parameters() const override {
+        return net::tcp_keepalive_params {std::chrono::seconds(0), std::chrono::seconds(0), 0};
+    }
+
+    void set_sockopt(int, int, const void*, size_t) override {
+        throw std::runtime_error("Setting custom socket options is not supported");
+    }
+
+    int get_sockopt(int, int, void*, size_t) const override {
+        throw std::runtime_error("Getting custom socket options is not supported");
+    }
+
+    socket_address local_address() const noexcept override {
+        return {};
+    }
+
+    socket_address remote_address() const noexcept override {
+        return {};
+    }
+
+    future<> wait_input_shutdown() override {
+        return make_ready_future<>();
+    }
+};
+
+template <typename Source, typename Sink>
+class test_connected_socket_impl : public net::connected_socket_impl {
+public:
+    data_source source() override {
+        return data_source(std::make_unique<Source>());
+    }
+
+    data_sink sink() override {
+        return data_sink(std::make_unique<Sink>());
+    }
+
+    void shutdown_input() override {
+    }
+
+    void shutdown_output() override {
+    }
+
+    void set_nodelay(bool) override {
+    }
+
+    bool get_nodelay() const override {
+        return true;
+    }
+
+    void set_keepalive(bool) override {
+    }
+
+    bool get_keepalive() const override {
+        return false;
+    }
+
+    void set_keepalive_parameters(const net::keepalive_params&) override {
+    }
+
+    net::keepalive_params get_keepalive_parameters() const override {
+        return net::tcp_keepalive_params {std::chrono::seconds(0), std::chrono::seconds(0), 0};
+    }
+
+    void set_sockopt(int, int, const void*, size_t) override {
+        throw std::runtime_error("Setting custom socket options is not supported");
+    }
+
+    int get_sockopt(int, int, void*, size_t) const override {
+        throw std::runtime_error("Getting custom socket options is not supported");
+    }
+
+    socket_address local_address() const noexcept override {
+        return {};
+    }
+
+    socket_address remote_address() const noexcept override {
+        return {};
+    }
+
+    future<> wait_input_shutdown() override {
+        return make_ready_future<>();
+    }
+};
+
+std::string buffer_to_string(const temporary_buffer<char>& buf) {
+    return std::string(buf.begin(), buf.end());
+}
+
+std::string make_websocket_frame(uint8_t opcode, std::string_view payload = {}, bool masked = false, bool fin = true,
+        uint32_t masking_key = 0) {
+    std::string frame;
+    frame.push_back(static_cast<char>((fin ? 0x80 : 0) | opcode));
+
+    uint8_t mask_bit = masked ? 0x80 : 0;
+    if (payload.size() < 126) {
+        frame.push_back(static_cast<char>(mask_bit | payload.size()));
+    } else if (payload.size() <= std::numeric_limits<uint16_t>::max()) {
+        frame.push_back(static_cast<char>(mask_bit | 126));
+        char len[sizeof(uint16_t)];
+        write_be<uint16_t>(len, payload.size());
+        frame.append(len, sizeof(len));
+    } else {
+        frame.push_back(static_cast<char>(mask_bit | 127));
+        char len[sizeof(uint64_t)];
+        write_be<uint64_t>(len, payload.size());
+        frame.append(len, sizeof(len));
+    }
+
+    if (masked) {
+        char mask[sizeof(uint32_t)];
+        write_be<uint32_t>(mask, masking_key);
+        frame.append(mask, sizeof(mask));
+        auto masked_payload = std::string(payload);
+        for (size_t i = 0; i < masked_payload.size(); ++i) {
+            masked_payload[i] ^= mask[i % sizeof(mask)];
+        }
+        frame.append(masked_payload);
+    } else {
+        frame.append(payload);
+    }
+    return frame;
+}
+
+std::string make_websocket_frame_header(uint8_t opcode, uint64_t payload_size, bool masked = false, bool fin = true) {
+    std::string frame;
+    frame.push_back(static_cast<char>((fin ? 0x80 : 0) | opcode));
+
+    uint8_t mask_bit = masked ? 0x80 : 0;
+    if (payload_size < 126) {
+        frame.push_back(static_cast<char>(mask_bit | payload_size));
+    } else if (payload_size <= std::numeric_limits<uint16_t>::max()) {
+        frame.push_back(static_cast<char>(mask_bit | 126));
+        char len[sizeof(uint16_t)];
+        write_be<uint16_t>(len, payload_size);
+        frame.append(len, sizeof(len));
+    } else {
+        frame.push_back(static_cast<char>(mask_bit | 127));
+        char len[sizeof(uint64_t)];
+        write_be<uint64_t>(len, payload_size);
+        frame.append(len, sizeof(len));
+    }
+
+    if (masked) {
+        frame.append(4, '\0');
+    }
+    return frame;
+}
 
 std::string build_request(std::string_view key_base64, std::string_view subprotocol) {
     std::string subprotocol_line;
@@ -51,8 +391,10 @@ future<> test_websocket_handshake_common(std::string subprotocol) {
         dummy.register_handler(subprotocol, [] (input_stream<char>& in,
                         output_stream<char>& out) {
                 return repeat([&in, &out]() {
-                    return in.read().then([&out](temporary_buffer<char> f) {
-                        std::cerr << "f.size(): " << f.size() << "\n";
+                    return in.read().handle_exception_type([] (std::system_error& e) {
+                            BOOST_REQUIRE_EQUAL(e.code().value(), static_cast<int>(std::errc::broken_pipe));
+                            return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>());
+                        }).then([&out](temporary_buffer<char> f) {
                         if (f.empty()) {
                             return make_ready_future<stop_iteration>(stop_iteration::yes);
                         } else {
@@ -68,7 +410,7 @@ future<> test_websocket_handshake_common(std::string subprotocol) {
         websocket::server_connection conn(dummy, acceptor.get().connection);
         future<> serve = conn.process();
         auto close = defer([&conn, &input, &output, &serve] () noexcept {
-            conn.close().get();
+            conn.close(false).get();
             input.close().get();
             output.close().get();
             serve.get();
@@ -91,9 +433,6 @@ future<> test_websocket_handshake_common(std::string subprotocol) {
             websocket_accept.erase(websocket_accept.begin(), it);
         }
         BOOST_REQUIRE_EQUAL(websocket_accept, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
-        for (auto& header : resp->_headers) {
-            std::cout << header.first << ':' << header.second << std::endl;
-        }
     });
 }
 
@@ -121,17 +460,19 @@ future<> test_websocket_handler_registration_common(std::string subprotocol) {
         ws.register_handler(subprotocol, [] (input_stream<char>& in,
                         output_stream<char>& out) {
             return repeat([&in, &out]() {
-                return in.read().then([&out](temporary_buffer<char> f) {
-                    std::cerr << "f.size(): " << f.size() << "\n";
-                    if (f.empty()) {
-                        return make_ready_future<stop_iteration>(stop_iteration::yes);
-                    } else {
-                        return out.write(std::move(f)).then([&out]() {
-                            return out.flush().then([] {
-                                return make_ready_future<stop_iteration>(stop_iteration::no);
-                            });
-                        });
-                    }
+                return in.read().handle_exception_type([] (std::system_error& e) {
+                            BOOST_REQUIRE_EQUAL(e.code().value(), static_cast<int>(std::errc::broken_pipe));
+                            return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>());
+                        }).then([&out](temporary_buffer<char> f) {
+                            if (f.empty()) {
+                                return make_ready_future<stop_iteration>(stop_iteration::yes);
+                            } else {
+                                return out.write(std::move(f)).then([&out]() {
+                                    return out.flush().then([] {
+                                        return make_ready_future<stop_iteration>(stop_iteration::no);
+                                    });
+                                });
+                            }
                 });
             });
         });
@@ -240,6 +581,527 @@ SEASTAR_TEST_CASE(test_websocket_parser_split) {
     });
 }
 
+SEASTAR_TEST_CASE(test_websocket_parser_rejects_unknown_opcodes) {
+    return seastar::async([] {
+        const std::vector<uint8_t> unknown_opcodes = {
+            0x3, 0x4, 0x5, 0x6, 0x7,
+            0xB, 0xC, 0xD, 0xE, 0xF,
+        };
+
+        for (auto opcode : unknown_opcodes) {
+            websocket::websocket_parser parser;
+            auto bufs = std::vector<temporary_buffer<char>>{};
+            bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame(opcode, {}, true)));
+            input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+            in.consume(parser).get();
+
+            BOOST_REQUIRE_MESSAGE(!parser.is_valid(), fmt::format("opcode 0x{:x} was accepted", opcode));
+            BOOST_REQUIRE(!parser.eof());
+            BOOST_REQUIRE_EQUAL(parser.opcode(), static_cast<websocket::opcodes>(opcode));
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_websocket_parser_rejects_oversized_control_frames) {
+    return seastar::async([] {
+        websocket::websocket_parser parser;
+        auto bufs = std::vector<temporary_buffer<char>>{};
+        bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame(websocket::opcodes::PING, std::string(126, 'x'), true)));
+        input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+        in.consume(parser).get();
+
+        BOOST_REQUIRE(!parser.is_valid());
+        BOOST_REQUIRE(!parser.eof());
+        BOOST_REQUIRE_EQUAL(parser.opcode(), websocket::opcodes::PING);
+    });
+}
+
+SEASTAR_TEST_CASE(test_websocket_parser_rejects_fragmented_control_frames) {
+    return seastar::async([] {
+        websocket::websocket_parser parser;
+        auto bufs = std::vector<temporary_buffer<char>>{};
+        bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame(websocket::opcodes::CLOSE, {}, true, false)));
+        input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+        in.consume(parser).get();
+
+        BOOST_REQUIRE(!parser.is_valid());
+        BOOST_REQUIRE(!parser.eof());
+        BOOST_REQUIRE_EQUAL(parser.opcode(), websocket::opcodes::CLOSE);
+    });
+}
+
+SEASTAR_TEST_CASE(test_websocket_parser_rejects_huge_declared_data_frame_before_allocating) {
+    return seastar::async([] {
+        websocket::websocket_parser parser;
+        auto bufs = std::vector<temporary_buffer<char>>{};
+        bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame_header(websocket::opcodes::BINARY, uint64_t(1) << 60, true)));
+        input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+        in.consume(parser).get();
+
+        BOOST_REQUIRE(!parser.is_valid());
+        BOOST_REQUIRE(!parser.eof());
+        BOOST_REQUIRE_EQUAL(parser.opcode(), websocket::opcodes::BINARY);
+    });
+}
+
+SEASTAR_TEST_CASE(test_websocket_parser_respects_configured_data_frame_limit) {
+    return seastar::async([] {
+        {
+            websocket::websocket_parser parser(true, 5);
+            auto bufs = std::vector<temporary_buffer<char>>{};
+            bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame(websocket::opcodes::BINARY, "12345", true)));
+            input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+            in.consume(parser).get();
+
+            BOOST_REQUIRE(parser.is_valid());
+            BOOST_REQUIRE_EQUAL(buffer_to_string(parser.result()), "12345");
+        }
+        {
+            websocket::websocket_parser parser(true, 5);
+            auto bufs = std::vector<temporary_buffer<char>>{};
+            bufs.push_back(temporary_buffer<char>::copy_of(make_websocket_frame_header(websocket::opcodes::BINARY, 6, true)));
+            input_stream<char> in = util::as_input_stream(std::move(bufs));
+
+            in.consume(parser).get();
+
+            BOOST_REQUIRE(!parser.is_valid());
+            BOOST_REQUIRE(!parser.eof());
+            BOOST_REQUIRE_EQUAL(parser.opcode(), websocket::opcodes::BINARY);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_websocket_close_timer_fires_when_peer_never_echoes_close) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    Acc::set_close_timeout(conn, 50ms);
+    auto start = lowres_clock::now();
+    auto close_f = conn.close(true);
+
+    auto close_frame = co_await client_input.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(close_frame), make_websocket_frame(websocket::opcodes::CLOSE));
+
+    co_await with_timeout(lowres_clock::now() + 2s, std::move(close_f));
+    auto elapsed = lowres_clock::now() - start;
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+    BOOST_REQUIRE_GE(elapsed_ms, 50);
+    BOOST_REQUIRE_LT(elapsed_ms, 500);
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_close_handshake_send_failure_tears_down) {
+    using socket_impl = test_connected_socket_impl<eof_data_source_impl, write_failing_data_sink_impl>;
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(connected_socket(std::make_unique<socket_impl>()));
+
+    co_await conn.close(true).then_wrapped([] (future<> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+        } catch (const std::runtime_error& e) {
+            BOOST_REQUIRE_EQUAL(std::string(e.what()), "write failed");
+        }
+    });
+
+    auto buf = co_await Acc::input(conn).read();
+    BOOST_REQUIRE(buf.empty());
+}
+
+SEASTAR_TEST_CASE(test_websocket_send_chain_failure_is_terminal_until_drained) {
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    unsigned put_attempts = 0;
+    Conn conn(connected_socket(std::make_unique<counting_connected_socket_impl>(put_attempts)));
+    Acc::poison_send_chain(conn, std::make_exception_ptr(std::runtime_error("test poisoned send chain")));
+
+    co_await Acc::send_data(conn, websocket::opcodes::BINARY, temporary_buffer<char>::copy_of("after poison")).then_wrapped([] (future<> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+        } catch (const std::runtime_error& e) {
+            BOOST_REQUIRE_EQUAL(std::string(e.what()), "test poisoned send chain");
+        }
+    });
+
+    BOOST_REQUIRE_EQUAL(put_attempts, 0);
+
+    co_await Acc::drain_send_chain_error(conn);
+    co_await Acc::send_data(conn, websocket::opcodes::BINARY, temporary_buffer<char>::copy_of("after drain"));
+    BOOST_REQUIRE_EQUAL(put_attempts, 1);
+
+    co_await conn.close(false).handle_exception([] (std::exception_ptr) {});
+}
+
+SEASTAR_TEST_CASE(test_websocket_concurrent_send_data_frames_are_not_interleaved) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    const std::string first_payload(9000, 'a');
+    const std::string second_payload(9000, 'b');
+
+    auto first_send = Acc::send_data(conn, websocket::opcodes::BINARY, temporary_buffer<char>::copy_of(first_payload));
+    auto second_send = Acc::send_data(conn, websocket::opcodes::BINARY, temporary_buffer<char>::copy_of(second_payload));
+
+    const auto expected = make_websocket_frame(websocket::opcodes::BINARY, first_payload)
+        + make_websocket_frame(websocket::opcodes::BINARY, second_payload);
+    auto read_f = client_input.read_exactly(expected.size());
+
+    co_await when_all_succeed(std::move(first_send), std::move(second_send));
+    auto raw_frames = co_await std::move(read_f);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(raw_frames), expected);
+
+    co_await conn.close(false);
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_input_unmasks_non_zero_masked_frame) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    auto read_f = Acc::input(conn).read();
+    BOOST_REQUIRE(!read_f.available());
+
+    co_await client_output.write(make_websocket_frame(websocket::opcodes::BINARY,
+            "masked payload", true, true, 0x12345678));
+    co_await client_output.flush();
+
+    auto buf = co_await std::move(read_f);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(buf), "masked payload");
+
+    co_await conn.close(false);
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_peer_close_while_handler_is_reading) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    auto read_f = Acc::input(conn).read();
+    BOOST_REQUIRE(!read_f.available());
+
+    co_await client_output.write(make_websocket_frame(websocket::opcodes::CLOSE, {}, true));
+    co_await client_output.flush();
+
+    auto close_frame = co_await client_input.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(close_frame), make_websocket_frame(websocket::opcodes::CLOSE));
+
+    auto buf = co_await std::move(read_f);
+    BOOST_REQUIRE(buf.empty());
+
+    co_await Acc::output(conn).close();
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_invalid_frame_while_handler_is_reading_reports_error_once) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    auto read_f = Acc::input(conn).read();
+    BOOST_REQUIRE(!read_f.available());
+
+    co_await client_output.write(make_websocket_frame(0x3, {}, true));
+    co_await client_output.flush();
+
+    co_await std::move(read_f).then_wrapped([] (future<temporary_buffer<char>> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+        } catch (const websocket::exception& e) {
+            BOOST_REQUIRE_EQUAL(std::string(e.what()), "Reading from socket has failed.");
+        }
+    });
+
+    auto buf = co_await Acc::input(conn).read();
+    BOOST_REQUIRE(buf.empty());
+
+    auto eof = co_await client_input.read();
+    BOOST_REQUIRE(eof.empty());
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_wait_close_stops_after_invalid_frame) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    Conn conn(std::move(server_sock));
+    auto close_f = conn.close(true);
+
+    auto close_frame = co_await client_input.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(close_frame), make_websocket_frame(websocket::opcodes::CLOSE));
+
+    co_await client_output.write(make_websocket_frame(0x3, {}, true));
+    co_await client_output.close();
+
+    co_await with_timeout(lowres_clock::now() + 2s, std::move(close_f));
+    co_await client_input.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_close2_double_close) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    Conn conn(std::move(server_sock));
+    auto first_close = conn.close(false);
+    auto second_close = conn.close(false);
+
+    co_await when_all_succeed(std::move(first_close), std::move(second_close));
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_close2_double_close_handshake_sends_one_close) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    Conn conn(std::move(server_sock));
+    auto first_close = conn.close(true);
+    auto second_close = conn.close(true);
+
+    auto close_frame = co_await client_input.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(close_frame), make_websocket_frame(websocket::opcodes::CLOSE));
+
+    co_await client_output.write(make_websocket_frame(websocket::opcodes::CLOSE, {}, true));
+    co_await client_output.flush();
+
+    co_await when_all_succeed(std::move(first_close), std::move(second_close));
+
+    auto extra = co_await client_input.read();
+    BOOST_REQUIRE(extra.empty());
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_close_while_consuming_sends_close_frame_and_tears_down) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn(std::move(server_sock));
+    auto read_f = Acc::input(conn).read();
+    BOOST_REQUIRE(!read_f.available());
+
+    auto close_f = conn.close(true);
+
+    auto close_frame = co_await client_input.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(buffer_to_string(close_frame), make_websocket_frame(websocket::opcodes::CLOSE));
+
+    co_await with_timeout(lowres_clock::now() + 2s, std::move(close_f));
+
+    co_await std::move(read_f).then_wrapped([] (future<temporary_buffer<char>> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+            BOOST_FAIL("read should fail after direct teardown");
+        } catch (const std::system_error& e) {
+            BOOST_REQUIRE_EQUAL(e.code().value(), static_cast<int>(std::errc::broken_pipe));
+        }
+    });
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_client_shutdown_before_connect) {
+    websocket::client<> ws_client;
+    ws_client.shutdown();
+    co_await ws_client.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_client_shutdown_during_connect_handshake) {
+    auto listener = seastar::listen(make_ipv4_address({"127.0.0.1", 0}), listen_options());
+    auto accept_f = listener.accept();
+
+    websocket::client<> ws_client;
+    auto connect_f = ws_client.connect(listener.local_address(), "/", "localhost", "",
+            [] (input_stream<char>&, output_stream<char>&) {
+        return make_ready_future<>();
+    });
+
+    auto server_sock = (co_await std::move(accept_f)).connection;
+    auto server_input = server_sock.input();
+    auto server_output = server_sock.output();
+
+    auto request = co_await server_input.read();
+    BOOST_REQUIRE(!request.empty());
+
+    ws_client.shutdown();
+    co_await with_timeout(lowres_clock::now() + 2s, std::move(connect_f).then_wrapped([] (future<> f) {
+        BOOST_REQUIRE(f.failed());
+        f.ignore_ready_future();
+    }));
+    co_await ws_client.close();
+
+    co_await server_input.close();
+    co_await server_output.close();
+    listener.abort_accept();
+}
+
+SEASTAR_TEST_CASE(test_websocket_process_propagates_handler_exception) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    auto acceptor = factory.get_server_socket().accept();
+    auto connector = lsi.connect(socket_address(), socket_address());
+
+    auto server_sock = (co_await std::move(acceptor)).connection;
+    auto client_sock = co_await std::move(connector);
+    auto client_input = client_sock.input();
+    auto client_output = client_sock.output();
+
+    websocket::server ws;
+    ws.register_handler("", [] (input_stream<char>&, output_stream<char>&) {
+        return make_exception_future<>(std::runtime_error("handler failed"));
+    });
+
+    websocket::server_connection conn(ws, std::move(server_sock));
+    auto serve = conn.process();
+
+    co_await client_output.write(build_request("dGhlIHNhbXBsZSBub25jZQ==", ""));
+    co_await client_output.flush();
+    co_await client_input.read_exactly(156);
+
+    co_await std::move(serve).then_wrapped([] (future<> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+        } catch (const std::runtime_error& e) {
+            BOOST_REQUIRE_EQUAL(std::string(e.what()), "handler failed");
+        }
+    });
+
+    co_await conn.close(false);
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_client_process_preserves_handler_exception_when_output_close_fails) {
+    using socket_impl = test_connected_socket_impl<eof_data_source_impl, close_failing_data_sink_impl>;
+    websocket::client_connection conn(connected_socket(std::make_unique<socket_impl>()),
+            "/", "localhost", "",
+            [] (input_stream<char>&, output_stream<char>&) {
+        return make_exception_future<>(std::runtime_error("handler failed"));
+    });
+
+    co_await conn.process().then_wrapped([] (future<> f) {
+        BOOST_REQUIRE(f.failed());
+        try {
+            f.get();
+        } catch (const std::runtime_error& e) {
+            BOOST_REQUIRE_EQUAL(std::string(e.what()), "handler failed");
+        }
+    });
+
+    co_await conn.close(false).handle_exception([] (std::exception_ptr) {});
+}
+
 SEASTAR_TEST_CASE(test_websocket_client_server) {
     loopback_connection_factory factory;
     loopback_socket_impl lsi(factory);
@@ -281,7 +1143,6 @@ SEASTAR_TEST_CASE(test_websocket_client_server) {
 
             auto buf = co_await in.read();
             received_data = sstring(buf.get(), buf.size());
-
             co_await out.close();
             client_done.set_value();
         });
@@ -291,12 +1152,165 @@ SEASTAR_TEST_CASE(test_websocket_client_server) {
         [] (std::exception_ptr) {});
 
     co_await client_done.get_future();
-
     BOOST_REQUIRE_EQUAL(received_data, "hello");
 
-    // Shut down cleanly: close client first (sends CLOSE frame), then server
-    co_await client_conn.close();
-    co_await std::move(client_process);
-    co_await server_conn.close();
     co_await std::move(serve);
+    co_await std::move(client_process);
+    co_await client_conn.close(false);
+    co_await server_conn.close(false);
+}
+
+SEASTAR_TEST_CASE(test_websocket_server_stop_shuts_down_active_connections) {
+    loopback_connection_factory factory;
+    loopback_socket_impl lsi(factory);
+
+    websocket::server ws;
+    promise<> handler_blocked;
+    promise<> handler_done;
+    ws.register_handler("", [&handler_blocked, &handler_done] (input_stream<char>& in, output_stream<char>&) -> future<> {
+        handler_blocked.set_value();
+        try {
+            co_await in.read();
+        } catch (...) {
+            // expected: broken pipe or other error when server stops
+        }
+        handler_done.set_value();
+    });
+
+    ws.listen(factory.get_server_socket());
+
+    // Connect a raw client and complete the WebSocket handshake
+    auto connector = lsi.connect(socket_address(), socket_address());
+    connected_socket sock = co_await std::move(connector);
+    auto client_input = sock.input();
+    auto client_output = sock.output();
+
+    co_await client_output.write(build_request("dGhlIHNhbXBsZSBub25jZQ==", ""));
+    co_await client_output.flush();
+
+    // Consume the 101 response
+    http_response_parser parser;
+    parser.init();
+    co_await client_input.consume(parser);
+    BOOST_REQUIRE(parser.get_parsed_response());
+
+    // Wait until the handler is blocked inside in.read()
+    co_await handler_blocked.get_future();
+
+    // Stop the server — should shut down active connections
+    co_await with_timeout(lowres_clock::now() + 2s, ws.stop());
+
+    // Handler should have observed EOF/error and returned
+    co_await with_timeout(lowres_clock::now() + 2s, handler_done.get_future());
+
+    co_await client_input.close();
+    co_await client_output.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_respond_to_peer_close_write_failure_still_tears_down) {
+    // Build a CLOSE frame that the server-side parser (expecting masked frames) will accept.
+    std::string close_frame = make_websocket_frame(websocket::opcodes::CLOSE, {}, /*masked=*/true);
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc  = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn2(connected_socket(std::make_unique<close_source_write_failing_socket_impl>(close_frame)));
+
+    // read() triggers consume() → CLOSE frame → respond_to_peer_close()
+    // respond_to_peer_close() tries to send CLOSE → write_failing_data_sink_impl → handle_exception swallows
+    // → tear_down_streams() runs → _pending_inbound is set to empty → read() returns empty.
+    // With fix B applied, the exception is swallowed and teardown completes.
+    auto buf = co_await with_timeout(lowres_clock::now() + 2s, Acc::input(conn2).read());
+    BOOST_REQUIRE(buf.empty());
+
+    // A second read must also return empty (not hang), confirming teardown completed.
+    auto buf2 = co_await with_timeout(lowres_clock::now() + 2s, Acc::input(conn2).read());
+    BOOST_REQUIRE(buf2.empty());
+}
+
+SEASTAR_TEST_CASE(test_websocket_close_from_within_handler_does_not_deadlock) {
+    loopback_connection_factory factory2;
+    loopback_socket_impl lsi2(factory2);
+
+    auto acceptor2 = factory2.get_server_socket().accept();
+    auto connector2 = lsi2.connect(socket_address(), socket_address());
+    auto server_sock2 = (co_await std::move(acceptor2)).connection;
+    auto client_sock2 = co_await std::move(connector2);
+    auto client_input2 = client_sock2.input();
+    auto client_output2 = client_sock2.output();
+
+    using Conn = websocket::basic_connection<false, false>;
+    using Acc  = websocket::basic_connection_test_accessor<false, false>;
+    Conn conn2(std::move(server_sock2));
+    Acc::set_close_timeout(conn2, 200ms);
+
+    // Start a handler that reads one message then closes output.
+    // Closing the output triggers close(true), which exercises the _in_consume path.
+    auto handler_f = Acc::input(conn2).read().then([&conn2] (temporary_buffer<char>) {
+        return Acc::output(conn2).close();
+    });
+
+    // Send a data frame from the client side
+    co_await client_output2.write(make_websocket_frame(websocket::opcodes::BINARY, "hi", /*masked=*/true));
+    co_await client_output2.flush();
+
+    // handler_f should complete (close drives the CLOSE handshake via _in_consume path)
+    // with_timeout ensures we don't hang if the _in_consume guard is broken
+    co_await with_timeout(lowres_clock::now() + 2s, std::move(handler_f));
+
+    co_await conn2.close(false).handle_exception([] (std::exception_ptr) {});
+    co_await client_input2.close();
+    co_await client_output2.close();
+}
+
+SEASTAR_TEST_CASE(test_websocket_client_shutdown_unblocks_blocked_handler) {
+    auto listener = seastar::listen(make_ipv4_address({"127.0.0.1", 0}), listen_options());
+
+    websocket::client<> ws_client;
+    promise<> handler_reading;
+    auto connect_f = ws_client.connect(listener.local_address(), "/", "localhost", "",
+            [&handler_reading] (input_stream<char>& in, output_stream<char>&) -> future<> {
+        handler_reading.set_value();
+        co_await in.read(); // blocks until shutdown
+    });
+
+    // Accept the TCP connection and send a valid 101 upgrade response manually
+    auto ar = co_await listener.accept();
+    auto server_input  = ar.connection.input();
+    auto server_output = ar.connection.output();
+
+    // Read and discard the upgrade request
+    auto req_buf = co_await server_input.read();
+    BOOST_REQUIRE(!req_buf.empty());
+
+    // Parse the Sec-WebSocket-Key header from req_buf.
+    sstring req_str(req_buf.get(), req_buf.size());
+    auto key_pos = req_str.find("Sec-WebSocket-Key: ");
+    BOOST_REQUIRE(key_pos != sstring::npos);
+    auto key_start = key_pos + 19;
+    auto key_end = req_str.find("\r\n", key_start);
+    BOOST_REQUIRE(key_end != sstring::npos);
+    sstring ws_key = req_str.substr(key_start, key_end - key_start);
+
+    auto accept_val = websocket::sha1_base64(fmt::format("{}{}", ws_key, websocket::websocket_magic_guid));
+    auto response_101 = fmt::format(
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Accept: {}\r\n"
+        "\r\n",
+        accept_val);
+
+    co_await server_output.write(response_101);
+    co_await server_output.flush();
+
+    // Wait until the handler is blocked on in.read()
+    co_await with_timeout(lowres_clock::now() + 2s, handler_reading.get_future());
+
+    // shutdown() + close() should both resolve
+    ws_client.shutdown();
+    co_await with_timeout(lowres_clock::now() + 2s, ws_client.close());
+
+    co_await server_input.close();
+    co_await server_output.close();
+    listener.abort_accept();
 }


### PR DESCRIPTION
  ## Summary

  Refactor the WebSocket connection lifecycle to replace the previous
  dual-queue producer/consumer model with an on-demand `consume()` loop and a
  per-connection `_send_chain` for outbound serialization, introduce a proper
  state machine for orderly close, and harden the frame parser against RFC 6455
  edge cases.

  ## Motivation

  The previous implementation used two `queue<temporary_buffer>` mailboxes of size
  512 between the network I/O loop and the user handler. That design:

  - Buffered an unbounded amount of work in the queues without bounded backpressure
    semantics that the handler could observe.
  - Had no proper CLOSE handshake — receiving a peer CLOSE could lead to a second
    CLOSE being sent, and there was no timeout for a peer that never responded.
  - Conflated stream lifetime with the queue's drain state via `_done`/`_half_close`
    booleans, which were hard to reason about across re-entrant calls.
  - Did not bound parser memory: an attacker-supplied 64-bit length field would
    drive an allocation of that size before any validation.
  - Had a long-standing bug in `is_opcode_known()` (`opcode < 0xA`) that rejected
    legitimate PONG frames.

  The dual-queue design made WebSocket state management hard to reason about, so this PR refactors it into an explicit lifecycle state machine.

  ## Key changes

  ### Connection lifecycle

  - New `lifecycle_state { running, closing_local, closing_peer, tearing_down,
    torn_down }` plus `shared_future`-backed `_close_future` and
    `_tear_down_future` for idempotent, concurrent-safe close.
  - `initiate_close_handshake()` sends CLOSE, arms a configurable `close_timeout`
    (default 200 ms, `lowres_clock`) that shuts the socket read side down if the
    peer never echoes CLOSE, then tears the streams down.
  - `respond_to_peer_close()` handles peer-initiated CLOSE on its own path.
  - A re-entrant close from inside `consume()` (the handler closes its output
    stream in response to a peer frame) skips `wait_close()` to avoid
    deadlocking against the in-progress read; gated by `_in_consume`.
  - `tear_down_streams()` relies on `input_stream::close()` issuing `SHUT_RD` so a blocked `in.read()` is unblocked without an explicit
    `shutdown_input()` at the `client::close()` site.

  ### Outbound serialization

  Outbound frames are serialized through a per-connection `_send_chain` future.
  Once any send fails, the chain stays poisoned until `drain_send_chain()` runs
  at teardown, so a write failure is terminal for the send path. This matches
  WebSocket's "any framing error is fatal" model and makes the behavior testable
  (`test_websocket_send_chain_failure_is_terminal_until_drained`).

  ### Parser hardening

  - Added `connection_options::max_payload_length` (default 16 MiB) so an
    attacker-controlled 64-bit length field cannot drive arbitrarily large
    allocations. The check fires before the payload buffer is allocated.
  - Enforced RFC 6455 §5.5 control-frame limits: CLOSE / PING / PONG payloads
    must be ≤ 125 bytes and must not be fragmented.
  - Fixed `is_opcode_known()` to accept PONG (`0xA`); the previous
    `opcode < 0xA` check rejected legitimate PONG frames.

  ### Public API

  - New `connection_options { max_payload_length, output_buffer_size,
    close_timeout }`, threaded through `basic_connection`, `server`, `client`,
    `server_connection`, and `client_connection` constructors.
  - New `server::server(connection_options)` ctor.
  - New `server::listen(server_socket)` overload (accept on a pre-created
    listener).
  - New `websocket::client::shutdown()` — an out-of-band escape hatch for the
    case where the outbound path itself is stalled (peer recv-window full, dead
    peer holding the connection open). Normal teardown still goes through
    `close()`.

  ## Behavior changes

  - `client::close()` now resets `_conn` after teardown, so a `client` is
    single-use across `connect`/`close`. A second `connect()` is guarded by
    `SEASTAR_ASSERT(!_conn)`.
  - `server::stop()` no longer initiates a WebSocket CLOSE handshake on active
    connections; it shuts inputs down and lets the task gate drain. This is the
    abortive-teardown semantics documented in `server.hh` and
    `doc/websocket.md`.
  - Existing protected methods `read_one()`, `response_loop()`, and
    `server_connection::read_loop()` are removed.

  ## Tests

  `tests/unit/websocket_test.cc` grows by ~1062 lines. New coverage:

  - Parser: unknown opcodes, oversized control frames, fragmented control
    frames, oversized data frames declared before allocation, configurable
    per-parser limit.
  - Close lifecycle: close timer firing when the peer never echoes CLOSE,
    close-handshake send-failure teardown, double close (both `(false, false)`
    and `(true, true)`), `respond_to_peer_close` write failure still tearing
    down, close from inside the consume path not deadlocking.
  - Send chain: poisoned send chain is terminal until drained; concurrent
    `send_data` calls are FIFO-serialized on the wire.
  - Input path: masked-frame unmasking on the server side, peer CLOSE while the
    handler is mid-read, invalid frame reporting once and then EOF, `wait_close()`
    stopping on parse error.
  - Server / client: `server::stop()` while handlers are blocked in read,
    `client::shutdown()` before / during / after the connect handshake,
    `process()` propagating handler exceptions, `client::process` preserving
    the handler exception even when output close fails.

  ## Refs

  - RFC 6455 §1.3 (handshake), §5.1 (opcodes), §5.5 (control frames), §5.5.1
    (close handshake), §5.5.2 (ping/pong)

  ## AI assistance disclosure

  Parts of this PR were produced with AI assistance:

  - **Test cases** (`tests/unit/websocket_test.cc`): generated and iterated with
    Codex and Claude.
  - **Documentation** (`doc/websocket.md`, doxygen comments in
    `include/seastar/websocket/*.hh`): drafted and refined with Codex and
    Claude.
  - **Code review**: a structured multi-reviewer pass was run with both Codex
    and Claude (via the compound-engineering review pipeline); findings were
    triaged and the substantive ones (close-handshake resource cleanup, parser
    opcode default-arm safety, doxygen accuracy) addressed before submission.

  The C++ refactor itself — connection lifecycle, send-chain serialization, and
  parser hardening — was authored manually; the AI tools contributed test
  coverage, prose, and review feedback.