### PR TITLE
tests: fix two C++26 ambiguities in unit/perf tests

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -932,6 +932,7 @@ void run_all(const std::vector<std::string>& test_patterns, config& conf) {
 int main(int ac, char** av)
 {
     using namespace perf_tests::internal;
+    using namespace std::string_view_literals;
     namespace bpo = boost::program_options;
 
     app_template app;
@@ -1008,7 +1009,7 @@ int main(int ac, char** av)
             }
 
             auto selected_mad_str = split(app.configuration()["mad-columns"].as<std::string>());
-            if (std::ranges::find(selected_mad_str, "all") != selected_mad_str.end()) {
+            if (std::ranges::find(selected_mad_str, "all"sv) != selected_mad_str.end()) {
                 selected_mad_str.clear();
                 // add all column names
                 for (const column& col : selected_columns) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -692,8 +692,8 @@ SEASTAR_TEST_CASE(test_chunked_sink_two_chunks_two_bufs) {
         raw_out.close().get();
 
         const std::string expected =
-                  format("{:x}", A.size() + B.size()) + "\r\n" + A + B + "\r\n"
-                + format("{:x}", C.size() + D.size()) + "\r\n" + C + D + "\r\n";
+                  std::string(format("{:x}", A.size() + B.size())) + "\r\n" + A + B + "\r\n"
+                + std::string(format("{:x}", C.size() + D.size())) + "\r\n" + C + D + "\r\n";
         BOOST_REQUIRE_EQUAL(ss.str(), expected);
     });
 }


### PR DESCRIPTION
Two small test-source fixes for ambiguities that surface under `-std=gnu++26`. Both were discovered while compiling the seastar tree under C++26 in preparation for the broader C++26 enablement work — but neither requires the C++26 switch to be flipped to land. The fixes are no-ops under C++20/C++23 (the wrapped value already implicitly converts the same way), so it's safe to merge them now and clear them off the C++26 prep list.

## Commits

- **tests/httpd: fix sstring + std::string ambiguity under C++26** — C++26 added `std::basic_string::operator+(string_view)` overloads (P2591R5). With `seastar::basic_sstring` providing implicit conversions to both `std::string` and `string_view`, plus its own member `operator+(const basic_sstring&)`, `seastar::format(...) + std::string` becomes ambiguous on clang-22 `-std=gnu++26`. Wrap the `format()` result in `std::string()` so the chained `+` is unambiguously a `std::string` operation.

- **tests/perf: fix `ranges::find` string-literal ambiguity under C++26** — Under gcc-16 / libstdc++-16 `-std=gnu++26`, `std::ranges::find(vec_of_string, "all")` deduces the needle as `const char[4]`, then fails the `equality_comparable_with<std::string&, char(&)[4]>` constraint chain because array types don't satisfy weakly-eq-comparable-with-self. Pass the literal as `std::string_view{"all"}` so the constraint resolves through the existing `string`↔`string_view` comparison.
