### PR TITLE
cooking_recipe: shim CMAKE_CXX_COMPILER for Boost bootstrap

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -138,6 +138,21 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 else ()
   set(boost_toolset "cook_cxx")
 endif ()
+
+# Boost's bootstrap.sh runs a C++11 capability check that invokes a hardcoded
+# binary name ("clang++"/"g++") regardless of CMAKE_CXX_COMPILER, and does not
+# accept --cxx (it neither parses the flag nor forwards $CXX to its build.sh).
+# When CMAKE_CXX_COMPILER is e.g. clang++-20 and no unversioned clang++ is on
+# PATH, bootstrap fails. Create a per-project shim directory exposing
+# CMAKE_CXX_COMPILER under the expected unversioned name and prepend it to
+# PATH for the bootstrap step.
+set (boost_shim_dir "${CMAKE_CURRENT_BINARY_DIR}/cook_boost_shim")
+file (MAKE_DIRECTORY "${boost_shim_dir}")
+if (boost_toolset STREQUAL "clang")
+  file (CREATE_LINK "${CMAKE_CXX_COMPILER}" "${boost_shim_dir}/clang++" SYMBOLIC)
+elseif (boost_toolset STREQUAL "gcc")
+  file (CREATE_LINK "${CMAKE_CXX_COMPILER}" "${boost_shim_dir}/g++" SYMBOLIC)
+endif ()
 set (boost_user_config "${CMAKE_CURRENT_BINARY_DIR}/cook_boost.jam")
 if (CMAKE_C_FLAGS)
   string (JOIN " <cflags>" boost_cflags
@@ -159,6 +174,7 @@ cooking_ingredient (Boost
     URL https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.bz2
     URL_HASH SHA256=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
     PATCH_COMMAND
+      ${CMAKE_COMMAND} -E env "PATH=${boost_shim_dir}:$ENV{PATH}"
       ./bootstrap.sh
       --prefix=<INSTALL_DIR>
       --with-libraries=atomic,chrono,date_time,filesystem,program_options,system,test,thread


### PR DESCRIPTION
Fixes #3420.

## Problem

When `--cook Boost` is used with a versioned compiler (e.g. `--compiler clang++-20`) and no unversioned `clang++`/`g++` symlink exists on `PATH`, configure fails during Boost bootstrap:

```
> clang++ -x c++ -std=c++11  check_cxx11.cpp
./tools/build/src/engine/build.sh: 120: clang++: not found
```

`bootstrap.sh` hardcodes the binary name `clang++`/`g++` for its C++11 capability check, does not accept `--cxx`, and scrubs `$CXX` before invoking `build.sh`. The `cook_boost.jam` user-config the recipe writes carries the full compiler path but is only consumed by the later `b2 install` step. This is unchanged in Boost 1.86 and current master, so it is not solved by upgrading Boost.

## Fix

Create a per-project shim directory at `${CMAKE_CURRENT_BINARY_DIR}/cook_boost_shim/` containing a symlink under the unversioned name (`clang++` or `g++`) that points to `CMAKE_CXX_COMPILER`, and prepend it to `PATH` only for the `bootstrap.sh` invocation. The rest of the build is unchanged.

## Test plan

- [x] Verified locally on Linux aarch64 with `clang++-20` (no `clang++` symlink on PATH); bootstrap now succeeds and `b2` invokes `clang++-20` for the library compile.
- [ ] CI on x86_64 with default unversioned compilers (no change in behavior expected; symlink target is the same binary path).
