### PR TITLE
tests: avoid printing std::vector in BOOST_CHECK_EQUAL

### DIFF
--- a/apps/memcached/tests/test_ascii_parser.cc
+++ b/apps/memcached/tests/test_ascii_parser.cc
@@ -27,6 +27,8 @@
 #include "ascii.hh"
 #include <seastar/core/loop.hh>
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<seastar::sstring>)
+
 using namespace seastar;
 using namespace net;
 using namespace memcache;

--- a/tests/unit/simple_stream_test.cc
+++ b/tests/unit/simple_stream_test.cc
@@ -24,6 +24,8 @@
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/simple-stream.hh>
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<char>)
+
 using namespace seastar;
 
 template<typename Input, typename Output>

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -12,6 +12,8 @@
 #include <seastar/util/memory-data-source.hh>
 #include "loopback_socket.hh"
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<seastar::sstring>)
+
 using namespace seastar;
 using namespace seastar::experimental;
 using namespace std::literals::string_view_literals;


### PR DESCRIPTION
  With -DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF, std::vector has no
  operator<<, so BOOST_CHECK_EQUAL on a vector fails to build. Mark the
  types with BOOST_TEST_DONT_PRINT_LOG_VALUE.