### PR TITLE
reactor: add EPERM touch_directory diagnostics without behavior change

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2459,12 +2459,39 @@ reactor::make_directory(std::string_view name_view, file_permissions permissions
 future<>
 reactor::touch_directory(std::string_view name_view, file_permissions permissions) noexcept {
     auto name = sstring(name_view);
+    auto mode = static_cast<mode_t>(permissions);
     syscall_result<int> sr = co_await _thread_pool->submit<syscall_result<int>>(
             internal::thread_pool_submit_reason::file_operation, [&] {
-        auto mode = static_cast<mode_t>(permissions);
         return wrap_syscall<int>(::mkdir(name.c_str(), mode));
     });
     if (sr.result == -1 && sr.error != EEXIST) {
+        if (sr.error == EPERM || sr.error == EACCES) {
+            // Refs: scylladb/scylladb#28259
+            // Diagnostic-only logging to capture mkdir/stat state on intermittent CI failures.
+            auto pid = ::getpid();
+            auto shard_id = this_shard_id();
+            sstring stat_state;
+            try {
+                auto sd = co_await file_stat(name, follow_symlink::no);
+                stat_state = format("exists type={} mode={:o} perms={:o} uid={} gid={}",
+                        static_cast<int>(sd.type),
+                        sd.mode,
+                        sd.mode & static_cast<mode_t>(file_permissions::all_permissions),
+                        sd.uid,
+                        sd.gid);
+            } catch (...) {
+                stat_state = format("failed: {}", std::current_exception());
+            }
+
+            seastar_logger.error(
+                    "touch_directory: mkdir({}) failed with errno={} (expected mode={:o}) on shard={} pid={}, stat={}",
+                    name,
+                    sr.error,
+                    mode,
+                    shard_id,
+                    pid,
+                    stat_state);
+        }
         sr.throw_fs_exception("mkdir failed", fs::path(name));
     }
 }


### PR DESCRIPTION
## Summary
- add targeted diagnostics in `reactor::touch_directory()` when `mkdir` fails with `EPERM`/`EACCES`
- perform a single `file_stat()` on the target path and log the resulting status (exists/type/mode/uid/gid, or stat failure)
- include shard id and process id in the same log line for correlation with host security/audit logs
- keep existing behavior unchanged: after logging, still throw the original filesystem exception so CI failures remain visible

## Why
Issue scylladb/scylladb#28259 is intermittent and hard to reproduce. We need one more failing occurrence with richer context to determine whether directories are actually created despite the error and whether follow-up mitigation (e.g. stat-and-ignore) would be valid.

Refs: scylladb/scylladb#28259

## Notes
- diagnostic-only PR (no success-path masking)
- scoped only to `touch_directory()` (`mkdir` path)