### PR TITLE
file: assert dma alignments are powers of two

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -311,12 +311,16 @@ public:
     // we will end up with various pages around, some of them with
     // overlapping ranges. Those would be very challenging to cache.
 
-    /// Alignment requirement for file offsets (for reads)
+    /// Alignment requirement for file offsets (for reads).
+    ///
+    /// The returned value is guaranteed to be a power of two.
     uint64_t disk_read_dma_alignment() const noexcept {
         return _file_impl->_disk_read_dma_alignment;
     }
 
-    /// Alignment requirement for file offsets (for writes)
+    /// Alignment requirement for file offsets (for writes).
+    ///
+    /// The returned value is guaranteed to be a power of two.
     uint64_t disk_write_dma_alignment() const noexcept {
         return _file_impl->_disk_write_dma_alignment;
     }
@@ -327,11 +331,15 @@ public:
     /// overwrites (writes to a location that was previously written).
     /// This can be smaller than \ref disk_write_dma_alignment(), allowing
     /// a reduction in disk bandwidth used.
+    ///
+    /// The returned value is guaranteed to be a power of two.
     uint64_t disk_overwrite_dma_alignment() const noexcept {
         return _file_impl->_disk_overwrite_dma_alignment;
     }
 
-    /// Alignment requirement for data buffers
+    /// Alignment requirement for data buffers.
+    ///
+    /// The returned value is guaranteed to be a power of two.
     uint64_t memory_dma_alignment() const noexcept {
         return _file_impl->_memory_dma_alignment;
     }

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <coroutine>
 #include <deque>
 #include <functional>
@@ -86,6 +87,20 @@ struct alignments {
     unsigned disk_read;
     unsigned disk_write;
     unsigned disk_overwrite;
+
+    // The kernel/FS ABIs that produce these values (BLKSSZGET, XFS_IOC_DIOINFO,
+    // statx dio_*_align, posix_memalign) all guarantee power-of-two alignments,
+    // and seastar's own I/O paths consume them via `x & (align - 1)` masking
+    // (e.g. computing the unaligned prefix of a read offset), which would
+    // silently produce wrong offsets for a non-power-of-two value.
+    // Returns *this for convenience.
+    const alignments& validated() const {
+        SEASTAR_ASSERT(std::has_single_bit(memory));
+        SEASTAR_ASSERT(std::has_single_bit(disk_read));
+        SEASTAR_ASSERT(std::has_single_bit(disk_write));
+        SEASTAR_ASSERT(std::has_single_bit(disk_overwrite));
+        return *this;
+    }
 };
 
 // Minimum memory alignment required by posix_memalign
@@ -1265,7 +1280,7 @@ internal::alignments filesystem_alignments(
         align.disk_overwrite = std::max<unsigned>(align.disk_overwrite, *device_info.physical_block_size);
     }
 
-    return align;
+    return align.validated();
 }
 
 // Query block device alignment properties using ioctl and statx
@@ -1301,12 +1316,12 @@ blkdev_alignments(int fd, dev_t device_id) {
     //
     // The Linux kernel only enforces logical_block_size alignment for O_DIRECT (see block/fops.c:blkdev_dio_invalid).
     // Using physical_block_size avoids RMW at the hardware level.
-    return {
+    return internal::alignments{
         .memory = std::max(static_cast<unsigned>(device_info.memory_alignment.value_or(physical_block_size)), internal::min_memory_alignment),
         .disk_read = static_cast<unsigned>(logical_block_size),  // For reads: use logical_block_size (no performance penalty for reading 512-byte blocks from 4K sector disks)
         .disk_write = static_cast<unsigned>(physical_block_size),
         .disk_overwrite = static_cast<unsigned>(physical_block_size),
-    };
+    }.validated();
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Add a `validated()` method on the internal `alignments` struct that asserts each of `memory`, `disk_read`, `disk_write`, and `disk_overwrite` is a power of two, and call it from the two producers (`filesystem_alignments` and `blkdev_alignments`).

The kernel/FS ABIs that supply these values (`BLKSSZGET`, `XFS_IOC_DIOINFO`, `statx dio_*_align`, `posix_memalign`) all guarantee power-of-two alignments, and seastar's own I/O paths consume them via `x & (align - 1)` masking (e.g. computing the unaligned prefix of a read offset). A non-power-of-two value would silently produce wrong offsets, so we check once at the producer rather than per-I/O.

Also documents the power-of-two guarantee on the four public accessors (`disk_read_dma_alignment` / `disk_write_dma_alignment` / `disk_overwrite_dma_alignment` / `memory_dma_alignment`).