### PR TITLE
build: fail fast when cooking Boost with clang>=20 on aarch64

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -154,6 +154,39 @@ file (WRITE "${boost_user_config}"
   " : ${boost_cflags}${boost_cxxflags} <cxxflags>-std=c++${CMAKE_CXX_STANDARD}"
   " ;\n")
 
+# Boost 1.81's bundled B2 emits an invalid `--target=arm64-pc-linux` flag for
+# the clang toolset on aarch64 Linux. clang < 20 silently accepted the unknown
+# triple and the build worked; clang >= 20 rejects it, so every Boost source
+# fails with `'cstddef' file not found`. See
+# https://github.com/scylladb/seastar/issues/3415 and the upstream B2 ticket
+# https://github.com/bfgroup/b2/issues/449. Detect this combination up front
+# rather than letting the cook fail mid-build.
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$"
+    AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+    AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20)
+  set (_seastar_boost_will_be_cooked TRUE)
+  if (Cooking_INCLUDED_INGREDIENTS)
+    if (NOT ("Boost" IN_LIST Cooking_INCLUDED_INGREDIENTS))
+      set (_seastar_boost_will_be_cooked FALSE)
+    endif ()
+  elseif (Cooking_EXCLUDED_INGREDIENTS)
+    if ("Boost" IN_LIST Cooking_EXCLUDED_INGREDIENTS)
+      set (_seastar_boost_will_be_cooked FALSE)
+    endif ()
+  endif ()
+  if (_seastar_boost_will_be_cooked)
+    message (FATAL_ERROR
+      "Refusing to cook Boost 1.81 with clang ${CMAKE_CXX_COMPILER_VERSION} on "
+      "${CMAKE_SYSTEM_PROCESSOR}: B2's clang toolset emits "
+      "--target=arm64-pc-linux, which clang >= 20 rejects. The build will fail "
+      "with `'cstddef' file not found`. See "
+      "https://github.com/scylladb/seastar/issues/3415. Workaround: use a "
+      "distro-provided Boost (drop `--cook Boost`); any version >= 1.79.0 is "
+      "accepted and recent Ubuntu/Fedora/Debian ship 1.83+.")
+  endif ()
+  unset (_seastar_boost_will_be_cooked)
+endif ()
+
 cooking_ingredient (Boost
   EXTERNAL_PROJECT_ARGS
     URL https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.bz2


### PR DESCRIPTION
## Summary
- Detect the aarch64 + clang>=20 combination when Boost is among the requested cooking ingredients, and abort `cmake` configuration with a clear `FATAL_ERROR` pointing at #3415, rather than letting B2 fail mid-build with the cryptic `'cstddef' file not found`.
- The check only fires when Boost would actually be cooked (it consults `Cooking_INCLUDED_INGREDIENTS` / `Cooking_EXCLUDED_INGREDIENTS`), so users on the same host who skip `--cook Boost` are unaffected.

## Why
Boost 1.81's bundled B2 emits `--target=arm64-pc-linux` for the clang toolset on aarch64 Linux. clang < 20 silently accepted the unknown triple and located the standard library headers via its usual heuristics; clang >= 20 tightened triple validation and rejects it outright, so every Boost compile fails. See #3415 and the upstream B2 ticket [bfgroup/b2#449](https://github.com/bfgroup/b2/issues/449). The follow-up [bfgroup/b2#466](https://github.com/bfgroup/b2/pull/466) only added an opt-in `<triple>` mechanism; the default behavior is still broken on `boostorg/build` master and in every released Boost through 1.91.0.

Failing at configure-time tells the user immediately what's happening and points at the documented workaround (use a distro-provided Boost — Seastar's minimum is 1.79.0 per `cmake/SeastarDependencies.cmake`, and recent Ubuntu/Fedora/Debian ship 1.83+).


Refs #3415.