### PR TITLE
core, util: add initial RISC-V port

### DIFF
--- a/include/seastar/core/cacheline.hh
+++ b/include/seastar/core/cacheline.hh
@@ -36,6 +36,8 @@ constexpr size_t cache_line_size =
     128;
 #elif defined(__aarch64__)
     128; // from Linux, may vary among different microarchitetures?
+#elif defined(__riscv)
+    64;
 #else
 #error "cache_line_size not defined for this architecture"
 #endif

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -137,6 +137,8 @@ constexpr inline size_t huge_page_size =
     1 << 21; // 2M
 #elif defined(__PPC__)
     1 << 24; // 16M
+#elif defined(__riscv)
+    1 << 21; // 2M
 #else
 #error "Huge page size is not defined for this architecture"
 #endif

--- a/include/seastar/util/spinlock.hh
+++ b/include/seastar/util/spinlock.hh
@@ -64,6 +64,16 @@ inline void cpu_relax() {
     __asm__ volatile("yield");
 }
 
+#elif defined(__riscv)
+
+[[gnu::always_inline]]
+inline void cpu_relax() {
+    // Zihintpause `pause` hint, encoded directly so old assemblers without
+    // Zihintpause support still build. On cores that don't implement the hint
+    // it decodes as a NOP.
+    __asm__ volatile(".int 0x0100000F" : : : "memory");
+}
+
 #else
 
 [[gnu::always_inline]]

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4260,6 +4260,8 @@ static void sigsegv_action(siginfo_t *info, ucontext_t* uc) noexcept {
         ip = uc->uc_mcontext.gregs[REG_RIP];
 #elif defined(__aarch64__)
         ip = uc->uc_mcontext.pc;
+#elif defined(__riscv)
+        ip = uc->uc_mcontext.__gregs[REG_PC];
 #else
         ip = 0xBAD;
 #endif

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -300,6 +300,8 @@ thread_context::main() {
     asm(".cfi_undefined x30");
 #elif defined(__s390x__)
     asm(".cfi_undefined %r14");
+#elif defined(__riscv)
+    asm(".cfi_undefined ra");
 #else
     #warning "Backtracing from seastar threads may be broken"
 #endif


### PR DESCRIPTION
- cacheline: 64B
- memory: 2 MiB huge pages
- spinlock: cpu_relax() emits Zihintpause `pause`
- thread: .cfi_undefined ra to stop unwinders at thread bottom
- reactor: read faulting PC from uc_mcontext.__gregs[REG_PC]

Tested on SG2044, GCC 16.1.0 / glibc 2.39:

- release ctest: pass
- sanitize-mode thread_test: pass