### PR TITLE
core/alien: use aligned new/delete for message_queue array

### DIFF
--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -118,15 +118,19 @@ void message_queue::start() {
 }
 
 
+static constexpr std::align_val_t message_queue_alignment{alignof(alien::message_queue)};
+
 void internal::qs_deleter::operator()(alien::message_queue* qs) const {
     for (unsigned i = 0; i < count; i++) {
         qs[i].~message_queue();
     }
-    ::operator delete[](qs);
+    ::operator delete[](qs, message_queue_alignment);
 }
 
 instance::qs instance::create_qs(const std::vector<reactor*>& reactors) {
-    auto queues = reinterpret_cast<alien::message_queue*>(operator new[] (sizeof(alien::message_queue) * reactors.size()));
+    auto queues = reinterpret_cast<alien::message_queue*>(
+            operator new[](sizeof(alien::message_queue) * reactors.size(),
+                           message_queue_alignment));
     for (unsigned i = 0; i < reactors.size(); i++) {
         new (&queues[i]) alien::message_queue(reactors[i]);
     }


### PR DESCRIPTION
`alien::message_queue` has `alignas(cache_line_size)` members but the
queue array was allocated with the plain `operator new[]` overload,
which only guarantees `__STDCPP_DEFAULT_NEW_ALIGNMENT__`. This was
latent until 5a8218f58 raised `cache_line_size` on aarch64 to 256,
after which UBSan aborts at startup on nearly every sanitize-arm test:

```
src/core/alien.cc:131:26: runtime error: constructor call on misaligned
address ... for type 'alien::message_queue', which requires 256 byte alignment
```

Switch to the `std::align_val_t` overloads, mirroring the existing
`smp_message_queue` pattern in `reactor.cc`.

Fixes #3429.