### PR TITLE
rpc: use fmt::format for remote exception reporting

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -618,10 +618,13 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t 
             } else {
                 data = std::invoke(marshall<Serializer, const RetTypes&>, std::ref(client->template serializer<Serializer>()), response_frame_headroom, std::move(ret.get()));
             }
-        } catch (std::exception& ex) {
-            const auto type_name = pretty_type_name(typeid(ex));
-            const auto message = std::string_view(ex.what());
-            uint32_t len = message.size() + type_name.size() + 2; // 2 bytes for separating type name and what() message
+        } catch (...) {
+            // Use fmt::format with exception_ptr to properly render all exception
+            // details, including nested exceptions (seastar::nested_exception,
+            // std::nested_exception) which would otherwise lose their inner context
+            // if we only called what().
+            const auto msg = fmt::format("{}", std::current_exception());
+            const uint32_t len = msg.size();
             data = snd_buf(response_frame_headroom + 2 * sizeof(uint32_t) + len);
             auto os = make_serializer_stream(data);
             os.skip(response_frame_headroom);
@@ -629,9 +632,7 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t 
             os.write(reinterpret_cast<char*>(&v32), sizeof(v32));
             v32 = cpu_to_le(len);
             os.write(reinterpret_cast<char*>(&v32), sizeof(v32));
-            os.write(type_name.data(), type_name.size());
-            os.write(": ", 2);
-            os.write(message.data(), message.size());
+            os.write(msg.data(), len);
             msg_id = -msg_id;
         }
 
@@ -648,8 +649,8 @@ inline future<> reply(no_wait_type, future<no_wait_type>&& r, uint64_t verb, int
         std::optional<rpc_clock_type::time_point>, std::optional<rpc_clock_type::duration>) {
     try {
         r.get();
-    } catch (std::exception& ex) {
-        client->get_logger()(client->info(), msgid, format("exception \"{}\" in no_wait handler of the verb {} ignored", ex.what(), verb));
+    } catch (...) {
+        client->get_logger()(client->info(), msgid, format("exception \"{}\" in no_wait handler of the verb {} ignored", std::current_exception(), verb));
     }
     return make_ready_future<>();
 }

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -502,8 +502,26 @@ SEASTAR_TEST_CASE(test_rpc_remote_verb_error) {
         env.register_handler(1, []() { throw std::runtime_error("test_error"); }).get();
         auto f = env.proto().make_client<void ()>(1);
         BOOST_REQUIRE_EXCEPTION(f(c1).get(), rpc::remote_verb_error, [](const rpc::remote_verb_error& e) {
-            return std::string_view(e.what()) == "std::runtime_error: test_error";
+            return std::string_view(e.what()) == "std::runtime_error (test_error)";
         });
+
+        // Verify that nested exceptions are properly reported with full context.
+        // Without using fmt::format("{}", eptr), a seastar::nested_exception would
+        // only show "seastar::nested_exception" in what(), losing all inner/outer details.
+        env.register_handler(2, []() {
+            return make_exception_future<>(
+                std::make_exception_ptr(seastar::nested_exception(
+                    std::make_exception_ptr(std::runtime_error("inner")),
+                    std::make_exception_ptr(std::runtime_error("outer"))
+                ))
+            );
+        }).get();
+        auto f2 = env.proto().make_client<void ()>(2);
+        BOOST_REQUIRE_EXCEPTION(f2(c1).get(), rpc::remote_verb_error, [](const rpc::remote_verb_error& e) {
+            auto msg = std::string_view(e.what());
+            return msg == "seastar::nested_exception: std::runtime_error (inner) (while cleaning up after std::runtime_error (outer))";
+        });
+
         c1.stop().get();
     });
 }


### PR DESCRIPTION
The [previous approach](https://github.com/scylladb/seastar/pull/3305) (pretty_type_name + ": " + what()) fails to convey useful information for nested exceptions:
`seastar::nested_exception::what()` just returns the static string "seastar::nested_exception", discarding all inner/outer context.

Switch to `fmt::format("{}", std::current_exception())` which delegates to seastar's `operator<<(ostream&, const exception_ptr&)`. That function knows how to unpack `seastar::nested_exception`, `std::nested_exception`, `std::system_error` and regular `std::exception`, producing a complete human-readable description in every case.

As a side-effect, catch(...) instead of catch(std::exception&) so non-std::exception types also get reported rather than propagating unhandled.