### PR TITLE
tests/generator: silence gcc -Wmismatched-new-delete around sync_fibonacci_sequence

### DIFF
--- a/tests/unit/generator_test.cc
+++ b/tests/unit/generator_test.cc
@@ -45,6 +45,11 @@ using namespace seastar;
 
 using do_suspend = bool_class<struct do_suspend_tag>;
 
+#if !defined(__clang__)
+// Work around gcc -Wmismatched-new-delete false positive in std::generator; see seastar#3422.
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
 sync_generator<int>
 sync_fibonacci_sequence(unsigned count) {
     auto a = 0, b = 1;
@@ -59,6 +64,9 @@ sync_fibonacci_sequence(unsigned count) {
         co_yield next;
     }
 }
+#if !defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
 
 coroutine::experimental::generator<int>
 async_fibonacci_sequence(unsigned count, do_suspend suspend) {


### PR DESCRIPTION
## Summary

- gcc >= 15.2 strengthened `-Wmismatched-new-delete` enough to flag libstdc++'s `std::generator` promise type (`_Promise_alloc`) as a false positive: the class-level `operator new` calls unsized global `::operator new`, the class-level `operator delete` is the sized form, and after inlining gcc reports the pair as mismatched. Pairing unsized new with sized delete is well-formed C++ (sized delete was added in C++14 specifically to coexist with unsized new), so this is a compiler false positive — see [gcc PR middle-end/109224](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109224).
- In `tests/unit/generator_test.cc` the only `std::generator` coroutine is `sync_fibonacci_sequence`, so suppress `-Wmismatched-new-delete` just around that one function. Guard is `!defined(__clang__)` since clang doesn't have this diagnostic.
- Triggered in sanitize mode under e.g. Fedora 42's gcc 15.2.1-7. Background and reproducer in scylladb/seastar#3422 — this PR is a narrow workaround, not a fix for the underlying gcc bug.

## Test plan

- [x] Reproduce the failure on Fedora 42 (gcc 15.2.1-7) sanitize mode prior to the change
- [x] Verify `ninja -C build/sanitize tests/unit/CMakeFiles/test_unit_generator.dir/generator_test.cc.o` builds clean with the change applied
- [x] Verify `tests/unit/generator_test` links and all test cases pass (`*** No errors detected`)
- [x] CI green on master (though we need to check again on the new matrix)