### PR TITLE
core: use std::hardware_destructive_interference_size for cache_line_size

### DIFF
--- a/include/seastar/core/cacheline.hh
+++ b/include/seastar/core/cacheline.hh
@@ -21,26 +21,23 @@
 
 #pragma once
 
-#include <cstddef>
+#include <new>
 
 namespace seastar {
 
-
 // Platform-dependent cache line size for alignment and padding purposes.
-constexpr size_t cache_line_size =
-#if defined(__x86_64__) || defined(__i386__)
-    64;
-#elif defined(__s390x__) || defined(__zarch__)
-    256;
-#elif defined(__PPC64__)
-    128;
-#elif defined(__aarch64__)
-    128; // from Linux, may vary among different microarchitetures?
-#elif defined(__riscv)
-    64;
+// RISC-V: workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116662
+#ifdef __riscv
+constexpr std::size_t cache_line_size = 64;
 #else
-#error "cache_line_size not defined for this architecture"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winterference-size"
 #endif
-
+constexpr std::size_t cache_line_size = std::hardware_destructive_interference_size;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 }


### PR DESCRIPTION
Replace the per-architecture preprocessor ladder with std::hardware_destructive_interference_size from <new> (C++17).  This lets the compiler report the correct value for each target without manual maintenance, and picks up future architecture additions for free.

On x86, s390/SystemZ, and ppc64 the value is unchanged, verified by auditing the GCC and Clang source and cross-checking with a minimal program on Godbolt.  On aarch64 the value changes from 128 to 256: both GCC (for a generic aarch64 target without -mcpu) and Clang (by default) use 256 for hardware_destructive_interference_size.  The old value of 128 had no principled basis (the comment noted it "may vary among different microarchitectures").  256 is still larger than the 64-byte L1 cache line size common on actual aarch64 hardware, so it does not introduce false sharing; it is simply more conservative.  When `-mcpu=<cpu>` is specified, GCC instead derives the value from the tuned CPU's L1 cache line size, giving a more precise result.  Clang's defaults can likewise be overridden at Clang build time for a specific target.

RISC-V is excluded: GCC bug
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116662 causes `-Winterference-size` to fire unconditionally on that target even when the value matches the compiler default, so the known 64-byte constant is kept as a workaround until the GCC bug is fixed.  On RISC-V, Clang also uses 64, matching the old hardcoded value.