### PR TITLE
http/client: handle early server response during streaming body write

### DIFF
--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -151,10 +151,24 @@ future<connection::reply_ptr> connection::do_make_request(const request& req) {
             if (cont) {
                 return make_ready_future<reply_ptr>(std::move(cont));
             }
-
-            return write_body(req).then([this] {
-                return _write_buf.flush().then([this] {
-                    return recv_reply();
+        
+            return do_with(std::exception_ptr{}, [this, &req](std::exception_ptr& write_err) {
+                return when_all(
+                    write_body(req).then([this] {
+                        return _write_buf.flush();
+                    }).handle_exception([this, &write_err](std::exception_ptr e) {
+                        // Save the write error, then send EOF to the server so
+                        // recv_reply can complete (server will close after seeing EOF).
+                        write_err = std::move(e);
+                        _fd.shutdown_output();
+                    }),
+                    recv_reply()
+                ).then_unpack([&write_err](auto write_fut, auto recv_fut) -> future<connection::reply_ptr> {
+                    write_fut.ignore_ready_future();
+                    if (!write_err || !recv_fut.failed()) return std::move(recv_fut);
+                
+                    recv_fut.ignore_ready_future();
+                    return make_exception_future<connection::reply_ptr>(std::move(write_err));
                 });
             });
         });

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -888,6 +888,68 @@ SEASTAR_TEST_CASE(test_client_unexpected_reply_status) {
     });
 }
 
+SEASTAR_TEST_CASE(test_client_early_response_until_write_body_completed ) {
+    return seastar::async([] {
+        class handl : public httpd::handler_base {
+            promise<> *_replied;
+        public:
+            handl(promise<> *replied)
+                : _replied(replied)
+            {}
+            virtual future<std::unique_ptr<http::reply> > handle(const sstring& path,
+                    std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
+                fmt::print("Returning exception from server\n");
+
+                _replied->set_value();
+                return make_exception_future<std::unique_ptr<http::reply>>(httpd::bad_request_exception("error"));
+            }
+        };
+
+        loopback_connection_factory lcf(1);
+        http_server server("test");
+        server.set_content_streaming(true);
+        httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
+
+        promise<> replied;
+        future<> client = seastar::async([&lcf, &replied] {
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
+            auto req = http::request::make("POST", "test", "/test");
+            req.write_body("bin", [&replied] (output_stream<char>&& out) {
+                return do_with(std::move(out), temporary_buffer<char>(100 << 10 /*more than _write_buf buffer size */), [&replied] (auto &out, auto &data) {
+                    return out.write(data.get(), data.size()).handle_exception([] (auto e) {}).then([&out] {
+                        return out.flush();
+                    }).then([&replied] {
+                        return replied.get_future();
+                    }).then([] {
+                        return sleep(50ms);
+                    }).then([&out, &data] {
+                        return out.write(data.get(), data.size());
+                    }).then([&out] {
+                        return out.flush();
+                    }).then([&out] {
+                        return out.close();
+                    });
+                });
+            });
+            try {
+                cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
+                    return make_ready_future<>();
+                }).get();
+            } catch (httpd::unexpected_status_error &e) {
+                BOOST_REQUIRE(e.status() == http::reply::status_type::bad_request);
+            } catch (...) {
+                BOOST_REQUIRE(false);
+            }
+
+            cln.close().get();
+        });
+
+        server._routes.put(POST, "/test", new handl(&replied));
+        server.do_accepts(0).get();
+        client.get();
+        server.stop().get();
+    });
+}
 static void read_simple_http_request(input_stream<char>& in) {
     sstring req;
     while (true) {


### PR DESCRIPTION
When using body_writer for streaming uploads (e.g., chunked transfer), the server may send an error response and close the connection before the client finishes writing the body. Previously, do_make_request() serialized write_body and recv_reply, meaning the client could not detect the server's early response until write_body completed — which may never happen for long-lived streams, as writes continue to succeed into kernel/userspace buffers even after the remote end has closed.

Fix this by running write_body and recv_reply concurrently via when_all(). If recv_reply completes first (server responded early), shutdown_output() is called to immediately abort the in-progress write. If write_body completes first (normal flow), recv_reply proceeds as before without shutdown.

This resolves a hang where streaming HTTP clients would remain stuck in write_body indefinitely after the server had already rejected the request.