### PR TITLE
Improve tasks dump

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -306,7 +306,7 @@ private:
         void rename(sstring new_name, sstring new_shortname);
     private:
         void register_stats();
-        internal::log_buf::inserter_iterator do_dump(seastar::internal::log_buf::inserter_iterator it) const;
+        void do_dump() const;
     };
 
     struct task_queue_group final : public sched_entity {

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -218,7 +218,6 @@ public:
         uint64_t _dropped_messages = 0;
 
     private:
-        bool check();
         bool has_dropped_messages() const { return bool(_dropped_messages); }
         uint64_t get_and_reset_dropped_messages() {
             return std::exchange(_dropped_messages, 0);
@@ -226,6 +225,12 @@ public:
 
     public:
         explicit rate_limit(std::chrono::milliseconds interval);
+
+    /// Checks, if the rate limit has been already reached. If not - starts the rate limiting interval.
+    /// You should ignore messages if `rate_limited()` returns true and process if it returns false.
+    ///
+    /// \return true if the rate limit has been reached before and is still active, false otherwise.
+        bool rate_limited();
     };
 
 public:
@@ -283,7 +288,7 @@ public:
     ///
     template <typename... Args>
     void log(log_level level, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
-        if (is_enabled(level) && rl.check()) {
+        if (is_enabled(level) && !rl.rate_limited()) {
             try {
                 lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
                     if (rl.has_dropped_messages()) {
@@ -309,7 +314,7 @@ public:
     /// buffer directly, avoiding the use of any intermediary buffers.
     /// This is rate-limited version, see \ref rate_limit.
     void log(log_level level, rate_limit& rl, log_writer& writer, format_info_t<> fmt = {}) noexcept {
-        if (is_enabled(level) && rl.check()) {
+        if (is_enabled(level) && !rl.rate_limited()) {
             try {
                 lambda_log_writer writer_wrapper([&] (internal::log_buf::inserter_iterator it) {
                     if (rl.has_dropped_messages()) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <ranges>
 #include <regex>
+#include <seastar/util/log-level.hh>
 #include <thread>
 #include <unordered_set>
 #include <barrier>
@@ -2728,7 +2729,15 @@ void reactor::register_metrics() {
     });
 }
 
-seastar::internal::log_buf::inserter_iterator reactor::task_queue::do_dump(seastar::internal::log_buf::inserter_iterator it) const {
+void reactor::task_queue::do_dump() const {
+    static thread_local logger::rate_limit rate_limit(std::chrono::seconds(10));
+
+    if (rate_limit.rate_limited() || !seastar_logger.is_enabled(log_level::warn)) {
+        // Rate limit was hit or `warning` level is not enabled, we skip dumping the queue.
+        return;
+    }
+    seastar_logger.log(log_level::warn, "Too long queue accumulated for {} ({} tasks)", _name, _q.size());
+
     memory::scoped_critical_alloc_section _;
     std::unordered_map<std::pair<std::string_view, int>, std::pair<unsigned, task*>> infos;
     for (const auto& tp : _q) {
@@ -2740,24 +2749,27 @@ seastar::internal::log_buf::inserter_iterator reactor::task_queue::do_dump(seast
         ++count;
         task = tp;
     }
-    it = fmt::format_to(it, "Too long queue accumulated for {} ({} tasks)\n", _name, _q.size());
-    auto dump_task = [](auto it, task& task) {
-        const auto rp = task.get_resume_point();
-        const std::string_view file_name = rp.file_name();
-        return file_name.empty()
-            ? fmt::format_to(it, "{}\n", typeid(task).name())
-            : fmt::format_to(it, "{}:{}:{}\n", file_name, rp.line(), rp.column());
-    };
+
     for (const auto& ti : infos) {
         auto [ count, task ] = ti.second;
-        it = fmt::format_to(it, " {}: ", count);
-        it = dump_task(it, *task);
-        for (auto* t = task->waiting_task(); t; t = t->waiting_task()) {
-            it = fmt::format_to(it, "        ");
-            it = dump_task(it, *t);
+        auto count_text = " " + std::to_string(count);
+        count_text += ":";
+        if (count_text.size() < 8)
+            count_text.resize(8, ' ');
+
+        for (auto t = task; t; t = t->waiting_task()) {
+            const auto rp = t->get_resume_point();
+            const std::string_view file_name = rp.file_name();
+            if (file_name.empty()) {
+                seastar_logger.log(log_level::warn, "{}{}", count_text, typeid(t).name());
+            }
+            else {
+                seastar_logger.log(log_level::warn, "{}{}:{}:{}", count_text, rp.file_name(), rp.line(), rp.column());
+            }
+            count_text = "        ";
         }
     }
-    return it;
+    seastar_logger.log(log_level::warn, "End of dump for {} ({} tasks)", _name, _q.size());
 }
 
 bool reactor::task_queue::run_tasks() {
@@ -2787,9 +2799,7 @@ bool reactor::task_queue::run_tasks() {
                 r.reset_preemption_monitor();
                 lowres_clock::update();
 
-                static thread_local logger::rate_limit rate_limit(std::chrono::seconds(10));
-                logger::lambda_log_writer writer([this] (auto it) { return do_dump(it); });
-                seastar_logger.log(log_level::warn, rate_limit, writer);
+                do_dump();
                 if (r._cfg.abort_on_too_long_task_queue) {
                     auto msg = fmt::format("Too long task queue: {}, max_task_backlog={}", _q.size(), r._cfg.max_task_backlog);
                     on_fatal_internal_error(seastar_logger, msg);

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -314,14 +314,14 @@ logger::~logger() {
 
 static thread_local std::array<char, 8192> static_log_buf;
 
-bool logger::rate_limit::check() {
+bool logger::rate_limit::rate_limited() {
     const auto now = clock::now();
     if (now < _next) {
         ++_dropped_messages;
-        return false;
+        return true;
     }
     _next = now + _interval;
-    return true;
+    return false;
 }
 
 logger::rate_limit::rate_limit(std::chrono::milliseconds interval)


### PR DESCRIPTION
Previously dump of large task queue would build one, large message. It turned out it can cause memory allocation failures in rare cases. The patch updates function to log task queue info's each line as it's own log message. In current version it looks like this:
    
```
2026-06-15 12:19:07,294 [shard 0:main] seastar - Too long queue accumulated for main (15 tasks)
2026-06-15 12:19:07,294 [shard 0:main] seastar -  4:     seastar/include/seastar/core/smp.hh:378:32
2026-06-15 12:19:07,294 [shard 0:main] seastar -         PN7seastar4taskE
2026-06-15 12:19:07,294 [shard 0:main] seastar -         replica/database.cc:1332:5
2026-06-15 12:19:07,294 [shard 0:main] seastar -         replica/distributed_loader.cc:475:23
2026-06-15 12:19:07,294 [shard 0:main] seastar -         PN7seastar4taskE
2026-06-15 12:19:07,294 [shard 0:main] seastar -         replica/distributed_loader.cc:472:14
2026-06-15 12:19:07,294 [shard 0:main] seastar -         PN7seastar4taskE
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/include/seastar/core/thread.hh:261:28
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/include/seastar/core/thread.hh:263:12
2026-06-15 12:19:07,294 [shard 0:main] seastar -         PN7seastar4taskE
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/include/seastar/core/thread.hh:261:28
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/include/seastar/core/thread.hh:263:12
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/src/core/app-template.cc:165:37
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/src/core/app-template.cc:167:12
2026-06-15 12:19:07,294 [shard 0:main] seastar -         seastar/src/core/app-template.cc:169:12
2026-06-15 12:19:07,295 [shard 0:main] seastar -  2:     replica/database.cc:1332:5
2026-06-15 12:19:07,295 [shard 0:main] seastar -         replica/distributed_loader.cc:475:23
2026-06-15 12:19:07,295 [shard 0:main] seastar -  9:     PN7seastar4taskE
2026-06-15 12:19:07,295 [shard 0:main] seastar -         replica/database.cc:1332:5
2026-06-15 12:19:07,295 [shard 0:main] seastar -         replica/distributed_loader.cc:475:23
2026-06-15 12:19:07,295 [shard 0:main] seastar - End of dump for main (15 tasks)
```
    
Since log messages might interleave with other logs, to retrieve whole task dump you need to grep by `[shard 1:main]` and gather all lines between `Too long queue accumulated...` and `End of dump for` with the same name.

Refs: SCYLLADB-1734