### PR TITLE
tls: improved support for builds with a single backend (GnuTLS or OpenSSL)

### DIFF
--- a/.github/workflows/gen-matrix.py
+++ b/.github/workflows/gen-matrix.py
@@ -126,6 +126,22 @@ SPECIAL_ITEMS: list[dict[str, Any]] = [
         "mode": "fuzz",
         "test-args": "-- -R 'Seastar.fuzz.'",
     },
+    {
+        "compiler": "clang++-22",
+        "standard": 23,
+        "arch": "x86",
+        "mode": "debug",
+        "options": "--tls-mode=both",
+        "info": "dual-tls, ",
+    },
+    {
+        "compiler": "clang++-22",
+        "standard": 23,
+        "arch": "x86",
+        "mode": "debug",
+        "options": "--tls-mode=openssl",
+        "info": "openssl-tls, ",
+    },
 ]
 
 def _build_include(items: list[dict[str, Any]]) -> CommentedSeq:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,8 @@ jobs:
           - {compiler: clang++-22, standard: 23, arch: x86, mode: release, enables: --enable-dpdk, options: --cook dpdk --dpdk-machine corei7-avx, info: 'dpdk, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: debug, enables: --enable-cxx-modules, enable-ccache: false, info: 'modules, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: fuzz, test-args: -- -R 'Seastar.fuzz.'}
+          - {compiler: clang++-22, standard: 23, arch: x86, mode: debug, options: --tls-mode=both, info: 'dual-tls, '}
+          - {compiler: clang++-22, standard: 23, arch: x86, mode: debug, options: --tls-mode=openssl, info: 'openssl-tls, '}
     with:
       compiler: ${{ matrix.compiler }}
       standard: ${{ matrix.standard }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,11 +529,13 @@ seastar_generate_protobuf (
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/proto/metrics2.proto
   OUT_DIR ${Seastar_GEN_BINARY_DIR}/src/proto)
 
-set_option_if_package_is_found (Seastar_GNUTLS GnuTLS)
-set_option_if_package_is_found (Seastar_OPENSSL OpenSSL)
+option (Seastar_GNUTLS "Enable the GnuTLS-based TLS backend" ON)
+option (Seastar_OPENSSL "Enable the OpenSSL-based TLS backend" OFF)
 
 if (NOT Seastar_GNUTLS AND NOT Seastar_OPENSSL)
-  message (FATAL_ERROR "At least one TLS/crypto backend is required. Install GnuTLS or OpenSSL development packages.")
+  message (FATAL_ERROR "At least one TLS backend must be enabled. "
+    "Pass -DSeastar_GNUTLS=ON and/or -DSeastar_OPENSSL=ON, "
+    "or use configure.py --tls-mode=gnutls|openssl|both.")
 endif ()
 
 add_library (seastar
@@ -1141,6 +1143,15 @@ if (Seastar_OPENSSL)
   list (APPEND Seastar_PRIVATE_COMPILE_DEFINITIONS SEASTAR_HAVE_OPENSSL)
   target_link_libraries (seastar
     PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif ()
+
+if (Seastar_GNUTLS AND Seastar_OPENSSL)
+  # Public marker: both TLS backends are compiled in, so the active backend is
+  # selected at reactor startup. Code that needs to handle the no-reactor case
+  # (e.g. static initializers, unit tests without a reactor) can use this to
+  # distinguish from the single-backend builds where the backend is fixed at
+  # compile time and available unconditionally.
+  target_compile_definitions (seastar PUBLIC SEASTAR_TLS_DUAL_BACKEND)
 endif ()
 
 set_option_if_package_is_found (Seastar_IO_URING LibUring)

--- a/configure.py
+++ b/configure.py
@@ -173,6 +173,9 @@ arg_parser.add_argument('--cook', action='append', dest='cook', default=[],
 arg_parser.add_argument('--verbose', dest='verbose', action='store_true', help='Make configure output more verbose.')
 arg_parser.add_argument('--scheduling-groups-count', action='store', dest='scheduling_groups_count', default='16',
                         help='Number of available scheduling groups in the reactor')
+arg_parser.add_argument('--tls-mode', action='store', dest='tls_mode',
+                        choices=['gnutls', 'openssl', 'both'], default='gnutls',
+                        help='TLS backend(s) to enable: gnutls (default), openssl, or both')
 
 add_tristate(
     arg_parser,
@@ -294,6 +297,8 @@ def configure_mode(mode):
         '-DBUILD_SHARED_LIBS={}'.format('yes' if mode in ('debug', 'dev') else 'no'),
         '-DSeastar_API_LEVEL={}'.format(args.api_level),
         '-DSeastar_SCHEDULING_GROUPS_COUNT={}'.format(args.scheduling_groups_count),
+        '-DSeastar_GNUTLS={}'.format('ON' if args.tls_mode in ('gnutls', 'both') else 'OFF'),
+        '-DSeastar_OPENSSL={}'.format('ON' if args.tls_mode in ('openssl', 'both') else 'OFF'),
         tr(args.exclude_tests, 'EXCLUDE_TESTS_FROM_ALL'),
         tr(args.exclude_apps, 'EXCLUDE_APPS_FROM_ALL'),
         tr(args.exclude_demos, 'EXCLUDE_DEMOS_FROM_ALL'),

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -62,8 +62,13 @@ class network_stack_factory;
 struct reactor_options : public program_options::option_group {
     /// \brief Select cryptographic provider backend.
     ///
-    /// Available providers:
-    /// * gnutls (default)
+    /// In dual-backend builds (\c SEASTAR_TLS_DUAL_BACKEND), accepts:
+    /// * gnutls
+    /// * openssl
+    ///
+    /// In single-backend builds the only valid value is the backend that was
+    /// compiled in; the option is kept for CLI compatibility but is otherwise
+    /// a no-op (the provider is a compile-time-fixed static singleton).
     program_options::selection_value<crypto_provider_factory> crypto_provider;
     /// \brief Select network stack to use.
     ///

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -48,10 +48,31 @@ class socket_address;
  * Relatively thin SSL wrapper for socket IO.
  * (Can be expanded to other IO forms).
  *
- * The current underlying mechanism is
- * gnutls, however, all interfaces are kept
- * agnostic, so in theory it could be replaced
- * with OpenSSL or similar.
+ * Two underlying mechanisms are supported, GnuTLS and OpenSSL. Each one can
+ * be enabled or disabled at build time (\c Seastar_GNUTLS, \c Seastar_OPENSSL).
+ * When both are compiled in (\c SEASTAR_TLS_DUAL_BACKEND), the active backend
+ * is chosen at reactor startup via the \c --crypto-provider option; when only
+ * one is compiled in, that backend is fixed for the lifetime of the program.
+ *
+ * The interfaces here are kept agnostic so that either backend can be used
+ * without changes to client code.
+ *
+ * \section backend_lifetime When backend-dependent state is valid
+ *
+ * Several entry points below expose state that comes from the active backend
+ * (\ref error_category, \ref backend_name, the \c ERROR_* globals, and any
+ * function that internally creates a TLS session, credentials, or DH params).
+ *
+ * - In **single-backend** builds the backend is fixed at compile time and
+ *   initialized on first use. These entry points are valid at any time,
+ *   including from static initializers and from unit tests that never start
+ *   a reactor, with one exception: the \c ERROR_* globals are
+ *   zero-initialized and only take their final values once the backend is
+ *   first used (at reactor startup at the latest).
+ * - In **dual-backend** builds the backend is installed by
+ *   \c smp::configure() at reactor startup. Calling any backend-dependent
+ *   entry point before that point is undefined; the \c ERROR_* globals in
+ *   particular are zero-initialized and silently read as 0 until then.
  *
  */
 namespace tls {
@@ -696,20 +717,24 @@ namespace tls {
     std::ostream& operator<<(std::ostream&, subject_alt_name_type);
 
     /**
-     * Error handling.
+     * The error_category instance used by exceptions thrown by TLS.
      *
-     * The error_category instance used by exceptions thrown by TLS
+     * See \ref backend_lifetime for when this is valid to call.
      */
     const std::error_category& error_category();
 
     /**
      * Returns the name of the active TLS backend (e.g. "gnutls", "openssl").
+     *
+     * See \ref backend_lifetime for when this is valid to call.
      */
     const char* backend_name();
 
     /**
-     * The more common error codes encountered in TLS.
-     * Not an exhaustive list. Add exports as needed.
+     * The more common error codes encountered in TLS. Not an exhaustive
+     * list — add exports as needed.
+     *
+     * See \ref backend_lifetime for when these are valid to read.
      */
     extern int ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
     extern int ERROR_UNKNOWN_CIPHER_TYPE;

--- a/include/seastar/util/assert.hh
+++ b/include/seastar/util/assert.hh
@@ -34,3 +34,11 @@ namespace seastar::internal {
                                            __PRETTY_FUNCTION__);      \
         }                                                             \
     } while (0)
+
+/// Like SEASTAR_ASSERT(), but only active when SEASTAR_DEBUG is defined
+/// (Debug, Sanitize, and Fuzz build modes). Compiles to nothing otherwise.
+#ifdef SEASTAR_DEBUG
+#define SEASTAR_DEBUG_ASSERT(x) SEASTAR_ASSERT(x)
+#else
+#define SEASTAR_DEBUG_ASSERT(x) do { (void)sizeof(x); } while (0)
+#endif

--- a/src/core/crypto.cc
+++ b/src/core/crypto.cc
@@ -20,6 +20,7 @@
  */
 
 #include "crypto.hh"
+#include <seastar/util/assert.hh>
 #include <memory>
 
 namespace seastar::internal::crypto {
@@ -31,10 +32,12 @@ namespace seastar::internal::crypto {
 static std::unique_ptr<crypto_provider> the_provider;
 
 crypto_provider& provider() {
+    SEASTAR_DEBUG_ASSERT(the_provider != nullptr);
     return *the_provider;
 }
 
 void set_provider(std::unique_ptr<crypto_provider> p) {
+    SEASTAR_ASSERT(the_provider == nullptr);
     the_provider = std::move(p);
     provider().get_tls_backend().init_error_codes();
 }

--- a/src/core/crypto.cc
+++ b/src/core/crypto.cc
@@ -24,6 +24,10 @@
 
 namespace seastar::internal::crypto {
 
+#ifdef SEASTAR_TLS_DUAL_BACKEND
+
+// Dual-backend build: the active provider is selected at reactor startup
+// (--crypto-provider) and installed via set_provider() from smp::configure().
 static std::unique_ptr<crypto_provider> the_provider;
 
 crypto_provider& provider() {
@@ -34,6 +38,33 @@ void set_provider(std::unique_ptr<crypto_provider> p) {
     the_provider = std::move(p);
     provider().get_tls_backend().init_error_codes();
 }
+
+void reset_provider() {
+    the_provider.reset();
+}
+
+#else // single-backend
+
+// Single-backend build: the provider is fixed at compile time. Use a
+// function-local static so provider() works at any time, including before
+// reactor startup. No set_provider() is compiled or needed.
+crypto_provider& provider() {
+    static auto instance = [] {
+#ifdef SEASTAR_HAVE_GNUTLS
+        auto p = create_gnutls_provider();
+#else // SEASTAR_HAVE_OPENSSL
+        auto p = create_openssl_provider();
+#endif
+        // The tls::ERROR_* globals are zero-initialized and filled in by the
+        // backend; do that as part of creating the provider so they are
+        // valid from the first use of any crypto/TLS functionality.
+        p->get_tls_backend().init_error_codes();
+        return p;
+    }();
+    return *instance;
+}
+
+#endif // SEASTAR_TLS_DUAL_BACKEND
 
 md5_hasher make_md5_hasher() {
     return provider().make_md5_hasher();

--- a/src/core/crypto.hh
+++ b/src/core/crypto.hh
@@ -73,6 +73,11 @@ public:
     virtual std::unique_ptr<tls::dh_params_impl> make_dh_params(const tls::blob&, tls::x509_crt_format) = 0;
 
     /// \brief Initialize backend-specific TLS error code constants.
+    ///
+    /// In dual-backend builds this fills in the legacy \c tls::ERROR_*
+    /// globals from the active backend's values. In single-backend builds
+    /// the globals are \c const, statically initialized in the backend's
+    /// own translation unit, and this method is a no-op.
     virtual void init_error_codes() = 0;
 
     /// \brief Return the name of this TLS backend (e.g. "gnutls", "openssl").
@@ -106,15 +111,36 @@ public:
 
 /// \brief Return the process-wide crypto provider.
 ///
-/// Must be called after set_provider().  The returned reference
-/// remains valid for the lifetime of the process.
+/// In dual-backend builds, must be called after \ref set_provider(). The
+/// returned reference remains valid for the lifetime of the process.
+/// In single-backend builds the provider is fixed at compile time, lazily
+/// created on first call, and \ref provider() works at any time including
+/// from static initializers / before reactor startup.
 crypto_provider& provider();
 
+#ifdef SEASTAR_TLS_DUAL_BACKEND
 /// \brief Install the process-wide crypto provider.
 ///
-/// Must be called exactly once, before any call to provider().
-/// Ownership is transferred to the crypto subsystem.
+/// Must be called exactly once per \c set_provider / \c reset_provider
+/// cycle, before any call to \ref provider(). Ownership is transferred
+/// to the crypto subsystem.
+///
+/// Only compiled in dual-backend builds. In single-backend builds the
+/// provider is fixed at compile time and \ref provider() handles the
+/// lifetime internally.
 void set_provider(std::unique_ptr<crypto_provider> p);
+
+/// \brief Tear down the process-wide crypto provider installed by
+/// \ref set_provider.
+///
+/// Called from \c smp::cleanup() so that a subsequent \c app::run()
+/// (and the \c smp::configure() it triggers) starts from a clean slate
+/// and can call \ref set_provider again. Safe to call when no provider
+/// is installed.
+///
+/// Only compiled in dual-backend builds.
+void reset_provider();
+#endif
 
 #ifdef SEASTAR_HAVE_GNUTLS
 /// \brief Create a GnuTLS-backed crypto provider.

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3976,7 +3976,6 @@ static program_options::selection_value<crypto_provider_factory> create_crypto_p
 #ifdef SEASTAR_HAVE_GNUTLS
     candidates.push_back({"gnutls", {new crypto_provider_factory(internal::crypto::create_gnutls_provider), deleter}, {}});
 #endif
-
 #ifdef SEASTAR_HAVE_OPENSSL
     candidates.push_back({"openssl", {new crypto_provider_factory(internal::crypto::create_openssl_provider), deleter}, {}});
 #endif
@@ -4193,6 +4192,9 @@ void smp::cleanup() noexcept {
     _shard_to_numa_node_mapping = decltype(_shard_to_numa_node_mapping)();
     reactor_holder.reset();
     local_engine = nullptr;
+#ifdef SEASTAR_TLS_DUAL_BACKEND
+    internal::crypto::reset_provider();
+#endif
 }
 
 void smp::cleanup_cpu() {
@@ -4395,9 +4397,20 @@ unsigned smp::adjust_max_networking_aio_io_control_blocks(unsigned network_iocbs
 
 void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_opts)
 {
+#ifdef SEASTAR_TLS_DUAL_BACKEND
     // Install the crypto provider before anything else, so it is
     // available to all reactors from the moment they start.
+    //
+    // Only present in dual-backend builds; in single-backend builds the
+    // provider is a static singleton in src/core/crypto.cc and needs no
+    // installation step.
     internal::crypto::set_provider(reactor_opts.crypto_provider.get_selected_candidate()());
+#else
+    // Touch the compile-time-fixed provider so backend initialization (in
+    // particular filling in the tls::ERROR_* globals) has happened by the
+    // time the reactor starts, matching the dual-backend build above.
+    internal::crypto::provider();
+#endif
 
     bool use_transparent_hugepages = !reactor_opts.overprovisioned;
 


### PR DESCRIPTION
The thrust here is that the dual backend TLS mode has a few possible footguns, in particular that certain error "constants" and helper functions will return wrong values or trigger UB if they are called before the TLS backend is initalized (which necessarily happens after main(), in the smp::configure phase).

It is not easy to just solve these in an API-compatible way. So this series tries to improves this in the following ways:

 - When only one backend is configured, which is probably the most common today, we can simply avoid most of the footguns since the backend is known statically so we can do what we did before and everything can work even before main().
 - We add some asserts in the relevant places to catch misuse, e.g., trying to access the provider when none has been set.

Details:

Make seastar's TLS backend choice an explicit build-time setting and let
single-backend builds use the active backend without any reactor-time setup.

* New `configure.py --tls-mode={gnutls,openssl,both}` (default `gnutls`),
  backed by a new public `SEASTAR_TLS_DUAL_BACKEND` compile def when both
  backends are enabled. OpenSSL is no longer auto-enabled — users opt in
  via `--tls-mode=openssl` or `--tls-mode=both`.
* In single-backend builds, the `seastar::tls::ERROR_*` globals are declared
  `const` and statically initialized to the active backend's values, so
  they're valid from static initializers and from unit tests that never
  start a reactor. Today they read silently as 0 before reactor startup,
  which has bitten downstream unit tests that compare against these
  constants without spinning up a reactor.
* In single-backend builds, `internal::crypto::provider()` returns a
  function-local static singleton constructed lazily on first call — no
  `set_provider()` is compiled or needed.
* In dual-backend builds, the runtime-installed provider is now paired
  with `reset_provider()` called from `smp::cleanup()`, so a subsequent
  `app::run()` in the same process starts from a clean slate. The previous
  silent-overwrite behavior obscured cross-app lifecycle bugs.
* The lifecycle is now asserted: `SEASTAR_ASSERT` on double-install in
  `set_provider()`, `SEASTAR_DEBUG_ASSERT` on access-before-install in
  `provider()`. A new `SEASTAR_DEBUG_ASSERT` macro (no-op outside
  Debug/Sanitize/Fuzz) supports the latter.
* CI adds two dedicated jobs to keep the non-default modes covered:
  `build_with_dual_tls` (`--tls-mode=both`) and `build_with_openssl_tls`
  (`--tls-mode=openssl`). The existing matrix exercises the new
  gnutls-only default.
