### PR TITLE
Introduce NUMA and SMT awareness to the asymmetric io_uring reactor backend

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -34,6 +34,7 @@
 #include <ranges>
 #include <regex>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <barrier>
 #include <memory>
@@ -4747,10 +4748,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
         }
     };
 
-    auto master_uring_fds = std::make_shared<std::vector<int>>(_shard_count, -1);
-
     const shard_id first_shard_id = 0;
-    backend_configurator->initialize_shard_configuration(first_shard_id);
+    backend_configurator->initialize_shard_configuration_and_topology(first_shard_id, allocations);
 
     unsigned i;
     auto smp_tmain = smp::_tmain;

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -24,8 +24,11 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <set>
 #include <thread>
+#include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <fcntl.h>
 #include <signal.h>
@@ -39,6 +42,11 @@
 
 #ifdef SEASTAR_HAVE_URING
 #include <liburing.h>
+#include <liburing/io_uring.h>
+#endif
+
+#ifdef SEASTAR_HAVE_HWLOC
+#include <hwloc.h>
 #endif
 
 #include "core/reactor_backend.hh"
@@ -2174,24 +2182,173 @@ try_create_asymmetric_uring(const std::variant<std::monostate, int, ::io_uring>&
     }
 }
 
-unsigned
-select_worker_cpu(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) {
-    SEASTAR_ASSERT(!worker_cpus.empty());
-    const size_t selected_cpu_rank = get_uring_group_id(shard_id, worker_cpus);
-    return *std::next(worker_cpus.cbegin(), selected_cpu_rank);
-}
+std::shared_ptr<std::vector<numa_assignment>> compute_assignments(const std::vector<resource::cpu>& allocations, const resource::cpuset& networking_cores) {
+    if (networking_cores.empty()) {
+        throw std::logic_error("networking cores cannot be empty in compute_assignments");
+    }
 
-bool is_master_shard(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept {
-    return shard_id < worker_cpus.size();
-}
+    unsigned num_shards = allocations.size();
+    std::vector<numa_assignment> result;
 
-unsigned get_uring_group_id(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept {
-    return shard_id % worker_cpus.size();
+    // Calculate CPU to SMT/NUMA maps
+    resource::cpuset all_cpus = networking_cores;
+    for (const auto& cpu : allocations) {
+        all_cpus.insert(cpu.cpu_id);
+    }
+
+    std::unordered_map<unsigned, unsigned> cpu_to_smt_id;
+    std::unordered_map<unsigned, unsigned> cpu_to_numa_node;
+#ifdef SEASTAR_HAVE_HWLOC
+    hwloc_topology_t topology;
+    bool hwloc_successful_load = false;
+
+    if (hwloc_topology_init(&topology) == 0) {
+        if (hwloc_topology_load(topology) == 0) {
+            for (unsigned cpu : all_cpus) {
+                hwloc_obj_t pu = hwloc_get_pu_obj_by_os_index(topology, cpu);
+
+                if (!pu) {
+                    cpu_to_numa_node[cpu] = 0;
+                    cpu_to_smt_id[cpu] = cpu;
+                    continue;
+                }
+
+                hwloc_obj_t numa = hwloc_get_ancestor_obj_by_type(topology, HWLOC_OBJ_NUMANODE, pu);
+                hwloc_obj_t core = hwloc_get_ancestor_obj_by_type(topology, HWLOC_OBJ_CORE, pu);
+
+                cpu_to_numa_node[cpu] = numa ? numa->logical_index : 0;
+                cpu_to_smt_id[cpu] = core ? core->logical_index : cpu;
+            }
+            hwloc_successful_load = true;
+        }
+    }
+
+    hwloc_topology_destroy(topology);
+
+    if (!hwloc_successful_load) {
+        seastar_logger.warn("Seastar compiled with hwloc, but hwloc initialization failed");
+        for (auto cpu : all_cpus) {
+            cpu_to_numa_node[cpu] = 0;
+            cpu_to_smt_id[cpu] = cpu;
+        }
+    }
+
+#else
+    seastar_logger.info("Seastar compiled without hwloc, NUMA and SMT awareness is disabled");
+
+    for (auto cpu : all_cpus) {
+        cpu_to_numa_node[cpu] = 0;
+        cpu_to_smt_id[cpu] = cpu;
+    }
+#endif
+
+    result.resize(num_shards);
+
+    std::unordered_map<unsigned, std::vector<unsigned>> smt_to_net;
+    std::unordered_map<unsigned, std::vector<unsigned>> numa_to_net;
+
+    for (unsigned core : networking_cores) {
+        auto smt_it = cpu_to_smt_id.find(core);
+        auto numa_it = cpu_to_numa_node.find(core);
+        if (smt_it != cpu_to_smt_id.end()) {
+            smt_to_net[smt_it->second].push_back(core);
+        }
+        if (numa_it != cpu_to_numa_node.end()) {
+            numa_to_net[numa_it->second].push_back(core);
+        }
+    }
+
+    std::unordered_map<unsigned, std::vector<unsigned>> net_to_shards;
+    std::vector<bool> is_shard_assigned(num_shards, false);
+
+    auto choose_least_loaded = [&](const std::vector<unsigned>& candidates) {
+        SEASTAR_ASSERT(!candidates.empty());
+        return *std::min_element(
+            candidates.begin(),
+            candidates.end(),
+            [&](unsigned a, unsigned b) {
+                size_t load_a = net_to_shards[a].size();
+                size_t load_b = net_to_shards[b].size();
+
+                return (load_a < load_b) || (load_a == load_b && a < b);
+            }
+        );
+    };
+
+    auto maybe_assign_least_loaded = [&](auto&& candidate_selector) {
+        for (unsigned shard = 0; shard < num_shards; ++shard) {
+            if (is_shard_assigned[shard]) {
+                continue;
+            }
+
+            auto candidates = candidate_selector(shard);
+            if (candidates.empty()) {
+                continue;
+            }
+
+            unsigned net = choose_least_loaded(candidates);
+            result[shard].networking_core = net;
+            net_to_shards[net].push_back(shard);
+            is_shard_assigned[shard] = true;
+        }
+    };
+
+    // If an application core has a SMT sibling that is a networking core, it should delegate its I/O to it.
+    maybe_assign_least_loaded([&](unsigned shard) {
+        unsigned cpu = allocations[shard].cpu_id;
+        auto smt_it = cpu_to_smt_id[cpu];
+
+        auto net_it = smt_to_net.find(smt_it);
+        if (net_it != smt_to_net.end()) {
+            return net_it->second;
+        }
+
+        return std::vector<unsigned>{};
+    });
+
+    // Remaining application cores should be distributed evenly among networking cores on their NUMA nodes.
+    maybe_assign_least_loaded([&](unsigned shard) {
+        unsigned cpu = allocations[shard].cpu_id;
+        auto numa_it = cpu_to_numa_node[cpu];
+
+        auto it = numa_to_net.find(numa_it);
+        if (it != numa_to_net.end()) {
+            return it->second;
+        }
+
+        return std::vector<unsigned>{};
+    });
+
+    // If there is no networking core on a NUMA node, the application cores from this node should be delegated to other networking cores.
+    maybe_assign_least_loaded([&](unsigned) {
+        return std::vector<unsigned>(networking_cores.begin(), networking_cores.end());
+    });
+
+    for (unsigned shard = 0; shard < num_shards; ++shard) {
+        SEASTAR_ASSERT(is_shard_assigned[shard]);
+    }
+
+    // The first shard assigned to each networking group becomes a master.
+    unsigned group = 0;
+    for (unsigned net : networking_cores) {
+        auto& shards = net_to_shards[net];
+
+        result[shards[0]].is_master = true;
+
+        for (size_t i = 0; i < shards.size(); ++i) {
+            result[shards[i]].networking_group = group;
+        }
+
+        ++group;
+    }
+
+    return std::make_shared<std::vector<numa_assignment>>(std::move(result));
 }
 
 class asymmetric_uring_reactor_backend_configurator : public reactor_backend_configurator {
     resource::cpuset _cpu_set, _async_workers_cpuset;
     std::vector<int> _master_uring_fds;
+    std::shared_ptr<std::vector<uring::numa_assignment>> _uring_assignments;
 
     struct uring_groups_init_result {
         std::optional<::io_uring> ring;
@@ -2269,12 +2426,20 @@ public:
         }
     }
 
-    virtual void initialize_shard_configuration(shard_id shard) override {
-        const bool is_master = is_master_shard(shard, _async_workers_cpuset);
-        const unsigned uring_group_id = get_uring_group_id(shard, _async_workers_cpuset);
+    virtual void initialize_shard_configuration_and_topology(shard_id shard, const std::vector<resource::cpu>& allocations) override {
+        _uring_assignments = uring::compute_assignments(allocations, _async_workers_cpuset);
+        SEASTAR_ASSERT(_uring_assignments != nullptr && !((*_uring_assignments).empty()));
 
+        initialize_shard_configuration(shard);
+    }
+
+    virtual void initialize_shard_configuration(shard_id shard) override {
+        SEASTAR_ASSERT((*_uring_assignments).size() > shard);
+        const bool is_master = (*_uring_assignments)[shard].is_master;
+        const unsigned uring_group_id = (*_uring_assignments)[shard].networking_group;
+        const unsigned worker_cpu = (*_uring_assignments)[shard].networking_core;
         if (is_master) {
-            auto created_uring = try_create_base_asymmetric_uring(select_worker_cpu(shard, _async_workers_cpuset), true).value();
+            auto created_uring = try_create_base_asymmetric_uring(worker_cpu, true).value();
             _master_uring_fds.at(uring_group_id) = created_uring.ring_fd;
             _init_data[shard] = {created_uring, uring_group_id};
         } else {
@@ -2418,6 +2583,9 @@ public:
 
     }
 
+    virtual void initialize_shard_configuration_and_topology(shard_id id, const std::vector<resource::cpu>& allocations) override {
+        initialize_shard_configuration(id);
+    }
 
     virtual void initialize_shard_configuration(shard_id id) override {
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -408,10 +408,15 @@ class reactor_backend_configurator {
 public:
     virtual const resource::cpuset& configured_cpuset() const = 0;
     virtual void verify_allocations(const std::vector<resource::cpu>& allocations) const = 0;
+    virtual void initialize_shard_configuration_and_topology(shard_id id, const std::vector<resource::cpu>& allocations) = 0;
     virtual void initialize_shard_configuration(shard_id id) = 0;
     virtual reactor_config finalize_apply_shard_configuration(shard_id id, reactor_config cfg) = 0;
     virtual ~reactor_backend_configurator() = default;
 };
+
+namespace uring {
+    struct numa_assignment;
+}
 
 #ifdef SEASTAR_HAVE_URING
 
@@ -425,11 +430,13 @@ try_create_attached_asymmetric_uring(int uring_fd, bool throw_on_error);
 std::optional<::io_uring>
 try_create_base_asymmetric_uring(unsigned worker_cpu, bool throw_on_error);
 
-unsigned select_worker_cpu(seastar::shard_id shard_id, const resource::cpuset& worker_cpus);
+struct numa_assignment {
+    unsigned networking_core;
+    unsigned networking_group;
+    bool is_master;
+};
 
-bool is_master_shard(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept;
-
-unsigned get_uring_group_id(seastar::shard_id shard_id, const resource::cpuset& worker_cpus) noexcept;
+std::shared_ptr<std::vector<numa_assignment>> compute_assignments(const std::vector<resource::cpu>& allocations, const resource::cpuset& networking_cores);
 
 // QUEUE_LEN is more or less arbitrary. Too low and we'll be
 // issuing too small batches, too high and we require too much locked


### PR DESCRIPTION
This is a follow-up for the #3297 pull request, adding a new feature to the `reactor_backend_asymmetric_uring` in the last commit - `Introduce NUMA and SMT awareness`. To be merged only after the main PR is merged.

Changes affect the algorithm used to asign networking cores to app cores, so that it takes NUMA and SMT layout into account.
The new algorithm will first assign networking cores to the app cores which are their SMT-siblings, then to app cores that are on the same NUMA node, and finally to the app cores on different NUMA nodes, trying to keep the assignment balanced at each step.

Changes were tested manually by mocking `hwloc` topology in code. The tests produced expected assignment results.

Closes #3315 .