### PR TITLE
Fix `-Wmaybe-uninitialized` false positive

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -646,7 +646,27 @@ struct future_state :  public future_state_base, private internal::uninitialized
 
     void clear() noexcept {
         if (_u.has_result()) {
+            // The wrapped value is conditionally constructed in move_it()
+            // (and similar code paths) under the same `_u.has_result()`
+            // predicate that gates destruction here. The two checks read
+            // the same state tag, so when we reach this destroy the
+            // value was constructed -- but GCC's -Wmaybe-uninitialized
+            // analysis cannot prove the cross-function correlation and
+            // sometimes (e.g. for foreign_ptr or std::expected payloads
+            // under -O2) flags this destroy as reading uninitialized
+            // memory. Suppress at the destroy site, mirroring the
+            // pragma already used around the memmove in move_it().
+            // -Wmaybe-uninitialized is GCC-only; clang puts both definite
+            // and maybe cases under -Wuninitialized and would error on
+            // the unknown warning group, so guard on the compiler.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
             std::destroy_at(&this->uninitialized_get());
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
         } else {
             _u.check_failure();
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -374,6 +374,30 @@ seastar_add_test (execution_stage
 seastar_add_test (expiring_fifo
   SOURCES expiring_fifo_test.cc)
 
+seastar_add_test (future_state_maybe_uninit
+  SOURCES future_state_maybe_uninit_test.cc)
+# Re-enable -Wmaybe-uninitialized for just this test under compilers
+# that support it (GCC). It is otherwise disabled globally (see the
+# top-level CMakeLists.txt `-Wno-maybe-uninitialized` PUBLIC compile
+# option on the seastar target) because the warning has historically
+# been noisy on future<T>. Setting the option on the source file
+# (rather than the target) appends it AFTER the inherited
+# -Wno-maybe-uninitialized in the compile command, so the warning is
+# actually active here -- and together with the project-wide -Werror,
+# any regression of the specific false positive that this test guards
+# against breaks the build.
+#
+# -Wmaybe-uninitialized is GCC-only; clang puts both definite and
+# maybe cases under -Wuninitialized and rejects -Wmaybe-uninitialized
+# with -Wunknown-warning-option (an error under -Werror). The same
+# MaybeUninitialized_FOUND check the top-level CMakeLists.txt uses to
+# gate -Wno-maybe-uninitialized gates the positive form here too.
+if (MaybeUninitialized_FOUND)
+  set_source_files_properties (future_state_maybe_uninit_test.cc
+    PROPERTIES
+      COMPILE_OPTIONS "-Wmaybe-uninitialized")
+endif ()
+
 seastar_add_test (abortable_fifo
   SOURCES abortable_fifo_test.cc)
 

--- a/tests/unit/future_state_maybe_uninit_test.cc
+++ b/tests/unit/future_state_maybe_uninit_test.cc
@@ -1,0 +1,64 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Regression test for a GCC -Wmaybe-uninitialized false positive raised
+// in seastar::future_state<T>::clear(). future_state<T> stores its
+// payload in a discriminated raw-storage union; the payload is
+// constructed in move_it() and destroyed in clear() under the same
+// _u.has_result() predicate, so the invariant "value is constructed
+// iff _u.has_result()" holds at runtime. GCC's data-flow analysis
+// cannot correlate the two checks across function boundaries and, after
+// -O2 inlining of ~future -> ~future_state -> clear() -> destroy_at(),
+// flags the destroy as reading uninitialized memory whenever ~T() reads
+// a member before destroying (e.g. ~foreign_ptr reads _cpu).
+//
+// The minimal trigger we know of is future<foreign_ptr<unique_ptr<T>>>.
+// std::expected payloads and other shapes can amplify the warning to
+// additional fields but are not required to reproduce it.
+//
+// The CMakeLists.txt entry for this test re-enables
+// -Wmaybe-uninitialized for just this translation unit (it is
+// otherwise disabled globally as a PUBLIC compile option on the
+// seastar target) so any regression of the warning fails the build.
+
+#include <memory>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>  // for seastar::foreign_ptr
+#include <seastar/testing/test_case.hh>
+
+using namespace seastar;
+
+namespace {
+
+using value_t = foreign_ptr<std::unique_ptr<int>>;
+
+future<value_t> make_value() {
+    return make_ready_future<value_t>(std::make_unique<int>(42));
+}
+
+} // anonymous namespace
+
+SEASTAR_TEST_CASE(test_future_of_foreign_ptr_finally_compiles) {
+    // The bug is at compile time; if this file compiled, the warning is
+    // either present (regressed) or absent (still fixed). We also run
+    // the chain so the destructor path is exercised at runtime.
+    return make_value().finally([] {}).then([] (value_t v) {
+        BOOST_REQUIRE(v);
+    });
+}


### PR DESCRIPTION
The Seastar CMake build suppresses `-Wmaybe-uninitialized`, however it can still be triggered in public headers (e.g. `future.hh`) and not all projects will want to turn off this warning.

* First commit is the fix
* Second commit is a demonstration test

To reproduce, comment out `#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"` and then build the test with `-DCMAKE_BUILD_TYPE=Release`.