### PR TITLE
file: fix default DMA alignment

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1093,7 +1093,7 @@ internal::alignments filesystem_alignments(
     // Initialize with generic defaults for all filesystems
     internal::alignments align = {
         .memory = std::max(device_info.memory_alignment.value_or(4096), internal::min_memory_alignment),
-        .disk_read = 512,  // Linux O_DIRECT minimum
+        .disk_read = block_size,  // Linux O_DIRECT safe choice, might be reduced later
         .disk_write = block_size,
         .disk_overwrite = block_size,
     };


### PR DESCRIPTION
Prior to 15adc3ce590 ("file: Apply physical_block_size override to filesystem files"), the default DMA alignment was 4096, the initializer in file::_disk_read_dma_alignment that was not overridden.

After this commit, the default was changed to 512 (see "Linux O_DIRECT minimum" comment), later overriden if we had additional information. But if we did not, that ended up the alignment.

This alignment doesn't work if the device is mounted on a device with 4096 byte sectors.

Change to the filesystem block size, which should always work. It can still be overriden later by XFS specific code.