### PR TITLE
http: declare unsigned-char alphabet in ragel parsers

### DIFF
--- a/src/http/chunk_parsers.rl
+++ b/src/http/chunk_parsers.rl
@@ -32,6 +32,9 @@ namespace seastar {
 %%{
 
 access _fsm_;
+# alphtype + getkey: workaround for #3413
+alphtype unsigned char;
+getkey ((unsigned char)(*p));
 
 action mark {
     g.mark_start(p);
@@ -152,6 +155,9 @@ public:
 %%{
 
 access _fsm_;
+# alphtype + getkey: workaround for #3413
+alphtype unsigned char;
+getkey ((unsigned char)(*p));
 
 action mark {
     g.mark_start(p);

--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -33,6 +33,9 @@ namespace seastar {
 %%{
 
 access _fsm_;
+# alphtype + getkey: workaround for #3413
+alphtype unsigned char;
+getkey ((unsigned char)(*p));
 
 action mark {
     g.mark_start(p);

--- a/src/http/response_parser.rl
+++ b/src/http/response_parser.rl
@@ -35,6 +35,9 @@ namespace seastar {
 %%{
 
 access _fsm_;
+# alphtype + getkey: workaround for #3413
+alphtype unsigned char;
+getkey ((unsigned char)(*p));
 
 action mark {
     g.mark_start(p);


### PR DESCRIPTION
## Summary

ragel 6.10 -G2 generates incorrect code for `obs_text = 0x80..0xff` when the build host's default `char` is unsigned (notably aarch64). The state machine collapses byte 127 (DEL) and the legitimately allowed `obs_text` range into a single forbidden interval (`127 <= *p -> goto error`), so any HTTP field value containing bytes 0x80..0xff is rejected even though RFC 7230 §3.2.6 permits them.

x86_64 happens to produce correct code by way of a different range-merging path that picks `case 127: goto st0` plus a `0 <= *p && *p <= 31` ctrl-range check. The `.rl` source is identical; only the host's signed-or-unsigned-char default flips ragel's codegen.

## Failing tests this unblocks on aarch64

Three existing tests in the seastar test suite hit the obs_text input and fail on aarch64 today; they pass on x86_64 because of the codegen quirk described above:

- `tests/unit/chunk_parsers_test.cc :: test_trailer_headers_parsing` — row 5 has the header value `printable!@#%^&*()obs_text\x80\x81\xff`
- `tests/unit/request_parser_test.cc :: test_header_parsing` — same obs_text row
- `tests/unit/httpd_test.cc :: test_full_chunk_format` — chunked HTTP end-to-end test that runs the same parsers

## Fix

Two ragel directives per machine:

```
alphtype unsigned char;       # workaround for #3413
getkey ((unsigned char)(*p));
```

Both are needed; they fix different things.

- **`alphtype unsigned char;`** is the load-bearing fix. It tells ragel to treat the alphabet as 0..255 regardless of the host's `char` signedness, which picks the correct codegen path: ragel emits `case 127: goto st0` in the switch plus a `*p <= 31` ctrl-range check, leaving 0x80..0xff to fall through to the accept branch.
- **`getkey ((unsigned char)(*p));`** is required as a follow-on. With `alphtype unsigned char` in effect, ragel emits literals with the `u` suffix (e.g. `case 13u:`, `(*p) <= 31u`). The parser entry signature is `char* parse(char*, char*, char*)`, so the dereferenced `*p` is a plain `char` — signed on x86. Comparing signed-char against unsigned-int triggers `-Wsign-compare`, which seastar's build promotes to an error. The `getkey` directive forces the fetched byte to be unsigned before comparison, so both sides of every generated `case` / `<=` check are unsigned.

The fix is a few lines per `.rl` file; no compile flag, runtime cast, or buffer-type change is needed.

## Impact

Affects seastar's HTTP server (`http_request_parser` via `httpd.hh`) and HTTP client (`http_response_parser` via `client.cc`) on arm64; the chunked-transfer trailer parser (`http_chunk_trailer_parser`) inherits the same fix.

## Test

Verified end-to-end with a minimal standalone reproducer that runs the real ragel-generated `http_chunk_trailer_parser` against the obs_text test row, on both archs:

- x86_64 (Ubuntu 26.04, ragel 6.10, clang-20): `parser.failed()=0` before and after the fix; x86 was already correct.
- aarch64 (Ubuntu 22.04, ragel 6.10, clang-20): `parser.failed()=1` before, `parser.failed()=0` after.

x86 also compiles cleanly with `-Werror=sign-compare`, confirming the `getkey` cast does its job.

## Details

The investigation, side-by-side codegen diff, and standalone reproducer are in #3413.

## Notes

Ragel 6.10 (March 2017) is the last v6 release and ragel 7 was abandoned, so an upstream ragel fix is unlikely. The `# workaround for #3413` comment is there so the next reader doesn't strip the directives as redundant on x86.