### PR TITLE
`core`: propagate syscall errors via `coroutine::exception`

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -74,6 +74,7 @@
 #include <seastar/core/io_queue.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include "core/file-impl.hh"
 #include "core/syscall_result.hh"
 #include "core/thread_pool.hh"
@@ -273,7 +274,9 @@ future<> posix_file_impl::fdatasync(bool with_aio, int fd, internal::io_sink& si
             internal::thread_pool_submit_reason::file_operation, [fd] {
         return wrap_syscall<int>(::fdatasync(fd));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 future<struct stat>
@@ -284,7 +287,9 @@ posix_file_impl::stat() noexcept {
         auto ret = ::fstat(fd, &st);
         return wrap_syscall(ret, st);
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return ret.extra;
 }
 
@@ -296,7 +301,9 @@ posix_file_impl::statat(std::string_view name, int flags) noexcept {
         auto ret = ::fstatat(fd, name.data(), &st, flags);
         return wrap_syscall(ret, st);
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return ret.extra;
 }
 
@@ -306,7 +313,9 @@ posix_file_impl::truncate(uint64_t length) noexcept {
             internal::thread_pool_submit_reason::file_operation, [this, length] {
         return wrap_syscall<int>(::ftruncate(_fd, length));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 future<int>
@@ -315,7 +324,9 @@ posix_file_impl::ioctl(uint64_t cmd, void* argp) noexcept {
             internal::thread_pool_submit_reason::file_operation, [this, cmd, argp] () mutable {
         return wrap_syscall<int>(::ioctl(_fd, cmd, argp));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_system_error_ptr());
+    }
     // Some ioctls require to return a positive integer back.
     co_return sr.result;
 }
@@ -336,7 +347,9 @@ posix_file_impl::fcntl(int op, uintptr_t arg) noexcept {
             internal::thread_pool_submit_reason::file_operation, [this, op, arg] () mutable {
         return wrap_syscall<int>(::fcntl(_fd, op, arg));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_system_error_ptr());
+    }
     // Some fcntls require to return a positive integer back.
     co_return sr.result;
 }
@@ -358,7 +371,9 @@ posix_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
         return wrap_syscall<int>(::fallocate(_fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE,
             offset, length));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 future<>
@@ -378,7 +393,9 @@ posix_file_impl::allocate(uint64_t position, uint64_t length) noexcept {
         }
         return wrap_syscall<int>(ret);
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 #else
     return make_ready_future<>();
 #endif
@@ -391,7 +408,9 @@ posix_file_impl::mmap(size_t length, mmap_prot prot, mmap_private priv, size_t o
         int flags = bool(priv) ? MAP_PRIVATE : MAP_SHARED;
         return wrap_syscall<void*>(::mmap(nullptr, length, static_cast<int>(prot), flags, fd, offset));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_system_error_ptr());
+    }
     co_return file_mapping{sr.result, length};
 }
 
@@ -453,7 +472,9 @@ blockdev_file_impl::size() noexcept {
         int ret = ::ioctl(_fd, BLKGETSIZE64, &size);
         return wrap_syscall(ret, size);
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return ret.extra;
 }
 
@@ -494,7 +515,9 @@ future<size_t> posix_file_impl::read_directory(int fd, char* buffer, size_t buff
         auto ret = ::syscall(__NR_getdents64, fd, reinterpret_cast<linux_dirent64*>(buffer), buffer_size);
         return wrap_syscall(ret);
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return ret.result;
 }
 
@@ -769,7 +792,9 @@ blockdev_file_impl::discard(uint64_t offset, uint64_t length) noexcept {
         uint64_t range[2] { offset, length };
         return wrap_syscall<int>(::ioctl(_fd, BLKDISCARD, &range));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 future<>
@@ -1171,7 +1196,9 @@ future<> file_mapping::unmap() noexcept {
             internal::thread_pool_submit_reason::file_operation, [addr, length] {
         return wrap_syscall<int>(::munmap(addr, length));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 future<> file_mapping::flush() noexcept {
@@ -1179,7 +1206,9 @@ future<> file_mapping::flush() noexcept {
             internal::thread_pool_submit_reason::file_operation, [addr = _addr, length = _length] {
         return wrap_syscall<int>(::msync(addr, length, MS_SYNC));
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
 }
 
 // Some kernels can append to xfs filesystems, some cannot; determine

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -40,6 +40,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/io_intent.hh>
+#include <seastar/coroutine/exception.hh>
 #include "core/syscall_result.hh"
 #include "core/thread_pool.hh"
 #include <seastar/util/internal/iovec_utils.hh>
@@ -572,7 +573,9 @@ public:
                 internal::thread_pool_submit_reason::file_operation, [path = std::move(path), flags] {
             return wrap_syscall<int>(::open(path.c_str(), flags | O_CLOEXEC | O_NONBLOCK));
         });
-        sr.throw_if_error();
+        if (sr.failed()) {
+            co_return coroutine::exception(sr.make_system_error_ptr());
+        }
         co_return file_desc::from_fd(sr.result);
     }
 };

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -149,6 +149,7 @@
 #include <seastar/core/internal/stall_detector.hh>
 #include <seastar/core/internal/run_in_background.hh>
 #include <seastar/coroutine/all.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/net/native-stack.hh>
 #include <seastar/net/packet.hh>
 #include <seastar/net/posix-stack.hh>
@@ -1950,7 +1951,9 @@ reactor::open_file_dma(std::string_view nameref, open_flags flags, file_open_opt
         close_fd.cancel();
         return wrap_syscall(fd, st);
     });
-    sr.throw_fs_exception_if_error("open failed", name);
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_fs_exception_ptr("open failed", fs::path(name)));
+    }
     shared_ptr<file_impl> impl = co_await make_file_impl(sr.result, options, open_flags, sr.extra);
     co_return file(std::move(impl));
 }
@@ -1962,7 +1965,10 @@ reactor::remove_file(std::string_view pathname_view) noexcept {
             internal::thread_pool_submit_reason::file_operation, [pathname] {
         return wrap_syscall<int>(::remove(pathname.c_str()));
     });
-    sr.throw_fs_exception_if_error("remove failed", pathname);
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr("remove failed", fs::path(pathname)));
+    }
 }
 
 future<>
@@ -1975,7 +1981,10 @@ reactor::rename_file(std::string_view old_pathname_view, std::string_view new_pa
         return wrap_syscall<int>(static_cast<int>(
                 ::syscall(SYS_renameat2, AT_FDCWD, old_pathname.c_str(), AT_FDCWD, new_pathname.c_str(), raw_flags)));
     });
-    sr.throw_fs_exception_if_error("rename failed", old_pathname, new_pathname);
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr("rename failed", fs::path(old_pathname), fs::path(new_pathname)));
+    }
 }
 
 future<>
@@ -1986,7 +1995,10 @@ reactor::link_file(std::string_view oldpath_view, std::string_view newpath_view)
             internal::thread_pool_submit_reason::file_operation, [oldpath, newpath] {
         return wrap_syscall<int>(::link(oldpath.c_str(), newpath.c_str()));
     });
-    sr.throw_fs_exception_if_error("link failed", oldpath, newpath);
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr("link failed", fs::path(oldpath), fs::path(newpath)));
+    }
 }
 
 future<>
@@ -1997,9 +2009,10 @@ reactor::chmod(std::string_view name_view, file_permissions permissions) noexcep
             internal::thread_pool_submit_reason::file_operation, [name, mode] {
         return wrap_syscall<int>(::chmod(name.c_str(), mode));
     });
-    if (sr.result == -1) {
+    if (sr.failed()) {
         auto reason = format("chmod(0{:o}) failed", mode);
-        sr.throw_fs_exception(reason, fs::path(name));
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr(reason, fs::path(name)));
     }
 }
 
@@ -2038,9 +2051,9 @@ reactor::file_type(std::string_view name_view, follow_symlink follow) noexcept {
         auto ret = stat_syscall(name.c_str(), &st);
         return wrap_syscall(ret, st);
     });
-    if (long(sr.result) == -1) {
+    if (sr.failed()) {
         if (sr.error != ENOENT && sr.error != ENOTDIR) {
-            sr.throw_fs_exception_if_error("stat failed", name);
+            co_return coroutine::exception(sr.make_fs_exception_ptr("stat failed", fs::path(name)));
         }
         co_return std::optional<directory_entry_type>();
     }
@@ -2067,7 +2080,9 @@ reactor::inotify_add_watch(int fd, std::string_view path_view, uint32_t flags) {
         auto ret = ::inotify_add_watch(fd, path.c_str(), flags);
         return wrap_syscall(ret);
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return ret.result;
 }
 
@@ -2078,7 +2093,9 @@ reactor::make_pipe() {
             internal::thread_pool_submit_reason::file_operation, [&pipe] {
         return wrap_syscall<int>(::pipe2(pipe.data(), O_NONBLOCK));
     });
-    ret.throw_if_error();
+    if (ret.failed()) {
+        co_return coroutine::exception(ret.make_system_error_ptr());
+    }
     co_return std::tuple<file_desc, file_desc>(file_desc::from_fd(pipe[0]),
                                                                 file_desc::from_fd(pipe[1]));
 }
@@ -2224,8 +2241,10 @@ future<int> reactor::waitpid(pid_t pid) {
             // Success.  Return the waited pid status
             co_return wstatus;
         } else {
-            // Error.  Maybe throw exception, or return -1 status.
-            ret.throw_if_error();
+            // Error.  Maybe propagate exception, or return -1 status.
+            if (ret.failed()) {
+                co_return coroutine::exception(ret.make_system_error_ptr());
+            }
             co_return -1;
         }
     };
@@ -2283,7 +2302,9 @@ future<> reactor::chown(std::string_view filepath, uid_t owner, gid_t group) {
             return wrap_syscall(ret);
         });
 
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(sr.make_system_error_ptr());
+    }
     co_return;
 }
 
@@ -2316,7 +2337,9 @@ reactor::file_stat(std::string_view pathname_view, follow_symlink follow) noexce
         auto ret = stat_syscall(pathname.c_str(), &st);
         return wrap_syscall(ret, st);
     });
-    sr.throw_fs_exception_if_error("stat failed", pathname);
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_fs_exception_ptr("stat failed", fs::path(pathname)));
+    }
     co_return make_stat_data(sr.extra);
 }
 
@@ -2347,7 +2370,7 @@ reactor::file_accessible(std::string_view pathname_view, access_flags flags) noe
             (sr.error == EACCES && flags != access_flags::exists)) {
             co_return false;
         }
-        sr.throw_fs_exception("access failed", fs::path(pathname));
+        co_return coroutine::exception(sr.make_fs_exception_ptr("access failed", fs::path(pathname)));
     }
 
     co_return true;
@@ -2372,7 +2395,9 @@ reactor::file_system_at(std::string_view pathname_view) noexcept {
         { internal::fs_magic::tmpfs, fs_type::tmpfs },
         { internal::fs_magic::hugetlbfs, fs_type::hugetlbfs },
     };
-    sr.throw_fs_exception_if_error("statfs failed", pathname);
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_fs_exception_ptr("statfs failed", fs::path(pathname)));
+    }
 
     fs_type ret = fs_type::other;
     if (type_mapper.count(sr.extra.f_type) != 0) {
@@ -2389,7 +2414,9 @@ reactor::fstatfs(int fd) noexcept {
         auto ret = ::fstatfs(fd, &st);
         return wrap_syscall(ret, st);
     });
-    sr.throw_if_error();
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_system_error_ptr());
+    }
     struct statfs st = sr.extra;
     co_return st;
 }
@@ -2402,7 +2429,10 @@ reactor::file_system_space(std::string_view pathname) noexcept {
         auto si = std::filesystem::space(path, ec);
         return wrap_syscall(ec.value(), si);
     });
-    sr.throw_fs_exception_if_error("std::filesystem::space failed", sstring(pathname));
+    if (sr.failed()) {
+        co_return coroutine::exception(
+          sr.make_fs_exception_ptr("std::filesystem::space failed", fs::path(pathname)));
+    }
     co_return sr.extra;
 }
 
@@ -2415,7 +2445,9 @@ reactor::statvfs(std::string_view pathname_view) noexcept {
         auto ret = ::statvfs(pathname.c_str(), &st);
         return wrap_syscall(ret, st);
     });
-    sr.throw_fs_exception_if_error("statvfs failed", pathname);
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_fs_exception_ptr("statvfs failed", fs::path(pathname)));
+    }
     struct statvfs st = sr.extra;
     co_return st;
 }
@@ -2437,7 +2469,9 @@ reactor::open_directory(std::string_view name_view) noexcept {
         }
         return wrap_syscall(fd, st);
     });
-    sr.throw_fs_exception_if_error("open failed", name);
+    if (sr.failed()) {
+        co_return coroutine::exception(sr.make_fs_exception_ptr("open failed", fs::path(name)));
+    }
     auto options = file_open_options{
         .durable = !_cfg.bypass_fsync,
     };
@@ -2453,7 +2487,10 @@ reactor::make_directory(std::string_view name_view, file_permissions permissions
         auto mode = static_cast<mode_t>(permissions);
         return wrap_syscall<int>(::mkdir(name.c_str(), mode));
     });
-    sr.throw_fs_exception_if_error("mkdir failed", name);
+    if (sr.failed()) {
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr("mkdir failed", fs::path(name)));
+    }
 }
 
 future<>
@@ -2464,8 +2501,9 @@ reactor::touch_directory(std::string_view name_view, file_permissions permission
         auto mode = static_cast<mode_t>(permissions);
         return wrap_syscall<int>(::mkdir(name.c_str(), mode));
     });
-    if (sr.result == -1 && sr.error != EEXIST) {
-        sr.throw_fs_exception("mkdir failed", fs::path(name));
+    if (sr.failed() && sr.error != EEXIST) {
+        co_await coroutine::return_exception_ptr(
+          sr.make_fs_exception_ptr("mkdir failed", fs::path(name)));
     }
 }
 

--- a/src/core/syscall_result.hh
+++ b/src/core/syscall_result.hh
@@ -30,30 +30,33 @@ struct syscall_result {
     int error;
     syscall_result(T result, int error) : result{std::move(result)}, error{error} {
     }
+
+    bool failed() const noexcept {
+        return long(result) == -1;
+    }
+
     void throw_if_error() const {
-        if (long(result) == -1) {
+        if (failed()) {
             throw std::system_error(ec());
         }
     }
 
-    void throw_fs_exception(const sstring& reason, const fs::path& path) const {
-        throw fs::filesystem_error(reason, path, ec());
+    // Build (without throwing) an exception_ptr describing a system error
+    // for this syscall result. Intended for use in coroutines, paired with
+    // `co_return coroutine::exception(...)` (for future<T>) or
+    // `co_await coroutine::return_exception_ptr(...)` (for future<>), so the
+    // failure is propagated to the awaiter without invoking the throw/unwind
+    // machinery.
+    std::exception_ptr make_system_error_ptr() const noexcept {
+        return std::make_exception_ptr(std::system_error(ec()));
     }
 
-    void throw_fs_exception(const sstring& reason, const fs::path& path1, const fs::path& path2) const {
-        throw fs::filesystem_error(reason, path1, path2, ec());
+    std::exception_ptr make_fs_exception_ptr(const sstring& reason, const fs::path& path) const {
+        return std::make_exception_ptr(fs::filesystem_error(reason, path, ec()));
     }
 
-    void throw_fs_exception_if_error(const sstring& reason, const sstring& path) const {
-        if (long(result) == -1) {
-            throw_fs_exception(reason, fs::path(path));
-        }
-    }
-
-    void throw_fs_exception_if_error(const sstring& reason, const sstring& path1, const sstring& path2) const {
-        if (long(result) == -1) {
-            throw_fs_exception(reason, fs::path(path1), fs::path(path2));
-        }
+    std::exception_ptr make_fs_exception_ptr(const sstring& reason, const fs::path& path1, const fs::path& path2) const {
+        return std::make_exception_ptr(fs::filesystem_error(reason, path1, path2, ec()));
     }
 
     std::error_code ec() const {


### PR DESCRIPTION
According to newer guidance from `tutorial.MD` [1], we should tend to prefer propagating exceptions in coroutines using tools such as `co_return coroutine::exception()` or `co_await coroutine::return_exception_ptr()` over bare calls to `throw` within hot paths, since 1. coroutines which throw convert their exceptions to exceptional futures anyways (e.g. no observable difference to callers) and 2. we save on the cost of potential copies and stack unwinding when `throw` is called.

We also started logging these thrown exceptions at `DEBUG` level [2], which means these exceptions are inherently noisier than using the `coroutine` utilities.

For these reasons, rework `syscall_result` and callers of it with the `coroutine` exception utilities.

For more personal motivation, we had a user complain [3] about the increased level of logging/noise when setting all loggers in `redpanda` to `DEBUG`, with many of the logs tracing back all the way to these syscall utilities. 


[1]: https://github.com/scylladb/seastar/commit/56d18e2160308921e48ef939235bc1f550a707d9
[2]: https://github.com/scylladb/seastar/pull/2938/changes/2f802f57ee331997ce47c6be2084f2a58f392294
[3]: https://github.com/redpanda-data/redpanda/issues/30422