### PR TITLE
coroutine: disable g++ coroutine destroy-in-suspend bug workaround for fixed versions

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -51,7 +51,7 @@ namespace internal {
 inline
 void
 execute_involving_handle_destruction_in_await_suspend(std::invocable<> auto&& func) noexcept {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 15 || (__GNUC__ == 15 && __GNUC_MINOR__ >= 2))
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 15 && __GNUC_MINOR__ == 2)
     memory::scoped_critical_alloc_section _;
     schedule(new lambda_task(current_scheduling_group(), std::forward<decltype(func)>(func)));
 #else
@@ -62,7 +62,7 @@ execute_involving_handle_destruction_in_await_suspend(std::invocable<> auto&& fu
 inline
 void
 execute_involving_handle_destruction_in_await_suspend(task* tsk) noexcept {
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 15 || (__GNUC__ == 15 && __GNUC_MINOR__ >= 2))
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 15 && __GNUC_MINOR__ == 2)
     schedule(tsk);
 #else
     tsk->run_and_dispose();


### PR DESCRIPTION
A g++ bug [1] involving destruction during await_suspend() was
fixed for g++ 15.3/16, leaving 15.2 as the only vulenerable version.

Tighten the version check to include only g++ 15.2.
[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121961