### PR TITLE
build: also detect GCC's -Wno-error=cpp for #warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1169,10 +1169,17 @@ if (ErrorUnused_FOUND)
   endif ()
 endif ()
 
+# clang
 check_cxx_compiler_flag ("-Wno-error=#warnings" ErrorWarnings_FOUND)
 if (ErrorWarnings_FOUND)
   target_compile_options (seastar
       PRIVATE "-Wno-error=#warnings")
+endif ()
+# gcc
+check_cxx_compiler_flag ("-Wno-error=cpp" ErrorCpp_FOUND)
+if (ErrorCpp_FOUND)
+  target_compile_options (seastar
+      PRIVATE "-Wno-error=cpp")
 endif ()
 
 foreach (definition


### PR DESCRIPTION
The existing check only tries clang's "-Wno-error=#warnings" spelling, which GCC rejects, so an advisory #warning (e.g. from core/dpdk_rte.hh when DPDK has atomic mbuf refcnt) becomes fatal under -Werror.