### PR TITLE
bool_class: make operators constexpr

### DIFF
--- a/include/seastar/util/bool_class.hh
+++ b/include/seastar/util/bool_class.hh
@@ -68,20 +68,20 @@ public:
     constexpr explicit bool_class(bool v) noexcept : _value(v) { }
 
     /// Casts a bool_class object to an untyped \c bool.
-    explicit operator bool() const noexcept { return _value; }
+    constexpr explicit operator bool() const noexcept { return _value; }
 
     /// Logical OR.
-    friend bool_class operator||(bool_class x, bool_class y) noexcept {
+    friend constexpr bool_class operator||(bool_class x, bool_class y) noexcept {
         return bool_class(x._value || y._value);
     }
 
     /// Logical AND.
-    friend bool_class operator&&(bool_class x, bool_class y) noexcept {
+    friend constexpr bool_class operator&&(bool_class x, bool_class y) noexcept {
         return bool_class(x._value && y._value);
     }
 
     /// Logical NOT.
-    friend bool_class operator!(bool_class x) noexcept {
+    friend constexpr bool_class operator!(bool_class x) noexcept {
         return bool_class(!x._value);
     }
 

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -2871,6 +2871,23 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_promise_set_value) {
     BOOST_REQUIRE_EQUAL(getter.get(), other_shard);
 }
 
+namespace test_bool_class_constexpr_ns {
+using bc = bool_class<struct tag>;
+static_assert(static_cast<bool>(bc(true)));
+static_assert(!static_cast<bool>(bc(false)));
+static_assert(static_cast<bool>(bc(true) && bc(true)));
+static_assert(!static_cast<bool>(bc(true) && bc(false)));
+static_assert(static_cast<bool>(bc(true) || bc(false)));
+static_assert(static_cast<bool>(!bc(false)));
+static_assert(bc(true) == bc(true));
+static_assert(bc(true) != bc(false));
+#if __cpp_lib_three_way_comparison
+static_assert((bc(true) <=> bc(false)) > 0);
+static_assert((bc(false) <=> bc(true)) < 0);
+static_assert((bc(true) <=> bc(true)) == 0);
+#endif
+}
+
 #if __cpp_lib_three_way_comparison
 SEASTAR_TEST_CASE(test_bool_class_spaceship_operator) {
     using test_bool_class = bool_class<struct test_bool_class_tag>;


### PR DESCRIPTION
Mark operator bool, ||, &&, ! as constexpr so that bool_class values can be used in constant expressions.