### PR TITLE
reactor_backend: refactor aio retry into a long-lasting coroutine

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -168,7 +168,7 @@ future<> aio_storage_context::stop() noexcept {
     });
 
     // Wake up the retry coroutine so it can observe _stopping and exit.
-    _retry_cv.signal();
+    signal_retry_loop();
 
     return std::exchange(_pending_aio_retry_fut, make_ready_future<>()).finally([this] {
         return do_until([this] { return !_iocb_pool.outstanding(); }, [this] {
@@ -279,7 +279,7 @@ aio_storage_context::submit_work() {
         // so we don't want to call io_submit() from the reactor thread.
         //
         // Pretend that all aio failed with EAGAIN and submit them
-        // via schedule_retry(), below.
+        // via signal_retry_loop(), below.
         did_work = !_submission_queue.empty();
         for (auto& iocbp : _submission_queue) {
             set_nowait(*iocbp, false);
@@ -301,13 +301,13 @@ aio_storage_context::submit_work() {
     }
 
     if (need_to_retry()) {
-        schedule_retry();
+        signal_retry_loop();
     }
 
     return did_work;
 }
 
-void aio_storage_context::schedule_retry() {
+void aio_storage_context::signal_retry_loop() {
     _retry_cv.signal();
 }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -327,6 +327,9 @@ void aio_storage_context::signal_retry_loop() {
 // Long-lasting retry coroutine.  Loops until _stopping, waiting on
 // _retry_cv when idle.
 future<> aio_storage_context::retry_loop() {
+    timer retry_timer([this] {
+        signal_retry_loop();
+    });
     do {
         // Process retries: loop until both vectors are empty or _stopping is set.
         // While retrying _aio_retries, new retries may be queued onto _pending_aio_retry.
@@ -369,8 +372,10 @@ future<> aio_storage_context::retry_loop() {
             });
         } else if (!_stopping) {
             // Some iocbs failed retry and are left in _aio_retries.
-            // Wait for submit_work or stop to wake us up to re-attempt them or return, respectively.
+            // Wait up to 10ms submit_work or stop to wake us up to re-attempt them or return, respectively.
+            retry_timer.arm(10ms);
             co_await _retry_cv.wait();
+            retry_timer.cancel();
         }
     } while (!_stopping);
 }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/internal/uname.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
@@ -127,6 +128,9 @@ aio_storage_context::aio_storage_context(reactor& r)
                   "Mismatch between maximum allowed io and what the IO queues can produce");
     internal::setup_aio_context(max_aio, &_io_context);
     _r.do_at_exit([this] { return stop(); });
+
+    // Start the long-lasting retry coroutine.
+    _pending_aio_retry_fut = retry_loop();
 }
 
 aio_storage_context::~aio_storage_context() {
@@ -142,11 +146,8 @@ void aio_storage_context::reap_pending_retries() {
     }
     _pending_aio_retry.clear();
 
-    // _aio_retries is empty in the normal call path: this function only runs
-    // after the retry loop's future has resolved, and that loop's predicate
-    // only returns true when both vectors are empty. The drain below is
-    // defensive — if a future change to schedule_retry() leaves entries
-    // here, we still avoid leaking iocbs.
+    // _aio_retries is empty in the normal call path.
+    // However, if the retry_loop() fails to complete all retries, it might leave behind iocbs in _aio_retries.
     for (auto iocb : _aio_retries) {
         _iocb_pool.put_one(iocb);
         auto desc = get_user_data<kernel_completion>(*iocb);
@@ -156,8 +157,8 @@ void aio_storage_context::reap_pending_retries() {
 }
 
 future<> aio_storage_context::stop() noexcept {
-    // Set _stopping first so any reap_completions() and schedule_retry()
-    // calls that race with the drain below see the right state.
+    // Set _stopping first so the retry coroutine and reap_completions()
+    // see the right state.
     _stopping = true;
 
     // Drain items in io_sink (operations without allocated iocbs yet).
@@ -165,6 +166,9 @@ future<> aio_storage_context::stop() noexcept {
         desc->complete_with(-ECANCELED);
         return true;
     });
+
+    // Wake up the retry coroutine so it can observe _stopping and exit.
+    _retry_cv.signal();
 
     return std::exchange(_pending_aio_retry_fut, make_ready_future<>()).finally([this] {
         return do_until([this] { return !_iocb_pool.outstanding(); }, [this] {
@@ -304,41 +308,33 @@ aio_storage_context::submit_work() {
 }
 
 void aio_storage_context::schedule_retry() {
-    // Don't start a new retry loop if either:
-    //   (a) one is already in flight  (!_pending_aio_retry_fut.available()),
-    //   (b) we're shutting down       (_stopping) — stop() will drain the
-    //       queues itself; starting a second loop here would race with
-    //       stop()'s drain on the same iocb pool (the original double-free).
-    if (!_pending_aio_retry_fut.available() || _stopping) {
-        return;
-    }
+    _retry_cv.signal();
+}
 
-    // loop until both _pending_aio_retry and _aio_retries are empty.
-    // While retrying _aio_retries, new retries may be queued onto _pending_aio_retry.
-    _pending_aio_retry_fut = do_until([this] {
-        if (_aio_retries.empty()) {
-            if (_pending_aio_retry.empty()) {
-                return true;
+// Long-lasting retry coroutine.  Loops until _stopping, waiting on
+// _retry_cv when idle.
+future<> aio_storage_context::retry_loop() {
+    do {
+        // Process retries: loop until both vectors are empty or _stopping is set.
+        // While retrying _aio_retries, new retries may be queued onto _pending_aio_retry.
+        // If we're stopping, abandoned iocbs will be reaped and completed with -ECANCELED by reap_pending_retries().
+        while (need_to_retry() && !_stopping) {
+            if (_aio_retries.empty()) {
+                std::swap(_aio_retries, _pending_aio_retry);
             }
-            // _pending_aio_retry, holding a batch of new iocbs to retry,
-            // is swapped with the empty _aio_retries.
-            std::swap(_aio_retries, _pending_aio_retry);
-        }
-        return false;
-    }, [this] {
-        return _r._thread_pool->submit<syscall_result<int>>(
-                internal::thread_pool_submit_reason::aio_fallback, [this] () mutable {
-            auto r = io_submit(_io_context, _aio_retries.size(), _aio_retries.data());
-            return wrap_syscall<int>(r);
-        }).then_wrapped([this] (future<syscall_result<int>> f) {
-            // If submit failed, just log the error and exit the loop.
-            // The next call to submit_work will call schedule_retry again.
-            if (f.failed()) {
-                auto ex = f.get_exception();
-                seastar_logger.warn("aio_storage_context::schedule_retry failed: {}", std::move(ex));
-                return;
+            syscall_result<int> result(0, 0);
+            try {
+                result = co_await _r._thread_pool->submit<syscall_result<int>>(
+                        internal::thread_pool_submit_reason::aio_fallback, [this] () mutable {
+                    auto r = io_submit(_io_context, _aio_retries.size(), _aio_retries.data());
+                    return wrap_syscall<int>(r);
+                });
+            } catch (...) {
+                // If submit failed, just log the error and break out of the inner loop.
+                // The coroutine will wait for the next condition variable signal to retry (or return if stopping).
+                seastar_logger.warn("aio_storage_context::retry_loop failed: {}", std::current_exception());
+                break;
             }
-            auto result = f.get();
             auto iocbs = _aio_retries.data();
             size_t nr_consumed = 0;
             if (result.result == -1) {
@@ -352,14 +348,24 @@ void aio_storage_context::schedule_retry() {
                 nr_consumed = result.result;
             }
             _aio_retries.erase(_aio_retries.begin(), _aio_retries.begin() + nr_consumed);
-        });
-    });
+        }
+        if (_aio_retries.empty()) {
+            co_await _retry_cv.wait([this] {
+                // New iocbs are always queued onto _pending_aio_retry.
+                return _stopping || !_pending_aio_retry.empty();
+            });
+        } else if (!_stopping) {
+            // Some iocbs failed retry and are left in _aio_retries.
+            // Wait for submit_work or stop to wake us up to re-attempt them or return, respectively.
+            co_await _retry_cv.wait();
+        }
+    } while (!_stopping);
 }
 
 bool aio_storage_context::reap_completions(bool allow_retry)
 {
     // During shutdown, complete EAGAIN iocbs immediately instead of
-    // queuing them for retry — schedule_retry() is gated on _stopping.
+    // queuing them for retry — retry_loop() is gated on _stopping.
     if (_stopping) {
         allow_retry = false;
     }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -138,22 +138,18 @@ aio_storage_context::~aio_storage_context() {
 }
 
 void aio_storage_context::reap_pending_retries() {
+    auto cancel_iocbs = [this] (pending_aio_retry_t& retries) {
+        for (auto iocb : retries) {
+            cancel_iocb(iocb);
+        }
+        retries.clear();
+    };
     // Drain pending retries and complete them with -ECANCELED.
-    for (auto iocb : _pending_aio_retry) {
-        _iocb_pool.put_one(iocb);
-        auto desc = get_user_data<kernel_completion>(*iocb);
-        desc->complete_with(-ECANCELED);
-    }
-    _pending_aio_retry.clear();
+    cancel_iocbs(_pending_aio_retry);
 
     // _aio_retries is empty in the normal call path.
     // However, if the retry_loop() fails to complete all retries, it might leave behind iocbs in _aio_retries.
-    for (auto iocb : _aio_retries) {
-        _iocb_pool.put_one(iocb);
-        auto desc = get_user_data<kernel_completion>(*iocb);
-        desc->complete_with(-ECANCELED);
-    }
-    _aio_retries.clear();
+    cancel_iocbs(_aio_retries);
 }
 
 future<> aio_storage_context::stop() noexcept {
@@ -254,6 +250,23 @@ aio_storage_context::handle_aio_error(linux_abi::iocb* iocb, int ec) {
     }
 }
 
+void
+aio_storage_context::cancel_iocb(linux_abi::iocb* iocb) {
+    auto desc = get_user_data<kernel_completion>(*iocb);
+    _iocb_pool.put_one(iocb);
+    desc->complete_with(-ECANCELED);
+}
+
+void
+aio_storage_context::retry_iocb(linux_abi::iocb* iocb) {
+    if (_stopping) {
+        cancel_iocb(iocb);
+        return;
+    }
+    set_nowait(*iocb, false);
+    _pending_aio_retry.push_back(iocb);
+}
+
 bool
 aio_storage_context::submit_work() {
     bool did_work = false;
@@ -282,8 +295,7 @@ aio_storage_context::submit_work() {
         // via signal_retry_loop(), below.
         did_work = !_submission_queue.empty();
         for (auto& iocbp : _submission_queue) {
-            set_nowait(*iocbp, false);
-            _pending_aio_retry.push_back(iocbp);
+            retry_iocb(iocbp);
         }
         to_submit = 0;
     }
@@ -362,13 +374,8 @@ future<> aio_storage_context::retry_loop() {
     } while (!_stopping);
 }
 
-bool aio_storage_context::reap_completions(bool allow_retry)
+bool aio_storage_context::reap_completions()
 {
-    // During shutdown, complete EAGAIN iocbs immediately instead of
-    // queuing them for retry — retry_loop() is gated on _stopping.
-    if (_stopping) {
-        allow_retry = false;
-    }
     struct timespec timeout = {0, 0};
     auto n = io_getevents(_io_context, 1, max_aio, _ev_buffer, &timeout, _r._cfg.force_io_getevents_syscall);
     if (n == -1 && errno == EINTR) {
@@ -377,10 +384,9 @@ bool aio_storage_context::reap_completions(bool allow_retry)
     SEASTAR_ASSERT(n >= 0);
     for (size_t i = 0; i < size_t(n); ++i) {
         auto iocb = get_iocb(_ev_buffer[i]);
-        if (_ev_buffer[i].res == -EAGAIN && allow_retry) {
-            set_nowait(*iocb, false);
+        if (_ev_buffer[i].res == -EAGAIN) {
             _r._io_stats.aio_retries++;
-            _pending_aio_retry.push_back(iocb);
+            retry_iocb(iocb);
             continue;
         }
         _iocb_pool.put_one(iocb);

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -265,6 +265,7 @@ aio_storage_context::retry_iocb(linux_abi::iocb* iocb) {
     }
     set_nowait(*iocb, false);
     _pending_aio_retry.push_back(iocb);
+    signal_retry_loop();
 }
 
 bool
@@ -292,7 +293,7 @@ aio_storage_context::submit_work() {
         // so we don't want to call io_submit() from the reactor thread.
         //
         // Pretend that all aio failed with EAGAIN and submit them
-        // via signal_retry_loop(), below.
+        // via retry_iocb() which signals the retry coroutine.
         did_work = !_submission_queue.empty();
         for (auto& iocbp : _submission_queue) {
             retry_iocb(iocbp);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -87,6 +87,8 @@ class aio_storage_context {
     boost::container::static_vector<internal::linux_abi::iocb*, max_aio> _submission_queue;
     iocb_pool _iocb_pool;
     size_t handle_aio_error(internal::linux_abi::iocb* iocb, int ec);
+    void cancel_iocb(internal::linux_abi::iocb* iocb);
+    void retry_iocb(internal::linux_abi::iocb* iocb);
     using pending_aio_retry_t = boost::container::static_vector<internal::linux_abi::iocb*, max_aio>;
     pending_aio_retry_t _pending_aio_retry; // Pending retries iocbs
     pending_aio_retry_t _aio_retries;       // Currently retried iocbs
@@ -107,7 +109,7 @@ public:
     explicit aio_storage_context(reactor& r);
     ~aio_storage_context();
 
-    bool reap_completions(bool allow_retry = true);
+    bool reap_completions();
     bool submit_work();
     bool can_sleep() const;
     future<> stop() noexcept;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -100,6 +100,7 @@ class aio_storage_context {
     }
 
     future<> retry_loop();
+    void signal_retry_loop();
     void reap_pending_retries();
 
 public:
@@ -107,7 +108,6 @@ public:
     ~aio_storage_context();
 
     bool reap_completions(bool allow_retry = true);
-    void schedule_retry();
     bool submit_work();
     bool can_sleep() const;
     future<> stop() noexcept;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/condition-variable.hh>
 #include <seastar/core/internal/io_desc.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/core/internal/poll.hh>
@@ -90,6 +91,7 @@ class aio_storage_context {
     pending_aio_retry_t _pending_aio_retry; // Pending retries iocbs
     pending_aio_retry_t _aio_retries;       // Currently retried iocbs
     future<> _pending_aio_retry_fut = make_ready_future<>();
+    condition_variable _retry_cv;
     bool _stopping = false;
     internal::linux_abi::io_event _ev_buffer[max_aio];
 
@@ -97,6 +99,7 @@ class aio_storage_context {
         return !_pending_aio_retry.empty() || !_aio_retries.empty();
     }
 
+    future<> retry_loop();
     void reap_pending_retries();
 
 public:


### PR DESCRIPTION
Followup to #3182.

Refactor `aio_storage_context::schedule_retry` into a long-lasting coroutine that waits on a condition variable when idle, and is awaited in `stop()` via `_pending_aio_retry_fut`.

**Patch series:**

1. **turn aio retry into a long-lasting coroutine** — Replace the one-shot `schedule_retry()` future chain with a persistent `retry_loop()` coroutine started in the constructor. Uses `co_await` on a condition variable instead of `seastar::async`, avoiding the dependency on the thread system being initialized at construction time.

2. **rename schedule_retry to signal_retry_loop** — Rename `schedule_retry()` to `signal_retry_loop()` and make it private, since it is only called internally.

3. **drain pending retries in the retry fiber on shutdown** — Incorporate `reap_pending_retries` logic into the retry loop. When `_stopping`, iocbs are completed with `-ECANCELED` instead of resubmitted. Remove the now-unused `reap_pending_retries()` method.

4. **extract cancel_iocb and retry_iocb helpers** — Extract reusable `cancel_iocb()` and `retry_iocb()` helpers. Use them in the retry loop's shutdown drain and `reap_completions()`. Remove the `allow_retry` parameter.

5. **signal retry_loop from retry_iocb** — Move `signal_retry_loop()` into `retry_iocb()` so the CV is signaled each time an iocb is queued for retry. Fixes #3407.

**Tests:** `socket_test`, `epoll_test`, `reactor_backend_test`, `file_io_test` pass.