### PR TITLE
build: default Seastar_DEPRECATED_OSTREAM_FORMATTERS to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ option (Seastar_SSTRING
 
 option (Seastar_DEPRECATED_OSTREAM_FORMATTERS
   "Enable operator<< for formatting standard library containers, which will be deprecated in future"
-  ON)
+  OFF)
 
 set (Seastar_API_LEVEL
   "9"

--- a/apps/memcached/tests/CMakeLists.txt
+++ b/apps/memcached/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ target_include_directories (app_memcached_test_ascii
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${Seastar_APP_MEMCACHED_BINARY_DIR}
-    ${Seastar_APP_MEMCACHED_SOURCE_DIR})
+    ${Seastar_APP_MEMCACHED_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tests/unit)
 
 target_compile_definitions (app_memcached_test_ascii
   PRIVATE SEASTAR_TESTING_MAIN)

--- a/apps/memcached/tests/test_ascii_parser.cc
+++ b/apps/memcached/tests/test_ascii_parser.cc
@@ -26,8 +26,9 @@
 #include <seastar/util/memory-data-source.hh>
 #include "ascii.hh"
 #include <seastar/core/loop.hh>
+#include <fmt/ranges.h>
+#include "test_comparisons.hh"
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<seastar::sstring>)
 
 using namespace seastar;
 using namespace net;
@@ -241,19 +242,19 @@ SEASTAR_TEST_CASE(test_get_parsing) {
             return parse(make_packet({"get key1\r\n"}))
                     .then([] (auto p) {
                 BOOST_REQUIRE(p->_state == parser_type::state::cmd_get);
-                BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1"}));
+                SEASTAR_BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1"}));
             });
         }).then([make_packet] {
             return parse(make_packet({"get key1 key2\r\n"}))
                     .then([] (auto p) {
                 BOOST_REQUIRE(p->_state == parser_type::state::cmd_get);
-                BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1", "key2"}));
+                SEASTAR_BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1", "key2"}));
             });
         }).then([make_packet] {
             return parse(make_packet({"get key1 key2 key3\r\n"}))
                     .then([] (auto p) {
                 BOOST_REQUIRE(p->_state == parser_type::state::cmd_get);
-                BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1", "key2", "key3"}));
+                SEASTAR_BOOST_REQUIRE_EQUAL(as_strings(p->_keys), std::vector<sstring>({"key1", "key2", "key3"}));
             });
         });
     });

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -22,6 +22,7 @@
 #include <exception>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sleep.hh>
@@ -39,10 +40,10 @@ SEASTAR_TEST_CASE(test_abort_source_notifies_subscriber) {
     auto st_opt = as.subscribe([&signalled] () noexcept {
         signalled = true;
     });
-    BOOST_REQUIRE_EQUAL(true, bool(st_opt));
+    SEASTAR_BOOST_REQUIRE_EQUAL(true, bool(st_opt));
     as.request_abort();
-    BOOST_REQUIRE_EQUAL(true, signalled);
-    BOOST_REQUIRE_EQUAL(false, bool(st_opt));
+    SEASTAR_BOOST_REQUIRE_EQUAL(true, signalled);
+    SEASTAR_BOOST_REQUIRE_EQUAL(false, bool(st_opt));
     BOOST_REQUIRE_THROW(as.check(), abort_requested_exception);
     return make_ready_future<>();
 }
@@ -53,10 +54,10 @@ SEASTAR_TEST_CASE(test_abort_source_subscription_unregister) {
     auto st_opt = as.subscribe([&signalled] () noexcept {
         signalled = true;
     });
-    BOOST_REQUIRE_EQUAL(true, bool(st_opt));
+    SEASTAR_BOOST_REQUIRE_EQUAL(true, bool(st_opt));
     st_opt = { };
     as.request_abort();
-    BOOST_REQUIRE_EQUAL(false, signalled);
+    SEASTAR_BOOST_REQUIRE_EQUAL(false, signalled);
     return make_ready_future<>();
 }
 
@@ -64,7 +65,7 @@ SEASTAR_TEST_CASE(test_abort_source_rejects_subscription) {
     auto as = abort_source();
     as.request_abort();
     auto st_opt = as.subscribe([] () noexcept { });
-    BOOST_REQUIRE_EQUAL(false, bool(st_opt));
+    SEASTAR_BOOST_REQUIRE_EQUAL(false, bool(st_opt));
     return make_ready_future<>();
 }
 
@@ -128,7 +129,7 @@ SEASTAR_TEST_CASE(test_request_abort_with_exception) {
     try {
         std::rethrow_exception(*aborted_ex);
     } catch (const std::runtime_error& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), expected_message);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), expected_message);
         caught_exception = true;
     }
     BOOST_REQUIRE(caught_exception);
@@ -141,7 +142,7 @@ SEASTAR_TEST_CASE(test_request_abort_with_exception) {
     try {
         std::rethrow_exception(*aborted_ex);
     } catch (const std::runtime_error& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), expected_message);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), expected_message);
         caught_exception = true;
     }
     BOOST_REQUIRE(caught_exception);
@@ -155,7 +156,7 @@ SEASTAR_TEST_CASE(test_request_abort_with_exception) {
     try {
         std::rethrow_exception(*aborted_ex);
     } catch (const std::runtime_error& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), expected_message);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), expected_message);
         caught_exception = true;
     }
     BOOST_REQUIRE(caught_exception);
@@ -174,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(test_sleep_abortable_with_exception) {
     try {
         f.get();
     } catch (const std::runtime_error& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), expected_message);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), expected_message);
         caught_exception = true;
     }
     BOOST_REQUIRE(caught_exception);
@@ -190,7 +191,7 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     auto sub4 = as->subscribe([&] () noexcept { ++aborted; });
     sub4 = std::move(sub3);
     as.reset();
-    BOOST_REQUIRE_EQUAL(aborted, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aborted, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_request_abort_twice) {
@@ -207,12 +208,12 @@ SEASTAR_THREAD_TEST_CASE(test_on_abort_call_after_abort) {
         BOOST_REQUIRE(!signalled_ex);
         signalled_ex = *ex;
     });
-    BOOST_REQUIRE_EQUAL(bool(sub), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), true);
     BOOST_REQUIRE(signalled_ex == nullptr);
 
     // on_abort should trigger the subscribed callback
     as.request_abort_ex(std::make_exception_ptr(std::runtime_error("signaled")));
-    BOOST_REQUIRE_EQUAL(bool(sub), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), false);
     BOOST_REQUIRE(signalled_ex != nullptr);
     BOOST_REQUIRE_THROW(std::rethrow_exception(signalled_ex), std::runtime_error);
 
@@ -229,12 +230,12 @@ SEASTAR_THREAD_TEST_CASE(test_on_abort_call_before_abort) {
         BOOST_REQUIRE(!signalled_ex);
         signalled_ex = *ex;
     });
-    BOOST_REQUIRE_EQUAL(bool(sub), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), true);
     BOOST_REQUIRE(signalled_ex == nullptr);
 
     // on_abort should trigger the subscribed callback
     sub->on_abort(std::make_exception_ptr(std::runtime_error("signaled")));
-    BOOST_REQUIRE_EQUAL(bool(sub), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), false);
     BOOST_REQUIRE(signalled_ex != nullptr);
     BOOST_REQUIRE_THROW(std::rethrow_exception(signalled_ex), std::runtime_error);
 
@@ -255,7 +256,7 @@ SEASTAR_THREAD_TEST_CASE(test_subscribe_aborted_source) {
 
     // subscription is expected to evaluate to false
     // if abort_source was already aborted
-    BOOST_REQUIRE_EQUAL(bool(sub), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), false);
     BOOST_REQUIRE(signalled_ex == nullptr);
 
     // on_abort should trigger the subscribed callback
@@ -280,25 +281,25 @@ SEASTAR_THREAD_TEST_CASE(test_subscription_callback_lifetime) {
     auto sub = std::make_unique<optimized_optional<abort_source::subscription>>(as.subscribe([&, when_destroyed = std::move(when_destroyed)] (const std::optional<std::exception_ptr>& ex) noexcept {
         callback_called++;
     }));
-    BOOST_REQUIRE_EQUAL(bool(sub), true);
-    BOOST_REQUIRE_EQUAL(bool(*sub), true);
-    BOOST_REQUIRE_EQUAL(callback_destroyed, false);
-    BOOST_REQUIRE_EQUAL(callback_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(sub), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(*sub), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_destroyed, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_called, 0);
 
     // on_abort should trigger the subscribed callback
     as.request_abort_ex(std::make_exception_ptr(std::runtime_error("signaled")));
-    BOOST_REQUIRE_EQUAL(bool(*sub), false);
-    BOOST_REQUIRE_EQUAL(callback_destroyed, false);
-    BOOST_REQUIRE_EQUAL(callback_called, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bool(*sub), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_destroyed, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_called, 1);
 
     // on_abort is single-shot
     (*sub)->on_abort(std::make_exception_ptr(std::runtime_error("signaled")));
-    BOOST_REQUIRE_EQUAL(callback_destroyed, false);
-    BOOST_REQUIRE_EQUAL(callback_called, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_destroyed, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_called, 1);
 
     sub.reset();
-    BOOST_REQUIRE_EQUAL(callback_destroyed, true);
-    BOOST_REQUIRE_EQUAL(callback_called, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_destroyed, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(callback_called, 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_abort_on_expiry) {
@@ -316,7 +317,7 @@ SEASTAR_THREAD_TEST_CASE(test_abort_on_expiry) {
     manual_clock::advance(1s);
     yield().get();
     BOOST_REQUIRE(abort.abort_source().abort_requested());
-    BOOST_REQUIRE_EQUAL(called, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(called, 1);
     BOOST_REQUIRE(ex != nullptr);
     BOOST_REQUIRE_THROW(std::rethrow_exception(ex), timed_out_error);
 }

--- a/tests/unit/abortable_fifo_test.cc
+++ b/tests/unit/abortable_fifo_test.cc
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <exception>
+#include "test_comparisons.hh"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/test_case.hh>
@@ -40,42 +41,42 @@ SEASTAR_TEST_CASE(test_no_abortable_operations) {
     internal::abortable_fifo<int> fifo;
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
 
     fifo.push_back(1);
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     fifo.push_back(2);
     fifo.push_back(3);
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 3u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 3u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 2);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
 
     return make_ready_future<>();
@@ -94,18 +95,18 @@ SEASTAR_THREAD_TEST_CASE(test_abortable_operations) {
     fifo.push_back(1, as);
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     as.request_abort();
     yield().get();
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
-    BOOST_REQUIRE_EQUAL(expired.size(), 1u);
-    BOOST_REQUIRE_EQUAL(expired[0], 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 1);
 
     expired.clear();
     as = abort_source();
@@ -118,16 +119,16 @@ SEASTAR_THREAD_TEST_CASE(test_abortable_operations) {
     yield().get();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(expired.size(), 1u);
-    BOOST_REQUIRE_EQUAL(expired[0], 2);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
     expired.clear();
 
@@ -142,18 +143,18 @@ SEASTAR_THREAD_TEST_CASE(test_abortable_operations) {
     yield().get();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(expired.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 2u);
     std::sort(expired.begin(), expired.end());
-    BOOST_REQUIRE_EQUAL(expired[0], 1);
-    BOOST_REQUIRE_EQUAL(expired[1], 2);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[1], 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 4);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 4);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
     expired.clear();
 
@@ -168,16 +169,16 @@ SEASTAR_THREAD_TEST_CASE(test_abortable_operations) {
     yield().get();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(expired.size(), 3u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 3u);
     std::sort(expired.begin(), expired.end());
-    BOOST_REQUIRE_EQUAL(expired[0], 2);
-    BOOST_REQUIRE_EQUAL(expired[1], 3);
-    BOOST_REQUIRE_EQUAL(expired[2], 4);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[1], 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[2], 4);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
     expired.clear();
     as = abort_source();
@@ -191,13 +192,13 @@ SEASTAR_THREAD_TEST_CASE(test_abortable_operations) {
     as.request_abort();
     yield().get();
 
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 5);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_abort_exception) {
@@ -217,18 +218,18 @@ SEASTAR_THREAD_TEST_CASE(test_abort_exception) {
     fifo.push_back(1, aoe.abort_source());
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     manual_clock::advance(1s);
     yield().get();
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
-    BOOST_REQUIRE_EQUAL(expired.size(), 1u);
-    BOOST_REQUIRE_EQUAL(expired[0].value, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expired[0].value, 1);
     BOOST_REQUIRE(expired[0].ex);
     BOOST_REQUIRE_THROW(std::rethrow_exception(expired[0].ex), timed_out_error);
 }

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -28,6 +28,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/memory_diagnostics.hh>
+#include "test_comparisons.hh"
 
 #include <memory>
 #include <new>
@@ -186,12 +187,12 @@ SEASTAR_THREAD_TEST_CASE(test_cross_thread_realloc) {
             smp::submit_to(other_shard, [=] {
                 char* p2 = static_cast<char *>(realloc(p, realloc_size));
                 if (initial_size > 0 && realloc_size > 0) {
-                    BOOST_REQUIRE_EQUAL(p2[0], 'x');
+                    SEASTAR_BOOST_REQUIRE_EQUAL(p2[0], 'x');
                     if (realloc_size <= initial_size) {
-                        BOOST_REQUIRE_EQUAL(p2[realloc_size - 1], 'y');
+                        SEASTAR_BOOST_REQUIRE_EQUAL(p2[realloc_size - 1], 'y');
                     }
                     if (realloc_size > initial_size) {
-                        BOOST_REQUIRE_EQUAL(p2[initial_size - 1], 'z');
+                        SEASTAR_BOOST_REQUIRE_EQUAL(p2[initial_size - 1], 'z');
                     }
                 }
                 free(p2);
@@ -279,7 +280,7 @@ void* test_nullptr = nullptr;
 SEASTAR_TEST_CASE(test_realloc_nullptr) {
     auto p0 = realloc(test_nullptr, 8);
     BOOST_REQUIRE(p0 != nullptr);
-    BOOST_REQUIRE_EQUAL(realloc(p0, 0), nullptr);
+    SEASTAR_BOOST_REQUIRE_EQUAL(realloc(p0, 0), nullptr);
 
     p0 = realloc(test_nullptr, 0);
     BOOST_REQUIRE(p0 != nullptr);
@@ -322,30 +323,30 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
     // test that new throws
     stats = seastar::memory::stats();
     BOOST_REQUIRE_THROW(sink = operator new(size), std::bad_alloc);
-    BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that new[] throws
     stats = seastar::memory::stats();
     BOOST_REQUIRE_THROW(sink = new char[size], std::bad_alloc);
-    BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge malloc returns null
     stats = seastar::memory::stats();
-    BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
-    BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
+    SEASTAR_BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge realloc on nullptr returns null
     stats = seastar::memory::stats();
-    BOOST_REQUIRE_EQUAL(realloc(nullptr, size), nullptr);
-    BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(realloc(nullptr, size), nullptr);
+    SEASTAR_BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge realloc on an existing ptr returns null
     stats = seastar::memory::stats();
     void *p = malloc(1);
     BOOST_REQUIRE(p);
     void *p2 = realloc(p, size);
-    BOOST_REQUIRE_EQUAL(p2, nullptr);
-    BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(p2, nullptr);
+    SEASTAR_BOOST_CHECK_EQUAL(failed_allocs(), 1);
     free(p2 ?: p);
 
     return make_ready_future<>();
@@ -382,7 +383,7 @@ void check_function_allocation(const char* name, size_t expected_allocs, Func f)
     auto after = seastar::memory::stats();
 
     BOOST_TEST_INFO("After function: " << name);
-    BOOST_REQUIRE_EQUAL(expected_allocs, after.mallocs() - before.mallocs());
+    SEASTAR_BOOST_REQUIRE_EQUAL(expected_allocs, after.mallocs() - before.mallocs());
 }
 
 SEASTAR_TEST_CASE(test_diagnostics_allocation) {
@@ -420,7 +421,7 @@ SEASTAR_TEST_CASE(test_two_allocations_increase_total_bytes_allocated) {
 
     auto after = seastar::memory::stats();
 
-    BOOST_REQUIRE_EQUAL(after.total_bytes_allocated() - before.total_bytes_allocated(), size1 + size2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(after.total_bytes_allocated() - before.total_bytes_allocated(), size1 + size2);
 
     operator delete(p2);
     operator delete(p1);
@@ -449,7 +450,7 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 {
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     std::size_t count = 100;
@@ -476,20 +477,20 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         auto stats1 = seastar::memory::sampled_memory_profile();
 
         // two back-to-back copies of the sample should have the same value
-        BOOST_CHECK_EQUAL(stats0, stats1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats0, stats1);
 
         // check that we get the same value from the raw array iterface
         std::vector<seastar::memory::allocation_site> stats2(stats0.size());
         auto sz2 = seastar::memory::sampled_memory_profile(stats2.data(), stats2.size());
-        BOOST_CHECK_EQUAL(stats0.size(), sz2);
-        BOOST_CHECK_EQUAL(stats0, stats2);
+        SEASTAR_BOOST_CHECK_EQUAL(stats0.size(), sz2);
+        SEASTAR_BOOST_CHECK_EQUAL(stats0, stats2);
 
         // check with +1 size, we expect to still only get size elements
         std::vector<seastar::memory::allocation_site> stats3(stats0.size() + 1);
         auto sz3 = seastar::memory::sampled_memory_profile(stats3.data(), stats3.size());
-        BOOST_CHECK_EQUAL(stats0.size(), sz3);
+        SEASTAR_BOOST_CHECK_EQUAL(stats0.size(), sz3);
         stats3.resize(sz3);
-        BOOST_CHECK_EQUAL(stats0, stats3);
+        SEASTAR_BOOST_CHECK_EQUAL(stats0, stats3);
 
         return stats0;
     };
@@ -499,8 +500,8 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 
     {
         auto stats = get_samples();
-        BOOST_REQUIRE_EQUAL(stats.size(), 2);
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 100);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 100);
     }
 
     seastar::memory::set_heap_profiling_sampling_rate(100);
@@ -513,7 +514,7 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 
     {
         auto stats = get_samples();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     return seastar::make_ready_future();
@@ -523,7 +524,7 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
 {
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     std::size_t count = 100;
@@ -550,8 +551,8 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
 
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 2);
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
     }
 
     seastar::memory::set_heap_profiling_sampling_rate(1000000);
@@ -565,7 +566,7 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     {
         auto stats = seastar::memory::sampled_memory_profile();
         // NOTE this is because right now the tracking structure doesn't delete call sites ever
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     return seastar::make_ready_future();
@@ -589,7 +590,7 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_max_sites)
 
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 1000);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 1000);
     }
 
     for (auto ptr : ptrs) {
@@ -603,7 +604,7 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
 {
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     std::size_t sample_rate = 100;
@@ -625,9 +626,9 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
     size_t last_alloc_size = 0;
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 1);
         last_alloc_size = stats[0].size;
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
     }
 
     seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
@@ -642,10 +643,10 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
 
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 1);
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
-        BOOST_REQUIRE_NE(stats[0].size, last_alloc_size);
-        BOOST_REQUIRE_GT(stats[0].size, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
+        SEASTAR_BOOST_REQUIRE_NE(stats[0].size, last_alloc_size);
+        SEASTAR_BOOST_REQUIRE_GT(stats[0].size, 0);
         last_alloc_size = stats[0].size;
     }
 
@@ -660,8 +661,8 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
 
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 1);
-        BOOST_REQUIRE_LT(stats[0].size, last_alloc_size); // should not have underflowed
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        SEASTAR_BOOST_REQUIRE_LT(stats[0].size, last_alloc_size); // should not have underflowed
     }
 
     seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
@@ -675,7 +676,7 @@ SEASTAR_TEST_CASE(test_change_sample_rate)
 
     {
         auto stats = seastar::memory::sampled_memory_profile();
-        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     return seastar::make_ready_future();
@@ -719,7 +720,7 @@ SEASTAR_TEST_CASE(c23_free_sized) {
     free_sized(p1, 100);
     void* p2;
     int r = posix_memalign(&p2, 1024, 4096);
-    BOOST_REQUIRE_EQUAL(r, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(r, 0);
     free_aligned_sized(p2, 1024, 4096);
     return make_ready_future<>();
 }

--- a/tests/unit/app-template_test.cc
+++ b/tests/unit/app-template_test.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sleep.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -58,7 +59,7 @@ BOOST_AUTO_TEST_CASE(app_standard_memory_allocator) {
                 return make_ready_future<int>(expected_status);
             });
         });
-    BOOST_CHECK_EQUAL(actual_status, expected_status);
+    SEASTAR_BOOST_CHECK_EQUAL(actual_status, expected_status);
 }
 
 BOOST_AUTO_TEST_CASE(return_0_for_func_returning_void) {
@@ -67,7 +68,7 @@ BOOST_AUTO_TEST_CASE(return_0_for_func_returning_void) {
     char* args[] = {prog_name.data()};
     int status = app.run(std::size(args), std::data(args),
                          [] { return make_ready_future(); });
-    BOOST_CHECK_EQUAL(status, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(status, 0);
 }
 
 BOOST_AUTO_TEST_CASE(return_status_for_func_returning_int) {
@@ -80,5 +81,5 @@ BOOST_AUTO_TEST_CASE(return_status_for_func_returning_int) {
          [expected_status] {
              return make_ready_future<int>(expected_status);
          });
-    BOOST_CHECK_EQUAL(actual_status, expected_status);
+    SEASTAR_BOOST_CHECK_EQUAL(actual_status, expected_status);
 }

--- a/tests/unit/chunk_parsers_test.cc
+++ b/tests/unit/chunk_parsers_test.cc
@@ -30,6 +30,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -65,12 +66,12 @@ SEASTAR_TEST_CASE(test_size_and_extensions_parsing) {
     for (auto& tset : tests) {
         parser.init();
         BOOST_REQUIRE(parser(tset.buf()).get().has_value());
-        BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
+        SEASTAR_BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
-            BOOST_REQUIRE_EQUAL(parser.get_size(), std::move(tset.size));
+            SEASTAR_BOOST_REQUIRE_EQUAL(parser.get_size(), std::move(tset.size));
             auto exts = parser.get_parsed_extensions();
             for (auto& ext : tset.extensions) {
-                BOOST_REQUIRE_EQUAL(exts[ext.first], ext.second);
+                SEASTAR_BOOST_REQUIRE_EQUAL(exts[ext.first], ext.second);
             }
         }
     }
@@ -110,10 +111,10 @@ SEASTAR_TEST_CASE(test_trailer_headers_parsing) {
     for (auto& tset : tests) {
         parser.init();
         BOOST_REQUIRE(parser(tset.buf()).get().has_value());
-        BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
+        SEASTAR_BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto heads = parser.get_parsed_headers();
-            BOOST_REQUIRE_EQUAL(heads[std::move(tset.header_name)], std::move(tset.header_value));
+            SEASTAR_BOOST_REQUIRE_EQUAL(heads[std::move(tset.header_name)], std::move(tset.header_value));
         }
     }
     return make_ready_future<>();

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -20,7 +20,6 @@
  */
 
 
-#include <boost/test/tools/old/interface.hpp>
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/tools/context.hpp>
@@ -36,6 +35,7 @@
 #if __has_include(<version>)
 #include <version>
 #endif
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -50,29 +50,29 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_small) {
     // Check all the methods of chunked_fifo but with a trivial type (int) and
     // only a few elements - and in particular a single chunk is enough.
     chunked_fifo<int> fifo;
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
     fifo.push_back(3);
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
     fifo.push_back(17);
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 17);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 17);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
     // The previously allocated chunk should have been freed, and now
     // a new one will need to be allocated:
     fifo.push_back(57);
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
-    BOOST_REQUIRE_EQUAL(fifo.front(), 57);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 57);
     // check miscelleneous methods (at least they shouldn't crash)
     fifo.clear();
     fifo.shrink_to_fit();
@@ -91,16 +91,16 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_fullchunk) {
     for (int i = 0; i < static_cast<int>(N); i++) {
         fifo.push_back(i);
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N);
     fifo.push_back(N);
-    BOOST_REQUIRE_EQUAL(fifo.size(), N+1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N+1);
     for (int i = 0 ; i < static_cast<int>(N+1); i++) {
-        BOOST_REQUIRE_EQUAL(fifo.front(), i);
-        BOOST_REQUIRE_EQUAL(fifo.size(), N+1-i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N+1-i);
         fifo.pop_front();
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
 }
 
 struct trackable_totals {
@@ -157,21 +157,21 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_pop_n) {
                 // note that we add 2 and delete 1 element for every element added in
                 // fill_and_reset so that affects the numbers below
 
-                BOOST_REQUIRE_EQUAL(fifo.size(), size);
-                BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2);
-                BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size);
+                SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), size);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size);
 
                 fifo.pop_front_n(pop_count);
 
-                BOOST_REQUIRE_EQUAL(fifo.size(), size - pop_count);
-                BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2);
-                BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size + pop_count);
+                SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), size - pop_count);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size + pop_count);
 
                 fifo.emplace_back(ctor_calls);
 
-                BOOST_REQUIRE_EQUAL(fifo.size(), size - pop_count + 1);
-                BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2 + 1);
-                BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size + pop_count);
+                SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), size - pop_count + 1);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.cons_called, size * 2 + 1);
+                SEASTAR_BOOST_REQUIRE_EQUAL(ctor_calls.dtor_called, size + pop_count);
             }
         }
     }
@@ -185,15 +185,15 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_big) {
     for (int i=0; i < static_cast<int>(N); i++) {
         fifo.push_back(i);
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), N);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
     for (int i = 0 ; i < static_cast<int>(N); i++) {
-        BOOST_REQUIRE_EQUAL(fifo.front(), i);
-        BOOST_REQUIRE_EQUAL(fifo.size(), N-i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N-i);
         fifo.pop_front();
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
 }
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_constructor) {
@@ -215,17 +215,17 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_constructor) {
     for (unsigned i = 0; i < N; i++) {
         fifo.emplace_back(i, &constructed, &destructed);
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), N);
-    BOOST_REQUIRE_EQUAL(constructed, N);
-    BOOST_REQUIRE_EQUAL(destructed, 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(constructed, N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(destructed, 0u);
     for (unsigned i = 0 ; i < N; i++) {
-        BOOST_REQUIRE_EQUAL(fifo.front().val, static_cast<int>(i));
-        BOOST_REQUIRE_EQUAL(fifo.size(), N-i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front().val, static_cast<int>(i));
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), N-i);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(destructed, i+1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(destructed, i+1);
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
     // Check that destructing a fifo also destructs the objects it still
     // contains
     constructed = destructed = 0;
@@ -233,15 +233,15 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_constructor) {
         chunked_fifo<typ> fifo;
         for (unsigned i = 0; i < N; i++) {
             fifo.emplace_back(i, &constructed, &destructed);
-            BOOST_REQUIRE_EQUAL(fifo.front().val, 0);
-            BOOST_REQUIRE_EQUAL(fifo.size(), i+1);
-            BOOST_REQUIRE_EQUAL(fifo.empty(), false);
-            BOOST_REQUIRE_EQUAL(constructed, i+1);
-            BOOST_REQUIRE_EQUAL(destructed, 0u);
+            SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front().val, 0);
+            SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), i+1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+            SEASTAR_BOOST_REQUIRE_EQUAL(constructed, i+1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(destructed, 0u);
         }
     }
-    BOOST_REQUIRE_EQUAL(constructed, N);
-    BOOST_REQUIRE_EQUAL(destructed, N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(constructed, N);
+    SEASTAR_BOOST_REQUIRE_EQUAL(destructed, N);
 }
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
@@ -259,37 +259,37 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
         }
     };
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
 
     fill(0, fifo1);
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
 
     fill(5, fifo1);
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
 
     {
         auto fifox{fifo1}; // copy ctor
 
-        BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-        BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
-        BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-        BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
     }
 
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 5);
     fifo1.clear();
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 10);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 10);
 
     fill(5, fifo1);
 
@@ -297,43 +297,43 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
         // move ctor, no element ctors are called at all
         auto fifox{std::move(fifo1)};
 
-        BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-        BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
-        BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-        BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
     }
 
     fill(5, fifo1);
 
     fifo2 = fifo1;
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
 
     fifo1.clear();
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 5);
 
     fifo2 = fifo1;
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 10);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 10);
 
     fill(5, fifo1);
 
     fifo2 = std::move(fifo1);
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 0);
 
     fill(1, fifo1);
     fill(2, fifo2);
@@ -341,10 +341,10 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy_move_test) {
 
     fifo1 = fifo2;
 
-    BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.ccons_called, 2);
-    BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
-    BOOST_REQUIRE_EQUAL(calls.dtor_called, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.cons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.ccons_called, 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.mcons_called, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(calls.dtor_called, 1);
 }
 
 BOOST_AUTO_TEST_CASE(chunked_copy_ctor) {
@@ -384,15 +384,15 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_construct_fail) {
         }
     };
     chunked_fifo<typ> fifo;
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
     try {
         fifo.emplace_back();
     } catch(my_exception) {
         // expected, ignore
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
 }
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_construct_fail2) {
@@ -410,8 +410,8 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_construct_fail2) {
         }
     };
     chunked_fifo<typ, 2> fifo;
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
     fifo.emplace_back(false);
     fifo.emplace_back(false);
     try {
@@ -419,14 +419,14 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_construct_fail2) {
     } catch(my_exception) {
         // expected, ignore
     }
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), false);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
-    BOOST_REQUIRE_EQUAL(fifo.empty(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.empty(), true);
 }
 
 BOOST_AUTO_TEST_CASE(chunked_fifo_equals_op) {
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_copy) {
     BOOST_CHECK(empty_copy.empty());
 
     auto vec123_copy = vec123;
-    BOOST_CHECK_EQUAL(vec123.size(), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(vec123.size(), 3);
     BOOST_CHECK(vec123_copy == vec123);
 }
 
@@ -467,14 +467,14 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_assignment) {
     vec = empty;
     BOOST_CHECK(vec.empty());
     vec = vec123;
-    BOOST_CHECK_EQUAL(vec.size(), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(vec.size(), 3);
     BOOST_CHECK(vec == vec123);
     vec = {};
     BOOST_CHECK(vec.empty());
 
     // move assignment
     vec = std::move(vec123);
-    BOOST_CHECK_EQUAL(vec.size(), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(vec.size(), 3);
     BOOST_CHECK(vec123.empty());
 }
 
@@ -648,13 +648,13 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_const_iterator) {
 BOOST_AUTO_TEST_CASE(chunked_fifo_no_free_chunks_retained) {
     chunked_fifo<int, 1, 0> fifo;
     fifo.push_back(42);
-    BOOST_REQUIRE_EQUAL(fifo.nfree_chunks(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.nfree_chunks(), 0);
     fifo.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo.nfree_chunks(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.nfree_chunks(), 0);
 
     chunked_fifo<int, 1, 1> fifo_1;
     fifo_1.push_back(42);
-    BOOST_REQUIRE_EQUAL(fifo_1.nfree_chunks(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo_1.nfree_chunks(), 0);
     fifo_1.pop_front();
-    BOOST_REQUIRE_EQUAL(fifo_1.nfree_chunks(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo_1.nfree_chunks(), 1);
 }

--- a/tests/unit/circular_buffer_fixed_capacity_test.cc
+++ b/tests/unit/circular_buffer_fixed_capacity_test.cc
@@ -26,6 +26,7 @@
 #include <deque>
 #include <random>
 #include <seastar/core/circular_buffer_fixed_capacity.hh>
+#include "test_comparisons.hh"
 
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/equal.hpp>
@@ -66,40 +67,40 @@ BOOST_AUTO_TEST_CASE(test_edge_cases) {
         circular_buffer_fixed_capacity<int_with_stats, 16> cb;
         BOOST_REQUIRE(cb.begin() == cb.end());
         cb.push_front(get_val(3));  // underflows indexes
-        BOOST_REQUIRE_EQUAL(cb[0], 3);
+        BOOST_REQUIRE(int(cb[0]) == 3);
         BOOST_REQUIRE(cb.begin() < cb.end());
         cb.push_back(get_val(4));
-        BOOST_REQUIRE_EQUAL(cb.size(), 2u);
-        BOOST_REQUIRE_EQUAL(cb[0], 3);
-        BOOST_REQUIRE_EQUAL(cb[1], 4);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cb.size(), 2u);
+        BOOST_REQUIRE(int(cb[0]) == 3);
+        BOOST_REQUIRE(int(cb[1]) == 4);
         cb.pop_back();
-        BOOST_REQUIRE_EQUAL(cb.back(), 3);
+        BOOST_REQUIRE(int(cb.back()) == 3);
         cb.push_front(get_val(1));
         cb.pop_back();
-        BOOST_REQUIRE_EQUAL(cb.back(), 1);
+        BOOST_REQUIRE(int(cb.back()) == 1);
 
-        BOOST_REQUIRE_EQUAL(num_deleted, 5);
-        BOOST_REQUIRE_EQUAL(num_moved, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_deleted, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_moved, 3);
 
         cb.push_front(get_val(0));
         cb.push_back(get_val(2));
-        BOOST_REQUIRE_EQUAL(cb.size(), 3);
-        BOOST_REQUIRE_EQUAL(cb[0], 0);
-        BOOST_REQUIRE_EQUAL(cb[1], 1);
-        BOOST_REQUIRE_EQUAL(cb[2], 2);
-        BOOST_REQUIRE_EQUAL(num_deleted, 7);
-        BOOST_REQUIRE_EQUAL(num_moved, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cb.size(), 3);
+        BOOST_REQUIRE(int(cb[0]) == 0);
+        BOOST_REQUIRE(int(cb[1]) == 1);
+        BOOST_REQUIRE(int(cb[2]) == 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_deleted, 7);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_moved, 5);
 
         circular_buffer_fixed_capacity<int_with_stats, 16> cb2 = std::move(cb);
-        BOOST_REQUIRE_EQUAL(cb2.size(), 3);
-        BOOST_REQUIRE_EQUAL(cb2[0], 0);
-        BOOST_REQUIRE_EQUAL(cb2[1], 1);
-        BOOST_REQUIRE_EQUAL(cb2[2], 2);
-        BOOST_REQUIRE_EQUAL(num_deleted, 7);
-        BOOST_REQUIRE_EQUAL(num_moved, 8);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cb2.size(), 3);
+        BOOST_REQUIRE(int(cb2[0]) == 0);
+        BOOST_REQUIRE(int(cb2[1]) == 1);
+        BOOST_REQUIRE(int(cb2[2]) == 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_deleted, 7);
+        SEASTAR_BOOST_REQUIRE_EQUAL(num_moved, 8);
     }
-    BOOST_REQUIRE_EQUAL(num_deleted, 13);
-    BOOST_REQUIRE_EQUAL(num_moved, 8);
+    SEASTAR_BOOST_REQUIRE_EQUAL(num_deleted, 13);
+    SEASTAR_BOOST_REQUIRE_EQUAL(num_moved, 8);
 }
 
 using deque = std::deque<int>;
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             if (!d.empty()) {
                 auto n = d.back();
                 auto m = c.back();
-                BOOST_REQUIRE_EQUAL(n, m);
+                SEASTAR_BOOST_REQUIRE_EQUAL(n, m);
                 c.pop_back();
                 d.pop_back();
             }
@@ -139,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             if (!d.empty()) {
                 auto n = d.front();
                 auto m = c.front();
-                BOOST_REQUIRE_EQUAL(n, m);
+                SEASTAR_BOOST_REQUIRE_EQUAL(n, m);
                 c.pop_front();
                 d.pop_front();
             }
@@ -154,7 +155,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
                 auto idx = u(rand);
                 auto m = c[idx];
                 auto n = c[idx];
-                BOOST_REQUIRE_EQUAL(m, n);
+                SEASTAR_BOOST_REQUIRE_EQUAL(m, n);
             }
             break;
         case 6:
@@ -168,7 +169,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
         default:
             abort();
         }
-        BOOST_REQUIRE_EQUAL(c.size(), d.size());
+        SEASTAR_BOOST_REQUIRE_EQUAL(c.size(), d.size());
         BOOST_REQUIRE(boost::equal(c, d));
     }
 }

--- a/tests/unit/circular_buffer_test.cc
+++ b/tests/unit/circular_buffer_test.cc
@@ -28,6 +28,7 @@
 #include <deque>
 #include <random>
 #include <ranges>
+#include "test_comparisons.hh"
 #if __has_include(<version>)
 #include <version>
 #endif
@@ -60,9 +61,9 @@ BOOST_AUTO_TEST_CASE(test_erasing) {
     BOOST_REQUIRE(!buf.empty());
     {
         auto i = buf.begin();
-        BOOST_REQUIRE_EQUAL(*i++, 1);
-        BOOST_REQUIRE_EQUAL(*i++, 3);
-        BOOST_REQUIRE_EQUAL(*i++, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 5);
         BOOST_REQUIRE(i == buf.end());
     }
 }
@@ -104,16 +105,16 @@ BOOST_AUTO_TEST_CASE(test_erasing_in_the_middle) {
     }
 
     auto i = buf.erase(buf.begin() + 3, buf.begin() + 6);
-    BOOST_REQUIRE_EQUAL(*i, 6);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i, 6);
 
     i = buf.begin();
-    BOOST_REQUIRE_EQUAL(*i++, 0);
-    BOOST_REQUIRE_EQUAL(*i++, 1);
-    BOOST_REQUIRE_EQUAL(*i++, 2);
-    BOOST_REQUIRE_EQUAL(*i++, 6);
-    BOOST_REQUIRE_EQUAL(*i++, 7);
-    BOOST_REQUIRE_EQUAL(*i++, 8);
-    BOOST_REQUIRE_EQUAL(*i++, 9);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 6);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 7);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 8);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i++, 9);
     BOOST_REQUIRE(i == buf.end());
 }
 

--- a/tests/unit/closeable_test.cc
+++ b/tests/unit/closeable_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <ranges>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -46,7 +47,7 @@ SEASTAR_TEST_CASE(deferred_close_test) {
         // destroying close_gate should invoke g.close()
         // and wait for all background continuations to complete
         BOOST_REQUIRE(g.is_closed());
-        BOOST_REQUIRE_EQUAL(count, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(count, expected);
     });
   });
 }
@@ -80,7 +81,7 @@ SEASTAR_TEST_CASE(close_now_test) {
 
         close_gate.close_now();
         BOOST_REQUIRE(g.is_closed());
-        BOOST_REQUIRE_EQUAL(count, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(count, expected);
         // gate must not be double-closed.
     });
   });
@@ -108,10 +109,10 @@ SEASTAR_TEST_CASE(with_closeable_test) {
         }).then([&] (int res) {
             // res should be returned by the function called
             // by with_closeable.
-            BOOST_REQUIRE_EQUAL(res, 17);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, 17);
             // closing the gate should wait for
             // all background continuations to complete
-            BOOST_REQUIRE_EQUAL(count, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(count, expected);
         });
     });
 }
@@ -128,7 +129,7 @@ SEASTAR_TEST_CASE(with_closeable_exception_test) {
         }).handle_exception_type([&] (const expected_exception&) {
             // closing the gate should also happen when func throws,
             // waiting for all background continuations to complete
-            BOOST_REQUIRE_EQUAL(count, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(count, expected);
         });
     });
 }
@@ -172,7 +173,7 @@ SEASTAR_TEST_CASE(cancel_deferred_stop_test) {
         auto stop = deferred_stop(cs);
         stop.cancel();
     }
-    BOOST_REQUIRE_EQUAL(cs.stopped(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(cs.stopped(), 0);
     return make_ready_future<>();
 }
 
@@ -182,7 +183,7 @@ SEASTAR_TEST_CASE(deferred_stop_test) {
         auto stop_counting = deferred_stop(cs);
     }).then([&] {
         // cs.stop() should be called when stop_counting is destroyed
-        BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
     });
   });
 }
@@ -194,7 +195,7 @@ SEASTAR_TEST_CASE(move_deferred_stop_test) {
     }).then([&] {
         // cs.stop() should be called once and only once
         // when stop is destroyed
-        BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
     });
   });
 }
@@ -207,10 +208,10 @@ SEASTAR_TEST_CASE(stop_now_test) {
         stop_counting.stop_now();
         // cs.stop() should not be called again
         // when stop_counting is destroyed
-        BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
     }).then([&] {
         // cs.stop() should be called exactly once
-        BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(cs.stopped(), 1);
     });
   });
 }
@@ -222,9 +223,9 @@ SEASTAR_TEST_CASE(with_stoppable_test) {
         }).then([&] (int res) {
             // res should be returned by the function called
             // by with_closeable.
-            BOOST_REQUIRE_EQUAL(res, 17);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, 17);
             // cs.stop() should be called before count_stops is destroyed
-            BOOST_REQUIRE_EQUAL(stopped, 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(stopped, 1);
         });
     });
 }
@@ -236,7 +237,7 @@ SEASTAR_TEST_CASE(with_stoppable_exception_test) {
         }).handle_exception_type([&] (const expected_exception&) {
             // cs.stop() should be called before count_stops is destroyed
             // also when func throws
-            BOOST_REQUIRE_EQUAL(stopped, 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(stopped, 1);
         });
     });
 }
@@ -247,8 +248,8 @@ SEASTAR_THREAD_TEST_CASE(move_open_gate_test) {
     // move an open gate
     gate g2 = std::move(g1);
     // the state in g1 should be moved into g2
-    BOOST_CHECK_EQUAL(g1.get_count(), 0);
-    BOOST_REQUIRE_EQUAL(g2.get_count(), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(g1.get_count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g2.get_count(), 1);
     g2.leave();
     g2.close().get();
     BOOST_CHECK(!g1.is_closed());
@@ -261,8 +262,8 @@ SEASTAR_THREAD_TEST_CASE(move_closing_gate_test) {
     auto fut = g1.close();
     // move a closing gate
     gate g2 = std::move(g1);
-    BOOST_CHECK_EQUAL(g1.get_count(), 0);
-    BOOST_REQUIRE_EQUAL(g2.get_count(), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(g1.get_count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g2.get_count(), 1);
     g2.leave();
     fut.get();
     BOOST_CHECK(!g1.is_closed());
@@ -274,8 +275,8 @@ SEASTAR_THREAD_TEST_CASE(move_closed_gate_test) {
     g1.close().get();
     // move a closed gate
     gate g2 = std::move(g1);
-    BOOST_CHECK_EQUAL(g1.get_count(), 0);
-    BOOST_CHECK_EQUAL(g2.get_count(), 0);
+    SEASTAR_BOOST_CHECK_EQUAL(g1.get_count(), 0);
+    SEASTAR_BOOST_CHECK_EQUAL(g2.get_count(), 0);
     BOOST_CHECK(!g1.is_closed());
     BOOST_CHECK(g2.is_closed());
 }
@@ -366,10 +367,10 @@ SEASTAR_TEST_CASE(gate_holder_parallel_copy_test) {
         }).then([&, expected] (int res) {
             // res should be returned by the function called
             // by with_closeable.
-            BOOST_REQUIRE_EQUAL(res, 17);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, 17);
             // closing the gate should wait for
             // all background continuations to complete
-            BOOST_REQUIRE_EQUAL(count, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(count, expected);
         });
     });
 }

--- a/tests/unit/condition_variable_test.cc
+++ b/tests/unit/condition_variable_test.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/when_any.hh>
 #include <seastar/core/with_timeout.hh>
 #include <boost/range/irange.hpp>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -46,12 +47,12 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_signal_consume) {
     cv.signal();
     auto f = cv.wait();
 
-    BOOST_REQUIRE_EQUAL(f.available(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.available(), true);
     f.get();
 
     auto f2 = cv.wait();
 
-    BOOST_REQUIRE_EQUAL(f2.available(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f2.available(), false);
 
     cv.signal();
 
@@ -62,17 +63,17 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_signal_consume) {
     waiters.emplace_back(cv.wait());
     waiters.emplace_back(cv.wait());
 
-    BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 0u);
 
     cv.signal();
 
-    BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 1u);
     // FIFO
-    BOOST_REQUIRE_EQUAL(waiters.front().available(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(waiters.front().available(), true);
 
     cv.broadcast();
 
-    BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 3u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 3u);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_condition_variable_pred) {
@@ -109,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_signal_break) {
     waiters.emplace_back(cv.wait());
     waiters.emplace_back(cv.wait());
 
-    BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::count_if(waiters.begin(), waiters.end(), std::mem_fn(&future<>::available)), 0u);
 
     cv.broken();
 
@@ -138,10 +139,10 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_timeout) {
     condition_variable cv;
 
     auto f = cv.wait(100ms);
-    BOOST_REQUIRE_EQUAL(f.available(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.available(), false);
 
     sleep(200ms).get();
-    BOOST_REQUIRE_EQUAL(f.available(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.available(), true);
 
     try {
         f.get();
@@ -212,14 +213,14 @@ SEASTAR_THREAD_TEST_CASE(test_condition_variable_pred_wait) {
 SEASTAR_THREAD_TEST_CASE(test_condition_variable_has_waiter) {
     condition_variable cv;
 
-    BOOST_REQUIRE_EQUAL(cv.has_waiters(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(cv.has_waiters(), false);
 
     auto f = cv.wait();
-    BOOST_REQUIRE_EQUAL(cv.has_waiters(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(cv.has_waiters(), true);
 
     cv.signal();
     f.get();
-    BOOST_REQUIRE_EQUAL(cv.has_waiters(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(cv.has_waiters(), false);
 }
 
 SEASTAR_TEST_CASE(test_condition_variable_signal_consume_coroutine) {
@@ -327,7 +328,7 @@ SEASTAR_TEST_CASE(test_condition_variable_when_signal) {
 
     co_await cv.when();
     // ensure we did not resume before timer ran fully
-    BOOST_REQUIRE_EQUAL(ready, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ready, true);
 }
 
 SEASTAR_TEST_CASE(test_condition_variable_when_timeout) {
@@ -357,7 +358,7 @@ SEASTAR_TEST_CASE(test_condition_variable_when_timeout) {
     }
 
     // he should not have run yet...
-    BOOST_REQUIRE_EQUAL(f.available(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.available(), false);
     // now, if the code is broken, the timer will run once we switch out,
     // and cause the wait to time out, even though it did not. -> assert
 

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -24,6 +24,8 @@
 #include <ranges>
 #include <any>
 #include <expected>
+#include <fmt/ranges.h>
+#include "test_comparisons.hh"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/coroutine.hh>
@@ -108,12 +110,12 @@ future<int> failing_coroutine2() noexcept {
 }
 
 SEASTAR_TEST_CASE(test_simple_coroutines) {
-    BOOST_REQUIRE_EQUAL(co_await old_fashioned_continuations(), 42);
-    BOOST_REQUIRE_EQUAL(co_await simple_coroutine(), 53);
-    BOOST_REQUIRE_EQUAL(ready_coroutine().get(), 64);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await old_fashioned_continuations(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await simple_coroutine(), 53);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ready_coroutine().get(), 64);
     BOOST_REQUIRE(co_await tuple_coroutine() == std::tuple(1, 2.));
     BOOST_REQUIRE_EXCEPTION((void)co_await failing_coroutine(), int, [] (auto v) { return v == 42; });
-    BOOST_CHECK_EQUAL(co_await failing_coroutine().then_wrapped([] (future<int> f) -> future<int> {
+    SEASTAR_BOOST_CHECK_EQUAL(co_await failing_coroutine().then_wrapped([] (future<int> f) -> future<int> {
         BOOST_REQUIRE(f.failed());
         try {
             std::rethrow_exception(f.get_exception());
@@ -122,7 +124,7 @@ SEASTAR_TEST_CASE(test_simple_coroutines) {
         }
     }), 42);
     BOOST_REQUIRE_EXCEPTION((void)co_await failing_coroutine2(), int, [] (auto v) { return v == 17; });
-    BOOST_CHECK_EQUAL(co_await failing_coroutine2().then_wrapped([] (future<int> f) -> future<int> {
+    SEASTAR_BOOST_CHECK_EQUAL(co_await failing_coroutine2().then_wrapped([] (future<int> f) -> future<int> {
         BOOST_REQUIRE(f.failed());
         try {
             std::rethrow_exception(f.get_exception());
@@ -146,7 +148,7 @@ SEASTAR_TEST_CASE(test_abandond_coroutine) {
         p1.set_value();
         co_await p2.get_future();
     }
-    BOOST_CHECK_EQUAL(co_await std::move(*f), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(co_await std::move(*f), 1);
 }
 
 SEASTAR_TEST_CASE(test_scheduling_group) {
@@ -184,7 +186,7 @@ SEASTAR_TEST_CASE(test_scheduling_group) {
         co_await std::move(f2);
         BOOST_REQUIRE(current_scheduling_group() == default_scheduling_group());
         p2.set_value();
-        BOOST_REQUIRE_EQUAL(co_await std::move(f_ret), 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(co_await std::move(f_ret), 42);
         BOOST_REQUIRE(current_scheduling_group() == default_scheduling_group());
     } catch (...) {
         ex = std::current_exception();
@@ -333,8 +335,8 @@ SEASTAR_TEST_CASE(test_all_simple) {
         [] { return make_ready_future<int>(1); },
         [] { return make_ready_future<int>(2); }
     );
-    BOOST_REQUIRE_EQUAL(a, 1);
-    BOOST_REQUIRE_EQUAL(b, 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(a, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(b, 2);
 }
 
 SEASTAR_TEST_CASE(test_all_permutations) {
@@ -354,12 +356,12 @@ SEASTAR_TEST_CASE(test_all_permutations) {
             make_delayed_future_returning_nr(4),
             make_delayed_future_returning_nr(5)
         );
-        BOOST_REQUIRE_EQUAL(a, 0);
-        BOOST_REQUIRE_EQUAL(b, 1);
-        BOOST_REQUIRE_EQUAL(c, 2);
-        BOOST_REQUIRE_EQUAL(d, 3);
-        BOOST_REQUIRE_EQUAL(e, 4);
-        BOOST_REQUIRE_EQUAL(f, 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(a, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(b, 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(c, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(d, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e, 4);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f, 5);
     } while (std::ranges::next_permutation(delays).found);
 }
 
@@ -405,8 +407,8 @@ SEASTAR_TEST_CASE(test_all_heterogeneous_types) {
             co_return 2L;
         }
     );
-    BOOST_REQUIRE_EQUAL(a, 1);
-    BOOST_REQUIRE_EQUAL(b, 2L);
+    SEASTAR_BOOST_REQUIRE_EQUAL(a, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(b, 2L);
 }
 
 SEASTAR_TEST_CASE(test_all_noncopyable_types) {
@@ -415,7 +417,7 @@ SEASTAR_TEST_CASE(test_all_noncopyable_types) {
             co_return std::make_unique<int>(6);
         }
     );
-    BOOST_REQUIRE_EQUAL(*a, 6);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*a, 6);
 }
 
 SEASTAR_TEST_CASE(test_all_throw_in_input_func) {
@@ -438,10 +440,10 @@ SEASTAR_TEST_CASE(test_all_throw_in_input_func) {
             }
         );
     } catch (int n) {
-        BOOST_REQUIRE_EQUAL(n, 9);
+        SEASTAR_BOOST_REQUIRE_EQUAL(n, 9);
         exception_seen = true;
     }
-    BOOST_REQUIRE_EQUAL(nr_completed, 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(nr_completed, 2);
     BOOST_REQUIRE(exception_seen);
 }
 
@@ -467,11 +469,11 @@ static future<> check_coroutine_throws(auto fun) {
     // while quitting the coroutine.
     int counter = 0;
     BOOST_REQUIRE_THROW(co_await fun(counter), Ex);
-    BOOST_REQUIRE_EQUAL(counter, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0);
     co_await fun(counter).then_wrapped([&counter] (auto f) {
         BOOST_REQUIRE(f.failed());
         BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), Ex);
-        BOOST_REQUIRE_EQUAL(counter, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0);
     });
 }
 
@@ -557,7 +559,7 @@ SEASTAR_TEST_CASE(generator)
         accum += i;
         return seastar::make_ready_future<>();
     });
-    BOOST_REQUIRE_EQUAL(accum, 45);
+    SEASTAR_BOOST_REQUIRE_EQUAL(accum, 45);
 
     // test ability of seastar::max_concurrent_for_each to deal with move-only views
     accum = 0;
@@ -565,7 +567,7 @@ SEASTAR_TEST_CASE(generator)
         accum += i;
         return seastar::make_ready_future<>();
     });
-    BOOST_REQUIRE_EQUAL(accum, 45);
+    SEASTAR_BOOST_REQUIRE_EQUAL(accum, 45);
 }
 
 #endif
@@ -577,7 +579,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each_empty) {
     co_await coroutine::parallel_for_each(values, [&] (int x) {
         ++count;
     });
-    BOOST_REQUIRE_EQUAL(count, 0); // the test will hang if it doesn't work.
+    SEASTAR_BOOST_REQUIRE_EQUAL(count, 0); // the test will hang if it doesn't work.
 }
 
 SEASTAR_TEST_CASE(test_parallel_for_each_exception) {
@@ -598,7 +600,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each_exception) {
     // An exception thrown by the functor must be propagated
     BOOST_REQUIRE_THROW(co_await std::move(f0), std::runtime_error);
     // Functor must be called on all values, even if there's an exception
-    BOOST_REQUIRE_EQUAL(count, values.size());
+    SEASTAR_BOOST_REQUIRE_EQUAL(count, values.size());
 
     count = 0;
     throw_at = dist(eng) % values.size();
@@ -611,7 +613,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each_exception) {
         }
     });
     BOOST_REQUIRE_THROW(co_await std::move(f1), std::runtime_error);
-    BOOST_REQUIRE_EQUAL(count, values.size());
+    SEASTAR_BOOST_REQUIRE_EQUAL(count, values.size());
 }
 
 SEASTAR_TEST_CASE(test_parallel_for_each) {
@@ -626,7 +628,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
     co_await coroutine::parallel_for_each(values, [&sum_of_squares] (int x) {
         sum_of_squares += x * x;
     });
-    BOOST_REQUIRE_EQUAL(sum_of_squares, expected);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum_of_squares, expected);
 
     // Test non-ready futures
     sum_of_squares = 0;
@@ -636,7 +638,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
         }
         sum_of_squares += x * x;
     });
-    BOOST_REQUIRE_EQUAL(sum_of_squares, expected);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum_of_squares, expected);
 
     // Test legacy subrange
     sum_of_squares = 0;
@@ -646,7 +648,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
         }
         sum_of_squares += x * x;
     });
-    BOOST_REQUIRE_EQUAL(sum_of_squares, 10);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum_of_squares, 10);
 
     // clang 13.0.1 doesn't support subrange
     // so provide also a Iterator/Sentinel based constructor.
@@ -660,7 +662,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
         }
         sum_of_squares += x * x;
     });
-    BOOST_REQUIRE_EQUAL(sum_of_squares, 10);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum_of_squares, 10);
 #endif
 }
 
@@ -698,7 +700,7 @@ SEASTAR_TEST_CASE(test_void_as_future_without_preemption_check) {
 
 SEASTAR_TEST_CASE(test_non_void_as_future) {
     auto f = co_await coroutine::as_future(make_ready_future<int>(42));
-    BOOST_REQUIRE_EQUAL(f.get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 42);
 
     f = co_await coroutine::as_future(make_exception_future<int>(std::runtime_error("exception")));
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
@@ -706,7 +708,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future) {
     auto p = promise<int>();
     (void)sleep(1ms).then([&] { p.set_value(314); });
     f = co_await coroutine::as_future(p.get_future());
-    BOOST_REQUIRE_EQUAL(f.get(), 314);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 314);
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);
@@ -718,7 +720,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future) {
 
 SEASTAR_TEST_CASE(test_non_void_as_future_without_preemption_check) {
     auto f = co_await coroutine::as_future_without_preemption_check(make_ready_future<int>(42));
-    BOOST_REQUIRE_EQUAL(f.get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 42);
 
     f = co_await coroutine::as_future_without_preemption_check(make_exception_future<int>(std::runtime_error("exception")));
     BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
@@ -726,7 +728,7 @@ SEASTAR_TEST_CASE(test_non_void_as_future_without_preemption_check) {
     auto p = promise<int>();
     (void)sleep(1ms).then([&] { p.set_value(314); });
     f = co_await coroutine::as_future_without_preemption_check(p.get_future());
-    BOOST_REQUIRE_EQUAL(f.get(), 314);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 314);
 
     auto gen_exception = [] () -> future<int> {
         co_await sleep(1ms);
@@ -793,7 +795,7 @@ SEASTAR_TEST_CASE(test_lambda_coroutine_in_continuation) {
         (void)boo;
         co_return std::sin(n);
     }));
-    BOOST_REQUIRE_EQUAL(sin1, sin2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sin1, sin2);
 }
 
 #ifdef __cpp_explicit_this_parameter
@@ -807,7 +809,7 @@ SEASTAR_TEST_CASE(test_lambda_value_capture_coroutine) {
     // f1 is not ready at this point (due to the yield). Verify that the capture
     // group was copied to the coroutine frame.
     auto n = co_await std::move(f1);
-    BOOST_REQUIRE_EQUAL(n, 9);
+    SEASTAR_BOOST_REQUIRE_EQUAL(n, 9);
 }
 
 SEASTAR_TEST_CASE(test_lambda_value_capture_continuation) {
@@ -816,7 +818,7 @@ SEASTAR_TEST_CASE(test_lambda_value_capture_continuation) {
         co_await yield();
         co_return *p + 2;
     }).then([] (int n) {
-        BOOST_REQUIRE_EQUAL(n, 9);
+        SEASTAR_BOOST_REQUIRE_EQUAL(n, 9);
     });
 }
 
@@ -866,7 +868,7 @@ do_run_try_future_test(F underlying_func, int& ctor_dtor_counter, bool& run_past
         counter_ref c1{ctor_dtor_counter};
         counter_ref c2{ctor_dtor_counter};
 
-        BOOST_REQUIRE_GT(ctor_dtor_counter, 0);
+        SEASTAR_BOOST_REQUIRE_GT(ctor_dtor_counter, 0);
 
         using return_future_type = std::invoke_result_t<F>;
         using return_type = typename return_future_type::value_type;
@@ -904,7 +906,7 @@ do_run_try_future_test(F underlying_func, int& ctor_dtor_counter, bool& run_past
         const auto cxx_exception_before = seastar::engine().cxx_exceptions();
         return func().then_wrapped([cxx_exception_before] (auto&& fut) {
             const auto cxx_exception_after = seastar::engine().cxx_exceptions();
-            BOOST_REQUIRE_EQUAL(cxx_exception_before, cxx_exception_after);
+            SEASTAR_BOOST_REQUIRE_EQUAL(cxx_exception_before, cxx_exception_after);
             return std::move(fut);
         });
     });
@@ -930,7 +932,7 @@ future<> run_try_future_test(F underlying_func, std::optional<std::any> expected
         } else {
             auto res = co_await do_run_try_future_test<CheckPreempt>(std::move(underlying_func), ctor_dtor_counter, run_past);
             BOOST_REQUIRE(expected_value);
-            BOOST_REQUIRE_EQUAL(res.value, std::any_cast<return_type>(*expected_value));
+            SEASTAR_BOOST_REQUIRE_EQUAL(res.value, std::any_cast<return_type>(*expected_value));
         }
     } catch (test_exception&) {
         BOOST_REQUIRE(throws);
@@ -938,8 +940,8 @@ future<> run_try_future_test(F underlying_func, std::optional<std::any> expected
         BOOST_FAIL(fmt::format("Unexpected exception {}", std::current_exception()));
     }
 
-    BOOST_REQUIRE_EQUAL(run_past, !throws);
-    BOOST_REQUIRE_EQUAL(ctor_dtor_counter, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(run_past, !throws);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ctor_dtor_counter, 0);
 }
 
 SEASTAR_TEST_CASE(test_try_future) {
@@ -965,8 +967,8 @@ future<int> co_return_tup_int_clv() {
 }
 
 SEASTAR_TEST_CASE(test_std_expected_void_specialization) {
-    BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_rv(), 42);
-    BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_clv(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_rv(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await co_return_tup_int_clv(), 42);
 }
 
 #else
@@ -1015,13 +1017,13 @@ future<std::vector<int> &> co_return_reference() {
 SEASTAR_TEST_CASE(test_co_return_conversions) {
     std::ignore = co_await i2e();
     std::ignore = co_await e2i();
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(0), (std::vector<std::string>{}));
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await co_return_vector(0), (std::vector<std::string>{}));
     // gcc 13.3 will ICE if we inline the expected values here
     std::vector<std::string> foo_x2{"foo", "foo"};
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(2), foo_x2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await co_return_vector(2), foo_x2);
     std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(3), foo_x3);
-    BOOST_REQUIRE_EQUAL(&co_await co_return_reference(), &static_vector);
+    SEASTAR_BOOST_REQUIRE_EQUAL(co_await co_return_vector(3), foo_x3);
+    BOOST_REQUIRE(&co_await co_return_reference() == &static_vector);
 }
 
 future<thrower_on_copy> co_return_thrower_on_copy() {
@@ -1042,14 +1044,14 @@ SEASTAR_TEST_CASE(test_co_return_copy_counter) {
     {
         copy_move_counter cc;
         std::ignore = co_return_copy_counter_const_lv(cc);
-        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 0);
     }
     {
         copy_move_counter cc;
         std::ignore = co_await co_return_copy_counter_const_lv(cc);
-        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
-        BOOST_CHECK_EQUAL(cc.shared->moves, copy_move_counter::co_await_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, copy_move_counter::co_await_moves);
     }
 }
 
@@ -1069,12 +1071,12 @@ SEASTAR_TEST_CASE(test_co_return_move_counter) {
         {
             move_counter mc;
             std::ignore = (*fnptr)(std::move(mc));
-            BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+            SEASTAR_BOOST_CHECK_EQUAL(mc.shared->moves, 1);
         }
         {
             move_counter mc;
             std::ignore = co_await (*fnptr)(std::move(mc));
-            BOOST_CHECK_EQUAL(mc.shared->moves, 1 + copy_move_counter::co_await_moves);
+            SEASTAR_BOOST_CHECK_EQUAL(mc.shared->moves, 1 + copy_move_counter::co_await_moves);
         }
     }
 }

--- a/tests/unit/defer_test.cc
+++ b/tests/unit/defer_test.cc
@@ -23,6 +23,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/util/defer.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -56,9 +57,9 @@ BOOST_AUTO_TEST_CASE(test_defer_runs_once_when_moved) {
         {
             auto d2 = std::move(d);
         }
-        BOOST_REQUIRE_EQUAL(1, ran);
+        SEASTAR_BOOST_REQUIRE_EQUAL(1, ran);
     }
-    BOOST_REQUIRE_EQUAL(1, ran);
+    SEASTAR_BOOST_REQUIRE_EQUAL(1, ran);
 }
 
 BOOST_AUTO_TEST_CASE(test_defer_does_not_run_when_moved_after_cancelled) {
@@ -72,5 +73,5 @@ BOOST_AUTO_TEST_CASE(test_defer_does_not_run_when_moved_after_cancelled) {
             auto d2 = std::move(d);
         }
     }
-    BOOST_REQUIRE_EQUAL(0, ran);
+    SEASTAR_BOOST_REQUIRE_EQUAL(0, ran);
 }

--- a/tests/unit/directory_test.cc
+++ b/tests/unit/directory_test.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/test_runner.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/util/std-compat.hh>
 #ifdef SEASTAR_COROUTINES_ENABLED
@@ -166,10 +167,10 @@ SEASTAR_TEST_CASE(test_generator_with_statat) {
         auto& entry = *de;
         auto sd1 = co_await f.statat(entry.name);
         auto sd2 = co_await file_stat(f, entry.name, follow_symlink::no);
-        BOOST_REQUIRE_EQUAL(sd1.st_ino, sd2.inode_number);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sd1.st_ino, sd2.inode_number);
 
         auto sd3 = co_await file_stat(entry.name, follow_symlink::no);
-        BOOST_REQUIRE_EQUAL(sd1.st_ino, sd3.inode_number);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sd1.st_ino, sd3.inode_number);
     }
     co_await f.close();
 }

--- a/tests/unit/distributed_test.cc
+++ b/tests/unit/distributed_test.cc
@@ -34,6 +34,7 @@
 #include <seastar/util/later.hh>
 #include <mutex>
 #include <ranges>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -171,7 +172,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
                 return x.map_reduce(reduce{result}, map{}).then([&result] {
                     long n = this_smp_shard_count() - 1;
                     long expected = (n * (n + 1) * (2*n + 1)) / 6;
-                    BOOST_REQUIRE_EQUAL(result, expected);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(result, expected);
                 });
             });
         });
@@ -210,7 +211,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
             return x.map_reduce0(map{}, 0L, reduce{}).then([] (long result) {
                 long n = this_smp_shard_count() - 1;
                 long expected = (n * (n + 1) * (2*n + 1)) / 6;
-                BOOST_REQUIRE_EQUAL(result, expected);
+                SEASTAR_BOOST_REQUIRE_EQUAL(result, expected);
             });
         });
     });
@@ -234,9 +235,9 @@ SEASTAR_TEST_CASE(test_map_lifetime) {
     return do_with_distributed<X>([] (sharded<X>& x) {
         return x.start().then([&x] {
             return x.map(map{}).then([] (std::vector<int> result) {
-                BOOST_REQUIRE_EQUAL(result.size(), this_smp_shard_count());
+                SEASTAR_BOOST_REQUIRE_EQUAL(result.size(), this_smp_shard_count());
                 for (size_t i = 0; i < (size_t)this_smp_shard_count(); i++) {
-                    BOOST_REQUIRE_EQUAL(result[i], i * i);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(result[i], i * i);
                 }
             });
         });
@@ -299,10 +300,10 @@ SEASTAR_TEST_CASE(test_smp_invoke_on_others) {
         }).get();
 
         for (unsigned i = 0; i < this_smp_shard_count(); i++) {
-            BOOST_REQUIRE_EQUAL(calls[i].size(), this_smp_shard_count() - 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(calls[i].size(), this_smp_shard_count() - 1);
             for (unsigned f = 0; f < this_smp_shard_count(); f++) {
                 auto r = std::find(calls[i].begin(), calls[i].end(), f);
-                BOOST_REQUIRE_EQUAL(r == calls[i].end(), i == f);
+                SEASTAR_BOOST_REQUIRE_EQUAL(r == calls[i].end(), i == f);
             }
         }
     });

--- a/tests/unit/dns_test.cc
+++ b/tests/unit/dns_test.cc
@@ -21,6 +21,7 @@
  */
 #include <vector>
 #include <algorithm>
+#include "test_comparisons.hh"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/testing/test_case.hh>
@@ -43,9 +44,9 @@ static future<> test_resolve(dns_resolver::options opts) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     for (auto hostname : {"seastar.io", "scylladb.com", "kernel.org", "www.google.com"}) {
         hostent e = co_await d.get_host_by_name(hostname, inet_address::family::INET);
-        BOOST_REQUIRE_EQUAL(e.addr_list.size(), e.addr_entries.size());
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.addr_list.size(), e.addr_entries.size());
         for (auto i = 0ul; i < e.addr_entries.size(); ++i) {
-            BOOST_REQUIRE_EQUAL(e.addr_entries[i].addr, e.addr_list[i]);
+            SEASTAR_BOOST_REQUIRE_EQUAL(e.addr_entries[i].addr, e.addr_list[i]);
             BOOST_REQUIRE(e.addr_entries[i].ttl.count() != 0);
         }
 
@@ -91,8 +92,8 @@ SEASTAR_TEST_CASE(test_resolve_numeric,
     auto d = ::make_lw_shared<dns_resolver>(engine().net(), dns_resolver::options());
     return d->get_host_by_name("127.0.0.1").then_wrapped([d](future<hostent> f) {
         auto ent = f.get();
-        BOOST_REQUIRE_EQUAL(ent.addr_entries.size(), 1);
-        BOOST_REQUIRE_EQUAL(ent.addr_entries[0].ttl.count(), std::numeric_limits<signed int>::max());
+        SEASTAR_BOOST_REQUIRE_EQUAL(ent.addr_entries.size(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(ent.addr_entries[0].ttl.count(), std::numeric_limits<signed int>::max());
     }).finally([d]{
         return d->close();
     });
@@ -177,8 +178,8 @@ static future<> test_srv() {
         BOOST_REQUIRE(!records.empty());
         for (auto& record : records) {
             // record.target should end with "gmail.com"
-            BOOST_REQUIRE_GT(record.target.size(), gmail_domain.size());
-            BOOST_REQUIRE_EQUAL(record.target.compare(record.target.size() - gmail_domain.size(),
+            SEASTAR_BOOST_REQUIRE_GT(record.target.size(), gmail_domain.size());
+            SEASTAR_BOOST_REQUIRE_EQUAL(record.target.compare(record.target.size() - gmail_domain.size(),
                                                       gmail_domain.size(),
                                                       gmail_domain),
                                 0);

--- a/tests/unit/epoll_test.cc
+++ b/tests/unit/epoll_test.cc
@@ -28,6 +28,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <sys/socket.h>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -82,5 +83,5 @@ SEASTAR_THREAD_TEST_CASE(epoll_busy_spin_on_socket_error_test) {
 
     // Expectation is that we would busy spin for 3 seconds, we check that we
     // are below 1.5 seconds to avoid any kind of flakiness.
-    BOOST_REQUIRE_LT(busy_ms, 1500);
+    SEASTAR_BOOST_REQUIRE_LT(busy_ms, 1500);
 }

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -27,6 +27,7 @@
 #include <seastar/util/log.hh>
 #include <seastar/util/backtrace.hh>
 #include <ostream>
+#include "test_comparisons.hh"
 #include <regex>
 
 
@@ -126,7 +127,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging1) {
             } catch(...) {
                 log_msg << std::current_exception();
             }
-            BOOST_REQUIRE_EQUAL(log_msg.str(), exception_generator_str(inst, level));
+            SEASTAR_BOOST_REQUIRE_EQUAL(log_msg.str(), exception_generator_str(inst, level));
         }
     }
 }
@@ -140,7 +141,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging2) {
         log_msg << std::current_exception();
     }
 
-    BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("std::nested_exception: <no exception>"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("std::nested_exception: <no exception>"));
 }
 
 class very_important_exception : public std::exception {
@@ -173,7 +174,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging3) {
 
     std::string expected_string("std::_Nested_exception<unknown_obj>: std::_Nested_exception<std::system_error> (error generic:1, my error: Operation not permitted): very_important_exception (very important information)");
 
-    BOOST_REQUIRE_EQUAL(log_msg.str(), expected_string);
+    SEASTAR_BOOST_REQUIRE_EQUAL(log_msg.str(), expected_string);
 }
 
 BOOST_AUTO_TEST_CASE(unknown_object_thrown_test) {
@@ -184,7 +185,7 @@ BOOST_AUTO_TEST_CASE(unknown_object_thrown_test) {
         log_msg << std::current_exception();
     }
 
-    BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("unknown_obj"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("unknown_obj"));
 
 }
 
@@ -208,9 +209,9 @@ BOOST_AUTO_TEST_CASE(format_error_test) {
 #endif
 
     BOOST_TEST_MESSAGE(log_msg.str());
-    BOOST_REQUIRE_NE(log_msg.str().find(__builtin_FILE()), std::string::npos);
-    BOOST_REQUIRE_NE(log_msg.str().find(__builtin_FUNCTION()), std::string::npos);
-    BOOST_REQUIRE_NE(log_msg.str().find(fmt), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(log_msg.str().find(__builtin_FILE()), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(log_msg.str().find(__builtin_FUNCTION()), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(log_msg.str().find(fmt), std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {

--- a/tests/unit/execution_stage_test.cc
+++ b/tests/unit/execution_stage_test.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <vector>
 #include <chrono>
+#include "test_comparisons.hh"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/random.hh>
@@ -40,8 +41,8 @@ SEASTAR_TEST_CASE(test_create_stage_from_lvalue_function_object) {
     return seastar::async([] {
         auto dont_move = [obj = make_shared<int>(53)] { return *obj; };
         auto stage = seastar::make_execution_stage("test", dont_move);
-        BOOST_REQUIRE_EQUAL(stage().get(), 53);
-        BOOST_REQUIRE_EQUAL(dont_move(), 53);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage().get(), 53);
+        SEASTAR_BOOST_REQUIRE_EQUAL(dont_move(), 53);
     });
 }
 
@@ -49,7 +50,7 @@ SEASTAR_TEST_CASE(test_create_stage_from_rvalue_function_object) {
     return seastar::async([] {
         auto dont_copy = [obj = std::make_unique<int>(42)] { return *obj; };
         auto stage = seastar::make_execution_stage("test", std::move(dont_copy));
-        BOOST_REQUIRE_EQUAL(stage().get(), 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage().get(), 42);
     });
 }
 
@@ -60,7 +61,7 @@ int func() {
 SEASTAR_TEST_CASE(test_create_stage_from_function) {
     return seastar::async([] {
         auto stage = seastar::make_execution_stage("test", func);
-        BOOST_REQUIRE_EQUAL(stage().get(), 64);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage().get(), 64);
     });
 }
 
@@ -93,7 +94,7 @@ SEASTAR_TEST_CASE(test_simple_stage_returning_int) {
             }
         }, [] (int original, future<int> result) {
             if (original % 2) {
-                BOOST_REQUIRE_EQUAL(original * 2, result.get());
+                SEASTAR_BOOST_REQUIRE_EQUAL(original * 2, result.get());
             } else {
                 BOOST_REQUIRE_EXCEPTION(result.get(), int, [&] (int v) { return original == v; });
             }
@@ -111,7 +112,7 @@ SEASTAR_TEST_CASE(test_simple_stage_returning_future_int) {
             }
         }, [] (int original, future<int> result) {
             if (original % 2) {
-                BOOST_REQUIRE_EQUAL(original * 2, result.get());
+                SEASTAR_BOOST_REQUIRE_EQUAL(original * 2, result.get());
             } else {
                 BOOST_REQUIRE_EXCEPTION(result.get(), int, [&] (int v) { return original == v; });
             }
@@ -171,7 +172,7 @@ SEASTAR_TEST_CASE(test_rref_decays_to_value) {
         }
 
         for (size_t i = 0; i < 100; i++) {
-            BOOST_REQUIRE_EQUAL(fs[i].get(), i);
+            SEASTAR_BOOST_REQUIRE_EQUAL(fs[i].get(), i);
         }
     });
 }
@@ -192,7 +193,7 @@ SEASTAR_TEST_CASE(test_lref_does_not_decay) {
         for (auto&& f : fs) {
             f.get();
         }
-        BOOST_REQUIRE_EQUAL(value, 100);
+        SEASTAR_BOOST_REQUIRE_EQUAL(value, 100);
     });
 }
 
@@ -212,7 +213,7 @@ SEASTAR_TEST_CASE(test_explicit_reference_wrapper_is_not_unwrapped) {
         for (auto&& f : fs) {
             f.get();
         }
-        BOOST_REQUIRE_EQUAL(value, 100);
+        SEASTAR_BOOST_REQUIRE_EQUAL(value, 100);
     });
 }
 
@@ -234,9 +235,9 @@ SEASTAR_TEST_CASE(test_function_is_class_member) {
         }
 
         for (auto i = 0; i < 100; i++) {
-            BOOST_REQUIRE_EQUAL(fs[i].get(), i - 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(fs[i].get(), i - 1);
         }
-        BOOST_REQUIRE_EQUAL(object.value, 99);
+        SEASTAR_BOOST_REQUIRE_EQUAL(object.value, 99);
     });
 }
 
@@ -251,7 +252,7 @@ SEASTAR_TEST_CASE(test_function_is_const_class_member) {
         auto stage = seastar::make_execution_stage("test", &foo::member);
 
         const foo object;
-        BOOST_REQUIRE_EQUAL(stage(&object).get(), 999);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage(&object).get(), 999);
     });
 }
 
@@ -259,8 +260,8 @@ SEASTAR_TEST_CASE(test_stage_stats) {
     return seastar::async([] {
         auto stage = seastar::make_execution_stage("test", [] { });
 
-        BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_enqueued, 0u);
-        BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_executed, 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_enqueued, 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_executed, 0u);
 
         auto fs = std::vector<future<>>();
         static constexpr auto call_count = 53u;
@@ -268,14 +269,14 @@ SEASTAR_TEST_CASE(test_stage_stats) {
             fs.emplace_back(stage());
         }
 
-        BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_enqueued, call_count);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_enqueued, call_count);
 
         for (auto i = 0u; i < call_count; i++) {
             fs[i].get();
-            BOOST_REQUIRE_GE(stage.get_stats().tasks_scheduled, 1u);
-            BOOST_REQUIRE_GE(stage.get_stats().function_calls_executed, i);
+            SEASTAR_BOOST_REQUIRE_GE(stage.get_stats().tasks_scheduled, 1u);
+            SEASTAR_BOOST_REQUIRE_GE(stage.get_stats().function_calls_executed, i);
         }
-        BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_executed, call_count);
+        SEASTAR_BOOST_REQUIRE_EQUAL(stage.get_stats().function_calls_executed, call_count);
     });
 }
 
@@ -328,7 +329,7 @@ SEASTAR_THREAD_TEST_CASE(test_inheriting_concrete_execution_stage_reference_para
     // mostly a compile test, but take the opportunity to test that passing
     // by reference preserves the address
     auto check_ref = [] (a_struct& ref, a_struct* ptr) {
-        BOOST_REQUIRE_EQUAL(&ref, ptr);
+        SEASTAR_BOOST_REQUIRE_EQUAL(&ref, ptr);
     };
     auto es = seastar::inheriting_concrete_execution_stage<void, a_struct&, a_struct*>("stage", check_ref);
     a_struct obj;
@@ -338,9 +339,9 @@ SEASTAR_THREAD_TEST_CASE(test_inheriting_concrete_execution_stage_reference_para
 SEASTAR_THREAD_TEST_CASE(test_execution_stage_rename) {
     auto do_nothing = []{};
     auto stage = seastar::make_execution_stage("test", do_nothing);
-    BOOST_REQUIRE_EQUAL(stage.name(), "test");
+    SEASTAR_BOOST_REQUIRE_EQUAL(stage.name(), "test");
 
     // Default behaviour - should not change the name
     stage.update_name_and_metric_group();
-    BOOST_REQUIRE_EQUAL(stage.name(), "test");
+    SEASTAR_BOOST_REQUIRE_EQUAL(stage.name(), "test");
 }

--- a/tests/unit/expiring_fifo_test.cc
+++ b/tests/unit/expiring_fifo_test.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/expiring_fifo.hh>
 #include <seastar/util/later.hh>
 #include <boost/range/irange.hpp>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -34,42 +35,42 @@ SEASTAR_TEST_CASE(test_no_expiry_operations) {
     expiring_fifo<int> fifo;
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
 
     fifo.push_back(1);
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     fifo.push_back(2);
     fifo.push_back(3);
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 3u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 3u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 2);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(!fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
     BOOST_REQUIRE(bool(fifo));
-    BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
 
     fifo.pop_front();
 
     BOOST_REQUIRE(fifo.empty());
-    BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     BOOST_REQUIRE(!bool(fifo));
 
     return make_ready_future<>();
@@ -88,18 +89,18 @@ SEASTAR_TEST_CASE(test_expiry_operations) {
         fifo.push_back(1, manual_clock::now() + 1s);
 
         BOOST_REQUIRE(!fifo.empty());
-        BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
         BOOST_REQUIRE(bool(fifo));
-        BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
 
         manual_clock::advance(1s);
         yield().get();
 
         BOOST_REQUIRE(fifo.empty());
-        BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
         BOOST_REQUIRE(!bool(fifo));
-        BOOST_REQUIRE_EQUAL(expired.size(), 1u);
-        BOOST_REQUIRE_EQUAL(expired[0], 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 1);
 
         expired.clear();
 
@@ -111,16 +112,16 @@ SEASTAR_TEST_CASE(test_expiry_operations) {
         yield().get();
 
         BOOST_REQUIRE(!fifo.empty());
-        BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
         BOOST_REQUIRE(bool(fifo));
-        BOOST_REQUIRE_EQUAL(expired.size(), 1u);
-        BOOST_REQUIRE_EQUAL(expired[0], 2);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
         expired.clear();
 
@@ -133,18 +134,18 @@ SEASTAR_TEST_CASE(test_expiry_operations) {
         yield().get();
 
         BOOST_REQUIRE(!fifo.empty());
-        BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
         BOOST_REQUIRE(bool(fifo));
-        BOOST_REQUIRE_EQUAL(expired.size(), 2u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 2u);
         std::sort(expired.begin(), expired.end());
-        BOOST_REQUIRE_EQUAL(expired[0], 1);
-        BOOST_REQUIRE_EQUAL(expired[1], 2);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[1], 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 3);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 4);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 4);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
         expired.clear();
 
@@ -157,16 +158,16 @@ SEASTAR_TEST_CASE(test_expiry_operations) {
         yield().get();
 
         BOOST_REQUIRE(!fifo.empty());
-        BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
         BOOST_REQUIRE(bool(fifo));
-        BOOST_REQUIRE_EQUAL(expired.size(), 3u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired.size(), 3u);
         std::sort(expired.begin(), expired.end());
-        BOOST_REQUIRE_EQUAL(expired[0], 2);
-        BOOST_REQUIRE_EQUAL(expired[1], 3);
-        BOOST_REQUIRE_EQUAL(expired[2], 4);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[0], 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[1], 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expired[2], 4);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
 
         expired.clear();
 
@@ -179,12 +180,12 @@ SEASTAR_TEST_CASE(test_expiry_operations) {
         manual_clock::advance(1s);
         yield().get();
 
-        BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 2u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 1);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
-        BOOST_REQUIRE_EQUAL(fifo.front(), 5);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 1u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.front(), 5);
         fifo.pop_front();
-        BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fifo.size(), 0u);
     });
 }

--- a/tests/unit/fair_queue_test.cc
+++ b/tests/unit/fair_queue_test.cc
@@ -34,6 +34,7 @@
 #include <seastar/core/print.hh>
 #include <boost/range/irange.hpp>
 #include <chrono>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -173,9 +174,9 @@ public:
         for (auto i = 0ul; i < ratios.size(); ++i) {
             int min_expected = ratios[i] * (_results[0] - expected_error);
             int max_expected = ratios[i] * (_results[0] + expected_error);
-            BOOST_CHECK_GE(_results[i], min_expected);
-            BOOST_CHECK_LE(_results[i], max_expected);
-            BOOST_CHECK_EQUAL(_exceptions[i].size(), 0);
+            SEASTAR_BOOST_CHECK_GE(_results[i], min_expected);
+            SEASTAR_BOOST_CHECK_LE(_results[i], max_expected);
+            SEASTAR_BOOST_CHECK_EQUAL(_exceptions[i].size(), 0);
         }
     }
 
@@ -196,7 +197,7 @@ public:
         average_result /= adjusted_results.size();
         for (auto ar : adjusted_results) {
             auto dev = std::abs(ar - average_result) / average_result;
-            BOOST_CHECK_LE(dev, error);
+            SEASTAR_BOOST_CHECK_LE(dev, error);
         }
     }
 
@@ -208,7 +209,7 @@ public:
         }
         std::cout << str <<std::endl;
         for (unsigned i = 0; i < _results.size(); i++) {
-            BOOST_CHECK_EQUAL(_results[i], values[i]);
+            SEASTAR_BOOST_CHECK_EQUAL(_results[i], values[i]);
         }
     }
 };
@@ -615,9 +616,9 @@ SEASTAR_THREAD_TEST_CASE(test_fair_queue_nested_wakeups) {
             }
 
             auto res = env.tick(targets.size());
-            BOOST_REQUIRE_EQUAL(res, targets.size());
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, targets.size());
             res = env.tick(1);
-            BOOST_REQUIRE_EQUAL(res, 0);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, 0);
         } while (next());
     }
 }

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <filesystem>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
@@ -138,8 +139,8 @@ SEASTAR_TEST_CASE(file_ro_dup_test) {
         co_await smp::submit_to(1, [fi = std::move(fi)] () mutable -> future<> {
             auto f = std::move(fi.handle).to_file();
             auto st = co_await f.stat();
-            BOOST_REQUIRE_EQUAL(st.st_dev, fi.st.st_dev);
-            BOOST_REQUIRE_EQUAL(st.st_ino, fi.st.st_ino);
+            SEASTAR_BOOST_REQUIRE_EQUAL(st.st_dev, fi.st.st_dev);
+            SEASTAR_BOOST_REQUIRE_EQUAL(st.st_ino, fi.st.st_ino);
         });
     });
 }
@@ -159,19 +160,19 @@ SEASTAR_TEST_CASE(file_mmap_test) {
         auto f = co_await open_file_dma(filename, open_flags::rw | open_flags::create);
         co_await f.truncate(4096);
         auto map = co_await f.mmap(4096, mmap_prot::read | mmap_prot::write, mmap_private::no, 0);
-        BOOST_CHECK_EQUAL(map.size(), 4096);
+        SEASTAR_BOOST_CHECK_EQUAL(map.size(), 4096);
         // Write null-terminated string to the map.
         std::string_view str = "Hello, mmap!";
         std::memcpy(map.get(), str.data(), str.size() + 1);
         std::string_view map_str{reinterpret_cast<const char*>(map.get()), str.size()};
-        BOOST_CHECK_EQUAL(map_str, str);
+        SEASTAR_BOOST_CHECK_EQUAL(map_str, str);
         co_await map.flush();
         co_await map.unmap();
         // Read the string back through the file, using dma_read.
         auto buf = allocate_aligned_buffer<char>(4096, 4096);
         co_await f.dma_read(0, buf.get(), 4096);
         std::string_view buf_str{buf.get(), str.size()};
-        BOOST_CHECK_EQUAL(buf_str, str);
+        SEASTAR_BOOST_CHECK_EQUAL(buf_str, str);
         co_await f.close();
     });
 }
@@ -344,8 +345,8 @@ SEASTAR_THREAD_TEST_CASE(test_sanitize_iovecs) {
         auto original_iovecs = std::vector<iovec> { { buf.get_write(), buf.size() } };
         auto actual_iovecs = original_iovecs;
         auto actual_length = internal::sanitize_iovecs(actual_iovecs, 4096);
-        BOOST_CHECK_EQUAL(actual_length, 4096);
-        BOOST_CHECK_EQUAL(actual_iovecs.size(), 1);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_length, 4096);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_iovecs.size(), 1);
         BOOST_CHECK(iovec_equal(original_iovecs.back(), actual_iovecs.back()));
     }
 
@@ -356,8 +357,8 @@ SEASTAR_THREAD_TEST_CASE(test_sanitize_iovecs) {
         }
         auto actual_iovecs = original_iovecs;
         auto actual_length = internal::sanitize_iovecs(actual_iovecs, 4096);
-        BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
-        BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX - 1);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX - 1);
 
         original_iovecs.resize(IOV_MAX - 1);
         BOOST_CHECK(std::equal(original_iovecs.begin(), original_iovecs.end(),
@@ -371,8 +372,8 @@ SEASTAR_THREAD_TEST_CASE(test_sanitize_iovecs) {
         }
         auto actual_iovecs = original_iovecs;
         auto actual_length = internal::sanitize_iovecs(actual_iovecs, 4096);
-        BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
-        BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX);
 
         original_iovecs.resize(IOV_MAX);
         original_iovecs.back().iov_len = 512;
@@ -387,8 +388,8 @@ SEASTAR_THREAD_TEST_CASE(test_sanitize_iovecs) {
         }
         auto actual_iovecs = original_iovecs;
         auto actual_length = internal::sanitize_iovecs(actual_iovecs, 4096);
-        BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
-        BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_length, 512 * IOV_MAX);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_iovecs.size(), IOV_MAX);
 
         original_iovecs.resize(IOV_MAX);
         BOOST_CHECK(std::equal(original_iovecs.begin(), original_iovecs.end(),
@@ -410,7 +411,7 @@ SEASTAR_TEST_CASE(test_chmod) {
     auto f = open_file_dma(filename, oflags).get();
     f.close().get();
     auto sd = file_stat(filename).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
 
     // test chmod with new_permissions
     auto new_permissions = file_permissions::user_read | file_permissions::group_read | file_permissions::others_read;
@@ -418,7 +419,7 @@ SEASTAR_TEST_CASE(test_chmod) {
     BOOST_REQUIRE(file_exists(filename).get());
     chmod(filename, new_permissions).get();
     sd = file_stat(filename).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(new_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(new_permissions));
     remove_file(filename).get();
 
     umask(orig_umask);
@@ -439,7 +440,7 @@ SEASTAR_TEST_CASE(test_open_file_dma_permissions) {
     auto f = open_file_dma(filename, oflags).get();
     f.close().get();
     auto sd = file_stat(filename).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
     remove_file(filename).get();
 
     // test options.create_permissions
@@ -449,7 +450,7 @@ SEASTAR_TEST_CASE(test_open_file_dma_permissions) {
     f = open_file_dma(filename, oflags, options).get();
     f.close().get();
     sd = file_stat(filename).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(options.create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(options.create_permissions));
     remove_file(filename).get();
 
     umask(orig_umask);
@@ -464,7 +465,7 @@ SEASTAR_TEST_CASE(test_make_directory_permissions) {
     // test default_dir_permissions with make_directory
     make_directory(dirname).get();
     auto sd = file_stat(dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     remove_file(dirname).get();
 
     // test make_directory
@@ -472,7 +473,7 @@ SEASTAR_TEST_CASE(test_make_directory_permissions) {
     BOOST_REQUIRE(create_permissions != file_permissions::default_dir_permissions);
     make_directory(dirname, create_permissions).get();
     sd = file_stat(dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
     remove_file(dirname).get();
 
     umask(orig_umask);
@@ -487,7 +488,7 @@ SEASTAR_TEST_CASE(test_touch_directory_permissions) {
     // test default_dir_permissions with touch_directory
     touch_directory(dirname).get();
     auto sd = file_stat(dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     remove_file(dirname).get();
 
     // test touch_directory, dir creation
@@ -496,13 +497,13 @@ SEASTAR_TEST_CASE(test_touch_directory_permissions) {
     BOOST_REQUIRE(!file_exists(dirname).get());
     touch_directory(dirname, create_permissions).get();
     sd = file_stat(dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
 
     // test touch_directory of existing dir, dir mode need not change
     BOOST_REQUIRE(file_exists(dirname).get());
     touch_directory(dirname, file_permissions::default_dir_permissions).get();
     sd = file_stat(dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
     remove_file(dirname).get();
 
     umask(orig_umask);
@@ -525,9 +526,9 @@ SEASTAR_TEST_CASE(test_recursive_touch_directory_permissions) {
     // test default_dir_permissions with recursive_touch_directory
     recursive_touch_directory(dirpath).get();
     auto sd = file_stat(base_dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     sd = file_stat(dirpath).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     remove_file(dirpath).get();
 
     // test recursive_touch_directory, dir creation
@@ -537,17 +538,17 @@ SEASTAR_TEST_CASE(test_recursive_touch_directory_permissions) {
     BOOST_REQUIRE(!file_exists(dirpath).get());
     recursive_touch_directory(dirpath, create_permissions).get();
     sd = file_stat(base_dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     sd = file_stat(dirpath).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
 
     // test recursive_touch_directory of existing dir, dir mode need not change
     BOOST_REQUIRE(file_exists(dirpath).get());
     recursive_touch_directory(dirpath, file_permissions::default_dir_permissions).get();
     sd = file_stat(base_dirname).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_dir_permissions));
     sd = file_stat(dirpath).get();
-    BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(sd.mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(create_permissions));
     remove_file(dirpath).get();
     remove_file(base_dirname).get();
 
@@ -565,7 +566,7 @@ SEASTAR_TEST_CASE(test_file_stat_method) {
     auto f = open_file_dma(filename, oflags).get();
     auto close_f = deferred_close(f);
     auto st = f.stat().get();
-    BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
+    SEASTAR_BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
 
     umask(orig_umask);
   });
@@ -586,7 +587,7 @@ SEASTAR_TEST_CASE(test_dir_statat_method) {
         auto buf = temporary_buffer<char>::aligned(f.memory_dma_alignment(), buffer_size);
         memset(buf.get_write(), 0, buf.size());
         auto written = f.dma_write(0, buf.get(), buf.size()).get();
-        BOOST_REQUIRE_EQUAL(written, buffer_size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(written, buffer_size);
         close_f.close_now();
 
         // Open dir and get the file stat using statat
@@ -594,18 +595,18 @@ SEASTAR_TEST_CASE(test_dir_statat_method) {
         auto close_dir = deferred_close(dir);
 
         auto file_st = dir.statat(filename).get();
-        BOOST_REQUIRE_EQUAL(file_st.st_size, buffer_size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(file_st.st_size, buffer_size);
 
         const char* linkname = "test_link.tmp";
         auto rc = ::symlink((path / filename).c_str(), (path / linkname).c_str());
-        BOOST_REQUIRE_EQUAL(rc, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(rc, 0);
 
         auto link_st = dir.statat(linkname, AT_SYMLINK_NOFOLLOW).get();
-        BOOST_REQUIRE_NE(link_st.st_ino, file_st.st_ino);
+        SEASTAR_BOOST_REQUIRE_NE(link_st.st_ino, file_st.st_ino);
 
         // Default flags are expected to follow symlinks
         auto st = dir.statat(linkname).get();
-        BOOST_REQUIRE_EQUAL(st.st_ino, file_st.st_ino);
+        SEASTAR_BOOST_REQUIRE_EQUAL(st.st_ino, file_st.st_ino);
 
         // Test non-existing file resolving into exception
         BOOST_REQUIRE_EXCEPTION(dir.statat("no-such-file").get(), std::system_error, [] (auto& ex) {
@@ -640,7 +641,7 @@ SEASTAR_TEST_CASE(test_file_write_lifetime_method) {
             // Set and verify the lifetime hint of the inode
             f1.set_inode_lifetime_hint(hint).get();
             auto o_hint1 = f1.get_inode_lifetime_hint().get();
-            BOOST_CHECK_EQUAL(hint, o_hint1);
+            SEASTAR_BOOST_CHECK_EQUAL(hint, o_hint1);
         }
 
         // Perform invalid ops
@@ -661,11 +662,11 @@ SEASTAR_TEST_CASE(test_file_fcntl) {
         auto lease = F_WRLCK;
         BOOST_REQUIRE(!f.fcntl(F_SETLEASE, lease).get());
         auto o_lease = f.fcntl(F_GETLEASE).get();
-        BOOST_CHECK_EQUAL(lease, o_lease);
+        SEASTAR_BOOST_CHECK_EQUAL(lease, o_lease);
 
         // Use _short version and test the same
         o_lease = f.fcntl_short(F_GETLEASE).get();
-        BOOST_CHECK_EQUAL(lease, o_lease);
+        SEASTAR_BOOST_CHECK_EQUAL(lease, o_lease);
 
         // Perform invalid ops
         BOOST_REQUIRE_THROW(f.fcntl(F_SETLEASE, (uintptr_t)~0ul).get(), std::system_error);
@@ -693,7 +694,7 @@ SEASTAR_TEST_CASE(test_file_ioctl) {
             BOOST_REQUIRE(block_size != 0);
         } catch (std::system_error& e) {
             // anon_bdev filesystems do not support FIGETBSZ, and return EINVAL
-            BOOST_REQUIRE_EQUAL(e.code().value(), EINVAL);
+            SEASTAR_BOOST_REQUIRE_EQUAL(e.code().value(), EINVAL);
         }
 
         // Perform invalid ops
@@ -759,9 +760,9 @@ SEASTAR_TEST_CASE(test_underlying_file) {
         auto f = open_file_dma(filename, oflags).get();
         auto close_f = deferred_close(f);
         auto lf = file(make_shared<test_layered_file>(f));
-        BOOST_CHECK_EQUAL(f.memory_dma_alignment(), lf.memory_dma_alignment());
-        BOOST_CHECK_EQUAL(f.disk_read_dma_alignment(), lf.disk_read_dma_alignment());
-        BOOST_CHECK_EQUAL(f.disk_write_dma_alignment(), lf.disk_write_dma_alignment());
+        SEASTAR_BOOST_CHECK_EQUAL(f.memory_dma_alignment(), lf.memory_dma_alignment());
+        SEASTAR_BOOST_CHECK_EQUAL(f.disk_read_dma_alignment(), lf.disk_read_dma_alignment());
+        SEASTAR_BOOST_CHECK_EQUAL(f.disk_write_dma_alignment(), lf.disk_write_dma_alignment());
     });
 }
 
@@ -778,7 +779,7 @@ SEASTAR_TEST_CASE(test_file_stat_method_with_file) {
             ref = f;
             return f.stat();
         }).get();
-        BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
+        SEASTAR_BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
 
         // verify that the file was auto-closed
         BOOST_REQUIRE_THROW(ref.stat().get(), std::system_error);
@@ -831,7 +832,7 @@ SEASTAR_TEST_CASE(test_with_file_close_on_failure) {
         }).get();
         auto st = ref.stat().get();
         ref.close().get();
-        BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
+        SEASTAR_BOOST_CHECK_EQUAL(st.st_mode & static_cast<mode_t>(file_permissions::all_permissions), static_cast<mode_t>(file_permissions::default_file_permissions));
 
         // close-on-error case
         BOOST_REQUIRE_THROW(with_file_close_on_failure(open_file_dma(filename, oflags), [&ref] (file& f) {
@@ -942,7 +943,7 @@ SEASTAR_TEST_CASE(test_dma_iovec) {
         auto f = open_file_dma(filename, open_flags::rw | open_flags::create).get();
         iovecs.push_back(iovec{ wbuf.get(), alignment });
         auto count = f.dma_write(0, iovecs).get();
-        BOOST_REQUIRE_EQUAL(count, alignment);
+        SEASTAR_BOOST_REQUIRE_EQUAL(count, alignment);
         f.truncate(size).get();
         f.close().get();
 
@@ -954,7 +955,7 @@ SEASTAR_TEST_CASE(test_dma_iovec) {
         iovecs.clear();
         iovecs.push_back(iovec{ rbuf.get(), alignment });
         count = f.dma_read(0, iovecs).get();
-        BOOST_REQUIRE_EQUAL(count, size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(count, size);
 
         BOOST_REQUIRE(std::equal(wbuf.get(), wbuf.get() + alignment, rbuf.get(), rbuf.get() + alignment));
 
@@ -964,7 +965,7 @@ SEASTAR_TEST_CASE(test_dma_iovec) {
         iovecs.clear();
         iovecs.push_back(iovec{ rbuf.get(), alignment });
         count = f.dma_read(0, iovecs).get();
-        BOOST_REQUIRE_EQUAL(count, size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(count, size);
 
         BOOST_REQUIRE(std::equal(wbuf.get(), wbuf.get() + alignment, rbuf.get(), rbuf.get() + alignment));
     });
@@ -1070,10 +1071,10 @@ SEASTAR_TEST_CASE(test_file_system_space) {
         auto st = engine().statvfs(name).get();
         auto si = file_system_space(name).get();
 
-        BOOST_REQUIRE_EQUAL(st.f_blocks * st.f_frsize, si.capacity);
-        BOOST_REQUIRE_LE(si.free, si.capacity);
-        BOOST_REQUIRE_LE(si.available, si.capacity);
-        BOOST_REQUIRE_LE(si.available, si.free);
+        SEASTAR_BOOST_REQUIRE_EQUAL(st.f_blocks * st.f_frsize, si.capacity);
+        SEASTAR_BOOST_REQUIRE_LE(si.free, si.capacity);
+        SEASTAR_BOOST_REQUIRE_LE(si.available, si.capacity);
+        SEASTAR_BOOST_REQUIRE_LE(si.available, si.free);
     });
 }
 
@@ -1115,7 +1116,7 @@ public:
     future<> flush() {
         return _file->enqueue(opcode::flush, 0, 0, [this] {
             if (_fsync_is_exclusive) {
-                BOOST_CHECK_EQUAL(_writes, 0);
+                SEASTAR_BOOST_CHECK_EQUAL(_writes, 0);
             }
             _queue.emplace_back(_flushes);
             return _queue.back().complete.get_future();
@@ -1129,10 +1130,10 @@ public:
             uint64_t fsize = _fd.size();
             if (pos + _block_size > fsize) {
                 _appends++;
-                BOOST_CHECK_LE(_appends, _max_appends);
+                SEASTAR_BOOST_CHECK_LE(_appends, _max_appends);
             }
             if (_fsync_is_exclusive) {
-                BOOST_CHECK_EQUAL(_flushes, 0);
+                SEASTAR_BOOST_CHECK_EQUAL(_flushes, 0);
             }
             _queue.emplace_back(_writes, pos);
             return _queue.back().complete.get_future();
@@ -1152,7 +1153,7 @@ public:
     }
 
     future<> close() {
-        BOOST_CHECK_EQUAL(_appends, _max_appends);
+        SEASTAR_BOOST_CHECK_EQUAL(_appends, _max_appends);
         return _file->close();
     }
 };
@@ -1261,13 +1262,13 @@ SEASTAR_THREAD_TEST_CASE(test_posix_file_dma_read_bulk) {
         fmt::print(" read returned {} bytes\n", buf.size());
         if (offset >= data.size()) {
             // read past EOF --> empty buffer
-            BOOST_REQUIRE_EQUAL(buf.size(), 0);
+            SEASTAR_BOOST_REQUIRE_EQUAL(buf.size(), 0);
         } else {
             size_t avail = std::min(data.size() - offset, length);
             // must have read at least what's available
-            BOOST_REQUIRE_GE(buf.size(), avail);
+            SEASTAR_BOOST_REQUIRE_GE(buf.size(), avail);
             // no read past EOF
-            BOOST_REQUIRE_LE(offset + buf.size(), data.size());
+            SEASTAR_BOOST_REQUIRE_LE(offset + buf.size(), data.size());
             BOOST_REQUIRE(std::memcmp(buf.get(), data.get() + offset, buf.size()) == 0);
         }
     };

--- a/tests/unit/file_utils_test.cc
+++ b/tests/unit/file_utils_test.cc
@@ -22,6 +22,7 @@
 
 #include <stdlib.h>
 #include <random>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
@@ -73,7 +74,7 @@ SEASTAR_THREAD_TEST_CASE(test_tmp_file) {
             });
         });
     }).get();
-    BOOST_REQUIRE_EQUAL(expected , actual);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expected , actual);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_non_existing_TMPDIR) {
@@ -182,7 +183,7 @@ SEASTAR_THREAD_TEST_CASE(test_tmp_dir) {
             });
         });
     }).get();
-    BOOST_REQUIRE_EQUAL(expected , actual);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expected , actual);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_tmp_dir_with_path) {
@@ -201,7 +202,7 @@ SEASTAR_THREAD_TEST_CASE(test_tmp_dir_with_path) {
             });
         });
     }).get();
-    BOOST_REQUIRE_EQUAL(expected , actual);
+    SEASTAR_BOOST_REQUIRE_EQUAL(expected , actual);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_tmp_dir_with_non_existing_path) {
@@ -216,7 +217,7 @@ SEASTAR_TEST_CASE(tmp_dir_with_thread_test) {
         auto buf = get_init_buffer(f);
         auto expected = buf.size();
         auto actual = f.dma_write(0, buf.get(), buf.size()).get();
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expected, actual);
         tf.close().get();
         tf.remove().get();
     });
@@ -295,11 +296,11 @@ SEASTAR_TEST_CASE(test_read_entire_file_contiguous) {
                 wbuf.get_write()[i] = chars[dist(eng) % sizeof(chars)];
             }
 
-            BOOST_REQUIRE_EQUAL(f.dma_write(0, wbuf.begin(), wbuf.size()).get(), wbuf.size());
+            SEASTAR_BOOST_REQUIRE_EQUAL(f.dma_write(0, wbuf.begin(), wbuf.size()).get(), wbuf.size());
             f.flush().get();
 
             sstring res = util::read_entire_file_contiguous(tf.get_path()).get();
-            BOOST_REQUIRE_EQUAL(res, std::string_view(wbuf.begin(), wbuf.size()));
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, std::string_view(wbuf.begin(), wbuf.size()));
         });
     });
 }

--- a/tests/unit/foreign_ptr_test.cc
+++ b/tests/unit/foreign_ptr_test.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sharded.hh>
@@ -60,7 +61,7 @@ SEASTAR_TEST_CASE(foreign_ptr_copy_test) {
 
 SEASTAR_TEST_CASE(foreign_ptr_get_test) {
     auto p = make_foreign(std::make_unique<sstring>("foo"));
-    BOOST_REQUIRE_EQUAL(p.get(), &*p);
+    SEASTAR_BOOST_REQUIRE_EQUAL(p.get(), &*p);
     return make_ready_future<>();
 };
 
@@ -72,7 +73,7 @@ SEASTAR_TEST_CASE(foreign_ptr_release_test) {
     auto released_p = p.release();
     BOOST_REQUIRE(!bool(p));
     BOOST_REQUIRE(released_p->size() == 3);
-    BOOST_REQUIRE_EQUAL(raw_ptr, released_p.get());
+    SEASTAR_BOOST_REQUIRE_EQUAL(raw_ptr, released_p.get());
     return make_ready_future<>();
 }
 
@@ -94,7 +95,7 @@ class dummy {
     unsigned _cpu;
 public:
     dummy() : _cpu(this_shard_id()) { }
-    ~dummy() { BOOST_REQUIRE_EQUAL(_cpu, this_shard_id()); }
+    ~dummy() { SEASTAR_BOOST_REQUIRE_EQUAL(_cpu, this_shard_id()); }
 };
 
 SEASTAR_TEST_CASE(foreign_ptr_cpu_test) {
@@ -170,8 +171,8 @@ SEASTAR_THREAD_TEST_CASE(foreign_ptr_destroy_test) {
 
     val.destroy().get();
 
-    BOOST_REQUIRE_EQUAL(done[1].get_future().get(), true);
-    BOOST_REQUIRE_EQUAL(done[0].get_future().get(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(done[1].get_future().get(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(done[0].get_future().get(), false);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_foreign_ptr_use_count) {
@@ -180,21 +181,21 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_ptr_use_count) {
         return make_foreign(make_lw_shared<sstring>("foo"));
     }).get();
     smp::submit_to(shard, [&] {
-        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 1);
     }).get();
     auto p1 = p0.copy().get();
     smp::submit_to(shard, [&] {
-        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 2);
     }).get();
     smp::submit_to(shard, [&] {
         auto ptr = p0.release();
-        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
-        BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 2);
         ptr = {};
-        BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p1.unwrap_on_owner_shard().use_count(), 1);
     }).get();
     p1.reset();
     smp::submit_to(shard, [&] {
-        BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(p0.unwrap_on_owner_shard().use_count(), 0);
     }).get();
 }

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -43,6 +43,7 @@
 #include <boost/range/irange.hpp>
 #include <seastar/util/closeable.hh>
 #include <seastar/util/alloc_failure_injector.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 namespace fs = std::filesystem;
@@ -154,7 +155,7 @@ SEASTAR_TEST_CASE(test_consume_skip_bytes) {
                 if (_count < 8000) {
                     auto delta = std::min(buf.size(), 8000 - _count);
                     for (auto c : buf.share(0, delta)) {
-                        BOOST_REQUIRE_EQUAL(c, 'a');
+                        SEASTAR_BOOST_REQUIRE_EQUAL(c, 'a');
                     }
                     buf.trim_front(delta);
                     _count += delta;
@@ -168,7 +169,7 @@ SEASTAR_TEST_CASE(test_consume_skip_bytes) {
                     return make_ready_future<consumption_result_type>(continue_consuming{});
                 } else {
                     for (auto c : buf) {
-                        BOOST_REQUIRE_EQUAL(c, 'b');
+                        SEASTAR_BOOST_REQUIRE_EQUAL(c, 'b');
                     }
                     _count += buf.size();
                     if (_count < 14384) {
@@ -241,7 +242,7 @@ future<> test_consume_until_end(uint64_t size) {
             }).then([f] {
                 return f.size();
             }).then([size, f] (size_t real_size) {
-                BOOST_REQUIRE_EQUAL(size, real_size);
+                SEASTAR_BOOST_REQUIRE_EQUAL(size, real_size);
             }).then([size, f] {
                 auto consumer = [offset = uint64_t(0), size] (temporary_buffer<char> buf) mutable -> future<input_stream<char>::unconsumed_remainder> {
                     if (!buf) {
@@ -414,8 +415,8 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
             // no history we should start with a buffer sizes somewhere in
             // (0, buffer_size) range.
             mock_file->set_read_size_verifier([&] (size_t length) {
-                BOOST_CHECK_LE(length, initial_read_size.value_or(buffer_size - 1));
-                BOOST_CHECK_GE(length, initial_read_size.value_or(1));
+                SEASTAR_BOOST_CHECK_LE(length, initial_read_size.value_or(buffer_size - 1));
+                SEASTAR_BOOST_CHECK_GE(length, initial_read_size.value_or(1));
                 previous_buffer_length = length;
                 if (!initial_read_size) {
                     initial_read_size = length;
@@ -425,16 +426,16 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
             // Slow start phase
             while (true) {
                 // We should leave slow start before reading the whole file.
-                BOOST_CHECK_LT(total_read, file_size);
+                SEASTAR_BOOST_CHECK_LT(total_read, file_size);
 
                 mock_file->set_allowed_read_requests(requests_at_slow_start);
                 auto buf = fstr.read().get();
-                BOOST_CHECK_GT(buf.size(), 0u);
+                SEASTAR_BOOST_CHECK_GT(buf.size(), 0u);
 
                 mock_file->set_read_size_verifier([&] (size_t length) {
                     // There is no reason to reduce buffer size.
-                    BOOST_CHECK_LE(length, std::min(previous_buffer_length * 2, buffer_size));
-                    BOOST_CHECK_GE(length, previous_buffer_length);
+                    SEASTAR_BOOST_CHECK_LE(length, std::min(previous_buffer_length * 2, buffer_size));
+                    SEASTAR_BOOST_CHECK_GE(length, previous_buffer_length);
                     previous_buffer_length = length;
                 });
 
@@ -456,7 +457,7 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
 
             mock_file->set_allowed_read_requests(requests_at_full_speed);
             auto buf = fstr.read().get();
-            BOOST_CHECK_EQUAL(buf.size(), 0u);
+            SEASTAR_BOOST_CHECK_EQUAL(buf.size(), 0u);
             SEASTAR_ASSERT(buf.size() == 0);
         };
 
@@ -472,7 +473,7 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
 
             mock_file->set_allowed_read_requests(requests_at_full_speed);
             auto buf = fstr.read().get();
-            BOOST_CHECK_EQUAL(buf.size(), 0u);
+            SEASTAR_BOOST_CHECK_EQUAL(buf.size(), 0u);
         };
 
         auto read_and_skip_a_lot = [&] (auto fstr) {
@@ -482,8 +483,8 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
             mock_file->set_allowed_read_requests(std::numeric_limits<size_t>::max());
             mock_file->set_read_size_verifier([&] (size_t length) {
                 // There is no reason to reduce buffer size.
-                BOOST_CHECK_LE(length, previous_buffer_size);
-                BOOST_CHECK_GE(length, initial_read_size.value_or(1));
+                SEASTAR_BOOST_CHECK_LE(length, previous_buffer_size);
+                SEASTAR_BOOST_CHECK_GE(length, initial_read_size.value_or(1));
                 previous_buffer_size = length;
             });
             while (total_read != file_size) {
@@ -499,14 +500,14 @@ SEASTAR_TEST_CASE(test_fstream_slow_start) {
             }
 
             // We should be back at slow start at this stage.
-            BOOST_CHECK_LT(previous_buffer_size, buffer_size);
+            SEASTAR_BOOST_CHECK_LT(previous_buffer_size, buffer_size);
             if (initial_read_size) {
-                BOOST_CHECK_EQUAL(previous_buffer_size, *initial_read_size);
+                SEASTAR_BOOST_CHECK_EQUAL(previous_buffer_size, *initial_read_size);
             }
 
             mock_file->set_allowed_read_requests(requests_at_full_speed);
             auto buf = fstr.read().get();
-            BOOST_CHECK_EQUAL(buf.size(), 0u);
+            SEASTAR_BOOST_CHECK_EQUAL(buf.size(), 0u);
 
         };
 

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -30,6 +30,8 @@
 #include <type_traits>
 #include <vector>
 #include <seastar/testing/test_case.hh>
+#include <fmt/ranges.h>
+#include "test_comparisons.hh"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -89,7 +91,7 @@ SEASTAR_TEST_CASE(test_self_move) {
     future_state<std::unique_ptr<int>> s2;
     s2.set(std::make_unique<int>(42));
     std::swap(s2, s2);
-    BOOST_REQUIRE_EQUAL(*std::move(s2).get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*std::move(s2).get(), 42);
 
     promise<std::unique_ptr<int>> p1;
     p1.set_value(std::make_unique<int>(42));
@@ -98,14 +100,14 @@ SEASTAR_TEST_CASE(test_self_move) {
     promise<std::unique_ptr<int>> p2;
     p2.set_value(std::make_unique<int>(42));
     std::swap(p2, p2);
-    BOOST_REQUIRE_EQUAL(*p2.get_future().get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*p2.get_future().get(), 42);
 
     auto  f1 = make_ready_future<std::unique_ptr<int>>(std::make_unique<int>(42));
     f1 = std::move(f1); // no crash, but the value of f1 is not defined.
 
     auto f2 = make_ready_future<std::unique_ptr<int>>(std::make_unique<int>(42));
     std::swap(f2, f2);
-    BOOST_REQUIRE_EQUAL(*f2.get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*f2.get(), 42);
 
     return make_ready_future<>();
 }
@@ -151,7 +153,7 @@ SEASTAR_TEST_CASE(test_stream_drop_sub) {
     std::optional<future<>> ret;
     {
         auto sub = s->listen([expected](int actual) {
-            BOOST_REQUIRE_EQUAL(expected, actual);
+            SEASTAR_BOOST_REQUIRE_EQUAL(expected, actual);
             return make_ready_future<>();
         });
         ret = sub.done();
@@ -169,7 +171,7 @@ SEASTAR_TEST_CASE(test_reference) {
     future<int&> fut = std::move(orig);
     int& r = fut.get();
     r = 43;
-    BOOST_REQUIRE_EQUAL(a, 43);
+    SEASTAR_BOOST_REQUIRE_EQUAL(a, 43);
     return make_ready_future<>();
 }
 
@@ -189,7 +191,7 @@ SEASTAR_TEST_CASE(test_make_ready_future_tuple) {
     // into T. The tuple special-case is removed in v10 — the emplace path used
     // there direct-initializes T from the args, which rejects a tuple arg.
     auto f = make_ready_future<int>(std::tuple(42));
-    BOOST_REQUIRE_EQUAL(f.get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 42);
     return make_ready_future<>();
 }
 #endif
@@ -220,7 +222,7 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         promise<std::vector<std::string>> p;
         auto f = p.get_future();
         p.set_value({});
-        BOOST_REQUIRE_EQUAL(f.get(), (std::vector<std::string>{}));
+        SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), (std::vector<std::string>{}));
     }
     // brace-init-list: initializer_list<string> ctor
     {
@@ -228,7 +230,7 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         auto f = p.get_future();
         p.set_value({"foo", "foo"});
         std::vector<std::string> foo_x2{"foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), foo_x2);
     }
     // brace-init-list: (count, value) ctor
     {
@@ -236,14 +238,14 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         auto f = p.get_future();
         p.set_value({3, "foo"});
         std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
     }
     // reference preserved
     {
         promise<std::vector<int>&> p;
         auto f = p.get_future();
         p.set_value(conversion_test_static_vector);
-        BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
+        SEASTAR_BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
     }
     return make_ready_future<>();
 }
@@ -274,8 +276,8 @@ SEASTAR_TEST_CASE(test_set_value_copy_counter) {
         const tests::copy_move_counter cc;
         p.set_value(cc);
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 0);
     }
     // non-const lvalue → 1 copy
     {
@@ -284,8 +286,8 @@ SEASTAR_TEST_CASE(test_set_value_copy_counter) {
         tests::copy_move_counter cc;
         p.set_value(cc);
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 0);
     }
     // rvalue (equivalent to prvalue — same category) → 1 move
     {
@@ -294,8 +296,8 @@ SEASTAR_TEST_CASE(test_set_value_copy_counter) {
         tests::copy_move_counter cc;
         p.set_value(std::move(cc));
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(cc.shared->copies, 0);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 1);
     }
     return make_ready_future<>();
 }
@@ -307,7 +309,7 @@ SEASTAR_TEST_CASE(test_set_value_move_counter) {
     tests::move_counter mc;
     p.set_value(std::move(mc));
     std::ignore = f.get();
-    BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+    SEASTAR_BOOST_CHECK_EQUAL(mc.shared->moves, 1);
     return make_ready_future<>();
 }
 
@@ -316,12 +318,12 @@ SEASTAR_TEST_CASE(test_make_ready_future_conversions) {
     {
         auto f = make_ready_future<std::vector<std::string>>(3, "foo");
         std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
     }
     // reference preserved
     {
         auto f = make_ready_future<std::vector<int>&>(conversion_test_static_vector);
-        BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
+        SEASTAR_BOOST_REQUIRE_EQUAL(&f.get(), &conversion_test_static_vector);
     }
     // Emplace uses direct-initialization, so explicit converting ctors are
     // accepted — differs from co_return and promise::set_value, which gate on
@@ -339,8 +341,8 @@ SEASTAR_TEST_CASE(test_make_ready_future_copy_counter) {
         tests::copy_move_counter cc;
         auto f = make_ready_future(std::move(cc));
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(cc.shared->copies, 0);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 1);
     }
     // explicit-T emplace form with const lvalue → 1 copy (single-arg
     // overload's T&& cannot bind to const lvalue, so emplace overload wins)
@@ -348,8 +350,8 @@ SEASTAR_TEST_CASE(test_make_ready_future_copy_counter) {
         const tests::copy_move_counter cc;
         auto f = make_ready_future<tests::copy_move_counter>(cc);
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(cc.shared->copies, 1);
-        BOOST_CHECK_EQUAL(cc.shared->moves, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(cc.shared->moves, 0);
     }
     return make_ready_future<>();
 }
@@ -360,7 +362,7 @@ SEASTAR_TEST_CASE(test_make_ready_future_move_counter) {
         tests::move_counter mc;
         auto f = make_ready_future(std::move(mc));
         std::ignore = f.get();
-        BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(mc.shared->moves, 1);
     }
     // no-arg emplace: the single-arg T&& overload needs one argument, so the
     // variadic overload wins and default-constructs move_counter in place
@@ -369,7 +371,7 @@ SEASTAR_TEST_CASE(test_make_ready_future_move_counter) {
     {
         auto f = make_ready_future<tests::move_counter>();
         auto mc = f.get();
-        BOOST_CHECK_EQUAL(mc.shared->moves, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(mc.shared->moves, 1);
     }
     return make_ready_future<>();
 }
@@ -428,7 +430,7 @@ SEASTAR_TEST_CASE(test_finally_is_called_on_success_and_failure) {
 SEASTAR_TEST_CASE(test_get_on_promise) {
     auto p = promise<uint32_t>();
     p.set_value(10);
-    BOOST_REQUIRE_EQUAL(10u, p.get_future().get());
+    SEASTAR_BOOST_REQUIRE_EQUAL(10u, p.get_future().get());
     return make_ready_future();
 }
 
@@ -450,7 +452,7 @@ SEASTAR_TEST_CASE(test_get_on_exceptional_promise) {
 }
 
 static void check_finally_exception(std::exception_ptr ex) {
-  BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
+  SEASTAR_BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
         "seastar::nested_exception: test_exception (bar) (while cleaning up after test_exception (foo))");
   try {
       // convert to the concrete type nested_exception
@@ -459,12 +461,12 @@ static void check_finally_exception(std::exception_ptr ex) {
     try {
         std::rethrow_exception(ex.inner);
     } catch (test_exception& inner) {
-        BOOST_REQUIRE_EQUAL(inner.what(), "bar");
+        SEASTAR_BOOST_REQUIRE_EQUAL(inner.what(), "bar");
     }
     try {
         ex.rethrow_nested();
     } catch (test_exception& outer) {
-        BOOST_REQUIRE_EQUAL(outer.what(), "foo");
+        SEASTAR_BOOST_REQUIRE_EQUAL(outer.what(), "foo");
     }
   }
 }
@@ -734,7 +736,7 @@ template<typename Container>
 void test_iterator_range_estimate() {
     Container container{1,2,3};
 
-    BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
+    SEASTAR_BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
         container.begin(), container.end()), 3);
 }
 
@@ -745,7 +747,7 @@ BOOST_AUTO_TEST_CASE(test_iterator_range_estimate_vector_capacity) {
     {
         int n = 42;
         auto seq = std::views::iota(0, n);
-        BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
+        SEASTAR_BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
             seq.begin(), seq.end()), n);
     }
     {
@@ -753,7 +755,7 @@ BOOST_AUTO_TEST_CASE(test_iterator_range_estimate_vector_capacity) {
         // might actually consume or transform the underlying sequence, in this
         // case, the function under test returns 0.
         auto seq = std::views::iota(1);
-        BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
+        SEASTAR_BOOST_REQUIRE_EQUAL(internal::iterator_range_estimate_vector_capacity(
             seq.begin(), seq.end()), 0);
     }
 }
@@ -908,7 +910,7 @@ SEASTAR_TEST_CASE(test_map_reduce) {
     return map_reduce(boost::make_counting_iterator<long>(0), boost::make_counting_iterator<long>(n),
             square, long(0), std::plus<long>()).then([n] (auto result) {
         auto m = n - 1; // counting does not include upper bound
-        BOOST_REQUIRE_EQUAL(result, (m * (m + 1) * (2*m + 1)) / 6);
+        SEASTAR_BOOST_REQUIRE_EQUAL(result, (m * (m + 1) * (2*m + 1)) / 6);
     });
 }
 
@@ -919,7 +921,7 @@ SEASTAR_TEST_CASE(test_map_reduce_simple) {
                 [] (long x) { return x; },
                 [&res] (long x) { res += x; }).then([n, &res] {
             long expected = (n * (n - 1)) / 2;
-            BOOST_REQUIRE_EQUAL(res, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
         });
     });
 }
@@ -931,8 +933,8 @@ SEASTAR_TEST_CASE(test_map_reduce_tuple) {
                 [] (long x) { return std::tuple<long, long>(x, -x); },
                 [&res0, &res1] (std::tuple<long, long> t) { res0 += std::get<0>(t); res1 += std::get<1>(t); }).then([n, &res0, &res1] {
             long expected = (n * (n - 1)) / 2;
-            BOOST_REQUIRE_EQUAL(res0, expected);
-            BOOST_REQUIRE_EQUAL(res1, -expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res0, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res1, -expected);
         });
     });
 }
@@ -973,7 +975,7 @@ SEASTAR_TEST_CASE(test_map_reduce_lifetime) {
         return map_reduce(boost::make_counting_iterator<long>(0), boost::make_counting_iterator<long>(n),
                 map{}, reduce{res}).then([n, &res] {
             long expected = (n * (n - 1)) / 2;
-            BOOST_REQUIRE_EQUAL(res, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
         });
     });
 }
@@ -1009,7 +1011,7 @@ SEASTAR_TEST_CASE(test_map_reduce0_lifetime) {
     return map_reduce(boost::make_counting_iterator<long>(0), boost::make_counting_iterator<long>(n),
             map{}, 0L, reduce{}).then([n] (long res) {
         long expected = (n * (n - 1)) / 2;
-        BOOST_REQUIRE_EQUAL(res, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
     });
 }
 
@@ -1055,7 +1057,7 @@ SEASTAR_TEST_CASE(test_map_reduce1_lifetime) {
     return map_reduce(boost::make_counting_iterator<long>(0), boost::make_counting_iterator<long>(n),
                       map{}, reduce{}).then([n] (long res) {
         long expected = (n * (n - 1)) / 2;
-        BOOST_REQUIRE_EQUAL(res, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
     });
 }
 
@@ -1123,34 +1125,34 @@ SEASTAR_TEST_CASE(test_sleep) {
 
 SEASTAR_TEST_CASE(test_do_with_1) {
     return do_with(1, [] (int& one) {
-       BOOST_REQUIRE_EQUAL(one, 1);
+       SEASTAR_BOOST_REQUIRE_EQUAL(one, 1);
        return make_ready_future<>();
     });
 }
 
 SEASTAR_TEST_CASE(test_do_with_2) {
     return do_with(1, 2L, [] (int& one, long two) {
-        BOOST_REQUIRE_EQUAL(one, 1);
-        BOOST_REQUIRE_EQUAL(two, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(one, 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(two, 2);
         return make_ready_future<>();
     });
 }
 
 SEASTAR_TEST_CASE(test_do_with_3) {
     return do_with(1, 2L, 3, [] (int& one, long two, int three) {
-        BOOST_REQUIRE_EQUAL(one, 1);
-        BOOST_REQUIRE_EQUAL(two, 2);
-        BOOST_REQUIRE_EQUAL(three, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(one, 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(two, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(three, 3);
         return make_ready_future<>();
     });
 }
 
 SEASTAR_TEST_CASE(test_do_with_4) {
     return do_with(1, 2L, 3, 4, [] (int& one, long two, int three, int four) {
-        BOOST_REQUIRE_EQUAL(one, 1);
-        BOOST_REQUIRE_EQUAL(two, 2);
-        BOOST_REQUIRE_EQUAL(three, 3);
-        BOOST_REQUIRE_EQUAL(four, 4);
+        SEASTAR_BOOST_REQUIRE_EQUAL(one, 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(two, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(three, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(four, 4);
         return make_ready_future<>();
     });
 }
@@ -1246,7 +1248,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
             sum += v;
             return make_ready_future<>();
         }).get();
-        BOOST_REQUIRE_EQUAL(sum, 15);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sum, 15);
 
         // all suspend
         sum = 0;
@@ -1255,7 +1257,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each) {
                 sum += v;
             });
         }).get();
-        BOOST_REQUIRE_EQUAL(sum, 15);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sum, 15);
 
         // throws immediately
         BOOST_CHECK_EXCEPTION(parallel_for_each(range, [] (int) -> future<> {
@@ -1284,7 +1286,7 @@ SEASTAR_TEST_CASE(test_parallel_for_each_early_failure) {
                 return make_ready_future<>();
             });
         }).then_wrapped([&counter] (future<> f) {
-            BOOST_REQUIRE_EQUAL(counter, 11000);
+            SEASTAR_BOOST_REQUIRE_EQUAL(counter, 11000);
             BOOST_REQUIRE(f.failed());
             try {
                 f.get();
@@ -1375,7 +1377,7 @@ SEASTAR_TEST_CASE(futurize_invoke_val_ok) {
     return futurize_invoke([] (int arg) { return arg * 2; }, 2).then_wrapped([] (future<int> f) {
         try {
             auto x = f.get();
-            BOOST_REQUIRE_EQUAL(x, 4);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x, 4);
         } catch (expected_exception& e) {
             BOOST_FAIL("should not have thrown");
         }
@@ -1404,7 +1406,7 @@ SEASTAR_TEST_CASE(futurize_invoke_val_future_ok) {
     }, 2).then_wrapped([] (future<int> f) {
         try {
             auto x = f.get();
-            BOOST_REQUIRE_EQUAL(x, 200);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x, 200);
         } catch (expected_exception& e) {
             BOOST_FAIL("should not have thrown");
         }
@@ -1451,7 +1453,7 @@ SEASTAR_TEST_CASE(futurize_invoke_void_future_ok) {
     }, *a).then_wrapped([a] (future<> f) {
         try {
             f.get();
-            BOOST_REQUIRE_EQUAL(*a, 100);
+            SEASTAR_BOOST_REQUIRE_EQUAL(*a, 100);
         } catch (expected_exception& e) {
             BOOST_FAIL("should not have thrown");
         }
@@ -1592,19 +1594,19 @@ SEASTAR_TEST_CASE(test_futurize_from_tuple_const_ref) {
         unmovable_object& operator=(const unmovable_object&) { BOOST_FAIL("unmovable_object should not be copied"); return *this; }
         unmovable_object(unmovable_object&&) { BOOST_FAIL("unmovable_object should not be moved"); }
         unmovable_object& operator=(unmovable_object&&) { BOOST_FAIL("unmovable_object should not be moved"); return *this; }
-        ~unmovable_object() { BOOST_REQUIRE_EQUAL(v, 5); }
+        ~unmovable_object() { SEASTAR_BOOST_REQUIRE_EQUAL(v, 5); }
     };
     unmovable_object n{5};
 
     // Ensure the support through `make_ready_future` as well.
-    BOOST_REQUIRE_EQUAL(make_ready_future<unmovable_object&>(n).get().v, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(make_ready_future<unmovable_object&>(n).get().v, 5);
 
     auto f = make_ready_future<>();
-    f = std::move(f).then([&]() -> unmovable_object& { return n; }).then([](unmovable_object& x) { BOOST_REQUIRE_EQUAL(x.v, 5); });
-    f = std::move(f).then([&]() -> const unmovable_object& { return n; }).then([](const unmovable_object& x) { BOOST_REQUIRE_EQUAL(x.v, 5); });
+    f = std::move(f).then([&]() -> unmovable_object& { return n; }).then([](unmovable_object& x) { SEASTAR_BOOST_REQUIRE_EQUAL(x.v, 5); });
+    f = std::move(f).then([&]() -> const unmovable_object& { return n; }).then([](const unmovable_object& x) { SEASTAR_BOOST_REQUIRE_EQUAL(x.v, 5); });
     // Without the annotation, it would be pass-by-value or moved
-    f = std::move(f).then([]() { int x = 1; return x; }).then([](int x) { BOOST_REQUIRE_EQUAL(x, 1); });
-    f = std::move(f).then([x = n.v] { return x; }).then([](int x) { BOOST_REQUIRE_EQUAL(x, 5); });
+    f = std::move(f).then([]() { int x = 1; return x; }).then([](int x) { SEASTAR_BOOST_REQUIRE_EQUAL(x, 1); });
+    f = std::move(f).then([x = n.v] { return x; }).then([](int x) { SEASTAR_BOOST_REQUIRE_EQUAL(x, 5); });
     co_await std::move(f);
 }
 
@@ -1670,7 +1672,7 @@ SEASTAR_TEST_CASE(test_when_all_functions) {
         throw 42;
         return make_ready_future<>();
     }, yield()).then([] (std::tuple<future<int>, future<>, future<>> res) {
-        BOOST_REQUIRE_EQUAL(std::get<0>(res).get(), 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<0>(res).get(), 42);
 
         BOOST_REQUIRE(std::get<1>(res).available());
         BOOST_REQUIRE(std::get<1>(res).failed());
@@ -1790,7 +1792,7 @@ SEASTAR_TEST_CASE(test_with_timeout_when_it_does_not_time_out) {
 
             pr.set_value(42);
 
-            BOOST_REQUIRE_EQUAL(f.get(), 42);
+            SEASTAR_BOOST_REQUIRE_EQUAL(f.get(), 42);
         }
 
         // Check that timer was indeed cancelled
@@ -1830,7 +1832,7 @@ SEASTAR_TEST_CASE(test_shared_future_with_timeout) {
 
         pr.set_value(42);
 
-        BOOST_REQUIRE_EQUAL(42, f3.get());
+        SEASTAR_BOOST_REQUIRE_EQUAL(42, f3.get());
     });
 }
 
@@ -1859,7 +1861,7 @@ SEASTAR_THREAD_TEST_CASE(test_shared_future_with_abort) {
 
     pr.set_value(42);
 
-    BOOST_REQUIRE_EQUAL(42, f3.get());
+    SEASTAR_BOOST_REQUIRE_EQUAL(42, f3.get());
 
     auto f4 = pr.get_shared_future(as);
     BOOST_REQUIRE(f4.available());
@@ -1937,11 +1939,11 @@ SEASTAR_TEST_CASE(test_when_all_succeed_tuples) {
         make_ready_future<std::tuple<int, sstring>>(std::tuple(84, "hi")),
         make_ready_future<bool>(true)
     ).then_unpack([] (sstring msg, int v, std::tuple<int, sstring> t, bool b) {
-        BOOST_REQUIRE_EQUAL(msg, "hello world");
-        BOOST_REQUIRE_EQUAL(v, 42);
-        BOOST_REQUIRE_EQUAL(std::get<0>(t), 84);
-        BOOST_REQUIRE_EQUAL(std::get<1>(t), "hi");
-        BOOST_REQUIRE_EQUAL(b, true);
+        SEASTAR_BOOST_REQUIRE_EQUAL(msg, "hello world");
+        SEASTAR_BOOST_REQUIRE_EQUAL(v, 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<0>(t), 84);
+        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<1>(t), "hi");
+        SEASTAR_BOOST_REQUIRE_EQUAL(b, true);
 
         return seastar::when_all_succeed(
                 make_exception_future<>(42),
@@ -2034,10 +2036,10 @@ SEASTAR_TEST_CASE(test_when_all_succeed_vector) {
         vecs.emplace_back(make_ready_future<int>(3));
         return seastar::when_all_succeed(vecs.begin(), vecs.end());
     }).then([] (std::vector<int> vals) {
-        BOOST_REQUIRE_EQUAL(vals.size(), 3u);
-        BOOST_REQUIRE_EQUAL(vals[0], 1);
-        BOOST_REQUIRE_EQUAL(vals[1], 2);
-        BOOST_REQUIRE_EQUAL(vals[2], 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(vals.size(), 3u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(vals[0], 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(vals[1], 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(vals[2], 3);
 
         std::vector<future<int>> vecs;
         vecs.emplace_back(make_ready_future<int>(1));
@@ -2144,11 +2146,11 @@ SEASTAR_THREAD_TEST_CASE(test_exception_future_with_backtrace) {
         });
     };
 
-    BOOST_REQUIRE_EQUAL(outer(false).get(), -1);
-    BOOST_REQUIRE_EQUAL(counter, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(outer(false).get(), -1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 1);
 
     BOOST_CHECK_THROW(outer(true).get(), expected_exception);
-    BOOST_REQUIRE_EQUAL(counter, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 1);
 
     // Example code where we expect a "Exceptional future ignored"
     // warning.
@@ -2243,7 +2245,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_gate) {
 
     // test normal operation when gate is opened
     BOOST_CHECK_NO_THROW(with_gate(g, [&] { counter++; }).get());
-    BOOST_REQUIRE_EQUAL(counter, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 1);
 
     // test that an exception returned by the calling func
     // is propagated to with_gate future
@@ -2312,7 +2314,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         sum += v;
         return make_ready_future<>();
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("const iterator");
     sum = 0;
@@ -2320,7 +2322,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         sum += v;
         return make_ready_future<>();
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("reverse iterator");
     sum = 0;
@@ -2328,7 +2330,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         sum += v;
         return make_ready_future<>();
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("immediate result");
     sum = 0;
@@ -2336,7 +2338,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         sum += v;
         return make_ready_future<>();
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("suspend");
     sum = 0;
@@ -2345,7 +2347,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
             sum += v;
         });
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("throw immediately");
     sum = 0;
@@ -2356,7 +2358,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         }
         return make_ready_future<>();
     }).get(), int, [] (int v) { return v == 5; });
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 
     BOOST_TEST_MESSAGE("throw after suspension");
     sum = 0;
@@ -2375,7 +2377,7 @@ SEASTAR_THREAD_TEST_CASE(test_max_concurrent_for_each) {
         sum += v;
         return make_ready_future<>();
     }).get();
-    BOOST_REQUIRE_EQUAL(sum, 28);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sum, 28);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_for_each_set) {
@@ -2388,7 +2390,7 @@ SEASTAR_THREAD_TEST_CASE(test_for_each_set) {
     do_for_each(range, [&res] (auto i) {
         res |= 1 << i;
     }).get();
-    BOOST_REQUIRE_EQUAL(res, 17);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, 17);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_yield) {
@@ -2396,9 +2398,9 @@ SEASTAR_THREAD_TEST_CASE(test_yield) {
     auto one = yield().then([&] {
         flag = true;
     });
-    BOOST_REQUIRE_EQUAL(flag, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(flag, false);
     one.get();
-    BOOST_REQUIRE_EQUAL(flag, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(flag, true);
 
 #ifndef SEASTAR_DEBUG
     // same thing, with now(), but for non-DEBUG only, otherwise .then() doesn't
@@ -2408,7 +2410,7 @@ SEASTAR_THREAD_TEST_CASE(test_yield) {
         flag = true;
     });
     // now() does not yield
-    BOOST_REQUIRE_EQUAL(flag, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(flag, true);
 #endif
 }
 
@@ -2495,7 +2497,7 @@ SEASTAR_THREAD_TEST_CASE(test_ready_future_across_shards) {
     auto other_shard = (this_shard_id() + 1) % this_smp_shard_count();
     auto f1 = make_ready_future<int>(42);
     smp::submit_to(other_shard, [f1 = std::move(f1)] () mutable {
-        BOOST_REQUIRE_EQUAL(f1.get(), 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f1.get(), 42);
     }).get();
 }
 
@@ -2692,13 +2694,13 @@ void test_lifetimes_and_movement() {
         auto stats = std::make_shared<canary_stats>();
         apply_unready(canary_callable_move_only{stats});
         // Rvalue lambda gets moved into then() implementation
-        BOOST_CHECK_EQUAL(stats->copies, 0);
-        BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
-        BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
-        BOOST_CHECK_EQUAL(stats->move_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copies, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->move_assignments, 0);
 
-        BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
-        BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
     }
 
     // Test 2: Passing lvalue lambda to then()
@@ -2708,13 +2710,13 @@ void test_lifetimes_and_movement() {
         canary_callable callable{stats};
         apply_unready(callable);
         // Lvalue lambda gets copied once, then moved through then() chain
-        BOOST_CHECK_EQUAL(stats->copies, 1);
-        BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
-        BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
-        BOOST_CHECK_EQUAL(stats->move_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->move_assignments, 0);
 
-        BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
-        BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
 
         BOOST_CHECK(!callable.c.is_moved_from());
     }
@@ -2726,13 +2728,13 @@ void test_lifetimes_and_movement() {
         canary_callable_move_only callable{stats};
         apply_unready(std::move(callable));
         // std::move(lvalue lambda) behaves like rvalue lambda - only moves
-        BOOST_CHECK_EQUAL(stats->copies, 0);
-        BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
-        BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
-        BOOST_CHECK_EQUAL(stats->move_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copies, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->moves, if_erased(4, 1) + extra_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->move_assignments, 0);
 
-        BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
-        BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
 
         BOOST_CHECK(callable.c.is_moved_from());
     }
@@ -2747,13 +2749,13 @@ void test_lifetimes_and_movement() {
         auto stats = std::make_shared<canary_stats>();
         apply_ready(canary_callable_move_only{stats});
         // Ready future: lambda moved fewer times since future is already ready
-        BOOST_CHECK_EQUAL(stats->copies, 0);
-        BOOST_CHECK_EQUAL(stats->moves, if_erased(3, 0) + is_debug() + extra_moves);
-        BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
-        BOOST_CHECK_EQUAL(stats->move_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copies, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->moves, if_erased(3, 0) + is_debug() + extra_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->move_assignments, 0);
 
-        BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
-        BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
     }
 
     // Test 5: ready future with lvalue lambda
@@ -2763,13 +2765,13 @@ void test_lifetimes_and_movement() {
         canary_callable callable{stats};
         apply_ready(callable);
         // Ready future: lvalue lambda copied once, then moved fewer times
-        BOOST_CHECK_EQUAL(stats->copies, 1);
-        BOOST_CHECK_EQUAL(stats->moves, if_erased(3, 0) + is_debug() + extra_moves);
-        BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
-        BOOST_CHECK_EQUAL(stats->move_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copies, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->moves, if_erased(3, 0) + is_debug() + extra_moves);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->copy_assignments, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->move_assignments, 0);
 
-        BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
-        BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->lvalue_calls, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(stats->rvalue_calls, 1);
 
         BOOST_CHECK(!callable.c.is_moved_from());
     }
@@ -2868,7 +2870,7 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_promise_set_value) {
 
     setter.get();
 
-    BOOST_REQUIRE_EQUAL(getter.get(), other_shard);
+    SEASTAR_BOOST_REQUIRE_EQUAL(getter.get(), other_shard);
 }
 
 namespace test_bool_class_constexpr_ns {
@@ -2894,17 +2896,17 @@ SEASTAR_TEST_CASE(test_bool_class_spaceship_operator) {
     auto a = test_bool_class::yes;
     auto b = test_bool_class::no;
 
-    BOOST_REQUIRE_EQUAL(a, a);
+    SEASTAR_BOOST_REQUIRE_EQUAL(a, a);
     BOOST_REQUIRE(a <=> a == 0);
-    BOOST_REQUIRE_EQUAL(a, test_bool_class(true));
+    SEASTAR_BOOST_REQUIRE_EQUAL(a, test_bool_class(true));
     BOOST_REQUIRE(a <=> test_bool_class(true) == 0);
-    BOOST_REQUIRE_EQUAL(b, b);
+    SEASTAR_BOOST_REQUIRE_EQUAL(b, b);
     BOOST_REQUIRE(b <=> b == 0);
-    BOOST_REQUIRE_EQUAL(b, test_bool_class(false));
+    SEASTAR_BOOST_REQUIRE_EQUAL(b, test_bool_class(false));
     BOOST_REQUIRE(b <=> test_bool_class(false) == 0);
-    BOOST_REQUIRE_GT(a, b);
+    SEASTAR_BOOST_REQUIRE_GT(a, b);
     BOOST_REQUIRE(a <=> b > 0);
-    BOOST_REQUIRE_LT(b, a);
+    SEASTAR_BOOST_REQUIRE_LT(b, a);
     BOOST_REQUIRE(b <=> a < 0);
 
     return make_ready_future();

--- a/tests/unit/gate_test.cc
+++ b/tests/unit/gate_test.cc
@@ -21,6 +21,7 @@
 
 #include <exception>
 #include <functional>
+#include "test_comparisons.hh"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
@@ -47,7 +48,7 @@ static future<> check_gate_closed_exception(Func func) {
         co_await futurize_invoke(func);
         BOOST_FAIL("func was expected to throw gate_closed_exception");
     } catch (const gate_closed_exception& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), "gate closed");
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), "gate closed");
     } catch (...) {
         BOOST_FAIL(format("unexpected exception: {}", std::current_exception()));
     }
@@ -56,26 +57,26 @@ static future<> check_gate_closed_exception(Func func) {
 SEASTAR_TEST_CASE(basic_gate_test) {
     gate g;
 
-    BOOST_REQUIRE_EQUAL(g.get_count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 0);
     BOOST_REQUIRE(!g.is_closed());
     BOOST_REQUIRE_NO_THROW(g.check());
-    BOOST_REQUIRE_EQUAL(g.get_count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 0);
     BOOST_REQUIRE_NO_THROW(g.enter());
-    BOOST_REQUIRE_EQUAL(g.get_count(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 1);
     auto gh0 = g.try_hold();
     BOOST_REQUIRE(gh0.has_value());
-    BOOST_REQUIRE_EQUAL(g.get_count(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 2);
     auto gh1 = g.hold();
-    BOOST_REQUIRE_EQUAL(g.get_count(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 3);
     BOOST_REQUIRE(!g.is_closed());
     auto f = g.close();
     BOOST_REQUIRE(!f.available());
     g.leave();
-    BOOST_REQUIRE_EQUAL(g.get_count(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 2);
     gh0->release();
-    BOOST_REQUIRE_EQUAL(g.get_count(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 1);
     gh1.release();
-    BOOST_REQUIRE_EQUAL(g.get_count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(g.get_count(), 0);
     BOOST_REQUIRE_NO_THROW(co_await std::move(f));
     BOOST_REQUIRE(g.is_closed());
 }
@@ -113,7 +114,7 @@ static future<> check_named_gate_closed_exception(Func func, sstring name) {
         co_await futurize_invoke(func);
         BOOST_FAIL("func was expected to throw gate_closed_exception");
     } catch (const gate_closed_exception& e) {
-        BOOST_REQUIRE_EQUAL(e.what(), fmt::format("{} gate closed", name));
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), fmt::format("{} gate closed", name));
     } catch (...) {
         BOOST_FAIL(format("unexpected exception: {}", std::current_exception()));
     }

--- a/tests/unit/generator_test.cc
+++ b/tests/unit/generator_test.cc
@@ -31,6 +31,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include "test_comparisons.hh"
 #if __cplusplus >= 202302L && defined(__cpp_lib_generator)
 #include <generator>
 template <typename T>
@@ -90,7 +91,7 @@ verify_fib_drained(coroutine::experimental::generator<int> actual_fibs, unsigned
 
     while (auto actual_fib = co_await actual_fibs()) {
         BOOST_REQUIRE(expected_fib != std::end(expected_fibs));
-        BOOST_REQUIRE_EQUAL(*actual_fib, *expected_fib);
+        SEASTAR_BOOST_REQUIRE_EQUAL(actual_fib->get(), *expected_fib);
         ++expected_fib;
     }
     BOOST_REQUIRE(expected_fib == std::end(expected_fibs));
@@ -112,7 +113,7 @@ seastar::future<> test_generator_not_drained(do_suspend suspend) {
     auto fib = async_fibonacci_sequence(42, suspend);
     auto actual_fib = co_await fib();
     BOOST_REQUIRE(actual_fib.has_value());
-    BOOST_REQUIRE_EQUAL(*actual_fib, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(actual_fib->get(), 0);
 }
 
 SEASTAR_TEST_CASE(test_generator_not_drained_with_suspend) {
@@ -143,10 +144,10 @@ SEASTAR_TEST_CASE(test_generator_value_reference) {
     while (auto actual = co_await actual_quoted()) {
         BOOST_REQUIRE(idx < expected_quoted.size());
         // generator<std::string_view, std::string> returns std::string_view as a value
-        BOOST_REQUIRE_EQUAL(*actual, expected_quoted[idx]);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*actual, expected_quoted[idx]);
         ++idx;
     }
-    BOOST_REQUIRE_EQUAL(idx, expected_quoted.size());
+    SEASTAR_BOOST_REQUIRE_EQUAL(idx, expected_quoted.size());
 }
 
 coroutine::experimental::generator<std::string>
@@ -163,10 +164,10 @@ SEASTAR_TEST_CASE(test_generator_rvalue_reference) {
     while (auto actual = co_await actual_strings()) {
         BOOST_REQUIRE(idx < expected_strings.size());
         // generator<std::string> returns std::string&& wrapped in reference_wrapper
-        BOOST_REQUIRE_EQUAL(actual->get(), expected_strings[idx]);
+        SEASTAR_BOOST_REQUIRE_EQUAL(actual->get(), expected_strings[idx]);
         ++idx;
     }
-    BOOST_REQUIRE_EQUAL(idx, expected_strings.size());
+    SEASTAR_BOOST_REQUIRE_EQUAL(idx, expected_strings.size());
 }
 
 SEASTAR_TEST_CASE(test_generator_move_ctor) {
@@ -230,7 +231,7 @@ SEASTAR_TEST_CASE(test_generator_throws_from_generator) {
     auto f = co_await coroutine::as_future(count_to(42));
     BOOST_REQUIRE(f.failed());
     BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), std::invalid_argument);
-    BOOST_REQUIRE_EQUAL(total, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(total, 0);
 }
 
 SEASTAR_TEST_CASE(test_generator_throws_from_consumer) {
@@ -247,7 +248,7 @@ SEASTAR_TEST_CASE(test_generator_throws_from_consumer) {
     auto f = co_await coroutine::as_future(count_to(42));
     BOOST_REQUIRE(f.failed());
     BOOST_REQUIRE_THROW(std::rethrow_exception(f.get_exception()), std::invalid_argument);
-    BOOST_REQUIRE_EQUAL(total, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(total, 0);
 }
 
 SEASTAR_TEST_CASE(test_batch_generator_empty_sequence) {
@@ -290,7 +291,7 @@ verify_fib_drained(coroutine::experimental::generator<int, int, std::vector<int>
 
     while (auto actual_fib = co_await actual_fibs()) {
         BOOST_REQUIRE(expected_fib != std::end(expected_fibs));
-        BOOST_REQUIRE_EQUAL(*actual_fib, *expected_fib);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*actual_fib, *expected_fib);
         ++expected_fib;
     }
     BOOST_REQUIRE(expected_fib == std::end(expected_fibs));
@@ -314,7 +315,7 @@ seastar::future<> test_batch_generator_not_drained(do_suspend suspend) {
     auto fib = async_fibonacci_sequence_batch(42, 12, suspend);
     auto actual_fib = co_await fib();
     BOOST_REQUIRE(actual_fib.has_value());
-    BOOST_REQUIRE_EQUAL(*actual_fib, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*actual_fib, 0);
 }
 
 SEASTAR_TEST_CASE(test_batch_generator_not_drained_with_suspend) {
@@ -358,7 +359,7 @@ SEASTAR_TEST_CASE(test_batch_generator_move_away) {
 
     int expected_n = 0;
     while (auto n = co_await numbers()) {
-        BOOST_REQUIRE_EQUAL(n->get().value, expected_n++);
+        SEASTAR_BOOST_REQUIRE_EQUAL(n->get().value, expected_n++);
     }
 }
 
@@ -393,7 +394,7 @@ SEASTAR_TEST_CASE(test_batch_generator_convertible) {
 
     int expected_n = 0;
     while (auto n = co_await numbers()) {
-        BOOST_REQUIRE_EQUAL(*n, expected_n++);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*n, expected_n++);
     }
 }
 
@@ -523,15 +524,15 @@ SEASTAR_TEST_CASE(test_batch_generator_elements_of_borrowed_range) {
     }
 
     // Elements must have been copied, not moved: data strings are still intact.
-    BOOST_REQUIRE_EQUAL(data[0], "hello");
-    BOOST_REQUIRE_EQUAL(data[1], "world");
-    BOOST_REQUIRE_EQUAL(data[2], "foo");
-    BOOST_REQUIRE_EQUAL(data[3], "bar");
+    SEASTAR_BOOST_REQUIRE_EQUAL(data[0], "hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(data[1], "world");
+    SEASTAR_BOOST_REQUIRE_EQUAL(data[2], "foo");
+    SEASTAR_BOOST_REQUIRE_EQUAL(data[3], "bar");
 
-    BOOST_REQUIRE_EQUAL(received[0], "hello");
-    BOOST_REQUIRE_EQUAL(received[1], "world");
-    BOOST_REQUIRE_EQUAL(received[2], "foo");
-    BOOST_REQUIRE_EQUAL(received[3], "bar");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received[0], "hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received[1], "world");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received[2], "foo");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received[3], "bar");
 }
 
 // Regression test: a buffered generator with count not a multiple of buffer_size
@@ -550,7 +551,7 @@ SEASTAR_TEST_CASE(test_batch_generator_partial_last_batch) {
     for (int expected = 0; expected < count; ++expected) {
         auto val = co_await gen();
         BOOST_REQUIRE(val.has_value());
-        BOOST_REQUIRE_EQUAL(*val, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*val, expected);
     }
     auto exhausted = co_await gen();
     BOOST_REQUIRE(!exhausted.has_value());
@@ -567,10 +568,10 @@ SEASTAR_TEST_CASE(test_generator_waiting_task_no_infinite_loop) {
     }();
     // First yield would set the generator's waiting task to itself
     auto val = co_await gen();
-    BOOST_REQUIRE_EQUAL(*val, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(val->get(), 0);
     // To reach the second yield, the generator must finish a large number of concurrent tasks, which should
     // cause a dump of tasks in the task queue. If the generator's waiting task was set to itself,
     // the dump would never finish.
     auto val2 = co_await gen();
-    BOOST_REQUIRE_EQUAL(*val2, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(val2->get(), 1);
 }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -39,6 +39,7 @@
 #include <seastar/http/internal/content_source.hh>
 #include <seastar/util/closeable.hh>
 #include <seastar/net/tls.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace httpd;
@@ -73,7 +74,7 @@ SEASTAR_TEST_CASE(test_reply)
 {
     http::reply r;
     r.set_content_type("txt");
-    BOOST_REQUIRE_EQUAL(r._headers["Content-Type"], sstring("text/plain"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(r._headers["Content-Type"], sstring("text/plain"));
     return make_ready_future<>();
 }
 
@@ -82,7 +83,7 @@ SEASTAR_TEST_CASE(test_str_matcher)
 
     str_matcher m("/hello");
     parameters param;
-    BOOST_REQUIRE_EQUAL(m.match("/abc/hello", 4, param), 10u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(m.match("/abc/hello", 4, param), 10u);
     return make_ready_future<>();
 }
 
@@ -91,9 +92,9 @@ SEASTAR_TEST_CASE(test_param_matcher)
 
     param_matcher m("param");
     parameters param;
-    BOOST_REQUIRE_EQUAL(m.match("/abc/hello", 4, param), 10u);
-    BOOST_REQUIRE_EQUAL(param.path("param"), "/hello");
-    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(m.match("/abc/hello", 4, param), 10u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(param.path("param"), "/hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello");
     return make_ready_future<>();
 }
 
@@ -105,16 +106,16 @@ SEASTAR_TEST_CASE(test_match_rule)
     match_rule mr(h);
     mr.add_str("/hello").add_param("param");
     httpd::handler_base* res = mr.get("/hello/val1", param);
-    BOOST_REQUIRE_EQUAL(res, h);
-    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "val1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, h);
+    SEASTAR_BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "val1");
     res = mr.get("/hell/val1", param);
     httpd::handler_base* nl = nullptr;
-    BOOST_REQUIRE_EQUAL(res, nl);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, nl);
 
     // Test that URL decoding happens correctly on the path part of
     // the URL. Reproduces issue #725.
     res = mr.get("/hello/hello%21hi", param);
-    BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello!hi");
+    SEASTAR_BOOST_REQUIRE_EQUAL(param.get_decoded_param("param"), "hello!hi");
 
     return make_ready_future<>();
 }
@@ -131,7 +132,7 @@ SEASTAR_TEST_CASE(test_match_rule_order)
     route.add(operation_type::GET, url("/hello"), h2);
 
     auto rh = route.get_handler(GET, "/hello", param);
-    BOOST_REQUIRE_EQUAL(rh, h1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(rh, h1);
 
     return make_ready_future<>();
 }
@@ -145,12 +146,12 @@ SEASTAR_TEST_CASE(test_put_drop_rule)
     {
         auto reg = handler_registration(rts, *h, "/hello", operation_type::GET);
         auto res = rts.get_handler(operation_type::GET, "/hello", params);
-        BOOST_REQUIRE_EQUAL(res, h.get());
+        SEASTAR_BOOST_REQUIRE_EQUAL(res, h.get());
     }
 
     auto res = rts.get_handler(operation_type::GET, "/hello", params);
     httpd::handler_base* nl = nullptr;
-    BOOST_REQUIRE_EQUAL(res, nl);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, nl);
     return make_ready_future<>();
 }
 
@@ -190,26 +191,26 @@ SEASTAR_TEST_CASE(test_add_del_cookie)
     {
         auto reg = rule_registration(rts, mr, operation_type::GET);
         auto res = rts.get_handler(operation_type::GET, "/hello", params);
-        BOOST_REQUIRE_EQUAL(res, h);
+        SEASTAR_BOOST_REQUIRE_EQUAL(res, h);
     }
 
     auto res = rts.get_handler(operation_type::GET, "/hello", params);
     httpd::handler_base* nl = nullptr;
-    BOOST_REQUIRE_EQUAL(res, nl);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, nl);
     return make_ready_future<>();
 }
 
 SEASTAR_TEST_CASE(test_formatter)
 {
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(true), "true");
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(false), "false");
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(1), "1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(true), "true");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(false), "false");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(1), "1");
     const char* txt = "efg";
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(txt), "\"efg\"");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(txt), "\"efg\"");
     sstring str = "abc";
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(str), "\"abc\"");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(str), "\"abc\"");
     float f = 1;
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(f), "1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(f), "1");
     f = 1.0/0.0;
     BOOST_CHECK_THROW(json::formatter::to_json(f), std::out_of_range);
     f = -1.0/0.0;
@@ -217,7 +218,7 @@ SEASTAR_TEST_CASE(test_formatter)
     f = 0.0/0.0;
     BOOST_CHECK_THROW(json::formatter::to_json(f), std::invalid_argument);
     double d = -1;
-    BOOST_REQUIRE_EQUAL(json::formatter::to_json(d), "-1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(json::formatter::to_json(d), "-1");
     d = 1.0/0.0;
     BOOST_CHECK_THROW(json::formatter::to_json(d), std::out_of_range);
     d = -1.0/0.0;
@@ -232,15 +233,15 @@ SEASTAR_TEST_CASE(test_decode_url) {
     req._url = "/a?q=%23%24%23";
     sstring url = req.parse_query_param();
     const auto& query_parameters = deprecated_query_parameters(req);
-    BOOST_REQUIRE_EQUAL(url, "/a");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "#$#");
-    BOOST_REQUIRE_EQUAL(query_parameters.at("q"), "#$#");
+    SEASTAR_BOOST_REQUIRE_EQUAL(url, "/a");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "#$#");
+    SEASTAR_BOOST_REQUIRE_EQUAL(query_parameters.at("q"), "#$#");
     req._url = "/a?a=%23%24%23&b=%22%26%22";
     req.parse_query_param();
-    BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "#$#");
-    BOOST_REQUIRE_EQUAL(query_parameters.at("a"), "#$#");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "\"&\"");
-    BOOST_REQUIRE_EQUAL(query_parameters.at("b"), "\"&\"");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "#$#");
+    SEASTAR_BOOST_REQUIRE_EQUAL(query_parameters.at("a"), "#$#");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "\"&\"");
+    SEASTAR_BOOST_REQUIRE_EQUAL(query_parameters.at("b"), "\"&\"");
     req._url = "/a?b=%22%26%22&a=%21&b=%23%24%23&a=%23%24%23";
     req.parse_query_param();
     const auto& b = req.get_query_param_array("b");
@@ -261,12 +262,12 @@ SEASTAR_TEST_CASE(test_decode_path) {
     req.param.set("param4", "/yet%20another");
     req.param.set("invalid_param", "/%2");
 
-    BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "a+b");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "same+a+b");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("param3"), "another_param");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("param4"), "yet another");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("invalid_param"), "");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("missing_param"), "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "a+b");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "same+a+b");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param3"), "another_param");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param4"), "yet another");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("invalid_param"), "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("missing_param"), "");
     return make_ready_future<>();
 }
 
@@ -282,7 +283,7 @@ SEASTAR_TEST_CASE(test_routes) {
     auto f1 =
             route.handle("/api", std::move(req), std::move(rep)).then(
                     [] (std::unique_ptr<http::reply> rep) {
-                        BOOST_REQUIRE_EQUAL((int )rep->_status, (int )http::reply::status_type::ok);
+                        SEASTAR_BOOST_REQUIRE_EQUAL((int )rep->_status, (int )http::reply::status_type::ok);
                     });
     req.reset(new http::request);
     rep.reset(new http::reply);
@@ -290,7 +291,7 @@ SEASTAR_TEST_CASE(test_routes) {
     auto f2 =
             route.handle("/", std::move(req), std::move(rep)).then(
                     [] (std::unique_ptr<http::reply> rep) {
-                        BOOST_REQUIRE_EQUAL((int )rep->_status, (int )http::reply::status_type::ok);
+                        SEASTAR_BOOST_REQUIRE_EQUAL((int )rep->_status, (int )http::reply::status_type::ok);
                     });
     req.reset(new http::request);
     rep.reset(new http::reply);
@@ -303,7 +304,7 @@ SEASTAR_TEST_CASE(test_routes) {
     auto f4 =
             route.handle("/ap", std::move(req), std::move(rep)).then(
                     [] (std::unique_ptr<http::reply> rep) {
-                        BOOST_REQUIRE_EQUAL((int )rep->_status,
+                        SEASTAR_BOOST_REQUIRE_EQUAL((int )rep->_status,
                                             (int )http::reply::status_type::not_found);
                     });
     return when_all(std::move(f1), std::move(f2), std::move(f3), std::move(f4))
@@ -324,9 +325,9 @@ SEASTAR_THREAD_TEST_CASE(test_text_route) {
     auto reply = route.handle("/hello", std::make_unique<http::request>(),
             std::make_unique<http::reply>()).get();
 
-    BOOST_CHECK_EQUAL((int )reply->_status, (int )http::reply::status_type::ok);
-    BOOST_CHECK_EQUAL(reply->_headers["Content-Type"], "text/plain");
-    BOOST_CHECK_EQUAL(reply->_content, "hello, you");
+    SEASTAR_BOOST_CHECK_EQUAL((int )reply->_status, (int )http::reply::status_type::ok);
+    SEASTAR_BOOST_CHECK_EQUAL(reply->_headers["Content-Type"], "text/plain");
+    SEASTAR_BOOST_CHECK_EQUAL(reply->_content, "hello, you");
 }
 
 SEASTAR_TEST_CASE(test_json_path) {
@@ -349,29 +350,29 @@ SEASTAR_TEST_CASE(test_json_path) {
 
     path1.set(*route, [res1] (const_req req) {
         (*res1) = true;
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value1");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value1");
         return "";
     });
 
     path2.set(*route, [res2] (const_req req) {
         (*res2) = true;
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value4+value4 value4");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value4+value4 value4");
 
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text4+text4");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text4+text4");
         return "";
     });
 
     path3.set(*route, [res3] (const_req req) {
         (*res3) = true;
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value3");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "value3");
 
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text2/text3");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "text2/text3");
         return "";
     });
 
     path4.set(*route, [res4] (const_req req) {
         (*res4) = true;
-        BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "example%20");
+        SEASTAR_BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "example%20");
         return "";
     });
 
@@ -380,7 +381,7 @@ SEASTAR_TEST_CASE(test_json_path) {
         req._url = raw_url;
         sstring url = req.parse_query_param();
         return route->handle(url, std::make_unique<http::request>(), std::make_unique<http::reply>()).then([res, route] (auto f) {
-            BOOST_REQUIRE_EQUAL(*res, true);
+            SEASTAR_BOOST_REQUIRE_EQUAL(*res, true);
         });
     };
 
@@ -412,8 +413,8 @@ SEASTAR_TEST_CASE(test_match_rule_order_with_param) {
     route.add(operation_type::GET, url("/ward").remainder("path"), h3);
     route.add(operation_type::GET, url("/ward"), h4);
 
-    BOOST_REQUIRE_EQUAL(route.get_handler(GET, "/draw", param), h1);
-    BOOST_REQUIRE_EQUAL(route.get_handler(GET, "/ward", param), h3); // ATTN: it's NOT h4
+    SEASTAR_BOOST_REQUIRE_EQUAL(route.get_handler(GET, "/draw", param), h1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(route.get_handler(GET, "/ward", param), h3); // ATTN: it's NOT h4
 
     return make_ready_future<>();
 }
@@ -444,13 +445,13 @@ SEASTAR_TEST_CASE(test_transformer) {
                 return os.close();
             });
         }).then([&ss, &cr] () {
-            BOOST_REQUIRE_EQUAL(ss.str(), "hello-{{Protocol}}-xyz-{{Host}}");
+            SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), "hello-{{Protocol}}-xyz-{{Host}}");
             return test_transformer_stream(ss, cr, {"hell", "o-{", "{Pro", "tocol}}-xyz-{{Ho", "st}}{{Pr"}).then([&ss, &cr] {
-                BOOST_REQUIRE_EQUAL(ss.str(), "hello-http-xyz-localhost{{Pr");
+                SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), "hello-http-xyz-localhost{{Pr");
                 return test_transformer_stream(ss, cr, {"hell", "o-{{", "Pro", "tocol}}{{Protocol}}-{{Protoxyz-{{Ho", "st}}{{Pr"}).then([&ss, &cr] {
-                    BOOST_REQUIRE_EQUAL(ss.str(), "hello-httphttp-{{Protoxyz-localhost{{Pr");
+                    SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), "hello-httphttp-{{Protoxyz-localhost{{Pr");
                     return test_transformer_stream(ss, cr, {"hell", "o-{{Pro", "t{{Protocol}}ocol}}", "{{Host}}"}).then([&ss] {
-                        BOOST_REQUIRE_EQUAL(ss.str(), "hello-{{Prothttpocol}}localhost");
+                        SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), "hello-{{Prothttpocol}}localhost");
                     });
                 });
             });
@@ -562,9 +563,9 @@ public:
                         write_request(output).get();
                         size_t body_size = response_body_size(input);
                         if (std::get<bool>(tests[count])) {
-                            BOOST_REQUIRE_EQUAL(body_size, std::get<size_t>(tests[count]));
+                            SEASTAR_BOOST_REQUIRE_EQUAL(body_size, std::get<size_t>(tests[count]));
                         } else {
-                            BOOST_REQUIRE_EQUAL(input.eof(), true);
+                            SEASTAR_BOOST_REQUIRE_EQUAL(input.eof(), true);
                             more = false;
                         }
                         count++;
@@ -694,7 +695,7 @@ SEASTAR_TEST_CASE(test_chunked_sink_two_chunks_two_bufs) {
         const std::string expected =
                   std::string(format("{:x}", A.size() + B.size())) + "\r\n" + A + B + "\r\n"
                 + std::string(format("{:x}", C.size() + D.size())) + "\r\n" + C + D + "\r\n";
-        BOOST_REQUIRE_EQUAL(ss.str(), expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), expected);
     });
 }
 #endif
@@ -768,7 +769,7 @@ SEASTAR_TEST_CASE(json_stream) {
         vec.emplace_back(1000000);
     }
     return test_client_server::run_test(json::stream_object(vec), [total_size](size_t s, size_t body_size) {
-        BOOST_REQUIRE_EQUAL(body_size, total_size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(body_size, total_size);
         return false;
     });
 }
@@ -782,7 +783,7 @@ SEASTAR_TEST_CASE(dont_abort) {
         co_await stream.close();
     }
     , [](size_t s, size_t body_size) {
-        BOOST_REQUIRE_EQUAL(body_size, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(body_size, 3);
         return false;
     });
 
@@ -824,7 +825,7 @@ SEASTAR_TEST_CASE(content_length_limit) {
                     });
                 }).get();
                 BOOST_REQUIRE(status.has_value());
-                BOOST_REQUIRE_EQUAL(status.value(), expected);
+                SEASTAR_BOOST_REQUIRE_EQUAL(status.value(), expected);
             };
 
             check_status("",                    http::reply::status_type::ok);
@@ -875,7 +876,7 @@ SEASTAR_TEST_CASE(test_client_unexpected_reply_status) {
                     return make_ready_future<>();
                 }).get();
                 BOOST_REQUIRE(status.has_value());
-                BOOST_REQUIRE_EQUAL(status.value(), http::reply::status_type::internal_server_error);
+                SEASTAR_BOOST_REQUIRE_EQUAL(status.value(), http::reply::status_type::internal_server_error);
             }
 
             cln.close().get();
@@ -950,8 +951,8 @@ SEASTAR_TEST_CASE(test_client_head_empty_body) {
             auto req = http::request::make("HEAD", "test", "/test");
             cln.make_request(std::move(req), [] (const http::reply& rep, input_stream<char>&& in) {
                 return seastar::async([&rep, in = std::move(in)] () mutable {
-                    BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::ok);
-                    BOOST_REQUIRE_EQUAL(rep.content_length, 128);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::ok);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(rep.content_length, 128);
                     auto buf = in.read().get();
                     BOOST_REQUIRE(buf.empty());
                     in.close().get();
@@ -1021,7 +1022,7 @@ SEASTAR_TEST_CASE(test_client_retry_nested) {
                                     [](auto& ex) { return ex.code().value() == ENOBUFS; });
 
             cln.close().get();
-            BOOST_REQUIRE_EQUAL(count, 2);
+            SEASTAR_BOOST_REQUIRE_EQUAL(count, 2);
         });
 
         when_all(std::move(client_ex), std::move(server)).discard_result().get();
@@ -1297,15 +1298,15 @@ SEASTAR_TEST_CASE(test_100_continue) {
                         if (need_cont) {
                             BOOST_REQUIRE(body_sent);
                         }
-                        BOOST_REQUIRE_NE(resp.find("200 OK"), std::string::npos);
+                        SEASTAR_BOOST_REQUIRE_NE(resp.find("200 OK"), std::string::npos);
                     }
                 }
             }
             output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\nContent-Length: 17\r\nExpect: 100-continue\r\n\r\n")).get();
             output.flush().get();
             auto resp = input.read().get();
-            BOOST_REQUIRE_EQUAL(std::string(resp.get(), resp.size()).find("100 Continue"), std::string::npos);
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Payload Too Large"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_EQUAL(std::string(resp.get(), resp.size()).find("100 Continue"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("413 Payload Too Large"), std::string::npos);
 
             input.close().get();
             output.close().get();
@@ -1336,8 +1337,8 @@ SEASTAR_TEST_CASE(test_unparsable_request) {
             output.write(sstring("GET /test HTTP/1.1\r\nhello\r\nContent-Length: 17\r\nExpect: 100-continue\r\n\r\n")).get();
             output.flush().get();
             auto resp = input.read().get();
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("400 Bad Request"), std::string::npos);
-            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("Can't parse the request"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("400 Bad Request"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("Can't parse the request"), std::string::npos);
 
             input.close().get();
             output.close().get();
@@ -1444,10 +1445,10 @@ future<> check_http_reply(std::vector<sstring>&& req_parts, std::vector<std::str
             auto resp = input.read().get();
             std::string resp_str(resp.get(), resp.size());
             for (auto& str : resp_parts) {
-                BOOST_REQUIRE_NE(resp_str.find(str), std::string::npos);
+                SEASTAR_BOOST_REQUIRE_NE(resp_str.find(str), std::string::npos);
             }
             for (auto& str : absent_parts) {
-                BOOST_REQUIRE_EQUAL(resp_str.find(str), std::string::npos);
+                SEASTAR_BOOST_REQUIRE_EQUAL(resp_str.find(str), std::string::npos);
             }
 
             input.close().get();
@@ -1479,7 +1480,7 @@ future<> head_handler_no_body(bool chunked) {
             auto resp = input.read().get();
             auto resp_s = std::string(resp.get(), resp.size());
             fmt::print("resp:[{}]", resp_s);
-            BOOST_REQUIRE_NE(resp_s.find("200 OK"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_NE(resp_s.find("200 OK"), std::string::npos);
 
             // RFC7231 section 4.3.2
             // The HEAD method is identical to GET except that the server MUST NOT
@@ -1492,13 +1493,13 @@ future<> head_handler_no_body(bool chunked) {
 
             // Seastar HTTPD doesn't omit header fields ..
             if (chunked) {
-                BOOST_REQUIRE_NE(resp_s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
+                SEASTAR_BOOST_REQUIRE_NE(resp_s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
             } else {
-                BOOST_REQUIRE_NE(resp_s.find("Content-Length: 1\r\n"), std::string::npos);
+                SEASTAR_BOOST_REQUIRE_NE(resp_s.find("Content-Length: 1\r\n"), std::string::npos);
             }
 
             // ... but does omit the body itself
-            BOOST_REQUIRE_EQUAL(resp_s.find("\r\n\r\n"), resp_s.size() - 4);
+            SEASTAR_BOOST_REQUIRE_EQUAL(resp_s.find("\r\n\r\n"), resp_s.size() - 4);
 
             input.close().get();
             output.close().get();
@@ -1552,13 +1553,13 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 auto req = http::request::make("GET", "test", "/test");
                 req.write_body("txt", sstring("12345 78901\t34521345"));
                 cln.make_request(std::move(req), [&] (const http::reply& resp, input_stream<char>&& in) {
-                    BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, 20);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, 20);
                     }
                     return seastar::async([in = std::move(in)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, sstring("12345 78901\t34521345"));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, sstring("12345 78901\t34521345"));
                     });
                 }).get();
             }
@@ -1572,11 +1573,11 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 });
                 cln.make_request(std::move(req), [&] (const http::reply& resp, input_stream<char>&& in) {
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, 12);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, 12);
                     }
                     return seastar::async([in = std::move(in)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, sstring("1234567890AB"));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, sstring("1234567890AB"));
                     });
                 }, http::reply::status_type::ok).get();
             }
@@ -1596,11 +1597,11 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 });
                 cln.make_request(std::move(req), [chunked_reply, size, jumbo_copy = std::move(jumbo_copy)] (const http::reply& resp, input_stream<char>&& in) mutable {
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, size);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, size);
                     }
                     return seastar::async([in = std::move(in), jumbo_copy = std::move(jumbo_copy)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, to_sstring(std::move(jumbo_copy)));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, to_sstring(std::move(jumbo_copy)));
                     });
                 }, http::reply::status_type::ok).get();
             }
@@ -1613,13 +1614,13 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                     co_await out.write(seastar::temporary_buffer<char>{msg, 5});
                 });
                 cln.make_request(std::move(req), [&] (const http::reply& resp, input_stream<char>&& in) {
-                    BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, 5);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, 5);
                     }
                     return seastar::async([in = std::move(in)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, sstring("hello"));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, sstring("hello"));
                     });
                 }).get();
             }
@@ -1632,13 +1633,13 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                     co_await out.write(sstring("1234\r\n7890"));
                 });
                 cln.make_request(std::move(req), [&] (const http::reply& resp, input_stream<char>&& in) {
-                    BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, 13);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, 13);
                     }
                     return seastar::async([in = std::move(in)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, sstring("req1234\r\n7890"));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, sstring("req1234\r\n7890"));
                     });
                 }).get();
             }
@@ -1649,13 +1650,13 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                 req.write_body("txt", sstring("foobar"));
                 req.set_expects_continue();
                 cln.make_request(std::move(req), [&] (const http::reply& resp, input_stream<char>&& in) {
-                    BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(resp._status, http::reply::status_type::ok);
                     if (!chunked_reply) {
-                        BOOST_REQUIRE_EQUAL(resp.content_length, 6);
+                        SEASTAR_BOOST_REQUIRE_EQUAL(resp.content_length, 6);
                     }
                     return seastar::async([in = std::move(in)] () mutable {
                         sstring body = util::read_entire_stream_contiguous(in).get();
-                        BOOST_REQUIRE_EQUAL(body, sstring("foobar"));
+                        SEASTAR_BOOST_REQUIRE_EQUAL(body, sstring("foobar"));
                     });
                 }).get();
             }
@@ -1684,7 +1685,7 @@ static future<> test_basic_content(bool streamed, bool chunked_reply) {
                         callback_completed = true;
                     });
                 });
-                BOOST_REQUIRE_NE(callback_completed, true); // should throw early
+                SEASTAR_BOOST_REQUIRE_NE(callback_completed, true); // should throw early
                 BOOST_REQUIRE_THROW(cln.make_request(std::move(req), [] (const auto& resp, auto&& in) {
                     BOOST_REQUIRE(false); // should throw before handling response
                     return make_ready_future<>();
@@ -1832,9 +1833,9 @@ SEASTAR_TEST_CASE(test_date_header_disabled) {
 SEASTAR_TEST_CASE(case_insensitive_header) {
     std::unique_ptr<seastar::http::request> req = std::make_unique<seastar::http::request>();
     req->_headers["conTEnt-LengtH"] = "17";
-    BOOST_REQUIRE_EQUAL(req->get_header("content-length"), "17");
-    BOOST_REQUIRE_EQUAL(req->get_header("Content-Length"), "17");
-    BOOST_REQUIRE_EQUAL(req->get_header("cOnTeNT-lEnGTh"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req->get_header("content-length"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req->get_header("Content-Length"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req->get_header("cOnTeNT-lEnGTh"), "17");
     return make_ready_future<>();
 }
 
@@ -1844,8 +1845,8 @@ SEASTAR_TEST_CASE(broken_reply) {
     char r101[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
     parser.parse(r101, r101 + sizeof(r101), r101 + sizeof(r101));
-    BOOST_REQUIRE_EQUAL(parser.failed(), true);
-    BOOST_REQUIRE_EQUAL(parser.error_message().starts_with("Parsing error at offset 0: encountered \"Lorem ipsum dolor sit amet, cons\""), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(parser.failed(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(parser.error_message().starts_with("Parsing error at offset 0: encountered \"Lorem ipsum dolor sit amet, cons\""), true);
 
     return make_ready_future<>();
 }
@@ -1858,9 +1859,9 @@ SEASTAR_TEST_CASE(case_insensitive_header_reply) {
     parser.parse(r101, r101 + sizeof(r101), r101 + sizeof(r101));
     auto response = parser.get_parsed_response();
     std::unique_ptr<seastar::http::reply> rep = std::make_unique<seastar::http::reply>(std::move(*response));
-    BOOST_REQUIRE_EQUAL(rep->get_header("content-length"), "17");
-    BOOST_REQUIRE_EQUAL(rep->get_header("Content-Length"), "17");
-    BOOST_REQUIRE_EQUAL(rep->get_header("cOnTeNT-lEnGTh"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep->get_header("content-length"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep->get_header("Content-Length"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep->get_header("cOnTeNT-lEnGTh"), "17");
 
     return make_ready_future<>();
 }
@@ -1890,12 +1891,12 @@ SEASTAR_TEST_CASE(http_parse_response_status) {
 
     parser.parse(r101, r101 + sizeof(r101), r101 + sizeof(r101));
     auto response = parser.get_parsed_response();
-    BOOST_REQUIRE_EQUAL(response->_status, http::reply::status_type::switching_protocols);
+    SEASTAR_BOOST_REQUIRE_EQUAL(response->_status, http::reply::status_type::switching_protocols);
 
     parser.init();
     parser.parse(r200, r200 + sizeof(r200), r200 + sizeof(r200));
     response = parser.get_parsed_response();
-    BOOST_REQUIRE_EQUAL(response->_status, http::reply::status_type::ok);
+    SEASTAR_BOOST_REQUIRE_EQUAL(response->_status, http::reply::status_type::ok);
     return make_ready_future<>();
 }
 
@@ -1906,11 +1907,11 @@ SEASTAR_TEST_CASE(http_parse_response_small_json) {
 
     parser.parse(r101, r101 + sizeof(r101), r101 + sizeof(r101));
     auto resp = parser.get_parsed_response();
-    BOOST_REQUIRE_EQUAL((int)resp->_status, 200);
-    BOOST_REQUIRE_EQUAL(resp->get_header("Content-Length"), "17");
-    BOOST_REQUIRE_EQUAL(resp->get_header("Content-Type"), "application/json");
-    BOOST_REQUIRE_EQUAL(resp->get_header("server"), "uvicorn");
-    BOOST_REQUIRE_EQUAL(resp->get_header("date"), "Thu, 25 May 2023 16:13:59 GMT");
+    SEASTAR_BOOST_REQUIRE_EQUAL((int)resp->_status, 200);
+    SEASTAR_BOOST_REQUIRE_EQUAL(resp->get_header("Content-Length"), "17");
+    SEASTAR_BOOST_REQUIRE_EQUAL(resp->get_header("Content-Type"), "application/json");
+    SEASTAR_BOOST_REQUIRE_EQUAL(resp->get_header("server"), "uvicorn");
+    SEASTAR_BOOST_REQUIRE_EQUAL(resp->get_header("date"), "Thu, 25 May 2023 16:13:59 GMT");
 
     return make_ready_future<>();
 }
@@ -1940,15 +1941,15 @@ SEASTAR_TEST_CASE(test_url_encode_decode) {
     sstring all_valid = "~abcdefghijklmnopqrstuvwhyz-ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789.";
     encoded = http::internal::url_encode(all_valid);
     ok = http::internal::url_decode(encoded, decoded);
-    BOOST_REQUIRE_EQUAL(ok, true);
-    BOOST_REQUIRE_EQUAL(decoded, all_valid);
-    BOOST_REQUIRE_EQUAL(all_valid, encoded);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ok, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(decoded, all_valid);
+    SEASTAR_BOOST_REQUIRE_EQUAL(all_valid, encoded);
 
     sstring some_invalid = "a?/!@#$%^&*()[]=.\\ \tZ";
     encoded = http::internal::url_encode(some_invalid);
     ok = http::internal::url_decode(encoded, decoded);
-    BOOST_REQUIRE_EQUAL(ok, true);
-    BOOST_REQUIRE_EQUAL(decoded, some_invalid);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ok, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(decoded, some_invalid);
     for (size_t i = 0; i < encoded.length(); i++) {
         if (encoded[i] != '%' && encoded[i] != '+') {
             auto f = std::find(std::begin(all_valid), std::end(all_valid), encoded[i]);
@@ -1971,13 +1972,13 @@ SEASTAR_TEST_CASE(test_url_param_encode_decode) {
     to_recv._url = to_send.format_url();
     sstring url = to_recv.parse_query_param();
 
-    BOOST_REQUIRE_EQUAL(url, to_send._url);
+    SEASTAR_BOOST_REQUIRE_EQUAL(url, to_send._url);
     const auto& to_recv_query_parameters = deprecated_query_parameters(to_recv);
-    BOOST_REQUIRE_EQUAL(to_recv_query_parameters.size(), to_send_query_parameters.size());
+    SEASTAR_BOOST_REQUIRE_EQUAL(to_recv_query_parameters.size(), to_send_query_parameters.size());
     for (const auto& p : to_send_query_parameters) {
         auto it = to_recv_query_parameters.find(p.first);
         BOOST_REQUIRE(it != to_recv_query_parameters.end());
-        BOOST_REQUIRE_EQUAL(it->second, p.second);
+        SEASTAR_BOOST_REQUIRE_EQUAL(it->second, p.second);
     }
 
     return make_ready_future<>();
@@ -1993,7 +1994,7 @@ SEASTAR_TEST_CASE(test_url_param_encode_decode_multiple) {
     http::request to_recv;
     to_recv._url = to_send.format_url();
     sstring url = to_recv.parse_query_param();
-    BOOST_REQUIRE_EQUAL(url, to_send._url);
+    SEASTAR_BOOST_REQUIRE_EQUAL(url, to_send._url);
     const auto& to_send_a = to_send.get_query_param_array("a");
     const auto& to_recv_a = to_recv.get_query_param_array("a");
     BOOST_REQUIRE(to_send_a == to_recv_a);
@@ -2001,8 +2002,8 @@ SEASTAR_TEST_CASE(test_url_param_encode_decode_multiple) {
     const auto& to_recv_b = to_recv.get_query_param_array("b");
     BOOST_REQUIRE(to_send_b == to_recv_b);
 
-    BOOST_REQUIRE_EQUAL(to_recv.get_query_param("a"), to_send.get_query_param("a"));
-    BOOST_REQUIRE_EQUAL(to_recv.get_query_param("b"), to_send.get_query_param("b"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(to_recv.get_query_param("a"), to_send.get_query_param("a"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(to_recv.get_query_param("b"), to_send.get_query_param("b"));
     return make_ready_future<>();
 }
 
@@ -2012,7 +2013,7 @@ SEASTAR_TEST_CASE(test_url_param_empty) {
     req._url = test_url;
     req.parse_query_param();
     const auto& query_params = deprecated_query_parameters(req);
-    BOOST_REQUIRE_EQUAL(query_params.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(query_params.size(), 2);
     BOOST_REQUIRE(query_params.at("key").empty());
     BOOST_REQUIRE(query_params.at("key2").empty());
 
@@ -2024,8 +2025,8 @@ SEASTAR_TEST_CASE(test_url_param_empty) {
     const auto& actual_key2 = req.get_query_param_array("key2");
     BOOST_REQUIRE(actual_key2 == expected_key2);
 
-    BOOST_REQUIRE_EQUAL(req.get_query_param("key"), "");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("key2"), "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("key"), "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("key2"), "");
 
     return make_ready_future<>();
 }
@@ -2047,18 +2048,18 @@ SEASTAR_TEST_CASE(test_url_params_get_set) {
         BOOST_REQUIRE(it->second == values);
     }
 
-    BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "lasta");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "lastb");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "lasta");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("b"), "lastb");
 
     req.set_query_param("a", "new_a");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "new_a");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("a"), "new_a");
 
     req.set_query_param("c", "c/c\%c");
-    BOOST_REQUIRE_EQUAL(req.get_query_param("c"), "c/c%c");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("c"), "c/c%c");
 
     std::vector<sstring> d_params = {"d/d%d", "lastd"};
     req.set_query_param("d", d_params);
-    BOOST_REQUIRE_EQUAL(req.get_query_param("d"), "lastd");
+    SEASTAR_BOOST_REQUIRE_EQUAL(req.get_query_param("d"), "lastd");
     const auto& d_values = req.get_query_param_array("d");
     BOOST_REQUIRE(d_values == d_params);
 
@@ -2069,7 +2070,7 @@ SEASTAR_TEST_CASE(test_unexpected_exception_format) {
     try {
         throw httpd::unexpected_status_error(http::reply::status_type::see_other);
     } catch (const std::exception& ex) {
-        BOOST_REQUIRE_EQUAL(sstring(ex.what()), format("{}", http::reply::status_type::see_other));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring(ex.what()), format("{}", http::reply::status_type::see_other));
     }
     return make_ready_future<>();
 }
@@ -2110,8 +2111,8 @@ SEASTAR_TEST_CASE(test_redirect_exception) {
                     return make_ready_future<>();
                 }).get();
                 BOOST_REQUIRE(status.has_value());
-                BOOST_REQUIRE_EQUAL(status.value(), expected_status);
-                BOOST_REQUIRE_EQUAL(location, expected_dest);
+                SEASTAR_BOOST_REQUIRE_EQUAL(status.value(), expected_status);
+                SEASTAR_BOOST_REQUIRE_EQUAL(location, expected_dest);
             };
 
             test("/perm", "/perm_loc", http::reply::status_type::moved_permanently);
@@ -2132,17 +2133,17 @@ BOOST_AUTO_TEST_CASE(test_redirect_exception_to_reply) {
     // Basic redirect: Location header and status set correctly
     httpd::redirect_exception e("/new-loc");
     auto rep = e.to_reply();
-    BOOST_REQUIRE_EQUAL(rep.get_header("Location"), "/new-loc");
-    BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::moved_permanently);
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep.get_header("Location"), "/new-loc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::moved_permanently);
 
     // Extra headers are included in the reply
     httpd::redirect_exception e2("/other", http::reply::status_type::moved_temporarily,
             {{"Retry-After", "120"}, {"X-Custom", "val"}});
     auto rep2 = e2.to_reply();
-    BOOST_REQUIRE_EQUAL(rep2.get_header("Location"), "/other");
-    BOOST_REQUIRE_EQUAL(rep2.get_header("Retry-After"), "120");
-    BOOST_REQUIRE_EQUAL(rep2.get_header("X-Custom"), "val");
-    BOOST_REQUIRE_EQUAL(rep2._status, http::reply::status_type::moved_temporarily);
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep2.get_header("Location"), "/other");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep2.get_header("Retry-After"), "120");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep2.get_header("X-Custom"), "val");
+    SEASTAR_BOOST_REQUIRE_EQUAL(rep2._status, http::reply::status_type::moved_temporarily);
 }
 
 SEASTAR_TEST_CASE(test_redirect_exception_sync_throw) {
@@ -2176,9 +2177,9 @@ SEASTAR_TEST_CASE(test_redirect_exception_sync_throw) {
                 return make_ready_future<>();
             }).get();
             BOOST_REQUIRE(status.has_value());
-            BOOST_REQUIRE_EQUAL(status.value(), http::reply::status_type::moved_temporarily);
-            BOOST_REQUIRE_EQUAL(location, "/sync_dest");
-            BOOST_REQUIRE_EQUAL(retry_after, "30");
+            SEASTAR_BOOST_REQUIRE_EQUAL(status.value(), http::reply::status_type::moved_temporarily);
+            SEASTAR_BOOST_REQUIRE_EQUAL(location, "/sync_dest");
+            SEASTAR_BOOST_REQUIRE_EQUAL(retry_after, "30");
             cln.close().get();
         });
 
@@ -2196,7 +2197,7 @@ BOOST_AUTO_TEST_CASE(test_path_decode_unchanged) {
     auto success = http::internal::path_decode(unchanged_chars, result);
 
     BOOST_REQUIRE(success);
-    BOOST_REQUIRE_EQUAL(result, unchanged_chars);
+    SEASTAR_BOOST_REQUIRE_EQUAL(result, unchanged_chars);
 }
 
 BOOST_AUTO_TEST_CASE(test_path_decode_changed) {
@@ -2207,7 +2208,7 @@ BOOST_AUTO_TEST_CASE(test_path_decode_changed) {
     BOOST_REQUIRE(success);
 
     auto expected_chars = seastar::sstring{" "};
-    BOOST_REQUIRE_EQUAL(result, expected_chars);
+    SEASTAR_BOOST_REQUIRE_EQUAL(result, expected_chars);
 }
 
 namespace seastar::http {
@@ -2239,30 +2240,30 @@ BOOST_AUTO_TEST_CASE(test_http_status_classification) {
         auto classification = http::reply::classify_status(static_cast<http::reply::status_type>(i));
         if (i >= 100 && i < 200) {
             ++informational;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::informational);
+            BOOST_REQUIRE(classification == http::reply::status_class::informational);
         } else if (i >= 200 && i < 300) {
             ++success;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::success);
+            BOOST_REQUIRE(classification == http::reply::status_class::success);
         } else if (i >= 300 && i < 400) {
             ++redirection;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::redirection);
+            BOOST_REQUIRE(classification == http::reply::status_class::redirection);
         } else if (i >= 400 && i < 500) {
             ++client_error;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::client_error);
+            BOOST_REQUIRE(classification == http::reply::status_class::client_error);
         } else if (i >= 500 && i < 600) {
             ++server_error;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::server_error);
+            BOOST_REQUIRE(classification == http::reply::status_class::server_error);
         } else {
             ++unclassified;
-            BOOST_REQUIRE_EQUAL(classification, http::reply::status_class::unclassified);
+            BOOST_REQUIRE(classification == http::reply::status_class::unclassified);
         }
     }
-    BOOST_REQUIRE_EQUAL(informational, 100);
-    BOOST_REQUIRE_EQUAL(success, 100);
-    BOOST_REQUIRE_EQUAL(redirection, 100);
-    BOOST_REQUIRE_EQUAL(client_error, 100);
-    BOOST_REQUIRE_EQUAL(server_error, 100);
-    BOOST_REQUIRE_EQUAL(unclassified, 300);
+    SEASTAR_BOOST_REQUIRE_EQUAL(informational, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(success, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(redirection, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(client_error, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(server_error, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(unclassified, 300);
 }
 
 // #2661. Check that trying a http connection with a wire error
@@ -2402,7 +2403,7 @@ SEASTAR_THREAD_TEST_CASE(test_content_length_data_sink) {
         sstring expected_ss;
         output_stream<char> data = output_stream<char>(testing::memory_data_sink(ss));
         output_stream<char> out = http::internal::make_http_content_length_output_stream(data, len, written);
-        BOOST_CHECK_EQUAL(written, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(written, 0);
 
         unsigned values = 0;
         while (true) {
@@ -2415,19 +2416,19 @@ SEASTAR_THREAD_TEST_CASE(test_content_length_data_sink) {
             auto f = out.flush();
             if (expected > len) {
                 BOOST_CHECK_EXCEPTION(f.get(), std::runtime_error, [] (const auto& e) { return sstring(e.what()).starts_with("body content length overflow"); });
-                BOOST_CHECK_EQUAL(written, expected - value.size());
+                SEASTAR_BOOST_CHECK_EQUAL(written, expected - value.size());
                 break;
             }
 
             f.get();
-            BOOST_CHECK_EQUAL(written, expected);
+            SEASTAR_BOOST_CHECK_EQUAL(written, expected);
             data.flush().get();
             expected_ss += value;
             values++;
         }
 
-        BOOST_CHECK_EQUAL(values, len / value.size());
-        BOOST_CHECK_EQUAL(ss.str(), expected_ss);
+        SEASTAR_BOOST_CHECK_EQUAL(values, len / value.size());
+        SEASTAR_BOOST_CHECK_EQUAL(ss.str(), expected_ss);
     };
 
     do_check(2, "1", false);
@@ -2458,8 +2459,8 @@ SEASTAR_THREAD_TEST_CASE(test_write_reply_content) {
 
     auto s = ss.str();
     BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
-    BOOST_REQUIRE_NE(s.find("Content-Type: text/plain\r\n"), std::string::npos);
-    BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("Content-Type: text/plain\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
     BOOST_REQUIRE(s.ends_with("hello"));
 }
 
@@ -2485,11 +2486,11 @@ SEASTAR_THREAD_TEST_CASE(test_write_reply_body_writer) {
 
     auto s = ss.str();
     BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
-    BOOST_REQUIRE_NE(s.find("Content-Type: application/json\r\n"), std::string::npos);
-    BOOST_REQUIRE_NE(s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
-    BOOST_REQUIRE_EQUAL(s.find("Content-Length:"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("Content-Type: application/json\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("Transfer-Encoding: chunked\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(s.find("Content-Length:"), std::string::npos);
     // chunk: "2\r\n{}\r\n" followed by terminal "0\r\n\r\n"
-    BOOST_REQUIRE_NE(s.find("2\r\n{}\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("2\r\n{}\r\n"), std::string::npos);
     BOOST_REQUIRE(s.ends_with("0\r\n\r\n"));
 }
 
@@ -2513,8 +2514,8 @@ SEASTAR_THREAD_TEST_CASE(test_write_reply_body_no_content_type) {
 
     auto s = ss.str();
     BOOST_REQUIRE(s.starts_with("HTTP/1.1 200 OK\r\n"));
-    BOOST_REQUIRE_EQUAL(s.find("Content-Type:"), std::string::npos);
-    BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(s.find("Content-Type:"), std::string::npos);
+    SEASTAR_BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
     BOOST_REQUIRE(s.ends_with("hello"));
 }
 
@@ -2539,14 +2540,14 @@ SEASTAR_THREAD_TEST_CASE(test_reply_cookies) {
 
     std::vector<sstring> lines;
     boost::split(lines, headers_str_no_cr, boost::is_any_of("\n"));
-    BOOST_REQUIRE_EQUAL(lines.size(), 4);
+    SEASTAR_BOOST_REQUIRE_EQUAL(lines.size(), 4);
     lines.pop_back(); // last line is empty
     std::sort(lines.begin(), lines.end());
 
     // Check that both headers and cookies are present
-    BOOST_REQUIRE_EQUAL(lines[0], "Content-Encoding: gzip");
-    BOOST_REQUIRE_EQUAL(lines[1], "Set-Cookie: cookie1=1");
-    BOOST_REQUIRE_EQUAL(lines[2], "Set-Cookie: cookie2=2");
+    SEASTAR_BOOST_REQUIRE_EQUAL(lines[0], "Content-Encoding: gzip");
+    SEASTAR_BOOST_REQUIRE_EQUAL(lines[1], "Set-Cookie: cookie1=1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(lines[2], "Set-Cookie: cookie2=2");
 }
 
 SEASTAR_TEST_CASE(test_http_request_formatting) {
@@ -2558,14 +2559,14 @@ SEASTAR_TEST_CASE(test_http_request_formatting) {
     fmt::print("{}\n", str);
     std::vector<std::string> parts;
     boost::split(parts, str, boost::is_any_of(" "));
-    BOOST_REQUIRE_EQUAL(parts.size(), 6);
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), 6);
     std::sort(parts.begin() + 2, parts.begin() + 5); // headers can come in any order
-    BOOST_REQUIRE_EQUAL(parts[0], "PUT");
-    BOOST_REQUIRE_EQUAL(parts[1], "/test");
-    BOOST_REQUIRE_EQUAL(parts[2], "Content-Length:12");
-    BOOST_REQUIRE_EQUAL(parts[3], "Content-Type:text/plain");
-    BOOST_REQUIRE_EQUAL(parts[4], "Host:host");
-    BOOST_REQUIRE_EQUAL(parts[5], "body-content");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[0], "PUT");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[1], "/test");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[2], "Content-Length:12");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[3], "Content-Type:text/plain");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[4], "Host:host");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[5], "body-content");
 
     return make_ready_future<>();
 }
@@ -2581,13 +2582,13 @@ SEASTAR_TEST_CASE(test_http_reply_formatting) {
     fmt::print("{}\n", str);
     std::vector<std::string> parts;
     boost::split(parts, str, boost::is_any_of(" "));
-    BOOST_REQUIRE_EQUAL(parts.size(), 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), 5);
     std::sort(parts.begin() + 2, parts.begin() + 4); // headers can come in any order
-    BOOST_REQUIRE_EQUAL(parts[0], "200");
-    BOOST_REQUIRE_EQUAL(parts[1], "OK");
-    BOOST_REQUIRE_EQUAL(parts[2], "Content-Type:text/plain");
-    BOOST_REQUIRE_EQUAL(parts[3], "Server:test_server");
-    BOOST_REQUIRE_EQUAL(parts[4], "body-content");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[0], "200");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[1], "OK");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[2], "Content-Type:text/plain");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[3], "Server:test_server");
+    SEASTAR_BOOST_REQUIRE_EQUAL(parts[4], "body-content");
 
     return make_ready_future<>();
 }

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -43,6 +43,7 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/integrated-length.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -163,20 +164,20 @@ static void do_test_large_request_flow(part_flaw flaw) {
     .then([&file, &values, &limits, flaw] (size_t len) {
         size_t expected = limits.max_write;
 
-        BOOST_REQUIRE_EQUAL(file.data[0 * limits.max_write], values[0]);
+        SEASTAR_BOOST_REQUIRE_EQUAL(file.data[0 * limits.max_write], values[0]);
 
         if (flaw == part_flaw::none) {
-            BOOST_REQUIRE_EQUAL(file.data[1 * limits.max_write], values[1]);
-            BOOST_REQUIRE_EQUAL(file.data[2 * limits.max_write], values[2]);
+            SEASTAR_BOOST_REQUIRE_EQUAL(file.data[1 * limits.max_write], values[1]);
+            SEASTAR_BOOST_REQUIRE_EQUAL(file.data[2 * limits.max_write], values[2]);
             expected += 2 * limits.max_write;
         }
 
         if (flaw == part_flaw::partial) {
-            BOOST_REQUIRE_EQUAL(file.data[1 * limits.max_write], values[1]);
+            SEASTAR_BOOST_REQUIRE_EQUAL(file.data[1 * limits.max_write], values[1]);
             expected += limits.max_write / 2;
         }
 
-        BOOST_REQUIRE_EQUAL(len, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(len, expected);
     });
 
     for (int i = 0; i < 3; i++) {
@@ -365,20 +366,20 @@ SEASTAR_TEST_CASE(test_request_buffer_split) {
         BOOST_REQUIRE(parts[idx].req.opcode() == req.opcode());
         const auto& op = req.as<internal::io_request::operation::read>();
         const auto& sub_op = parts[idx].req.as<internal::io_request::operation::read>();
-        BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
-        BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
-        BOOST_REQUIRE_EQUAL(sub_op.size, size);
-        BOOST_REQUIRE_EQUAL(sub_op.addr, reinterpret_cast<void*>(mem));
-        BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
-        BOOST_REQUIRE_EQUAL(parts[idx].iovecs.size(), 0);
-        BOOST_REQUIRE_EQUAL(parts[idx].size, sub_op.size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.size, size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.addr, reinterpret_cast<void*>(mem));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts[idx].iovecs.size(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts[idx].size, sub_op.size);
     };
 
     // No split
     {
         internal::io_request req = internal::io_request::make_read(5, 13, reinterpret_cast<void*>(0x420), 17, true);
         auto parts = req.split(21);
-        BOOST_REQUIRE_EQUAL(parts.size(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), 1);
         ensure(parts, req, 0, 13, 17, 0x420);
     }
 
@@ -386,7 +387,7 @@ SEASTAR_TEST_CASE(test_request_buffer_split) {
     {
         internal::io_request req = internal::io_request::make_read(7, 24, reinterpret_cast<void*>(0x4321), 24, true);
         auto parts = req.split(12);
-        BOOST_REQUIRE_EQUAL(parts.size(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), 2);
         ensure(parts, req, 0, 24,      12, 0x4321);
         ensure(parts, req, 1, 24 + 12, 12, 0x4321 + 12);
     }
@@ -395,7 +396,7 @@ SEASTAR_TEST_CASE(test_request_buffer_split) {
     {
         internal::io_request req = internal::io_request::make_read(9, 42, reinterpret_cast<void*>(0x1234), 33, true);
         auto parts = req.split(13);
-        BOOST_REQUIRE_EQUAL(parts.size(), 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), 3);
         ensure(parts, req, 0, 42,      13, 0x1234);
         ensure(parts, req, 1, 42 + 13, 13, 0x1234 + 13);
         ensure(parts, req, 2, 42 + 26,  7, 0x1234 + 26);
@@ -462,23 +463,23 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
                 }
             }
         }
-        BOOST_REQUIRE_EQUAL(fill_match, true);
-        BOOST_REQUIRE_EQUAL(train_match, true);
+        SEASTAR_BOOST_REQUIRE_EQUAL(fill_match, true);
+        SEASTAR_BOOST_REQUIRE_EQUAL(train_match, true);
     };
 
     auto ensure = [] (const std::vector<internal::io_request::part>& parts, const internal::io_request& req, int idx, uint64_t pos) {
         BOOST_REQUIRE(parts[idx].req.opcode() == req.opcode());
         const auto& op = req.as<internal::io_request::operation::writev>();
         const auto& sub_op = parts[idx].req.as<internal::io_request::operation::writev>();
-        BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
-        BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
-        BOOST_REQUIRE_EQUAL(sub_op.iov_len, parts[idx].iovecs.size());
-        BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
-        BOOST_REQUIRE_EQUAL(parts[idx].size, internal::iovec_len(parts[idx].iovecs));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.fd, op.fd);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.pos, pos);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.iov_len, parts[idx].iovecs.size());
+        SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.nowait_works, op.nowait_works);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts[idx].size, internal::iovec_len(parts[idx].iovecs));
 
         for (unsigned iov = 0; iov < parts[idx].iovecs.size(); iov++) {
-            BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_base, parts[idx].iovecs[iov].iov_base);
-            BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_len, parts[idx].iovecs[iov].iov_len);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_base, parts[idx].iovecs[iov].iov_base);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sub_op.iovec[iov].iov_len, parts[idx].iovecs[iov].iov_len);
         }
     };
 
@@ -519,18 +520,18 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
         seastar_logger.debug("Split {} into {}-bytes ({} parts)", total, max_len, nr_parts);
         auto parts = req.split(max_len);
         show_request_parts(parts, large_buffer);
-        BOOST_REQUIRE_EQUAL(parts.size(), nr_parts);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts.size(), nr_parts);
 
         size_t parts_total = 0;
         for (unsigned p = 0; p < nr_parts; p++) {
             ensure(parts, req, p, file_off + parts_total);
             if (p < nr_parts - 1) {
-                BOOST_REQUIRE_EQUAL(parts[p].size, max_len);
+                SEASTAR_BOOST_REQUIRE_EQUAL(parts[p].size, max_len);
             }
             parts_total += parts[p].size;
             bump_buffer(parts[p].iovecs);
         }
-        BOOST_REQUIRE_EQUAL(parts_total, total);
+        SEASTAR_BOOST_REQUIRE_EQUAL(parts_total, total);
         check_buffer(total, 2);
 
         if (parts.size() == 1) {
@@ -599,15 +600,15 @@ SEASTAR_THREAD_TEST_CASE(test_tb_params) {
 SEASTAR_THREAD_TEST_CASE(test_unconfigured_io_queue) {
     io_queue_for_tests tio;
 
-    BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::read_idx), tio.request_length_limit());
-    BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::write_idx), tio.request_length_limit());
+    SEASTAR_BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::read_idx), tio.request_length_limit());
+    SEASTAR_BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::write_idx), tio.request_length_limit());
 
     for (uint64_t reqsize = 512; reqsize < 128 << 10; reqsize <<= 1) {
         auto cost_read = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, reqsize));
         auto cost_write = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, reqsize));
 
-        BOOST_CHECK_EQUAL(cost_read, 0);
-        BOOST_CHECK_EQUAL(cost_write, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cost_read, 0);
+        SEASTAR_BOOST_CHECK_EQUAL(cost_write, 0);
     }
 }
 
@@ -663,9 +664,9 @@ SEASTAR_THREAD_TEST_CASE(test_nested_priority_classes_basic_linkage) {
 
     seastar::testing::fair_queue_test fq(tio.get_fair_queue());
 
-    BOOST_CHECK_EQUAL(fq.nr_children_for({}), 3);
-    BOOST_CHECK_EQUAL(fq.nr_children_for(0), 1);
-    BOOST_CHECK_EQUAL(fq.nr_children_for(1), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(fq.nr_children_for({}), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(fq.nr_children_for(0), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(fq.nr_children_for(1), 1);
 
     BOOST_CHECK(fq.is_root_group(0));
     BOOST_CHECK(fq.is_root_group(1));
@@ -692,7 +693,7 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_priority_class_with_requests) {
         desc->complete_with(1);
         return true;
     });
-    BOOST_REQUIRE_EQUAL(fx.get(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fx.get(), 1);
 
     BOOST_REQUIRE(tio.is_class_registered(pc));
     tio.queue.destroy_priority_class(internal::priority_class(sg));
@@ -731,8 +732,8 @@ SEASTAR_THREAD_TEST_CASE(test_gauge_integrator_test) {
         fmt::print("value={:<6d} integral={:<10d} duration={:<4d} result={:<6d}\n",
             value, delta, seconds.count(), delta / seconds.count()
         );
-        BOOST_REQUIRE_GE(delta / seconds.count(), (unsigned short)(value * 0.9));
-        BOOST_REQUIRE_LE(delta / seconds.count(), (unsigned short)(value * 1.9));
+        SEASTAR_BOOST_REQUIRE_GE(delta / seconds.count(), (unsigned short)(value * 0.9));
+        SEASTAR_BOOST_REQUIRE_LE(delta / seconds.count(), (unsigned short)(value * 1.9));
     }
 
     // step two -- check disperse values
@@ -751,8 +752,8 @@ SEASTAR_THREAD_TEST_CASE(test_gauge_integrator_test) {
         fmt::print("value=[{:d},{:d}] integral={:<10d} duration={:<4d} result={:<6d}\n",
             min_v, max_v, delta, seconds.count(), delta / seconds.count()
         );
-        BOOST_REQUIRE_GE(delta / seconds.count(), min_v);
-        BOOST_REQUIRE_LE(delta / seconds.count(), max_v);
+        SEASTAR_BOOST_REQUIRE_GE(delta / seconds.count(), min_v);
+        SEASTAR_BOOST_REQUIRE_LE(delta / seconds.count(), max_v);
     }
     fmt::print("done\n");
 }
@@ -843,7 +844,7 @@ SEASTAR_THREAD_TEST_CASE(test_class_bandwidth_throttler) {
     background_drain drain(tio);
 
     auto bw = run_and_check_bandwidth(tio, pc, bandwidth * 0.9).get();
-    BOOST_REQUIRE_LE(bw, bandwidth * 1.15);
+    SEASTAR_BOOST_REQUIRE_LE(bw, bandwidth * 1.15);
 
     drain.stop().get();
     destroy_scheduling_group(sg).get();
@@ -862,7 +863,7 @@ SEASTAR_THREAD_TEST_CASE(test_class_group_bandwidth_throttler) {
     background_drain drain(tio);
 
     auto bw = run_and_check_bandwidth(tio, pc, bandwidth * 0.9).get();
-    BOOST_REQUIRE_LE(bw, bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw, bandwidth + burst + bw_slack);
 
     drain.stop().get();
     destroy_scheduling_group(sg).get();
@@ -897,10 +898,10 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler) {
     auto bw1 = f1.get();
 
     // None of the classes must exceed its personal bandwidth
-    BOOST_REQUIRE_LE(bw0, bandwidth + burst + bw_slack);
-    BOOST_REQUIRE_LE(bw1, bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw0, bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw1, bandwidth + burst + bw_slack);
     // Both classes must not exceed the group bandwidth
-    BOOST_REQUIRE_LE(bw0 + bw1, group_bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw0 + bw1, group_bandwidth + burst + bw_slack);
 
     drain.stop().get();
     destroy_scheduling_group(sg1).get();
@@ -935,9 +936,9 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_1_unlimited) {
     auto bw1 = f1.get();
 
     // Limited class must not exceed its personal bandwidth
-    BOOST_REQUIRE_LE(bw0, bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw0, bandwidth + burst + bw_slack);
     // Both classes must not exceed the group bandwidth
-    BOOST_REQUIRE_LE(bw0 + bw1, group_bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(bw0 + bw1, group_bandwidth + burst + bw_slack);
 
     drain.stop().get();
     destroy_scheduling_group(sg1).get();
@@ -969,9 +970,9 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
     auto bw1 = f1.get();
 
     // Check that shares are roughly respected
-    BOOST_REQUIRE_LE(float(bw0) / float(bw1), 4.05);
-    BOOST_REQUIRE_GE(float(bw0) / float(bw1), 3.95);
-    BOOST_REQUIRE_LE(bw0 + bw1, bandwidth + burst + bw_slack);
+    SEASTAR_BOOST_REQUIRE_LE(float(bw0) / float(bw1), 4.05);
+    SEASTAR_BOOST_REQUIRE_GE(float(bw0) / float(bw1), 3.95);
+    SEASTAR_BOOST_REQUIRE_LE(bw0 + bw1, bandwidth + burst + bw_slack);
 
     drain.stop().get();
     destroy_scheduling_group(sg1).get();

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/log.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -59,11 +60,11 @@ SEASTAR_TEST_CASE(udp_packet_test) {
         return f2.then([sc = std::move(sc), src](auto pkt) mutable {
             auto a = sc.local_address();
             sc.close();
-            BOOST_REQUIRE_EQUAL(src, pkt.get_src());
+            SEASTAR_BOOST_REQUIRE_EQUAL(src, pkt.get_src());
             auto dst = pkt.get_dst();
             // Don't always get a dst address.
             if (dst != socket_address()) {
-                BOOST_REQUIRE_EQUAL(a, pkt.get_dst());
+                SEASTAR_BOOST_REQUIRE_EQUAL(a, pkt.get_dst());
             }
         });
     });
@@ -118,10 +119,10 @@ SEASTAR_TEST_CASE(ipv6_equal_test) {
     socket_address sock_addr4(ipv6_addr(str_addr3, port));
     socket_address sock_addr5(ipv6_addr(str_addr1, port2));
 
-    BOOST_CHECK_NE(sock_addr1, sock_addr2);
-    BOOST_CHECK_EQUAL(sock_addr1, sock_addr3);
-    BOOST_CHECK_NE(sock_addr1, sock_addr4);
-    BOOST_CHECK_NE(sock_addr1, sock_addr5);
+    SEASTAR_BOOST_CHECK_NE(sock_addr1, sock_addr2);
+    SEASTAR_BOOST_CHECK_EQUAL(sock_addr1, sock_addr3);
+    SEASTAR_BOOST_CHECK_NE(sock_addr1, sock_addr4);
+    SEASTAR_BOOST_CHECK_NE(sock_addr1, sock_addr5);
 
     return make_ready_future();
 }

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -20,6 +20,7 @@
  * Copyright (C) 2016 ScyllaDB.
  */
 #include <vector>
+#include "test_comparisons.hh"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/testing/test_case.hh>
@@ -37,39 +38,39 @@ static_assert(internal::is_string_like<std::string>);
 static_assert(internal::is_string_like<sstring>);
 
 SEASTAR_TEST_CASE(test_simple_values) {
-    BOOST_CHECK_EQUAL("3", formatter::to_json(3));
-    BOOST_CHECK_EQUAL("3", formatter::to_json(3.0));
-    BOOST_CHECK_EQUAL("3.5", formatter::to_json(3.5));
-    BOOST_CHECK_EQUAL("true", formatter::to_json(true));
-    BOOST_CHECK_EQUAL("false", formatter::to_json(false));
+    SEASTAR_BOOST_CHECK_EQUAL("3", formatter::to_json(3));
+    SEASTAR_BOOST_CHECK_EQUAL("3", formatter::to_json(3.0));
+    SEASTAR_BOOST_CHECK_EQUAL("3.5", formatter::to_json(3.5));
+    SEASTAR_BOOST_CHECK_EQUAL("true", formatter::to_json(true));
+    SEASTAR_BOOST_CHECK_EQUAL("false", formatter::to_json(false));
 
-    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa")); // to_json(const char*)
-    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json(sstring("apa"))); // to_json(const sstring&)
-    BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa", 3)); // to_json(const char*, size_t)
+    SEASTAR_BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa")); // to_json(const char*)
+    SEASTAR_BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json(sstring("apa"))); // to_json(const sstring&)
+    SEASTAR_BOOST_CHECK_EQUAL("\"apa\"", formatter::to_json("apa", 3)); // to_json(const char*, size_t)
 
     using namespace std::string_literals;
     sstring str = "\0 COWA\bU\nGA [{\r}]\x1a"s,
             expected = "\"\\u0000 COWA\\bU\\nGA [{\\r}]\\u001A\""s;
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(str)); // to_json(const sstring&)
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(str.c_str(), str.size())); // to_json(const char*, size_t)
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(str)); // to_json(const sstring&)
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(str.c_str(), str.size())); // to_json(const char*, size_t)
 
     return make_ready_future();
 }
 
 SEASTAR_TEST_CASE(test_collections) {
-    BOOST_CHECK_EQUAL("{1:2,3:4}", formatter::to_json(std::map<int,int>({{1,2},{3,4}})));
-    BOOST_CHECK_EQUAL("[1,2,3,4]", formatter::to_json(std::vector<int>({1,2,3,4})));
-    BOOST_CHECK_EQUAL("[{1:2},{3:4}]", formatter::to_json(std::vector<std::pair<int,int>>({{1,2},{3,4}})));
-    BOOST_CHECK_EQUAL("[{1:2},{3:4}]", formatter::to_json(std::vector<std::map<int,int>>({{{1,2}},{{3,4}}})));
-    BOOST_CHECK_EQUAL("[[1,2],[3,4]]", formatter::to_json(std::vector<std::vector<int>>({{1,2},{3,4}})));
+    SEASTAR_BOOST_CHECK_EQUAL("{1:2,3:4}", formatter::to_json(std::map<int,int>({{1,2},{3,4}})));
+    SEASTAR_BOOST_CHECK_EQUAL("[1,2,3,4]", formatter::to_json(std::vector<int>({1,2,3,4})));
+    SEASTAR_BOOST_CHECK_EQUAL("[{1:2},{3:4}]", formatter::to_json(std::vector<std::pair<int,int>>({{1,2},{3,4}})));
+    SEASTAR_BOOST_CHECK_EQUAL("[{1:2},{3:4}]", formatter::to_json(std::vector<std::map<int,int>>({{{1,2}},{{3,4}}})));
+    SEASTAR_BOOST_CHECK_EQUAL("[[1,2],[3,4]]", formatter::to_json(std::vector<std::vector<int>>({{1,2},{3,4}})));
 
     return make_ready_future();
 }
 
 SEASTAR_TEST_CASE(test_ranges) {
-    BOOST_CHECK_EQUAL("[1,2,3,4]", formatter::to_json(std::views::iota(1, 5)));
+    SEASTAR_BOOST_CHECK_EQUAL("[1,2,3,4]", formatter::to_json(std::views::iota(1, 5)));
 #ifdef __cpp_lib_ranges_enumerate
-    BOOST_CHECK_EQUAL("[{0:5},{1:6},{2:7},{3:8}]", formatter::to_json(std::views::iota(5, 9) | std::views::enumerate));
+    SEASTAR_BOOST_CHECK_EQUAL("[{0:5},{1:6},{2:7},{3:8}]", formatter::to_json(std::views::iota(5, 9) | std::views::enumerate));
 #endif
     return make_ready_future();
 }
@@ -77,10 +78,10 @@ SEASTAR_TEST_CASE(test_ranges) {
 SEASTAR_TEST_CASE(test_strings) {
     sstring s = "hello, world";
     const char* expected = "\"hello, world\"";
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(s));
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(std::string(s)));
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(std::string_view(s)));
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(s.c_str()));
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(s));
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(std::string(s)));
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(std::string_view(s)));
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(s.c_str()));
 
     // Test that a type with a user-defined conversion to sstring
     // (but not to std::string_view) works with to_json via a single
@@ -90,7 +91,7 @@ SEASTAR_TEST_CASE(test_strings) {
         operator sstring() const { return value; }
     };
     sstring_convertible sc{s};
-    BOOST_CHECK_EQUAL(expected, formatter::to_json(sc));
+    SEASTAR_BOOST_CHECK_EQUAL(expected, formatter::to_json(sc));
 
     return make_ready_future();
 }
@@ -120,7 +121,7 @@ SEASTAR_TEST_CASE(test_jsonable) {
     obj.values.push(2);
     obj.values.push(3);
 
-    BOOST_CHECK_EQUAL("{\"subject\": \"foo\", \"values\": [1,2,3]}", formatter::to_json(obj));
+    SEASTAR_BOOST_CHECK_EQUAL("{\"subject\": \"foo\", \"values\": [1,2,3]}", formatter::to_json(obj));
     return make_ready_future();
 }
 
@@ -134,7 +135,7 @@ void formatter_check_expected(sstring expected, F f, bool close = true) {
         out.close().get();
     }
 
-    BOOST_CHECK_EQUAL(expected, ss.str());
+    SEASTAR_BOOST_CHECK_EQUAL(expected, ss.str());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_stream_range_as_array_simple) {

--- a/tests/unit/libc_wrapper_test.cc
+++ b/tests/unit/libc_wrapper_test.cc
@@ -21,6 +21,7 @@
  */
 #include <coroutine>
 #include <iostream>
+#include "test_comparisons.hh"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor.hh>
@@ -40,5 +41,5 @@ SEASTAR_TEST_CASE(getgrnam_group_name_does_not_exist_test) {
 SEASTAR_TEST_CASE(getgrnam_group_name_exists_test) {
     std::optional<struct group_details> grp = co_await getgrnam("root");
     BOOST_REQUIRE(grp.has_value());
-    BOOST_REQUIRE_EQUAL(grp.value().group_name.c_str(), "root");
+    SEASTAR_BOOST_REQUIRE_EQUAL(grp.value().group_name.c_str(), "root");
 }

--- a/tests/unit/linux_perf_event_test.cc
+++ b/tests/unit/linux_perf_event_test.cc
@@ -20,11 +20,12 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/testing/linux_perf_event.hh>
+#include "test_comparisons.hh"
 
 BOOST_AUTO_TEST_CASE(test_always_zero_reads_zero) {
     auto event = linux_perf_event::always_zero();
-    BOOST_CHECK_EQUAL(event.read(), 0u);
-    BOOST_CHECK_EQUAL(event.read(), 0u);
+    SEASTAR_BOOST_CHECK_EQUAL(event.read(), 0u);
+    SEASTAR_BOOST_CHECK_EQUAL(event.read(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_always_zero_enable_disable) {
@@ -32,15 +33,15 @@ BOOST_AUTO_TEST_CASE(test_always_zero_enable_disable) {
     // These should be no-ops and not crash
     event.enable();
     event.disable();
-    BOOST_CHECK_EQUAL(event.read(), 0u);
+    SEASTAR_BOOST_CHECK_EQUAL(event.read(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_always_zero_move) {
     auto event = linux_perf_event::always_zero();
     auto event2 = std::move(event);
-    BOOST_CHECK_EQUAL(event2.read(), 0u);
+    SEASTAR_BOOST_CHECK_EQUAL(event2.read(), 0u);
 
     linux_perf_event event3 = linux_perf_event::always_zero();
     event3 = std::move(event2);
-    BOOST_CHECK_EQUAL(event3.read(), 0u);
+    SEASTAR_BOOST_CHECK_EQUAL(event3.read(), 0u);
 }

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -24,6 +24,7 @@
 #include <exception>
 #include <ranges>
 #include <stdexcept>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -70,11 +71,11 @@ SEASTAR_TEST_CASE(test_rwlock_exclusive) {
     return do_with(rwlock(), unsigned(0), [] (rwlock& l, unsigned& counter) {
         return parallel_for_each(std::views::iota(0, 10), [&l, &counter] (int idx) {
             return with_lock(l.for_write(), [&counter] {
-                BOOST_REQUIRE_EQUAL(counter, 0u);
+                SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 ++counter;
                 return sleep(1ms).then([&counter] {
                     --counter;
-                    BOOST_REQUIRE_EQUAL(counter, 0u);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 });
             });
         });
@@ -92,8 +93,8 @@ SEASTAR_TEST_CASE(test_rwlock_shared) {
                 });
             });
         }).finally([&counter, &max] {
-            BOOST_REQUIRE_EQUAL(counter, 0u);
-            BOOST_REQUIRE_NE(max, 0u);
+            SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
+            SEASTAR_BOOST_REQUIRE_NE(max, 0u);
         });
     });
 }
@@ -239,11 +240,11 @@ SEASTAR_TEST_CASE(test_shared_mutex_exclusive) {
     return do_with(shared_mutex(), unsigned(0), [] (shared_mutex& sm, unsigned& counter) {
         return parallel_for_each(std::views::iota(0, 10), [&sm, &counter] (int idx) {
             return with_lock(sm, [&counter] {
-                BOOST_REQUIRE_EQUAL(counter, 0u);
+                SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 ++counter;
                 return sleep(1ms).then([&counter] {
                     --counter;
-                    BOOST_REQUIRE_EQUAL(counter, 0u);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 });
             });
         });
@@ -261,8 +262,8 @@ SEASTAR_TEST_CASE(test_shared_mutex_shared) {
                 });
             });
         }).finally([&counter, &max] {
-            BOOST_REQUIRE_EQUAL(counter, 0u);
-            BOOST_REQUIRE_NE(max, 0u);
+            SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
+            SEASTAR_BOOST_REQUIRE_NE(max, 0u);
         });
     });
 }
@@ -363,7 +364,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_nothrow_move_func) {
     auto res = with_shared(sm, [expected] {
         return expected;
     }).get();
-    BOOST_REQUIRE_EQUAL(res, expected);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
 
     try {
         with_shared(sm, [expected] {
@@ -374,7 +375,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_nothrow_move_func) {
         }).get();
         BOOST_FAIL("No exception was thrown");
     } catch (const expected_exception& e) {
-        BOOST_REQUIRE_EQUAL(e.value, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.value, expected);
     } catch (const std::exception& e) {
         BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
     }
@@ -391,7 +392,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_shared_typed_return_throwing_move_func) {
                 auto expected = std::move(exp);
                 return expected.value;
             }).get();
-            BOOST_REQUIRE_EQUAL(res, expected_value);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, expected_value);
             done = true;
         } catch (const moved_exception& e) {
         } catch (const std::exception& e) {
@@ -407,7 +408,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_nothrow_move_func) {
     auto res = with_lock(sm, [expected] {
         return expected;
     }).get();
-    BOOST_REQUIRE_EQUAL(res, expected);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, expected);
 
     try {
         with_lock(sm, [expected] {
@@ -418,7 +419,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_nothrow_move_func) {
         }).get();
         BOOST_FAIL("No exception was thrown");
     } catch (const expected_exception& e) {
-        BOOST_REQUIRE_EQUAL(e.value, expected);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.value, expected);
     } catch (const std::exception& e) {
         BOOST_FAIL(format("Unexpected exception type: {}", e.what()));
     }
@@ -435,7 +436,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_lock_typed_return_throwing_move_func) {
                 auto expected = std::move(exp);
                 return expected.value;
             }).get();
-            BOOST_REQUIRE_EQUAL(res, expected_value);
+            SEASTAR_BOOST_REQUIRE_EQUAL(res, expected_value);
             done = true;
         } catch (const moved_exception& e) {
         } catch (const std::exception& e) {
@@ -477,11 +478,11 @@ SEASTAR_TEST_CASE(test_shared_mutex_exclusive_locks) {
 
     co_await coroutine::parallel_for_each(std::views::iota(0, 10), coroutine::lambda([&sm, &counter] (auto&&) -> future<> {
         const auto ulock = co_await get_unique_lock(sm);
-        BOOST_REQUIRE_EQUAL(counter, 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
         ++counter;
         co_await sleep(1ms);
         --counter;
-        BOOST_REQUIRE_EQUAL(counter, 0u);
+        SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
     }));
 }
 

--- a/tests/unit/log_buf_test.cc
+++ b/tests/unit/log_buf_test.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/log.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -31,7 +32,7 @@ SEASTAR_TEST_CASE(log_buf_realloc) {
 
     internal::log_buf b(external_buf.data(), external_buf.size());
 
-    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), external_buf_ptr);
+    SEASTAR_BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), external_buf_ptr);
 
     auto it = b.back_insert_begin();
 
@@ -41,11 +42,11 @@ SEASTAR_TEST_CASE(log_buf_realloc) {
 
     *it = 'a'; // should trigger realloc
 
-    BOOST_REQUIRE_NE(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf.data()));
+    SEASTAR_BOOST_REQUIRE_NE(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf.data()));
 
     const char* p = b.data();
     for (auto i = 0; i < 129; ++i) {
-        BOOST_REQUIRE_EQUAL(p[i], 'a');
+        SEASTAR_BOOST_REQUIRE_EQUAL(p[i], 'a');
     }
 
     return make_ready_future<>();
@@ -59,7 +60,7 @@ SEASTAR_TEST_CASE(log_buf_insert_iterator_format_to) {
 
     internal::log_buf b(external_buf_ptr, size);
 
-    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
+    SEASTAR_BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
 
     auto it = b.back_insert_begin();
 
@@ -67,10 +68,10 @@ SEASTAR_TEST_CASE(log_buf_insert_iterator_format_to) {
     str[size] = '\0';
 
     it = fmt::format_to(it, fmt::runtime(str), size);
-    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
+    SEASTAR_BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
 
     *it++ = '\n';
-    BOOST_REQUIRE_NE(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
+    SEASTAR_BOOST_REQUIRE_NE(reinterpret_cast<uintptr_t>(b.data()), reinterpret_cast<uintptr_t>(external_buf_ptr));
 
     memset(str, 'b', size);
     it = fmt::format_to(it, fmt::runtime(str), size);
@@ -79,13 +80,13 @@ SEASTAR_TEST_CASE(log_buf_insert_iterator_format_to) {
     const char* p = b.data();
     size_t pos = 0;
     for (size_t i = 0; i < size; i++) {
-        BOOST_REQUIRE_EQUAL(p[pos++], 'a');
+        SEASTAR_BOOST_REQUIRE_EQUAL(p[pos++], 'a');
     }
-    BOOST_REQUIRE_EQUAL(p[pos++], '\n');
+    SEASTAR_BOOST_REQUIRE_EQUAL(p[pos++], '\n');
     for (size_t i = 0; i < size; i++) {
-        BOOST_REQUIRE_EQUAL(p[pos++], 'b');
+        SEASTAR_BOOST_REQUIRE_EQUAL(p[pos++], 'b');
     }
-    BOOST_REQUIRE_EQUAL(p[pos++], '\n');
+    SEASTAR_BOOST_REQUIRE_EQUAL(p[pos++], '\n');
     return make_ready_future<>();
 }
 
@@ -96,19 +97,19 @@ SEASTAR_TEST_CASE(log_buf_clear) {
 
     fmt::format_to(it, "abcd");
 
-    BOOST_CHECK_EQUAL(buf.view(), "abcd");
+    SEASTAR_BOOST_CHECK_EQUAL(buf.view(), "abcd");
     auto cap_before = buf.capacity();
     buf.clear();
-    BOOST_CHECK_EQUAL(cap_before, buf.capacity());
-    BOOST_CHECK_EQUAL(0, buf.size());
+    SEASTAR_BOOST_CHECK_EQUAL(cap_before, buf.capacity());
+    SEASTAR_BOOST_CHECK_EQUAL(0, buf.size());
 
     fmt::format_to(it, "uuvvwwxxyyzz");
 
-    BOOST_CHECK_EQUAL(buf.view(), "uuvvwwxxyyzz");
+    SEASTAR_BOOST_CHECK_EQUAL(buf.view(), "uuvvwwxxyyzz");
     cap_before = buf.capacity();
     buf.clear();
-    BOOST_CHECK_EQUAL(cap_before, buf.capacity());
-    BOOST_CHECK_EQUAL(0, buf.size());
+    SEASTAR_BOOST_CHECK_EQUAL(cap_before, buf.capacity());
+    SEASTAR_BOOST_CHECK_EQUAL(0, buf.size());
 
     return make_ready_future<>();
 }

--- a/tests/unit/lowres_clock_test.cc
+++ b/tests/unit/lowres_clock_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/testing/test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
@@ -111,7 +112,7 @@ SEASTAR_TEST_CASE(system_clock_sanity) {
     return do_with(0ul, 0ul, [](std::size_t& index, std::size_t& success_count) {
         return repeat([&index, &success_count] {
             if (index >= 3) {
-                BOOST_REQUIRE_GE(success_count, 2u);
+                SEASTAR_BOOST_REQUIRE_GE(success_count, 2u);
                 return make_ready_future<stop_iteration>(stop_iteration::yes);
             }
 
@@ -134,7 +135,7 @@ SEASTAR_TEST_CASE(system_clock_dynamic) {
     return do_with(lowres_system_clock::now(), [](auto &&t1) {
         return seastar::sleep(std::chrono::milliseconds(100)).then([&t1] {
             auto const t2 = lowres_system_clock::now();
-            BOOST_REQUIRE_NE(t1.time_since_epoch().count(), t2.time_since_epoch().count());
+            SEASTAR_BOOST_REQUIRE_NE(t1.time_since_epoch().count(), t2.time_since_epoch().count());
 
             return make_ready_future<>();
         });

--- a/tests/unit/metrics_test.cc
+++ b/tests/unit/metrics_test.cc
@@ -39,6 +39,7 @@
 #include <seastar/testing/test_runner.hh>
 #include <boost/range/irange.hpp>
 #include <ranges>
+#include "test_comparisons.hh"
 
 SEASTAR_TEST_CASE(test_add_group) {
     using namespace seastar::metrics;
@@ -187,12 +188,12 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_add_labels) {
     rl[0].expr = "test_counter_.*";
 
     sm::metric_relabeling_result success = sm::set_relabel_configs(rl).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
-    BOOST_CHECK_EQUAL(count_by_label("level"), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("level"), 1);
     app_metrics.add_group("test", {
         sm::make_counter("counter_2", sm::description("counter 2"), [] { return 2; })
     });
-    BOOST_CHECK_EQUAL(count_by_label("level"), 2);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("level"), 2);
     sm::set_relabel_configs({}).get();
 }
 
@@ -226,14 +227,14 @@ SEASTAR_THREAD_TEST_CASE(test_metrics_family_aggregate) {
     int count = 0;
     for (auto&& md : (*values->metadata)) {
         if (md.mf.name == "test_gauge_1") {
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 1);
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "lb");
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 1);
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "lb");
         } else {
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 0);
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 0);
         }
         count++;
     }
-    BOOST_CHECK_EQUAL(count, 2);
+    SEASTAR_BOOST_CHECK_EQUAL(count, 2);
     app_metrics.add_group("test", {
         sm::make_gauge("gauge1_1", sm::description("gague 1"), [] { return 1; })(lb("1")),
         sm::make_gauge("gauge1_1", sm::description("gague 1"), [] { return 2; })(lb("2")),
@@ -244,17 +245,17 @@ SEASTAR_THREAD_TEST_CASE(test_metrics_family_aggregate) {
     count = 0;
     for (auto&& md : (*values->metadata)) {
         if (md.mf.name == "test_gauge_1") {
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 1);
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "lb");
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 1);
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "lb");
         } else if (md.mf.name == "test_gauge1_1") {
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 2);
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "ll");
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 2);
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels[0], "ll");
         } else {
-            BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 0);
+            SEASTAR_BOOST_CHECK_EQUAL(md.mf.aggregate_labels.size(), 0);
         }
         count++;
     }
-    BOOST_CHECK_EQUAL(count, 4);
+    SEASTAR_BOOST_CHECK_EQUAL(count, 4);
     std::vector<sm::relabel_config> rl1;
     sm::set_relabel_configs(rl1).get();
 }
@@ -268,7 +269,7 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_drop_label_prevent_runtime_conflicts) {
         sm::make_counter("counter_1", sm::description("counter 1"), [] { return 0; }),
         sm::make_counter("counter_1", sm::description("counter 1"), { sm::label_instance("lev", "2")}, [] { return 0; })
     });
-    BOOST_CHECK_EQUAL(count_by_label("lev"), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("lev"), 1);
 
     std::vector<sm::relabel_config> rl(1);
     rl[0].source_labels = {"lev"};
@@ -277,15 +278,15 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_drop_label_prevent_runtime_conflicts) {
     rl[0].action = sm::relabel_config::relabel_action::drop_label;
     // Dropping the lev label would cause a conflict, but not crash the system
     sm::metric_relabeling_result success = sm::set_relabel_configs(rl).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 1);
-    BOOST_CHECK_EQUAL(count_by_label("lev"), 0);
-    BOOST_CHECK_EQUAL(count_by_label("err"), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 1);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("lev"), 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("err"), 1);
 
     //reseting all the labels to their original state
     success = sm::set_relabel_configs({}).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
-    BOOST_CHECK_EQUAL(count_by_label("lev"), 1);
-    BOOST_CHECK_EQUAL(count_by_label("err"), 0);
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("lev"), 1);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label("err"), 0);
     sm::set_relabel_configs({}).get();
 }
 
@@ -307,9 +308,9 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_enable_disable_skip_when_empty) {
     rl[1].action = sm::relabel_config::relabel_action::keep;
     // We just disable all metrics besides those mark as lev3
     sm::metric_relabeling_result success = sm::set_relabel_configs(rl).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
-    BOOST_CHECK_EQUAL(count_by_label(""), 3);
-    BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label(""), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
         return mi.should_skip_when_empty() == sm::skip_when_empty::yes;
     }), 0);
 
@@ -326,9 +327,9 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_enable_disable_skip_when_empty) {
     rl2[2].action = sm::relabel_config::relabel_action::skip_when_empty;
 
     success = sm::set_relabel_configs(rl2).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
-    BOOST_CHECK_EQUAL(count_by_label(""), 3);
-    BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_label(""), 3);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
         return mi.should_skip_when_empty() == sm::skip_when_empty::yes;
     }), 3);
     // clear the configuration
@@ -349,8 +350,8 @@ SEASTAR_THREAD_TEST_CASE(test_relabel_enable_disable_skip_when_empty) {
     rl3[2].action = sm::relabel_config::relabel_action::report_when_empty;
 
     success = sm::set_relabel_configs(rl3).get();
-    BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
-    BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
+    SEASTAR_BOOST_CHECK_EQUAL(success.metrics_relabeled_due_to_collision, 0);
+    SEASTAR_BOOST_CHECK_EQUAL(count_by_fun([](const seastar::metrics::impl::metric_series_metadata& mi) {
         return mi.should_skip_when_empty() == sm::skip_when_empty::yes;
     }), 0);
     sm::set_relabel_configs({}).get();
@@ -376,9 +377,9 @@ SEASTAR_THREAD_TEST_CASE(test_estimated_histogram) {
         min = next;
         next *= 2;
     }
-    BOOST_CHECK_EQUAL(histogram1.count(), 64);
+    SEASTAR_BOOST_CHECK_EQUAL(histogram1.count(), 64);
     for (size_t i = 0; i < 64; i++) {
-        BOOST_CHECK_EQUAL(histogram1.get(i), 1);
+        SEASTAR_BOOST_CHECK_EQUAL(histogram1.get(i), 1);
     }
     min = std::chrono::microseconds(512);
     next = min*2;
@@ -390,26 +391,26 @@ SEASTAR_THREAD_TEST_CASE(test_estimated_histogram) {
         min = next;
         next *= 2;
     }
-    BOOST_CHECK_EQUAL(histogram2.count(), 32);
+    SEASTAR_BOOST_CHECK_EQUAL(histogram2.count(), 32);
     for (size_t i = 0; i < 32; i++) {
-        BOOST_CHECK_EQUAL(histogram2.get(i), 1);
+        SEASTAR_BOOST_CHECK_EQUAL(histogram2.get(i), 1);
     }
     for (size_t i = 33; i < 64; i++) {
-        BOOST_CHECK_EQUAL(histogram2.get(i), 0);
+        SEASTAR_BOOST_CHECK_EQUAL(histogram2.get(i), 0);
     }
     histogram1.merge(histogram2);
-    BOOST_CHECK_EQUAL(histogram1.count(), 96);
+    SEASTAR_BOOST_CHECK_EQUAL(histogram1.count(), 96);
     for (size_t i = 0; i < 32; i++) {
-        BOOST_CHECK_EQUAL(histogram1.get(i), 2);
+        SEASTAR_BOOST_CHECK_EQUAL(histogram1.get(i), 2);
     }
     for (size_t i = 33; i < 64; i++) {
-        BOOST_CHECK_EQUAL(histogram1.get(i), 1);
+        SEASTAR_BOOST_CHECK_EQUAL(histogram1.get(i), 1);
     }
     auto mh = histogram1.to_metrics_histogram();
     for (size_t i = 0; i < 32; i++) {
-        BOOST_CHECK_EQUAL(mh.buckets[i].count, 2 + i*2);
+        SEASTAR_BOOST_CHECK_EQUAL(mh.buckets[i].count, 2 + i*2);
     }
     for (size_t i = 33; i < 64; i++) {
-        BOOST_CHECK_EQUAL(mh.buckets[i].count, 33 + i);
+        SEASTAR_BOOST_CHECK_EQUAL(mh.buckets[i].count, 33 + i);
     }
 }

--- a/tests/unit/net_config_test.cc
+++ b/tests/unit/net_config_test.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <exception>
 #include <sstream>
+#include "test_comparisons.hh"
 
 using namespace seastar::net;
 
@@ -36,19 +37,19 @@ BOOST_AUTO_TEST_CASE(test_valid_config_with_pci_address) {
 
     // eth0 tests
     BOOST_REQUIRE(device_configs.find("eth0") != device_configs.end());
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").hw_cfg.pci_address, "0000:06:00.0");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").hw_cfg.pci_address, "0000:06:00.0");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
 
     // eth1 tests
     BOOST_REQUIRE(device_configs.find("eth1") != device_configs.end());
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").hw_cfg.pci_address, "0000:06:00.1");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.dhcp, true);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.ip, "");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.gateway, "");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.netmask, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").hw_cfg.pci_address, "0000:06:00.1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.dhcp, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.ip, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.gateway, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.netmask, "");
 }
 
 BOOST_AUTO_TEST_CASE(test_valid_config_with_port_index) {
@@ -59,19 +60,19 @@ BOOST_AUTO_TEST_CASE(test_valid_config_with_port_index) {
 
     // eth0 tests
     BOOST_REQUIRE(device_configs.find("eth0") != device_configs.end());
-    BOOST_REQUIRE_EQUAL(*device_configs.at("eth0").hw_cfg.port_index, 0u);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
+    SEASTAR_BOOST_REQUIRE_EQUAL(*device_configs.at("eth0").hw_cfg.port_index, 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
 
     // eth1 tests
     BOOST_REQUIRE(device_configs.find("eth1") != device_configs.end());
-    BOOST_REQUIRE_EQUAL(*device_configs.at("eth1").hw_cfg.port_index, 1u);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.dhcp, true);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.ip, "");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.gateway, "");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.netmask, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(*device_configs.at("eth1").hw_cfg.port_index, 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.dhcp, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.ip, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.gateway, "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth1").ip_cfg.netmask, "");
 }
 
 BOOST_AUTO_TEST_CASE(test_valid_config_single_device) {
@@ -82,11 +83,11 @@ BOOST_AUTO_TEST_CASE(test_valid_config_single_device) {
 
     // eth0 tests
     BOOST_REQUIRE(device_configs.find("eth0") != device_configs.end());
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").hw_cfg.pci_address, "0000:06:00.0");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
-    BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").hw_cfg.pci_address, "0000:06:00.0");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.dhcp, false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.ip, "192.168.100.10");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.gateway, "192.168.100.1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(device_configs.at("eth0").ip_cfg.netmask, "255.255.255.0");
 }
 
 BOOST_AUTO_TEST_CASE(test_unsupported_key) {

--- a/tests/unit/network_interface_test.cc
+++ b/tests/unit/network_interface_test.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/log.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -39,7 +40,7 @@ static_assert(std::is_nothrow_move_constructible_v<net::ethernet_address>);
 SEASTAR_TEST_CASE(list_interfaces) {
     // just verifying we have something. And can access all the stuff.
     auto interfaces = engine().net().network_interfaces();
-    BOOST_REQUIRE_GT(interfaces.size(), 0);
+    SEASTAR_BOOST_REQUIRE_GT(interfaces.size(), 0);
 
     for (auto& nif : interfaces) {
         niflog.info("Iface: {}, index = {}, mtu = {}, loopback = {}, virtual = {}, up = {}",
@@ -74,12 +75,12 @@ SEASTAR_TEST_CASE(match_ipv6_scope) {
 
         net::inet_address na(text);
 
-        BOOST_REQUIRE_EQUAL(na.as_ipv6_address(), i->as_ipv6_address());
+        SEASTAR_BOOST_REQUIRE_EQUAL(na.as_ipv6_address(), i->as_ipv6_address());
         // also verify that the inet_address itself matches
-        BOOST_REQUIRE_EQUAL(na, *i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(na, *i);
         // and that inet_address _without_ scope matches.
-        BOOST_REQUIRE_EQUAL(net::inet_address(na.as_ipv6_address()), *i);
-        BOOST_REQUIRE_EQUAL(na.scope(), nif.index());
+        SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address(na.as_ipv6_address()), *i);
+        SEASTAR_BOOST_REQUIRE_EQUAL(na.scope(), nif.index());
         // and that they are not ipv4 addresses
         BOOST_REQUIRE_THROW(i->as_ipv4_address(), std::invalid_argument);
         BOOST_REQUIRE_THROW(na.as_ipv4_address(), std::invalid_argument);
@@ -92,18 +93,18 @@ SEASTAR_TEST_CASE(match_ipv6_scope) {
 }
 
 SEASTAR_TEST_CASE(is_standard_addresses_sanity) {
-    BOOST_REQUIRE_EQUAL(net::inet_address("127.0.0.1").is_loopback(), true);
-    BOOST_REQUIRE_EQUAL(net::inet_address("127.0.0.11").is_loopback(), true);
-    BOOST_REQUIRE_EQUAL(net::inet_address(::in_addr{INADDR_ANY}).is_addr_any(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address("127.0.0.1").is_loopback(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address("127.0.0.11").is_loopback(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address(::in_addr{INADDR_ANY}).is_addr_any(), true);
     auto addr = net::inet_address("1.2.3.4");
-    BOOST_REQUIRE_EQUAL(addr.is_loopback(), false);
-    BOOST_REQUIRE_EQUAL(addr.is_addr_any(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addr.is_loopback(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addr.is_addr_any(), false);
 
-    BOOST_REQUIRE_EQUAL(net::inet_address("::1").is_loopback(), true);
-    BOOST_REQUIRE_EQUAL(net::inet_address(::in6addr_any).is_addr_any(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address("::1").is_loopback(), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(net::inet_address(::in6addr_any).is_addr_any(), true);
     auto addr6 = net::inet_address("acf1:f5e5:5a99:337f:ebe2:c57e:0e27:69c6");
-    BOOST_REQUIRE_EQUAL(addr6.is_loopback(), false);
-    BOOST_REQUIRE_EQUAL(addr6.is_addr_any(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addr6.is_loopback(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addr6.is_addr_any(), false);
 
     return make_ready_future<>();
 }
@@ -125,7 +126,7 @@ SEASTAR_TEST_CASE(test_inet_address_format) {
 
     for (auto expected : tests) {
         net::inet_address addr{expected};
-        BOOST_CHECK_EQUAL(fmt::to_string(addr), expected);
+        SEASTAR_BOOST_CHECK_EQUAL(fmt::to_string(addr), expected);
     }
 
     // scoped addresses
@@ -136,7 +137,7 @@ SEASTAR_TEST_CASE(test_inet_address_format) {
             net::inet_address addr{fmt::format("{}%{}", address, zone)};
             // we always use the zone-id to represent the zone
             auto expected = fmt::format("{}%{}", address, zone_id);
-            BOOST_CHECK_EQUAL(fmt::to_string(addr), expected);
+            SEASTAR_BOOST_CHECK_EQUAL(fmt::to_string(addr), expected);
         }
         // one of them would suffice
         break;

--- a/tests/unit/noncopyable_function_test.cc
+++ b/tests/unit/noncopyable_function_test.cc
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/util/noncopyable_function.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -39,10 +40,10 @@ BOOST_AUTO_TEST_CASE(basic_tests) {
     auto fn2 = noncopyable_function<int (s*, int)>(&s::f2);
     auto fn3 = noncopyable_function<int (int)>(&s::f3);
     auto fn4 = noncopyable_function<int (int)>(std::move(obj2));
-    BOOST_REQUIRE_EQUAL(fn1(&obj, 1), 2);
-    BOOST_REQUIRE_EQUAL(fn2(&obj, 1), 3);
-    BOOST_REQUIRE_EQUAL(fn3(1), 4);
-    BOOST_REQUIRE_EQUAL(fn4(1), 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fn1(&obj, 1), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fn2(&obj, 1), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fn3(1), 4);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fn4(1), 5);
 }
 
 template <size_t Extra>
@@ -64,16 +65,16 @@ template <size_t Extra>
 void do_move_tests() {
     using payload = ::payload<Extra>;
     auto f1 = noncopyable_function<int ()>(payload(3));
-    BOOST_REQUIRE_EQUAL(payload::live, 1u);
-    BOOST_REQUIRE_EQUAL(f1(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(payload::live, 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f1(), 3);
     auto f2 = noncopyable_function<int ()>();
     BOOST_CHECK_THROW(f2(), std::bad_function_call);
     f2 = std::move(f1);
     BOOST_CHECK_THROW(f1(), std::bad_function_call);
-    BOOST_REQUIRE_EQUAL(f2(), 3);
-    BOOST_REQUIRE_EQUAL(payload::live, 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(f2(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(payload::live, 1u);
     f2 = {};
-    BOOST_REQUIRE_EQUAL(payload::live, 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(payload::live, 0u);
     BOOST_CHECK_THROW(f2(), std::bad_function_call);
 }
 

--- a/tests/unit/output_stream_test.cc
+++ b/tests/unit/output_stream_test.cc
@@ -30,6 +30,7 @@
 #include <deque>
 #include <sstream>
 #include "memory-data-sink.hh"
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace net;
@@ -275,7 +276,7 @@ SEASTAR_THREAD_TEST_CASE(test_simple_write) {
 
     auto value = value1 + value2 + value3;
 
-    BOOST_REQUIRE_EQUAL(ss.str(), value);
+    SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), value);
 }
 
 namespace seastar::testing {
@@ -311,7 +312,7 @@ SEASTAR_THREAD_TEST_CASE(test_mixed_mode_write) {
 
     out.close().get();
 
-    BOOST_REQUIRE_EQUAL(ss.str(), "test");
+    SEASTAR_BOOST_REQUIRE_EQUAL(ss.str(), "test");
 }
 
 // Simple (mainly compilation) test for basic_memory_data_sink implementation over standard collections
@@ -323,10 +324,10 @@ void do_test_memory_data_sink() {
     for (unsigned i = 0; i < 3; i++) {
         s.put(temporary_buffer<char>::copy_of(fmt::to_string(i))).get();
     }
-    BOOST_REQUIRE_EQUAL(col.size(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(col.size(), 3);
     auto it = col.begin();
     for (unsigned i = 0; i < 3; i++) {
-        BOOST_REQUIRE_EQUAL(internal::to_sstring<std::string>(*it), fmt::to_string(i));
+        SEASTAR_BOOST_REQUIRE_EQUAL(internal::to_sstring<std::string>(*it), fmt::to_string(i));
         it++;
     }
 }

--- a/tests/unit/packet_test.cc
+++ b/tests/unit/packet_test.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <seastar/net/packet.hh>
 #include <array>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace net;
@@ -47,10 +48,10 @@ BOOST_AUTO_TEST_CASE(test_many_fragments) {
     p = append(std::move(p), 'd', 4096);
 
     auto verify = [&expected] (const net::packet& p) {
-        BOOST_CHECK_EQUAL(p.len(), expected.size());
+        SEASTAR_BOOST_CHECK_EQUAL(p.len(), expected.size());
         auto expected_it = expected.begin();
         for (auto&& frag : p.fragments()) {
-            BOOST_CHECK_LE(frag.size, static_cast<size_t>(expected.end() - expected_it));
+            SEASTAR_BOOST_CHECK_LE(frag.size, static_cast<size_t>(expected.end() - expected_it));
             BOOST_CHECK(std::equal(frag.base, frag.base + frag.size, expected_it));
             expected_it += frag.size;
         }
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(test_headers_are_contiguous) {
     packet p(f);
     p.prepend_header<tcp_header>();
     p.prepend_header<ip_header>();
-    BOOST_REQUIRE_EQUAL(p.nr_frags(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(p.nr_frags(), 2u);
 }
 
 BOOST_AUTO_TEST_CASE(test_headers_are_contiguous_even_with_small_fragment) {
@@ -102,7 +103,7 @@ BOOST_AUTO_TEST_CASE(test_headers_are_contiguous_even_with_small_fragment) {
     packet p(f);
     p.prepend_header<tcp_header>();
     p.prepend_header<ip_header>();
-    BOOST_REQUIRE_EQUAL(p.nr_frags(), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(p.nr_frags(), 2u);
 }
 
 BOOST_AUTO_TEST_CASE(test_headers_are_contiguous_even_with_many_fragments) {
@@ -116,6 +117,6 @@ BOOST_AUTO_TEST_CASE(test_headers_are_contiguous_even_with_many_fragments) {
     }
     p.prepend_header<tcp_header>();
     p.prepend_header<ip_header>();
-    BOOST_REQUIRE_EQUAL(p.nr_frags(), 9u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(p.nr_frags(), 9u);
 }
 

--- a/tests/unit/pipe_stream_test.cc
+++ b/tests/unit/pipe_stream_test.cc
@@ -21,6 +21,7 @@
 
 #include <sys/ioctl.h>
 #include <termios.h>
+#include "test_comparisons.hh"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
@@ -53,7 +54,7 @@ SEASTAR_THREAD_TEST_CASE(pipe_stream_roundtrip) {
     out.flush().get();
 
     auto buf = in.read_exactly(payload.size()).get();
-    BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
 
     out.close().get();
     in.close().get();
@@ -112,7 +113,7 @@ SEASTAR_THREAD_TEST_CASE(pipe_pty_stream_roundtrip) {
     out.flush().get();
 
     auto buf = in.read_exactly(payload.size()).get();
-    BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
 
     out.close().get();
     in.close().get();

--- a/tests/unit/pipe_test.cc
+++ b/tests/unit/pipe_test.cc
@@ -22,6 +22,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/pipe.hh>
 
@@ -42,10 +43,10 @@ SEASTAR_THREAD_TEST_CASE(simple_pipe_test) {
     auto f0 = p.reader.read();
     BOOST_CHECK(!f0.available());
     p.writer.write(17).get();
-    BOOST_REQUIRE_EQUAL(*f0.get(), 17);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*f0.get(), 17);
 
     p.writer.write(42).get();
     auto f2 = p.reader.read();
     BOOST_CHECK(f2.available());
-    BOOST_REQUIRE_EQUAL(*f2.get(), 42);
+    SEASTAR_BOOST_REQUIRE_EQUAL(*f2.get(), 42);
 }

--- a/tests/unit/program_options_test.cc
+++ b/tests/unit/program_options_test.cc
@@ -22,6 +22,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <seastar/util/program-options.hh>
+#include "test_comparisons.hh"
 
 #include <boost/program_options.hpp>
 #include <boost/test/unit_test.hpp>
@@ -55,9 +56,9 @@ BOOST_AUTO_TEST_CASE(string_map) {
     const auto& ages = vars["ages"].as<program_options::string_map>();
 
     // `string_map` values can be specified multiple times. The last association takes precedence.
-    BOOST_REQUIRE_EQUAL(ages.at("joe"), "11");
-    BOOST_REQUIRE_EQUAL(ages.at("phil"), "18");
-    BOOST_REQUIRE_EQUAL(ages.at("sally"), "20");
+    SEASTAR_BOOST_REQUIRE_EQUAL(ages.at("joe"), "11");
+    SEASTAR_BOOST_REQUIRE_EQUAL(ages.at("phil"), "18");
+    SEASTAR_BOOST_REQUIRE_EQUAL(ages.at("sally"), "20");
 
     BOOST_REQUIRE_THROW(parse(desc, {"--ages", "tim:"}), bpo::invalid_option_value);
 }

--- a/tests/unit/prometheus_http_test.cc
+++ b/tests/unit/prometheus_http_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include "loopback_socket.hh"
+#include "test_comparisons.hh"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/prometheus.hh>
@@ -54,7 +55,7 @@ std::string get_metrics_body(loopback_connection_factory& lcf, const sstring& pa
     std::string body;
     cln.make_request(http::request::make("GET", "test", path),
         [&body] (const http::reply& rep, input_stream<char>&& in) {
-            BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::ok);
+            SEASTAR_BOOST_REQUIRE_EQUAL(rep._status, http::reply::status_type::ok);
             return seastar::async([&body, in = std::move(in)] () mutable {
                 body = util::read_entire_stream_contiguous(in).get();
                 in.close().get();

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/prometheus.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/closeable.hh>
+#include "test_comparisons.hh"
 
 #include "core/prometheus-impl.hh"
 #include "memory-data-sink.hh"
@@ -442,16 +443,16 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_basic_counter) {
 
     // After aggregation, should have one metric with "shard" label removed
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 1);
 
     // Check that the aggregated value has the correct labels (without "shard")
     auto it = values.begin();
     // Labels are already filtered (aggregated labels removed)
-    BOOST_REQUIRE_EQUAL(it->second.labels.size(), 1);
-    BOOST_REQUIRE_EQUAL(it->second.labels.at("name").value(), "counter1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.labels.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.labels.at("name").value(), "counter1");
 
     // Check that values were summed: 123 + 456 = 579
-    BOOST_REQUIRE_EQUAL(it->second.m.d(), 579);
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.m.d(), 579);
 
     return make_ready_future<>();
 }
@@ -482,14 +483,14 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_multiple_labels) {
 
     // After aggregation, should have one metric with "shard" and "cpu" removed
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 1);
 
     auto it = values.begin();
     // Labels are already filtered (aggregated labels removed)
-    BOOST_REQUIRE_EQUAL(it->second.labels.size(), 2);
-    BOOST_REQUIRE_EQUAL(it->second.labels.at("name").value(), "metric1");
-    BOOST_REQUIRE_EQUAL(it->second.labels.at("type").value(), "typeA");
-    BOOST_REQUIRE_EQUAL(it->second.m.d(), 300);
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.labels.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.labels.at("name").value(), "metric1");
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.labels.at("type").value(), "typeA");
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.m.d(), 300);
 
     return make_ready_future<>();
 }
@@ -516,7 +517,7 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_different_label_values) {
 
     // Should have TWO separate aggregated metrics (different "name" values)
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 2);
 
     // Verify we have both metrics by iterating
     int count_metric1 = 0;
@@ -524,14 +525,14 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_different_label_values) {
     for (auto it = values.begin(); it != values.end(); ++it) {
         if (it->second.labels.at("name").value() == "metric1") {
             count_metric1++;
-            BOOST_REQUIRE_EQUAL(it->second.m.d(), 100);
+            SEASTAR_BOOST_REQUIRE_EQUAL(it->second.m.d(), 100);
         } else if (it->second.labels.at("name").value() == "metric2") {
             count_metric2++;
-            BOOST_REQUIRE_EQUAL(it->second.m.d(), 200);
+            SEASTAR_BOOST_REQUIRE_EQUAL(it->second.m.d(), 200);
         }
     }
-    BOOST_REQUIRE_EQUAL(count_metric1, 1);
-    BOOST_REQUIRE_EQUAL(count_metric2, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(count_metric1, 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(count_metric2, 1);
 
     return make_ready_future<>();
 }
@@ -542,7 +543,7 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_empty) {
     metric_aggregate_by_labels aggregator(aggregate_labels);
 
     BOOST_REQUIRE(aggregator.empty());
-    BOOST_REQUIRE_EQUAL(aggregator.get_values().size(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregator.get_values().size(), 0);
 
     return make_ready_future<>();
 }
@@ -568,7 +569,7 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_no_aggregation) {
 
     // Should have TWO separate metrics (no aggregation)
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 2);
 
     return make_ready_future<>();
 }
@@ -593,7 +594,7 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_real_counters) {
     aggregator.add(value2, labels2);
 
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 1);
 
     auto it = values.begin();
     BOOST_REQUIRE_CLOSE(it->second.m.d(), 580.2, 0.001);
@@ -634,17 +635,17 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_histograms) {
     aggregator.add(value2, labels2);
 
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 1);
 
     auto it = values.begin();
     const auto& aggregated_hist = it->second.m.get_histogram();
 
     // Check aggregated histogram values
-    BOOST_REQUIRE_EQUAL(aggregated_hist.sample_count, 30);
-    BOOST_REQUIRE_EQUAL(aggregated_hist.sample_sum, 400);
-    BOOST_REQUIRE_EQUAL(aggregated_hist.buckets.size(), 2);
-    BOOST_REQUIRE_EQUAL(aggregated_hist.buckets[0].count, 13);
-    BOOST_REQUIRE_EQUAL(aggregated_hist.buckets[1].count, 30);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregated_hist.sample_count, 30);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregated_hist.sample_sum, 400);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregated_hist.buckets.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregated_hist.buckets[0].count, 13);
+    SEASTAR_BOOST_REQUIRE_EQUAL(aggregated_hist.buckets[1].count, 30);
 
     return make_ready_future<>();
 }
@@ -665,10 +666,10 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_same_metric_added_twice) {
     aggregator.add(value2, labels);
 
     const auto& values = aggregator.get_values();
-    BOOST_REQUIRE_EQUAL(values.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(values.size(), 1);
 
     auto it = values.begin();
-    BOOST_REQUIRE_EQUAL(it->second.m.d(), 250);
+    SEASTAR_BOOST_REQUIRE_EQUAL(it->second.m.d(), 250);
 
     return make_ready_future<>();
 }

--- a/tests/unit/proxy_protocol_test.cc
+++ b/tests/unit/proxy_protocol_test.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/net/api.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -321,8 +322,8 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_local_mode) {
     // With LOCAL mode, addresses should be real connection addresses, not from header
     // We can't check exact match since the client port is ephemeral, but we can verify
     // that the addresses are not the fake proxy addresses and the IPs match
-    BOOST_REQUIRE_EQUAL(addrs.local, socket_address(listen_addr));
-    BOOST_REQUIRE_EQUAL(addrs.remote, client_actual_local);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.local, socket_address(listen_addr));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.remote, client_actual_local);
 }
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_local_mode_wrong_family) {
@@ -357,8 +358,8 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv4_addresses) {
     ss.abort_accept();
 
     // Verify addresses match what was sent in the header
-    BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
-    BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
 }
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv6_addresses) {
@@ -387,8 +388,8 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv6_addresses) {
     ss.abort_accept();
 
     // Verify addresses match what was sent in the header
-    BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
-    BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
 }
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_invalid_version) {
@@ -528,8 +529,8 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_with_tlvs) {
     ss.abort_accept();
 
     // Verify addresses still work correctly despite TLVs
-    BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
-    BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.remote, socket_address(expected_remote));
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.local, socket_address(expected_local));
 }
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_extreme_ports) {
@@ -558,8 +559,8 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_extreme_ports) {
     auto [addrs] = when_all_succeed(std::move(server), std::move(client)).get();
     ss.abort_accept();
 
-    BOOST_REQUIRE_EQUAL(addrs.remote.port(), 0);
-    BOOST_REQUIRE_EQUAL(addrs.local.port(), 65535);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.remote.port(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(addrs.local.port(), 65535);
 }
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_unspec_family) {

--- a/tests/unit/reactor_backend_test.cc
+++ b/tests/unit/reactor_backend_test.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/posix.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/testing/test_case.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -43,13 +44,13 @@ using namespace seastar;
 // backend-agnostic so it is exercised for all available backends.
 SEASTAR_TEST_CASE(pollable_fd_state_completion_reuse_test) {
     int sv[2];
-    BOOST_REQUIRE_EQUAL(::socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, sv), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(::socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, sv), 0);
 
     pollable_fd reader(file_desc::from_fd(sv[0]));
 
     // Write two bytes so both polls below complete without blocking.
     const char data[] = "ab";
-    BOOST_REQUIRE_EQUAL(::write(sv[1], data, 2), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(::write(sv[1], data, 2), 2);
 
     // First co_await readable() — first use of _completion_pollin.
     // await_resume() calls detach_promise(), setting _pr._state = nullptr.

--- a/tests/unit/request_parser_test.cc
+++ b/tests/unit/request_parser_test.cc
@@ -29,6 +29,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -64,10 +65,10 @@ SEASTAR_TEST_CASE(test_header_parsing) {
     for (auto& tset : tests) {
         parser.init();
         BOOST_REQUIRE(parser(tset.buf()).get().has_value());
-        BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
+        SEASTAR_BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto req = parser.get_parsed_request();
-            BOOST_REQUIRE_EQUAL(req->get_header(std::move(tset.header_name)), std::move(tset.header_value));
+            SEASTAR_BOOST_REQUIRE_EQUAL(req->get_header(std::move(tset.header_name)), std::move(tset.header_value));
         }
     }
     return make_ready_future<>();

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -43,6 +43,7 @@
 #include <seastar/util/later.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor.hh>
+#include "test_comparisons.hh"
 
 #include <boost/range/numeric.hpp>
 
@@ -375,14 +376,14 @@ SEASTAR_TEST_CASE(test_rpc_connect) {
                 }).get();
                 auto sum = env.proto().make_client<int (int, int)>(1);
                 auto result = sum(c1, 2, 3).get();
-                BOOST_REQUIRE_EQUAL(result, 2 + 3);
+                SEASTAR_BOOST_REQUIRE_EQUAL(result, 2 + 3);
             }).handle_exception([] (auto ep) {
                 BOOST_FAIL("No exception expected");
             }).finally([factory = std::move(factory), i, j = j & 1] {
                 if (i == 1 && j == 1) {
-                    BOOST_REQUIRE_EQUAL(factory->use_compression, 2);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(factory->use_compression, 2);
                 } else {
-                    BOOST_REQUIRE_EQUAL(factory->use_compression, 0);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(factory->use_compression, 0);
                 }
             });
             fs.emplace_back(std::move(f));
@@ -409,10 +410,10 @@ SEASTAR_TEST_CASE(test_rpc_connect_multi_compression_algo) {
         }).get();
         auto sum = env.proto().make_client<int (int, int)>(1);
         auto result = sum(c1, 2, 3).get();
-        BOOST_REQUIRE_EQUAL(result, 2 + 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(result, 2 + 3);
     }).finally([factory1 = std::move(factory1), factory2 = std::move(factory2)] {
-        BOOST_REQUIRE_EQUAL(factory1->use_compression, 0);
-        BOOST_REQUIRE_EQUAL(factory2->use_compression, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(factory1->use_compression, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(factory2->use_compression, 2);
     });
 }
 
@@ -471,7 +472,7 @@ SEASTAR_TEST_CASE(test_rpc_cancel) {
         } catch(rpc::canceled_error&) {
             good += 10*rpc_executed;
         };
-        BOOST_REQUIRE_EQUAL(good, 11);
+        SEASTAR_BOOST_REQUIRE_EQUAL(good, 11);
     });
 }
 
@@ -491,7 +492,7 @@ SEASTAR_TEST_CASE(test_message_to_big) {
         } catch(...) {
             good = false;
         }
-        BOOST_REQUIRE_EQUAL(good, true);
+        SEASTAR_BOOST_REQUIRE_EQUAL(good, true);
     });
 }
 
@@ -545,7 +546,7 @@ future<stream_test_result> stream_test_func(rpc_test_env<>& env, bool stop_clien
         test_rpc_proto::client c(env.proto(), {}, env.make_socket(), ipv4_addr());
         future<> server_done = make_ready_future();
         env.register_handler(1, [&](int i, rpc::source<int> source) {
-            BOOST_REQUIRE_EQUAL(i, 666);
+            SEASTAR_BOOST_REQUIRE_EQUAL(i, 666);
             auto sink = source.make_sink<serializer, sstring>();
             auto sink_loop = seastar::async([sink] () mutable {
                 for (auto i = 0; i < 100; i++) {
@@ -597,7 +598,7 @@ future<stream_test_result> stream_test_func(rpc_test_env<>& env, bool stop_clien
                 while (!r.client_source_closed) {
                     auto data = source().get();
                     if (data) {
-                        BOOST_REQUIRE_EQUAL(std::get<0>(*data), "seastar");
+                        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<0>(*data), "seastar");
                     } else {
                         r.client_source_closed = true;
                     }
@@ -1193,7 +1194,7 @@ void test_compressor(std::function<std::unique_ptr<seastar::rpc::compressor>()> 
                 });
             }
         );
-        BOOST_CHECK_EQUAL(actual_size, buffer.size);
+        SEASTAR_BOOST_CHECK_EQUAL(actual_size, buffer.size);
     };
 
     for (auto& in_func : inputs) {
@@ -1204,11 +1205,11 @@ void test_compressor(std::function<std::unique_ptr<seastar::rpc::compressor>()> 
         sanity_check(compressed);
 
         // Remove headroom
-        BOOST_CHECK_GE(compressed.size, headroom);
+        SEASTAR_BOOST_CHECK_GE(compressed.size, headroom);
         compressed.size -= headroom;
         seastar::visit(compressed.bufs,
             [&] (temporary_buffer<char>& buf) {
-                BOOST_CHECK_GE(buf.size(), headroom);
+                SEASTAR_BOOST_CHECK_GE(buf.size(), headroom);
                 buf.trim_front(headroom);
             },
             [&] (std::vector<temporary_buffer<char>>& bufs) {
@@ -1233,11 +1234,11 @@ void test_compressor(std::function<std::unique_ptr<seastar::rpc::compressor>()> 
             auto decompressed = compressor->decompress(std::move(received));
             sanity_check(decompressed);
 
-            BOOST_CHECK_EQUAL(decompressed.size, std::get<2>(in).size);
+            SEASTAR_BOOST_CHECK_EQUAL(decompressed.size, std::get<2>(in).size);
 
             auto out_l = linearize(decompressed);
 
-            BOOST_CHECK_EQUAL(in_l.size(), out_l.size());
+            SEASTAR_BOOST_CHECK_EQUAL(in_l.size(), out_l.size());
             BOOST_CHECK(in_l == out_l);
         }
     }
@@ -1296,7 +1297,7 @@ SEASTAR_TEST_CASE(test_max_absolute_timeout) {
         auto until = seastar::lowres_clock::now() + std::chrono::milliseconds(200);
         while (seastar::lowres_clock::now() <= until) {
             auto result = sum(c1, rpc::rpc_clock_type::time_point::max(), 2, 3).get();
-            BOOST_REQUIRE_EQUAL(result, 2 + 3);
+            SEASTAR_BOOST_REQUIRE_EQUAL(result, 2 + 3);
         }
     });
 }
@@ -1310,7 +1311,7 @@ SEASTAR_TEST_CASE(test_max_relative_timeout) {
         // The following call used to always hang, when max()+now()
         // overflowed and appeared to be a negative timeout.
         auto result = sum(c1, rpc::rpc_clock_type::duration::max(), 2, 3).get();
-        BOOST_REQUIRE_EQUAL(result, 2 + 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(result, 2 + 3);
     });
 }
 
@@ -1321,8 +1322,8 @@ SEASTAR_TEST_CASE(test_rpc_tuple) {
         }).get();
         auto f1 = env.proto().make_client<rpc::tuple<int, long> ()>(1);
         auto result = f1(c1).get();
-        BOOST_REQUIRE_EQUAL(std::get<0>(result), 1);
-        BOOST_REQUIRE_EQUAL(std::get<1>(result), 0x7'0000'0000L);
+        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<0>(result), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(std::get<1>(result), 0x7'0000'0000L);
     });
 }
 
@@ -1462,7 +1463,7 @@ SEASTAR_TEST_CASE(test_unregister_handler) {
             BOOST_REQUIRE(!unregister_future.available());
             handler_go_promise.set_value();
             unregister_future.get();
-            BOOST_REQUIRE_EQUAL(response_future.get(), "before_unregister");
+            SEASTAR_BOOST_REQUIRE_EQUAL(response_future.get(), "before_unregister");
         }
     });
 }
@@ -1488,7 +1489,7 @@ SEASTAR_TEST_CASE(test_loggers) {
 SEASTAR_TEST_CASE(test_connection_id_format) {
     rpc::connection_id cid = rpc::connection_id::make_id(0x123, 1);
     std::string res = format("{}", cid);
-    BOOST_REQUIRE_EQUAL(res, "1230001");
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, "1230001");
     return make_ready_future<>();
 }
 
@@ -1500,15 +1501,15 @@ SEASTAR_TEST_CASE(test_client_info) {
         const rpc::client_info& const_info = *const_cast<rpc::client_info*>(&info);
 
         info.attach_auxiliary("key", 0);
-        BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 0);
         info.retrieve_auxiliary<int>("key") = 1;
-        BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary<int>("key"), 1);
 
-        BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("key"), &info.retrieve_auxiliary<int>("key"));
-        BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("key"), &const_info.retrieve_auxiliary<int>("key"));
+        SEASTAR_BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("key"), &info.retrieve_auxiliary<int>("key"));
+        SEASTAR_BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("key"), &const_info.retrieve_auxiliary<int>("key"));
 
-        BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("missing"), nullptr);
-        BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("missing"), nullptr);
+        SEASTAR_BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("missing"), nullptr);
+        SEASTAR_BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("missing"), nullptr);
 
         return make_ready_future<>();
     });
@@ -1557,7 +1558,7 @@ SEASTAR_TEST_CASE(test_rpc_abort_connection) {
         test_rpc_proto::client c1(env.proto(), {}, env.make_socket(), ipv4_addr());
         int arrived = 0;
         env.register_handler(1, [&arrived] (rpc::client_info& cinfo, int x) {
-            BOOST_REQUIRE_EQUAL(x, arrived++);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x, arrived++);
             if (arrived == 2) {
                 cinfo.server.abort_connection(cinfo.conn_id);
             }
@@ -1566,10 +1567,10 @@ SEASTAR_TEST_CASE(test_rpc_abort_connection) {
             return 0;
         }).get();
         auto f = env.proto().make_client<int (int)>(1);
-        BOOST_REQUIRE_EQUAL(f(c1, 0).get(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(f(c1, 0).get(), 0);
         BOOST_REQUIRE_THROW(f(c1, 1).get(), rpc::closed_error);
         BOOST_REQUIRE_THROW(f(c1, 2).get(), rpc::closed_error);
-        BOOST_REQUIRE_EQUAL(arrived, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(arrived, 2);
         c1.stop().get();
     });
 }
@@ -1608,8 +1609,8 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_metric_domains) {
     };
 
     // Negotiation messages also count, so +1 for default domain and +2 for "dom" one
-    BOOST_CHECK_EQUAL(get_metrics("rpc_client_sent_messages", "dom1"), 4);
-    BOOST_CHECK_EQUAL(get_metrics("rpc_client_sent_messages", "dom2"), 9);
+    SEASTAR_BOOST_CHECK_EQUAL(get_metrics("rpc_client_sent_messages", "dom1"), 4);
+    SEASTAR_BOOST_CHECK_EQUAL(get_metrics("rpc_client_sent_messages", "dom2"), 9);
 }
 
 // Extract a piece of contiguous data from the front of the buffer (and trim the extracted front away).
@@ -1752,15 +1753,15 @@ SEASTAR_THREAD_TEST_CASE(test_compressor_empty_frames) {
         // Perform an RPC once to initialize the connection and compressors.
         env.register_handler(1, []() { return 42; }).get();
         auto proto_client = env.proto().make_client<int()>(1);
-        BOOST_REQUIRE_EQUAL(proto_client(c).get(), 42);
+        SEASTAR_BOOST_REQUIRE_EQUAL(proto_client(c).get(), 42);
         BOOST_REQUIRE(client_tracker._compressor);
         BOOST_REQUIRE(server_tracker._compressor);
         // Check that both compressors can send metadata to each other.
         for (int i = 0; i < 3; ++i) {
             client_tracker._compressor->send_metadata(2*i);
-            BOOST_REQUIRE_EQUAL(server_tracker._compressor->receive_metadata().get(), 2*i);
+            SEASTAR_BOOST_REQUIRE_EQUAL(server_tracker._compressor->receive_metadata().get(), 2*i);
             server_tracker._compressor->send_metadata(2*i+1);
-            BOOST_REQUIRE_EQUAL(client_tracker._compressor->receive_metadata().get(), 2*i+1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(client_tracker._compressor->receive_metadata().get(), 2*i+1);
         }
     }).get();
 }

--- a/tests/unit/scheduling_group_test.cc
+++ b/tests/unit/scheduling_group_test.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <vector>
 #include <chrono>
+#include "test_comparisons.hh"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/test_case.hh>
@@ -72,8 +73,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
         }
 
     }).get();
@@ -82,7 +83,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -91,7 +92,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_after_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
             });
 
         });
@@ -130,8 +131,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
         }
 
     }).get();
@@ -140,7 +141,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -149,7 +150,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
             });
 
         });
@@ -192,8 +193,8 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
         }
 
         for (int i=0; i < num_scheduling_groups; i++) {
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
-            BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<int>(key1) = (i + 1) * factor, (i + 1) * factor);
+            SEASTAR_BOOST_REQUIRE_EQUAL(sgs[i].get_specific<ivec>(key2)[0], (i + 1) * factor);
         }
 
     }).get();
@@ -202,7 +203,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
         return reduce_scheduling_group_specific<int>(std::plus<int>(), int(0), key1).then([] (int sum) {
             int factor = this_shard_id() + 1;
             int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-            BOOST_REQUIRE_EQUAL(expected_sum, sum);
+            SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
         }). then([key2] {
             auto ivec_to_int = [] (ivec& v) {
                 return v.size() ? v[0] : 0;
@@ -211,7 +212,7 @@ SEASTAR_THREAD_TEST_CASE(sg_specific_values_define_before_and_after_sg_create) {
             return map_reduce_scheduling_group_specific<ivec>(ivec_to_int, std::plus<int>(), int(0), key2).then([] (int sum) {
                 int factor = this_shard_id() + 1;
                 int expected_sum = ((1 + num_scheduling_groups)*num_scheduling_groups) * factor /2;
-                BOOST_REQUIRE_EQUAL(expected_sum, sum);
+                SEASTAR_BOOST_REQUIRE_EQUAL(expected_sum, sum);
             });
 
         });
@@ -227,15 +228,15 @@ SEASTAR_THREAD_TEST_CASE(sg_scheduling_group_inheritance_in_seastar_async_test) 
     thread_attributes attr = {};
     attr.sched_group = sg;
     seastar::async(attr, [attr] {
-        BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()),
+        SEASTAR_BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()),
                                 internal::scheduling_group_index(*(attr.sched_group)));
 
         seastar::async([attr] {
-            BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()),
+            SEASTAR_BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()),
                                 internal::scheduling_group_index(*(attr.sched_group)));
 
             smp::invoke_on_all([sched_group_idx = internal::scheduling_group_index(*(attr.sched_group))] () {
-                BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()), sched_group_idx);
+                SEASTAR_BOOST_REQUIRE_EQUAL(internal::scheduling_group_index(current_scheduling_group()), sched_group_idx);
             }).get();
         }).get();
     }).get();
@@ -247,7 +248,7 @@ SEASTAR_THREAD_TEST_CASE(yield_preserves_sg) {
     auto cleanup = defer([&] () noexcept { destroy_scheduling_group(sg).get(); });
     with_scheduling_group(sg, [&] {
         return yield().then([&] {
-            BOOST_REQUIRE_EQUAL(
+            SEASTAR_BOOST_REQUIRE_EQUAL(
                     internal::scheduling_group_index(current_scheduling_group()),
                     internal::scheduling_group_index(sg));
         });
@@ -271,18 +272,18 @@ SEASTAR_THREAD_TEST_CASE(sg_count) {
     // try to create 3 groups too many.
     for (auto i = internal::scheduling_group_count(); i < max_scheduling_groups() + 3; i++) {
         try {
-            BOOST_REQUIRE_LE(internal::scheduling_group_count(), max_scheduling_groups());
+            SEASTAR_BOOST_REQUIRE_LE(internal::scheduling_group_count(), max_scheduling_groups());
             scheduling_groups_deferred_cleanup.emplace_back(create_scheduling_group(format("sg_{}", i), 10).get());
         } catch (std::runtime_error& e) {
             // make sure it is the right exception.
-            BOOST_REQUIRE_EQUAL(e.what(), fmt::format("Scheduling group limit exceeded while creating sg_{}", i));
+            SEASTAR_BOOST_REQUIRE_EQUAL(e.what(), fmt::format("Scheduling group limit exceeded while creating sg_{}", i));
             // make sure that the scheduling group count makes sense
-            BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
+            SEASTAR_BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
             // make sure that we expect this exception at this point
-            BOOST_REQUIRE_GE(i, max_scheduling_groups());
+            SEASTAR_BOOST_REQUIRE_GE(i, max_scheduling_groups());
         }
     }
-    BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
+    SEASTAR_BOOST_REQUIRE_EQUAL(internal::scheduling_group_count(), max_scheduling_groups());
 }
 
 SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
@@ -324,7 +325,7 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     smp::invoke_on_all([&sgs, &keys] () {
         for (size_t s = 0; s < std::size(sgs); ++s) {
             for (size_t k = 0; k < std::size(keys); ++k) {
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-old-{}", s));
+                SEASTAR_BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-old-{}", s));
                 sgs[s].get_specific<value>(keys[k])._id = 1;
             }
         }
@@ -337,9 +338,9 @@ SEASTAR_THREAD_TEST_CASE(sg_rename_callback) {
     smp::invoke_on_all([&sgs, &keys] () {
         for (size_t s = 0; s < std::size(sgs); ++s) {
             for (size_t k = 0; k < std::size(keys); ++k) {
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-new-{}", s));
+                SEASTAR_BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._sg_name, fmt::format("sg-new-{}", s));
                 // Checks that the value only saw a rename(), not a reconstruction.
-                BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._id, 1);
+                SEASTAR_BOOST_REQUIRE_EQUAL(sgs[s].get_specific<value>(keys[k])._id, 1);
             }
         }
     }).get();

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -33,6 +33,7 @@
 #include <seastar/core/shared_mutex.hh>
 #include <ranges>
 #include <stdexcept>
+#include "test_comparisons.hh"
 
 #include "expected_exception.hh"
 
@@ -42,15 +43,15 @@ using namespace std::chrono_literals;
 SEASTAR_TEST_CASE(test_semaphore_consume) {
     semaphore sem(0);
     sem.consume(1);
-    BOOST_REQUIRE_EQUAL(sem.current(), 0u);
-    BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sem.current(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
 
-    BOOST_REQUIRE_EQUAL(sem.try_wait(0), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sem.try_wait(0), false);
     auto fut = sem.wait(1);
-    BOOST_REQUIRE_EQUAL(fut.available(), false);
-    BOOST_REQUIRE_EQUAL(sem.waiters(), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(fut.available(), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sem.waiters(), 1u);
     sem.signal(2);
-    BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sem.waiters(), 0u);
     return make_ready_future<>();
 }
 
@@ -61,7 +62,7 @@ SEASTAR_TEST_CASE(test_semaphore_1) {
         });
         x.first.signal();
         return sleep(10ms).then([&x] {
-            BOOST_REQUIRE_EQUAL(x.second, 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x.second, 1);
         });
     });
 }
@@ -73,7 +74,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_2) {
         x++;
     });
     sleep(10ms).get();
-    BOOST_REQUIRE_EQUAL(x, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 0);
     sem = std::nullopt;
     BOOST_CHECK_THROW(fut.get(), broken_promise);
 }
@@ -87,7 +88,7 @@ SEASTAR_TEST_CASE(test_semaphore_timeout_1) {
             x.first.signal();
         });
         return sleep(200ms).then([&x] {
-            BOOST_REQUIRE_EQUAL(x.second, 1);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x.second, 1);
         });
     });
 }
@@ -105,9 +106,9 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_timeout_2) {
     });
     sleep(200ms).get();
     fut2.get();
-    BOOST_REQUIRE_EQUAL(signaled, true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(signaled, true);
     BOOST_CHECK_THROW(fut1.get(), semaphore_timed_out);
-    BOOST_REQUIRE_EQUAL(x, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_mix_1) {
@@ -126,7 +127,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_mix_1) {
     fut3.get();
     fut2.get();
     BOOST_CHECK_THROW(fut1.get(), semaphore_timed_out);
-    BOOST_REQUIRE_EQUAL(x, 10);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 10);
 }
 
 SEASTAR_TEST_CASE(test_broken_semaphore) {
@@ -180,11 +181,11 @@ SEASTAR_TEST_CASE(test_shared_mutex_exclusive) {
     return do_with(shared_mutex(), unsigned(0), [] (shared_mutex& sm, unsigned& counter) {
         return parallel_for_each(std::views::iota(0, 10), [&sm, &counter] (int idx) {
             return with_lock(sm, [&counter] {
-                BOOST_REQUIRE_EQUAL(counter, 0u);
+                SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 ++counter;
                 return sleep(10ms).then([&counter] {
                     --counter;
-                    BOOST_REQUIRE_EQUAL(counter, 0u);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 });
             });
         });
@@ -204,8 +205,8 @@ SEASTAR_TEST_CASE(test_shared_mutex_shared) {
             });
         };
         return map_reduce(std::views::iota(0, 100), running_in_parallel, false, std::bit_or<bool>()).then([&counter] (bool result) {
-            BOOST_REQUIRE_EQUAL(result, true);
-            BOOST_REQUIRE_EQUAL(counter, 0u);
+            SEASTAR_BOOST_REQUIRE_EQUAL(result, true);
+            SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
         });
     });
 }
@@ -224,11 +225,11 @@ SEASTAR_TEST_CASE(test_shared_mutex_mixed) {
         };
         auto running_alone = [&sm, &counter] (int instance) {
             return with_lock(sm, [&counter] {
-                BOOST_REQUIRE_EQUAL(counter, 0u);
+                SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                 ++counter;
                 return sleep(10ms).then([&counter] {
                     --counter;
-                    BOOST_REQUIRE_EQUAL(counter, 0u);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
                     return true;
                 });
             });
@@ -241,8 +242,8 @@ SEASTAR_TEST_CASE(test_shared_mutex_mixed) {
             }
         };
         return map_reduce(std::views::iota(0, 100), run, false, std::bit_or<bool>()).then([&counter] (bool result) {
-            BOOST_REQUIRE_EQUAL(result, true);
-            BOOST_REQUIRE_EQUAL(counter, 0u);
+            SEASTAR_BOOST_REQUIRE_EQUAL(result, true);
+            SEASTAR_BOOST_REQUIRE_EQUAL(counter, 0u);
         });
     });
 }
@@ -257,7 +258,7 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
                 ++counter;
                 throw 123;
             }).then_wrapped([&counter] (auto&& fut) {
-                BOOST_REQUIRE_EQUAL(counter, 2);
+                SEASTAR_BOOST_REQUIRE_EQUAL(counter, 2);
                 BOOST_REQUIRE(fut.failed());
                 fut.ignore_ready_future();
             });
@@ -269,44 +270,44 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_units_valid_splitting) {
     auto sm = semaphore(2);
     auto units = get_units(sm, 2, 1min).get();
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
-        BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(units.count(), 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
         auto split = units.split(1);
-        BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     }
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_invalid_splitting) {
     auto sm = semaphore(2);
     auto units = get_units(sm, 2, 1min).get();
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return_when_destroyed) {
     auto sm = semaphore(3);
   {
     auto units = get_units(sm, 3, 1min).get();
-    BOOST_REQUIRE_EQUAL(units.count(), 3);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
-    BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
-    BOOST_REQUIRE_EQUAL(units.count(), 2);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(units.count(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(units.return_units(1), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(units.count(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
   }
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_return_all) {
     auto sm = semaphore(3);
     auto units = get_units(sm, 2, 1min).get();
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     BOOST_REQUIRE_THROW(units.return_units(10), std::invalid_argument);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     units.return_all();
-    BOOST_REQUIRE_EQUAL(units.count(), 0);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(units.count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), 3);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_try_get_units) {
@@ -320,20 +321,20 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_try_get_units) {
     BOOST_REQUIRE(!opt_units2);
 
     opt_units.reset();
-    BOOST_REQUIRE_EQUAL(sm.available_units(), initial_units);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), initial_units);
 
     opt_units = try_get_units(sm, 1);
     BOOST_REQUIRE(opt_units);
 
     opt_units->return_all();
-    BOOST_REQUIRE_EQUAL(opt_units->count(), 0);
-    BOOST_REQUIRE_EQUAL(sm.available_units(), initial_units);
+    SEASTAR_BOOST_REQUIRE_EQUAL(opt_units->count(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sm.available_units(), initial_units);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_abort) {
     auto sm = semaphore(3);
     auto units = get_units(sm, 3, 1min).get();
-    BOOST_REQUIRE_EQUAL(units.count(), 3);
+    SEASTAR_BOOST_REQUIRE_EQUAL(units.count(), 3);
 
     abort_source as;
 
@@ -389,7 +390,7 @@ SEASTAR_THREAD_TEST_CASE(test_named_semaphore_error) {
             f.get();
             BOOST_FAIL("Expecting an exception");
         } catch (broken_named_semaphore& ex) {
-            BOOST_REQUIRE_NE(std::string(ex.what()).find("name_of_the_semaphore"), std::string::npos);
+            SEASTAR_BOOST_REQUIRE_NE(std::string(ex.what()).find("name_of_the_semaphore"), std::string::npos);
         } catch (...) {
             BOOST_FAIL("Expected an instance of broken_named_semaphore with proper semaphore name");
         }
@@ -410,7 +411,7 @@ SEASTAR_THREAD_TEST_CASE(test_named_semaphore_timeout) {
         f.get();
         BOOST_FAIL("Expecting an exception");
     } catch (named_semaphore_timed_out& ex) {
-        BOOST_REQUIRE_NE(std::string(ex.what()).find("name_of_the_semaphore"), std::string::npos);
+        SEASTAR_BOOST_REQUIRE_NE(std::string(ex.what()).find("name_of_the_semaphore"), std::string::npos);
     } catch (...) {
         BOOST_FAIL("Expected an instance of named_semaphore_timed_out with proper semaphore name");
     }
@@ -426,7 +427,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_after_wait) {
     as.request_abort();
     sem.signal();
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
-    BOOST_REQUIRE_EQUAL(x, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_with_exception_after_wait) {
@@ -439,7 +440,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_with_exception_after_wait) {
     as.request_abort_ex(expected_exception());
     sem.signal();
     BOOST_CHECK_THROW(fut1.get(), expected_exception);
-    BOOST_REQUIRE_EQUAL(x, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
@@ -452,7 +453,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_abort_before_wait) {
     });
     sem.signal();
     BOOST_CHECK_THROW(fut1.get(), semaphore_aborted);
-    BOOST_REQUIRE_EQUAL(x, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(x, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_reassigned_units_are_returned) {

--- a/tests/unit/sharded_test.cc
+++ b/tests/unit/sharded_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/testing/thread_test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/sharded.hh>
@@ -95,8 +96,8 @@ SEASTAR_THREAD_TEST_CASE(test_const_map_reduces) {
     sharded<peering_counter> c;
     c.start().get();
 
-    BOOST_REQUIRE_EQUAL(c.local().count().get(), this_smp_shard_count());
-    BOOST_REQUIRE_EQUAL(c.local().count_from(1).get(), this_smp_shard_count() + 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(c.local().count().get(), this_smp_shard_count());
+    SEASTAR_BOOST_REQUIRE_EQUAL(c.local().count_from(1).get(), this_smp_shard_count() + 1);
 
     c.stop().get();
 }
@@ -105,10 +106,10 @@ SEASTAR_THREAD_TEST_CASE(test_member_map_reduces) {
     sharded<peering_counter> c;
     c.start().get();
 
-    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_const().get(), this_smp_shard_count());
-    BOOST_REQUIRE_EQUAL(c.local().count_mutate().get(), this_smp_shard_count());
-    BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_from_const(1).get(), this_smp_shard_count() + 1);
-    BOOST_REQUIRE_EQUAL(c.local().count_from_mutate(1).get(), this_smp_shard_count() + 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_const().get(), this_smp_shard_count());
+    SEASTAR_BOOST_REQUIRE_EQUAL(c.local().count_mutate().get(), this_smp_shard_count());
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::as_const(c.local()).count_from_const(1).get(), this_smp_shard_count() + 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(c.local().count_from_mutate(1).get(), this_smp_shard_count() + 1);
     c.stop().get();
 }
 
@@ -181,15 +182,15 @@ public:
 class service {
 public:
     void fn_local(argument& arg) {
-        BOOST_REQUIRE_EQUAL(arg.get(), this_shard_id());
+        SEASTAR_BOOST_REQUIRE_EQUAL(arg.get(), this_shard_id());
     }
 
     void fn_sharded(sharded<argument>& arg) {
-        BOOST_REQUIRE_EQUAL(arg.local().get(), this_shard_id());
+        SEASTAR_BOOST_REQUIRE_EQUAL(arg.local().get(), this_shard_id());
     }
 
     void fn_sharded_param(int arg) {
-        BOOST_REQUIRE_EQUAL(arg, this_shard_id());
+        SEASTAR_BOOST_REQUIRE_EQUAL(arg, this_shard_id());
     }
 };
 
@@ -264,10 +265,10 @@ SEASTAR_THREAD_TEST_CASE(invoke_on_range_contiguous) {
 
     auto f3 = s.invoke_on(coordinator_id, [mid, half1_id, half2_id] (coordinator_synced_shard_map& s) {
         for (unsigned i = 0; i < mid; ++i) {
-            BOOST_REQUIRE_EQUAL(half1_id, s.get_synced(i));
+            SEASTAR_BOOST_REQUIRE_EQUAL(half1_id, s.get_synced(i));
         }
         for (unsigned i = mid; i < this_smp_shard_count(); ++i) {
-            BOOST_REQUIRE_EQUAL(half2_id, s.get_synced(i));
+            SEASTAR_BOOST_REQUIRE_EQUAL(half2_id, s.get_synced(i));
         }
     });
     f3.get();
@@ -293,10 +294,10 @@ SEASTAR_THREAD_TEST_CASE(invoke_on_range_fragmented) {
 
     auto f3 = s.invoke_on(coordinator_id, [even_id, odd_id] (coordinator_synced_shard_map& s) {
         for (unsigned i = 0; i < this_smp_shard_count(); i += 2) {
-            BOOST_REQUIRE_EQUAL(even_id, s.get_synced(i));
+            SEASTAR_BOOST_REQUIRE_EQUAL(even_id, s.get_synced(i));
         }
         for (unsigned i = 1; i < this_smp_shard_count(); i += 2) {
-            BOOST_REQUIRE_EQUAL(odd_id, s.get_synced(i));
+            SEASTAR_BOOST_REQUIRE_EQUAL(odd_id, s.get_synced(i));
         }
     });
     f3.get();

--- a/tests/unit/shared_ptr_test.cc
+++ b/tests/unit/shared_ptr_test.cc
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -134,11 +135,11 @@ BOOST_AUTO_TEST_CASE(test_indirect_functors) {
 
 
         auto i = a_set.begin();
-        BOOST_REQUIRE_EQUAL(sstring("k0"), *(*i++));
-        BOOST_REQUIRE_EQUAL(sstring("k1"), *(*i++));
-        BOOST_REQUIRE_EQUAL(sstring("k2"), *(*i++));
-        BOOST_REQUIRE_EQUAL(sstring("k3"), *(*i++));
-        BOOST_REQUIRE_EQUAL(sstring("k4"), *(*i++));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring("k0"), *(*i++));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring("k1"), *(*i++));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring("k2"), *(*i++));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring("k3"), *(*i++));
+        SEASTAR_BOOST_REQUIRE_EQUAL(sstring("k4"), *(*i++));
     }
 
     {

--- a/tests/unit/signal_test.cc
+++ b/tests/unit/signal_test.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/testing/test_case.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -42,7 +43,7 @@ SEASTAR_TEST_CASE(test_sighup) {
         kill(getpid(), SIGHUP);
 
         return p->get_future().then([&] {
-            BOOST_REQUIRE_EQUAL(signaled, true);
+            SEASTAR_BOOST_REQUIRE_EQUAL(signaled, true);
         });
     });
 }

--- a/tests/unit/simple_stream_test.cc
+++ b/tests/unit/simple_stream_test.cc
@@ -23,8 +23,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/simple-stream.hh>
+#include <fmt/ranges.h>
+#include "test_comparisons.hh"
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<char>)
 
 using namespace seastar;
 
@@ -48,18 +49,18 @@ static void write_read_test(Input in, Output out)
 
     auto actual_aa = std::vector<char>(4);
     in.read(actual_aa.data(), actual_aa.size());
-    BOOST_CHECK_EQUAL(aa, actual_aa);
+    SEASTAR_BOOST_CHECK_EQUAL(aa, actual_aa);
 
     auto actual_bb = std::vector<char>(3);
     in.read(actual_bb.data(), actual_bb.size());
-    BOOST_CHECK_EQUAL(bb, actual_bb);
+    SEASTAR_BOOST_CHECK_EQUAL(bb, actual_bb);
 
     actual_aa.resize(1024);
     BOOST_CHECK_THROW(in.read(actual_aa.data(), actual_aa.size()), std::out_of_range);
 
     auto actual_cc = std::vector<char>(2);
     in.read(actual_cc.data(), actual_cc.size());
-    BOOST_CHECK_EQUAL(cc, actual_cc);
+    SEASTAR_BOOST_CHECK_EQUAL(cc, actual_cc);
 
     BOOST_CHECK_THROW(in.read(actual_aa.data(), 1), std::out_of_range);
 }

--- a/tests/unit/slab_test.cc
+++ b/tests/unit/slab_test.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <seastar/core/slab.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -98,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_allocation_2) {
     auto class_size = slab.class_size(size);
     auto per_slab_page = max_object_size / class_size;
     auto available_slab_pages = slab_limit_size / max_object_size;
-    BOOST_REQUIRE_EQUAL(allocations, per_slab_page * available_slab_pages);
+    SEASTAR_BOOST_REQUIRE_EQUAL(allocations, per_slab_page * available_slab_pages);
 
     free_vector<item>(slab, items);
     std::cout << __FUNCTION__ << " done!\n";
@@ -121,7 +122,7 @@ BOOST_AUTO_TEST_CASE(test_allocation_with_lru) {
         BOOST_REQUIRE(item != nullptr);
         _cache.push_front(*item);
     }
-    BOOST_REQUIRE_EQUAL(evictions, max * 999);
+    SEASTAR_BOOST_REQUIRE_EQUAL(evictions, max * 999);
 
     _cache.clear();
 

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -40,6 +40,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/posix-stack.hh>
 #include <stdexcept>
+#include "test_comparisons.hh"
 
 #include <optional>
 #include <tuple>
@@ -115,7 +116,7 @@ SEASTAR_TEST_CASE(socket_skip_test) {
 SEASTAR_TEST_CASE(test_file_desc_fdinfo) {
     auto fd = file_desc::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     auto info = fd.fdinfo();
-    BOOST_REQUIRE_EQUAL(info.substr(0, 8), "socket:[");
+    SEASTAR_BOOST_REQUIRE_EQUAL(info.substr(0, 8), "socket:[");
     return make_ready_future<>();
 }
 
@@ -132,7 +133,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
             connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get();
 
             auto close_wait_fiber = cln.wait_input_shutdown().then([&] {
-                BOOST_REQUIRE_EQUAL(server_closed, true);
+                SEASTAR_BOOST_REQUIRE_EQUAL(server_closed, true);
                 client_notified = true;
                 fmt::print("Client: server closed\n");
             });
@@ -166,7 +167,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
 
             for (int i = 0; i < 3; i++) {
                 auto buf = in.read().get();
-                BOOST_REQUIRE_EQUAL(client_notified, false);
+                SEASTAR_BOOST_REQUIRE_EQUAL(client_notified, false);
                 out.write(std::move(buf)).get();
                 out.flush().get();
                 fmt::print("Server: served\n");
@@ -195,7 +196,7 @@ SEASTAR_TEST_CASE(socket_on_close_local_shutdown_test) {
             connected_socket cln = connect(ipv4_addr("127.0.0.1", 12345)).get();
 
             auto close_wait_fiber = cln.wait_input_shutdown().then([&] {
-                BOOST_REQUIRE_EQUAL(server_closed, false);
+                SEASTAR_BOOST_REQUIRE_EQUAL(server_closed, false);
                 client_notified = true;
                 fmt::print("Client: socket closed\n");
             });
@@ -207,7 +208,7 @@ SEASTAR_TEST_CASE(socket_on_close_local_shutdown_test) {
             do {
                 seastar::yield().get();
             } while (!client_notified && std::chrono::steady_clock::now() < fin);
-            BOOST_REQUIRE_EQUAL(client_notified, true);
+            SEASTAR_BOOST_REQUIRE_EQUAL(client_notified, true);
 
             out.write("hello").get();
             out.flush().get();
@@ -274,7 +275,7 @@ SEASTAR_THREAD_TEST_CASE(socket_accept_abort_test) {
             BOOST_FAIL("Accept didn't resolve into exception");
         } catch (const std::system_error& e) {
             BOOST_REQUIRE(!too_late);
-            BOOST_REQUIRE_EQUAL(e.code(), std::error_code(ECONNABORTED, std::system_category()));
+            SEASTAR_BOOST_REQUIRE_EQUAL(e.code(), std::error_code(ECONNABORTED, std::system_category()));
         }
     });
 
@@ -312,7 +313,7 @@ SEASTAR_THREAD_TEST_CASE(socket_bufsize) {
         auto sockopt = [&](int option) {
             int val{};
             int ret = server.get_sockopt(SOL_SOCKET, option, &val, sizeof(val));
-            BOOST_REQUIRE_EQUAL(ret, 0);
+            SEASTAR_BOOST_REQUIRE_EQUAL(ret, 0);
             return val;
         };
 
@@ -342,26 +343,26 @@ SEASTAR_THREAD_TEST_CASE(socket_bufsize) {
     // The latter condition could plausibly fail if the OS clamped the size
     // at a small amount, but this is unlikely for the chosen buffer sizes.
 
-    BOOST_CHECK_LT(send_small, send_big);
-    BOOST_CHECK_LT(recv_small, recv_big);
+    SEASTAR_BOOST_CHECK_LT(send_small, send_big);
+    SEASTAR_BOOST_CHECK_LT(recv_small, recv_big);
 
-    BOOST_CHECK_GE(send_small, small_size);
-    BOOST_CHECK_GE(send_big, big_size);
+    SEASTAR_BOOST_CHECK_GE(send_small, small_size);
+    SEASTAR_BOOST_CHECK_GE(send_big, big_size);
 
-    BOOST_CHECK_GE(recv_small, small_size * 2);
-    BOOST_CHECK_GE(recv_big, big_size * 2);
+    SEASTAR_BOOST_CHECK_GE(recv_small, small_size * 2);
+    SEASTAR_BOOST_CHECK_GE(recv_big, big_size * 2);
 
     // not much to check here with "default" sizes, but let's at least call it
     // and check that we get a reasonable answer
     auto [send_default, recv_default] = buf_size({}, {});
 
-    BOOST_CHECK_GE(send_default, 4096);
-    BOOST_CHECK_GE(recv_default, 4096);
+    SEASTAR_BOOST_CHECK_GE(send_default, 4096);
+    SEASTAR_BOOST_CHECK_GE(recv_default, 4096);
 
     // we don't really know the default socket size and it can vary by kernel
     // config, but 20 MB should be enough for everyone.
-    BOOST_CHECK_LT(send_default, 20'000'000);
-    BOOST_CHECK_LT(recv_default, 20'000'000);
+    SEASTAR_BOOST_CHECK_LT(send_default, 20'000'000);
+    SEASTAR_BOOST_CHECK_LT(recv_default, 20'000'000);
 }
 
 static
@@ -510,15 +511,15 @@ test_load_balancing_algorithm_port(socket_address listen_addr, bool proxy_protoc
     client_done.get_future().get();
     server.stop().get();
     auto results = client.get();
-    BOOST_REQUIRE_EQUAL(results.attempts, 100);
-    BOOST_REQUIRE_EQUAL(results.bad_socket, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.attempts, 100);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.bad_socket, 0);
     // We can have bad binds due to other connection using the ports.
     // 20 should be plenty of margin.
-    BOOST_REQUIRE_LE(results.bad_bind, 20);
-    BOOST_REQUIRE_EQUAL(results.bad_connect, 0);
-    BOOST_REQUIRE_EQUAL(results.bad_proxy_send, 0);
-    BOOST_REQUIRE_EQUAL(results.bad_recv, 0);
-    BOOST_REQUIRE_EQUAL(results.bad_shard, 0);
+    SEASTAR_BOOST_REQUIRE_LE(results.bad_bind, 20);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.bad_connect, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.bad_proxy_send, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.bad_recv, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(results.bad_shard, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(load_balancing_algorithm_port_ipv4_test) {
@@ -546,8 +547,8 @@ SEASTAR_THREAD_TEST_CASE(inet_local_remote_address_sanity) {
     auto ar = ar_f.get();
     auto ss = std::move(ar.connection);
 
-    BOOST_CHECK_EQUAL(cs->local_address(), ss.remote_address());
-    BOOST_CHECK_EQUAL(cs->remote_address(), ss.local_address());
+    SEASTAR_BOOST_CHECK_EQUAL(cs->local_address(), ss.remote_address());
+    SEASTAR_BOOST_CHECK_EQUAL(cs->remote_address(), ss.local_address());
 
     // Now disconnect the server socket on the kernel level
     // For that -- write some data into client, then close the client. When

--- a/tests/unit/source_location_test.cc
+++ b/tests/unit/source_location_test.cc
@@ -23,6 +23,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
+#include "test_comparisons.hh"
 
 #include <seastar/util/std-compat.hh>
 #include <source_location>
@@ -30,8 +31,8 @@
 using namespace seastar;
 
 static void test_source_location_callee(const char* ref_file, const char* ref_func, int ref_line, std::source_location loc = std::source_location::current()) {
-    BOOST_REQUIRE_EQUAL(loc.file_name(), ref_file);
-    BOOST_REQUIRE_EQUAL(loc.line(), ref_line);
+    SEASTAR_BOOST_REQUIRE_EQUAL(loc.file_name(), ref_file);
+    SEASTAR_BOOST_REQUIRE_EQUAL(loc.line(), ref_line);
     BOOST_REQUIRE(std::string(loc.function_name()).find(ref_func) != std::string::npos);
 }
 

--- a/tests/unit/spawn_test.cc
+++ b/tests/unit/spawn_test.cc
@@ -23,6 +23,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/process.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -34,7 +35,7 @@ SEASTAR_TEST_CASE(test_spawn_success) {
     }).then([] (auto wstatus) {
         auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
         BOOST_REQUIRE(exit_status != nullptr);
-        BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
+        SEASTAR_BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
     });
 }
 
@@ -44,7 +45,7 @@ SEASTAR_TEST_CASE(test_spawn_failure) {
     }).then([] (auto wstatus) {
         auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
         BOOST_REQUIRE(exit_status != nullptr);
-        BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_FAILURE);
+        SEASTAR_BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_FAILURE);
     });
 }
 
@@ -110,12 +111,12 @@ SEASTAR_TEST_CASE(test_spawn_input) {
                 BOOST_TEST_ERROR(fmt::format("failed to read from cout: {}", e));
                 return make_ready_future<temporary_buffer<char>>();
             }).then([] (temporary_buffer<char> echo) {
-                BOOST_CHECK_EQUAL(sstring(echo.get(), echo.size()), text);
+                SEASTAR_BOOST_CHECK_EQUAL(sstring(echo.get(), echo.size()), text);
             }).finally([&p] {
                 return p.wait().then([](process::wait_status wstatus) {
                     auto* exit_status = std::get_if<process::wait_exited>(&wstatus);
                     BOOST_REQUIRE(exit_status != nullptr);
-                    BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
+                    SEASTAR_BOOST_CHECK_EQUAL(exit_status->exit_code, EXIT_SUCCESS);
                  });
             });
         });
@@ -133,7 +134,7 @@ SEASTAR_TEST_CASE(test_spawn_kill) {
         }).then([start](process::wait_status wait_status) {
             auto* wait_signaled = std::get_if<process::wait_signaled>(&wait_status);
             BOOST_REQUIRE(wait_signaled != nullptr);
-            BOOST_CHECK_EQUAL(wait_signaled->terminating_signal, SIGTERM);
+            SEASTAR_BOOST_CHECK_EQUAL(wait_signaled->terminating_signal, SIGTERM);
             auto end = std::chrono::high_resolution_clock::now();
             auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
             // sleep should be terminated in 10ms.
@@ -141,7 +142,7 @@ SEASTAR_TEST_CASE(test_spawn_kill) {
             // waitpid(2) with backoff (at least 20ms).
             // the minimal backoff is added to 10ms, so the test can pass on
             // older kernels as well.
-            BOOST_CHECK_LE(ms, 10 + 20);
+            SEASTAR_BOOST_CHECK_LE(ms, 10 + 20);
         });
     });
 }

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/sstring.hh>
 #include <list>
 #include <fmt/ranges.h>
+#include "test_comparisons.hh"
 #if FMT_VERSION >= FMT_VERSION_OPTIONAL_FORMAT
 #include <fmt/std.h>
 #endif
@@ -39,34 +40,34 @@ BOOST_AUTO_TEST_CASE(test_make_sstring) {
     std::string bar = "bar";
     sstring zed = "zed";
     const char* baz = "baz";
-    BOOST_REQUIRE_EQUAL(make_sstring(foo, bar, zed, baz, "bah"), sstring("foobarzedbazbah"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(make_sstring(foo, bar, zed, baz, "bah"), sstring("foobarzedbazbah"));
 }
 
 BOOST_AUTO_TEST_CASE(test_construction) {
-    BOOST_REQUIRE_EQUAL(sstring(std::string_view("abc")), sstring("abc"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring(std::string_view("abc")), sstring("abc"));
 }
 
 BOOST_AUTO_TEST_CASE(test_equality) {
-    BOOST_REQUIRE_EQUAL(sstring("aaa"), sstring("aaa"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("aaa"), sstring("aaa"));
 }
 
 BOOST_AUTO_TEST_CASE(test_to_sstring) {
-    BOOST_REQUIRE_EQUAL(to_sstring(1234567), sstring("1234567"));
+    SEASTAR_BOOST_REQUIRE_EQUAL(to_sstring(1234567), sstring("1234567"));
 }
 
 BOOST_AUTO_TEST_CASE(test_add_literal_to_sstring) {
-    BOOST_REQUIRE_EQUAL("x" + sstring("y"), sstring("xy"));
+    SEASTAR_BOOST_REQUIRE_EQUAL("x" + sstring("y"), sstring("xy"));
 }
 
 BOOST_AUTO_TEST_CASE(test_front) {
     sstring s("abcde");
-    BOOST_CHECK_EQUAL(s.front(), 'a');
-    BOOST_CHECK_EQUAL(std::as_const(s).front(), 'a');
+    SEASTAR_BOOST_CHECK_EQUAL(s.front(), 'a');
+    SEASTAR_BOOST_CHECK_EQUAL(std::as_const(s).front(), 'a');
 }
 
 BOOST_AUTO_TEST_CASE(test_find_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find('b'), 1u);
-    BOOST_REQUIRE_EQUAL(sstring("babcde").find('b',1), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find('b'), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("babcde").find('b',1), 2u);
 }
 
 BOOST_AUTO_TEST_CASE(test_find_sstring_compatible) {
@@ -76,9 +77,9 @@ BOOST_AUTO_TEST_CASE(test_find_sstring_compatible) {
 
         // verify that std::string really has the same behavior as we just tested for sstring
         if (xpos_ss == sstring::npos) {  // sstring::npos may not equal std::string::npos ?
-            BOOST_REQUIRE_EQUAL(xpos_std, std::string::npos);
+            SEASTAR_BOOST_REQUIRE_EQUAL(xpos_std, std::string::npos);
         } else {
-            BOOST_REQUIRE_EQUAL(xpos_ss, xpos_std);
+            SEASTAR_BOOST_REQUIRE_EQUAL(xpos_ss, xpos_std);
         }
     };
 
@@ -91,25 +92,25 @@ BOOST_AUTO_TEST_CASE(test_find_sstring_compatible) {
 }
 
 BOOST_AUTO_TEST_CASE(test_not_find_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find('x'), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find('x'), sstring::npos);
 }
 
 BOOST_AUTO_TEST_CASE(test_str_find_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find("bc"), 1u);
-    BOOST_REQUIRE_EQUAL(sstring("abcbcde").find("bc", 2), 3u);
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find("abcde"), 0u);
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find("", 5), 5u);
-    BOOST_REQUIRE_EQUAL(sstring("ababcbdbef").find("bef"), 7u);
-    BOOST_REQUIRE_EQUAL(sstring("").find("", 0), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find("bc"), 1u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcbcde").find("bc", 2), 3u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find("abcde"), 0u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find("", 5), 5u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababcbdbef").find("bef"), 7u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("").find("", 0), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_str_not_find_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").find("x"), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 6), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 4), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("ababcbdbe").find("bcd"), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("").find("", 1), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("abc").find("abcde"), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").find("x"), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 6), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcdefg").find("cde", 4), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababcbdbe").find("bcd"), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("").find("", 1), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").find("abcde"), sstring::npos);
 }
 
 BOOST_AUTO_TEST_CASE(test_str_starts_with) {
@@ -163,12 +164,12 @@ BOOST_AUTO_TEST_CASE(test_str_contains) {
 }
 
 BOOST_AUTO_TEST_CASE(test_substr_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").substr(1,2), "bc");
-    BOOST_REQUIRE_EQUAL(sstring("abc").substr(1,2), "bc");
-    BOOST_REQUIRE_EQUAL(sstring("abc").substr(1,3), "bc");
-    BOOST_REQUIRE_EQUAL(sstring("abc").substr(0, 2), "ab");
-    BOOST_REQUIRE_EQUAL(sstring("abc").substr(3, 2), "");
-    BOOST_REQUIRE_EQUAL(sstring("abc").substr(1), "bc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").substr(1,2), "bc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").substr(1,2), "bc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").substr(1,3), "bc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").substr(0, 2), "ab");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").substr(3, 2), "");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").substr(1), "bc");
 }
 
 BOOST_AUTO_TEST_CASE(test_substr_eor_sstring) {
@@ -176,38 +177,38 @@ BOOST_AUTO_TEST_CASE(test_substr_eor_sstring) {
 }
 
 BOOST_AUTO_TEST_CASE(test_at_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("abcde").at(1), 'b');
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abcde").at(1), 'b');
     BOOST_REQUIRE_THROW(sstring("abcde").at(6), std::out_of_range);
     sstring s("abcde");
     s.at(1) = 'd';
-    BOOST_REQUIRE_EQUAL(s, "adcde");
+    SEASTAR_BOOST_REQUIRE_EQUAL(s, "adcde");
 }
 
 BOOST_AUTO_TEST_CASE(test_find_last_sstring) {
-    BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a'), 4u);
-    BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',5), 4u);
-    BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',4), 4u);
-    BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',3), 2u);
-    BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('x'), sstring::npos);
-    BOOST_REQUIRE_EQUAL(sstring("").find_last_of('a'), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a'), 4u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',5), 4u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',4), 4u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('a',3), 2u);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("ababa").find_last_of('x'), sstring::npos);
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("").find_last_of('a'), sstring::npos);
 }
 
 
 BOOST_AUTO_TEST_CASE(test_append) {
-    BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 3), "aba123");
-    BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 4), "aba1234");
-    BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 0), "aba");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 3), "aba123");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 4), "aba1234");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("aba").append("1234", 0), "aba");
 }
 
 BOOST_AUTO_TEST_CASE(test_replace) {
-    BOOST_REQUIRE_EQUAL(sstring("abc").replace(1,1, "xyz", 1), "axc");
-    BOOST_REQUIRE_EQUAL(sstring("abc").replace(3,2, "xyz", 2), "abcxy");
-    BOOST_REQUIRE_EQUAL(sstring("abc").replace(2,2, "xyz", 2), "abxy");
-    BOOST_REQUIRE_EQUAL(sstring("abc").replace(0,2, "", 0), "c");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").replace(1,1, "xyz", 1), "axc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").replace(3,2, "xyz", 2), "abcxy");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").replace(2,2, "xyz", 2), "abxy");
+    SEASTAR_BOOST_REQUIRE_EQUAL(sstring("abc").replace(0,2, "", 0), "c");
     BOOST_REQUIRE_THROW(sstring("abc").replace(4,1, "xyz", 1), std::out_of_range);
     const char* s = "xyz";
     sstring str("abcdef");
-    BOOST_REQUIRE_EQUAL(str.replace(str.begin() + 1 , str.begin() + 3, s + 1, s + 3), "ayzdef");
+    SEASTAR_BOOST_REQUIRE_EQUAL(str.replace(str.begin() + 1 , str.begin() + 3, s + 1, s + 3), "ayzdef");
     BOOST_REQUIRE_THROW(sstring("abc").replace(4,1, "xyz", 1), std::out_of_range);
 
 }
@@ -216,7 +217,7 @@ BOOST_AUTO_TEST_CASE(test_insert) {
     sstring str("abc");
     const char* s = "xyz";
     str.insert(str.begin() +1, s + 1, s + 2);
-    BOOST_REQUIRE_EQUAL(str, "aybc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(str, "aybc");
     str = "abc";
     BOOST_REQUIRE_THROW(str.insert(str.begin() + 5, s + 1, s + 2), std::out_of_range);
 }
@@ -224,14 +225,14 @@ BOOST_AUTO_TEST_CASE(test_insert) {
 BOOST_AUTO_TEST_CASE(test_erase) {
     sstring str("abcdef");
     auto i = str.erase(str.begin() + 1, str.begin() + 3);
-    BOOST_REQUIRE_EQUAL(*i, 'd');
-    BOOST_REQUIRE_EQUAL(str, "adef");
+    SEASTAR_BOOST_REQUIRE_EQUAL(*i, 'd');
+    SEASTAR_BOOST_REQUIRE_EQUAL(str, "adef");
 }
 
 BOOST_AUTO_TEST_CASE(test_ctor_iterator) {
     std::list<char> data{{'a', 'b', 'c'}};
     sstring s(data.begin(), data.end());
-    BOOST_REQUIRE_EQUAL(s, "abc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(s, "abc");
 }
 
 BOOST_AUTO_TEST_CASE(test_nul_termination) {
@@ -239,41 +240,41 @@ BOOST_AUTO_TEST_CASE(test_nul_termination) {
 
     for (int size = 1; size <= 32; size *= 2) {
         auto s1 = uninitialized_string<stype>(size - 1);
-        BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
         auto s2 = uninitialized_string<stype>(size);
-        BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
 
         s1 = stype("01234567890123456789012345678901", size - 1);
-        BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
         s2 = stype("01234567890123456789012345678901", size);
-        BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
 
         s1 = stype(size - 1, ' ');
-        BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s1.c_str()[size - 1], '\0');
         s2 = stype(size, ' ');
-        BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[size], '\0');
 
         s2 = s1;
-        BOOST_REQUIRE_EQUAL(s2.c_str()[s1.size()], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[s1.size()], '\0');
         s2.resize(s1.size());
-        BOOST_REQUIRE_EQUAL(s2.c_str()[s1.size()], '\0');
-        BOOST_REQUIRE_EQUAL(s1, s2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[s1.size()], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s1, s2);
 
         auto new_size = size / 2;
         s2 = s1;
         s2.resize(new_size);
-        BOOST_REQUIRE_EQUAL(s2.c_str()[new_size], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[new_size], '\0');
         BOOST_REQUIRE(!strncmp(s1.c_str(), s2.c_str(), new_size));
 
         new_size = size * 2;
         s2 = s1;
         s2.resize(new_size);
-        BOOST_REQUIRE_EQUAL(s2.c_str()[new_size], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[new_size], '\0');
         BOOST_REQUIRE(!strncmp(s1.c_str(), s2.c_str(), std::min(s1.size(), s2.size())));
 
         new_size = size * 2;
         s2 = s1 + s1;
-        BOOST_REQUIRE_EQUAL(s2.c_str()[s2.size()], '\0');
+        SEASTAR_BOOST_REQUIRE_EQUAL(s2.c_str()[s2.size()], '\0');
         BOOST_REQUIRE(!strncmp(s1.c_str(), s2.c_str(), std::min(s1.size(), s2.size())));
     }
 }
@@ -288,7 +289,7 @@ BOOST_AUTO_TEST_CASE(test_resize_and_overwrite) {
             memset(buf, pattern, n);
             return n;
         });
-        BOOST_CHECK_EQUAL(s, sstring(new_size, pattern));
+        SEASTAR_BOOST_CHECK_EQUAL(s, sstring(new_size, pattern));
     }
     {
         // the size of new content is smaller than the specified count
@@ -298,7 +299,7 @@ BOOST_AUTO_TEST_CASE(test_resize_and_overwrite) {
             memset(buf, pattern, smaller_size);
             return smaller_size;
         });
-        BOOST_CHECK_EQUAL(s, sstring(smaller_size, pattern));
+        SEASTAR_BOOST_CHECK_EQUAL(s, sstring(smaller_size, pattern));
     }
 }
 

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -31,6 +31,7 @@
 #include <atomic>
 #include <chrono>
 #include <ranges>
+#include "test_comparisons.hh"
 
 #include <sys/mman.h>
 
@@ -93,7 +94,7 @@ SEASTAR_THREAD_TEST_CASE(normal_case) {
     std::atomic<unsigned> reports{};
     temporary_stall_detector_settings tsds(10ms, [&] { ++reports; });
     spin_some_cooperatively(1s);
-    BOOST_REQUIRE_EQUAL(reports, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(reports, 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(simple_stalls) {
@@ -108,7 +109,7 @@ SEASTAR_THREAD_TEST_CASE(simple_stalls) {
 
     // blocked-reactor-reports-per-minute defaults to 5, so we don't
     // get all 10 reports.
-    BOOST_REQUIRE_EQUAL(reports, 5);
+    SEASTAR_BOOST_REQUIRE_EQUAL(reports, 5);
 }
 
 SEASTAR_THREAD_TEST_CASE(no_poll_no_stall) {
@@ -128,7 +129,7 @@ SEASTAR_THREAD_TEST_CASE(no_poll_no_stall) {
         return make_ready_future<>();
     }).get();
     f.get();
-    BOOST_REQUIRE_EQUAL(reports, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(reports, 0);
 }
 
 // Triggers stalls by spinning with a specify "body" function
@@ -156,7 +157,7 @@ static void test_spin_with_body(const char* what, void_fn body) {
             spin(20ms, body);
         }
         testlog.info("Ending spin test: {}", what);
-        BOOST_CHECK_EQUAL(reports, count_stacks ? 5 : 0);
+        SEASTAR_BOOST_CHECK_EQUAL(reports, count_stacks ? 5 : 0);
     }
 }
 

--- a/tests/unit/stream_reader_test.cc
+++ b/tests/unit/stream_reader_test.cc
@@ -28,6 +28,7 @@
 #include <seastar/http/request.hh>
 #include <seastar/util/short_streams.hh>
 #include <string>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 using namespace util;
@@ -69,7 +70,7 @@ SEASTAR_TEST_CASE(test_read_all) {
             for (auto&& buf: all) {
                 s += seastar::to_sstring(std::move(buf));
             };
-            BOOST_REQUIRE_EQUAL(s, test);
+            SEASTAR_BOOST_REQUIRE_EQUAL(s, test);
         };
         input_stream<char> inp(data_source(std::make_unique<test_source_impl>(5, 15)));
         check_read_all(inp, "abcdefghijklmno");
@@ -82,13 +83,13 @@ SEASTAR_TEST_CASE(test_read_all) {
         BOOST_REQUIRE(empty_inp.eof());
 
         input_stream<char> inp_cont(data_source(std::make_unique<test_source_impl>(5, 15)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont).get()), "abcdefghijklmno");
+        SEASTAR_BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont).get()), "abcdefghijklmno");
         BOOST_REQUIRE(inp_cont.eof());
         input_stream<char> inp_cont2(data_source(std::make_unique<test_source_impl>(5, 16)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont2).get()), "abcdefghijklmnop");
+        SEASTAR_BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(inp_cont2).get()), "abcdefghijklmnop");
         BOOST_REQUIRE(inp_cont2.eof());
         input_stream<char> empty_inp_cont(data_source(std::make_unique<test_source_impl>(5, 0)));
-        BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(empty_inp_cont).get()), "");
+        SEASTAR_BOOST_REQUIRE_EQUAL(to_sstring(read_entire_stream_contiguous(empty_inp_cont).get()), "");
         BOOST_REQUIRE(empty_inp_cont.eof());
     });
 }
@@ -119,14 +120,14 @@ SEASTAR_THREAD_TEST_CASE(test_read_exactly) {
             auto buf = in.read_exactly(bs).get();
             total += buf.size();
             if (buf.size() != bs) {
-                BOOST_REQUIRE_LT(buf.size(), bs);
+                SEASTAR_BOOST_REQUIRE_LT(buf.size(), bs);
                 if (buf.size() != 0) {
                     buf = in.read_exactly(bs).get();
-                    BOOST_REQUIRE_EQUAL(buf.size(), 0);
+                    SEASTAR_BOOST_REQUIRE_EQUAL(buf.size(), 0);
                 }
                 break;
             }
         }
-        BOOST_REQUIRE_EQUAL(total, total_size);
+        SEASTAR_BOOST_REQUIRE_EQUAL(total, total_size);
     }
 }

--- a/tests/unit/temporary_buffer_test.cc
+++ b/tests/unit/temporary_buffer_test.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/internal/iovec_utils.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -56,7 +57,7 @@ static void do_test_detach_buffers(size_t initial_buffers, std::vector<size_t> i
     auto merge_buffers = [] (const std::vector<temporary_buffer<char>>& bufs) {
         size_t len = 0;
         for (auto& b : bufs) {
-            BOOST_REQUIRE_NE(b.size(), 0);
+            SEASTAR_BOOST_REQUIRE_NE(b.size(), 0);
             len += b.size();
         }
         temporary_buffer<char> res(len);
@@ -124,12 +125,12 @@ BOOST_AUTO_TEST_CASE(test_iovec_trim_front) {
             BOOST_REQUIRE(res.empty());
         } else {
             BOOST_REQUIRE(res.size() > 0);
-            BOOST_REQUIRE_EQUAL(*reinterpret_cast<char*>(res[0].iov_base), data[l]);
-            BOOST_REQUIRE_NE(res[0].iov_len, 0);
+            SEASTAR_BOOST_REQUIRE_EQUAL(*reinterpret_cast<char*>(res[0].iov_base), data[l]);
+            SEASTAR_BOOST_REQUIRE_NE(res[0].iov_len, 0);
             size_t total = std::accumulate(res.begin(), res.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.iov_len; });
-            BOOST_REQUIRE_EQUAL(total, 15 - l);
+            SEASTAR_BOOST_REQUIRE_EQUAL(total, 15 - l);
             if (res.size() > 1) {
-                BOOST_REQUIRE_EQUAL(*reinterpret_cast<char*>(res[1].iov_base), data[l + res[0].iov_len]);
+                SEASTAR_BOOST_REQUIRE_EQUAL(*reinterpret_cast<char*>(res[1].iov_base), data[l + res[0].iov_len]);
             }
         }
     }
@@ -169,8 +170,8 @@ BOOST_AUTO_TEST_CASE(test_iovec_trim_front_zero_length) {
         iovs.push_back(iovec{ &dummy, 0 });
         iovs.push_back(iovec{ (void*)data, 3 });
         auto res = internal::iovec_trim_front(std::span(iovs), 0);
-        BOOST_REQUIRE_EQUAL(res.size(), 1);
-        BOOST_REQUIRE_EQUAL(res[0].iov_len, 3);
-        BOOST_REQUIRE_EQUAL(*reinterpret_cast<const char*>(res[0].iov_base), 'a');
+        SEASTAR_BOOST_REQUIRE_EQUAL(res.size(), 1);
+        SEASTAR_BOOST_REQUIRE_EQUAL(res[0].iov_len, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(*reinterpret_cast<const char*>(res[0].iov_base), 'a');
     }
 }

--- a/tests/unit/test_comparisons.hh
+++ b/tests/unit/test_comparisons.hh
@@ -1,0 +1,163 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+#pragma once
+
+#include <string_view>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <ostream>
+#include <type_traits>
+
+namespace seastar::testing {
+
+/// A wrapper that makes any fmt-formattable type printable via operator<<,
+/// while forwarding all comparisons to the underlying value.
+///
+/// This bridges the gap between Seastar's move away from operator<< (in favor
+/// of fmt::format) and Boost.Test's reliance on operator<< for failure messages.
+template <typename T>
+class comparable_formattable {
+    // Store const char* as std::string_view to compare by string value rather than pointer value.
+    using ref_type = std::conditional_t<std::is_same_v<T, const char*>, std::string_view, const T&>;
+    ref_type _value;
+public:
+    explicit comparable_formattable(const T& value) noexcept : _value(value) {}
+
+    ref_type get() const noexcept { return _value; }
+
+    friend std::ostream& operator<<(std::ostream& os, const comparable_formattable& cf) {
+        if constexpr (fmt::is_formattable<T>::value) {
+            fmt::print(os, "{}", cf._value);
+        } else if constexpr (std::is_pointer_v<T>) {
+            fmt::print(os, "{}", fmt::ptr(cf._value));
+        } else if constexpr (requires(std::ostream& o, const T& v) { o << v; }) {
+            os << cf._value;
+        } else {
+            static_assert(fmt::is_formattable<T>::value,
+                "Type is not fmt-formattable; use BOOST_REQUIRE/BOOST_CHECK directly");
+        }
+        return os;
+    }
+
+    template <typename U>
+    friend bool operator==(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value == b.get();
+        #pragma GCC diagnostic pop
+    }
+
+    template <typename U>
+    friend bool operator!=(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value != b.get();
+        #pragma GCC diagnostic pop
+    }
+
+    template <typename U>
+    friend bool operator<(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value < b.get();
+        #pragma GCC diagnostic pop
+    }
+
+    template <typename U>
+    friend bool operator<=(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value <= b.get();
+        #pragma GCC diagnostic pop
+    }
+
+    template <typename U>
+    friend bool operator>(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value > b.get();
+        #pragma GCC diagnostic pop
+    }
+
+    template <typename U>
+    friend bool operator>=(const comparable_formattable& a, const comparable_formattable<U>& b) {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wsign-compare"
+        return a._value >= b.get();
+        #pragma GCC diagnostic pop
+    }
+};
+
+} // namespace seastar::testing
+
+// Wrapper macros that use fmt for formatting instead of operator<<.
+// Use these in place of BOOST_REQUIRE_EQUAL, BOOST_CHECK_EQUAL, etc.
+// when the types involved have fmt::formatter but not operator<<.
+
+#define SEASTAR_BOOST_REQUIRE_EQUAL(a, b) \
+    BOOST_REQUIRE_EQUAL(::seastar::testing::comparable_formattable(a), \
+                        ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_EQUAL(a, b) \
+    BOOST_CHECK_EQUAL(::seastar::testing::comparable_formattable(a), \
+                      ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_REQUIRE_NE(a, b) \
+    BOOST_REQUIRE_NE(::seastar::testing::comparable_formattable(a), \
+                     ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_NE(a, b) \
+    BOOST_CHECK_NE(::seastar::testing::comparable_formattable(a), \
+                   ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_REQUIRE_LT(a, b) \
+    BOOST_REQUIRE_LT(::seastar::testing::comparable_formattable(a), \
+                     ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_LT(a, b) \
+    BOOST_CHECK_LT(::seastar::testing::comparable_formattable(a), \
+                   ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_REQUIRE_LE(a, b) \
+    BOOST_REQUIRE_LE(::seastar::testing::comparable_formattable(a), \
+                     ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_LE(a, b) \
+    BOOST_CHECK_LE(::seastar::testing::comparable_formattable(a), \
+                   ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_REQUIRE_GT(a, b) \
+    BOOST_REQUIRE_GT(::seastar::testing::comparable_formattable(a), \
+                     ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_GT(a, b) \
+    BOOST_CHECK_GT(::seastar::testing::comparable_formattable(a), \
+                   ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_REQUIRE_GE(a, b) \
+    BOOST_REQUIRE_GE(::seastar::testing::comparable_formattable(a), \
+                     ::seastar::testing::comparable_formattable(b))
+
+#define SEASTAR_BOOST_CHECK_GE(a, b) \
+    BOOST_CHECK_GE(::seastar::testing::comparable_formattable(a), \
+                   ::seastar::testing::comparable_formattable(b))

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -21,6 +21,7 @@
  */
 
 #include <boost/test/execution_monitor.hpp>
+#include "test_comparisons.hh"
 
 #include <seastar/core/sleep.hh>
 #include <seastar/testing/test_case.hh>
@@ -177,7 +178,7 @@ BOOST_AUTO_TEST_CASE(test_nested_throw) {
         const_cast<test_nested_throw_helper&>(test_nested_throw_helper_instance).run();
     } catch (boost::execution_exception& e) {
         // Should get a cpp exception failure
-        BOOST_REQUIRE_EQUAL(e.code(), boost::execution_exception::error_code::cpp_exception_error);
+        SEASTAR_BOOST_REQUIRE_EQUAL(e.code(), boost::execution_exception::error_code::cpp_exception_error);
         // Should have the nested message
         BOOST_REQUIRE(e.what().find("Message 1") != std::string::npos);
         // Should have the outer message

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -32,6 +32,7 @@
 #include <seastar/util/assert.hh>
 #include <sys/mman.h>
 #include <signal.h>
+#include "test_comparisons.hh"
 
 #include <valgrind/valgrind.h>
 
@@ -44,7 +45,7 @@ SEASTAR_TEST_CASE(test_thread_1) {
             x = "abc";
         });
         return t1->join().then([&x, t1] {
-            BOOST_REQUIRE_EQUAL(x, "abc");
+            SEASTAR_BOOST_REQUIRE_EQUAL(x, "abc");
             delete t1;
         });
     });
@@ -67,10 +68,10 @@ SEASTAR_TEST_CASE(test_thread_2) {
         for (int i = 0; i < n; ++i) {
             x.threads.emplace_back(std::bind(&tmp::thread_fn, &x));
         }
-        BOOST_REQUIRE_EQUAL(x.counter, 0);
+        SEASTAR_BOOST_REQUIRE_EQUAL(x.counter, 0);
         x.sem1.signal(n);
         return x.sem2.wait(n).then([&x, n] {
-            BOOST_REQUIRE_EQUAL(x.counter, n);
+            SEASTAR_BOOST_REQUIRE_EQUAL(x.counter, n);
             return parallel_for_each(x.threads.begin(), x.threads.end(), std::mem_fn(&thread::join));
         });
     });
@@ -84,13 +85,13 @@ SEASTAR_TEST_CASE(test_thread_async) {
         return x + y;
     };
     return async(concat, x, y).then([] (sstring xy) {
-        BOOST_REQUIRE_EQUAL(xy, "xy");
+        SEASTAR_BOOST_REQUIRE_EQUAL(xy, "xy");
     });
 }
 
 SEASTAR_TEST_CASE(test_thread_async_immed) {
     return async([] { return 3; }).then([] (int three) {
-        BOOST_REQUIRE_EQUAL(three, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(three, 3);
     });
 }
 
@@ -100,7 +101,7 @@ SEASTAR_TEST_CASE(test_thread_async_nested) {
             return 3;
         }).get();
     }).then([] (int three) {
-        BOOST_REQUIRE_EQUAL(three, 3);
+        SEASTAR_BOOST_REQUIRE_EQUAL(three, 3);
     });
 }
 
@@ -163,7 +164,7 @@ SEASTAR_TEST_CASE(test_thread_custom_stack_size) {
     thread_attributes attr;
     attr.stack_size = 16384;
     return async(attr, concat, x, y).then([] (sstring xy) {
-        BOOST_REQUIRE_EQUAL(xy, "xy");
+        SEASTAR_BOOST_REQUIRE_EQUAL(xy, "xy");
     });
 }
 
@@ -248,7 +249,7 @@ seastar::future<> test_thread_custom_stack_size_failure::run_test_case() const {
     thread_attributes attr;
     attr.stack_size = 16384;
     return async(attr, concat, x, y).then([] (sstring xy) {
-        BOOST_REQUIRE_EQUAL(xy, "xy");
+        SEASTAR_BOOST_REQUIRE_EQUAL(xy, "xy");
         BOOST_REQUIRE(stack_guard_bypassed);
         auto ret = sigaction(SIGSEGV, &default_old_sigsegv_handler, nullptr);
         if (ret) {
@@ -258,7 +259,7 @@ seastar::future<> test_thread_custom_stack_size_failure::run_test_case() const {
         // The same function with a default stack will not trigger
         // a segfault, because its stack is much bigger than 10KiB
         return async(concat, x, y).then([] (sstring xy) {
-            BOOST_REQUIRE_EQUAL(xy, "xy");
+            SEASTAR_BOOST_REQUIRE_EQUAL(xy, "xy");
         });
     });
 }

--- a/tests/unit/timer_test.cc
+++ b/tests/unit/timer_test.cc
@@ -21,6 +21,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include "test_comparisons.hh"
 
 #include <seastar/core/timer.hh>
 #include <seastar/core/reactor.hh>
@@ -116,7 +117,7 @@ void test_timer_with_scheduling_groups() {
         timer<Clock> t2(sg2, make_callback_checking_sg(sg2));
         t2.arm(10ms);
         sleep(500ms).get();
-        BOOST_REQUIRE_EQUAL(expirations, 2);
+        SEASTAR_BOOST_REQUIRE_EQUAL(expirations, 2);
     }).get();
     destroy_scheduling_group(sg1).get();
     destroy_scheduling_group(sg2).get();

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -22,6 +22,7 @@
 
 #include <ranges>
 #include <iostream>
+#include "test_comparisons.hh"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/sstring.hh>
@@ -101,7 +102,7 @@ static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> c
                                         return make_ready_future<std::optional<bool>>(std::nullopt);
                                     }
                                     BOOST_CHECK(buffer.size() > 8);
-                                    BOOST_CHECK_EQUAL(buffer.substr(0, 5), sstring("HTTP/"));
+                                    SEASTAR_BOOST_CHECK_EQUAL(buffer.substr(0, 5), sstring("HTTP/"));
                                     return make_ready_future<std::optional<bool>>(true);
                                 });
                             });
@@ -260,7 +261,7 @@ SEASTAR_TEST_CASE(test_alpn_client_server) {
             auto s = co_await server.accept();
             auto alpn = co_await tls::get_selected_alpn_protocol(s.connection);
             BOOST_CHECK(alpn.has_value());
-            BOOST_CHECK_EQUAL(*alpn, "h2");
+            SEASTAR_BOOST_CHECK_EQUAL(*alpn, "h2");
             co_return;
         },
         [addr]() mutable -> future<> {
@@ -270,7 +271,7 @@ SEASTAR_TEST_CASE(test_alpn_client_server) {
             auto c = co_await tls::connect(b.build_certificate_credentials(), addr, client_opts);
             auto alpn = co_await tls::get_selected_alpn_protocol(c);
             BOOST_CHECK(alpn.has_value());
-            BOOST_CHECK_EQUAL(*alpn, "h2");
+            SEASTAR_BOOST_CHECK_EQUAL(*alpn, "h2");
             co_return;
         }
     );
@@ -750,8 +751,8 @@ SEASTAR_TEST_CASE(test_x509_client_server_cert_validation_fail) {
             std::rethrow_exception(ep);
         } catch (tls::verification_error& e) {
             // Verify exception contains info on subject/issuer
-            BOOST_REQUIRE_NE(sstring(e.what()).find("Issuer"), sstring::npos);
-            BOOST_REQUIRE_NE(sstring(e.what()).find("Subject"), sstring::npos);
+            SEASTAR_BOOST_REQUIRE_NE(sstring(e.what()).find("Issuer"), sstring::npos);
+            SEASTAR_BOOST_REQUIRE_NE(sstring(e.what()).find("Subject"), sstring::npos);
             // ok.
         } catch (...) {
             BOOST_FAIL("Unexpected exception");
@@ -1050,7 +1051,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
         in.read().get(); // ignore - just want eof
         in.close().get();
 
-        BOOST_CHECK_EQUAL(sstring(buf.begin(), buf.end()), "apa");
+        SEASTAR_BOOST_CHECK_EQUAL(sstring(buf.begin(), buf.end()), "apa");
     }
 }
 
@@ -1218,7 +1219,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_by_move) {
         // ok
     }
 
-    BOOST_REQUIRE_EQUAL(changed.size(), 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(changed.size(), 0);
 
     p = promise();
 
@@ -1228,7 +1229,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_by_move) {
     // now it should reload
     p.get_future().get();
 
-    BOOST_REQUIRE_EQUAL(changed.size(), 2);
+    SEASTAR_BOOST_REQUIRE_EQUAL(changed.size(), 2);
     changed.clear();
 
     // again, without delete
@@ -1303,7 +1304,7 @@ SEASTAR_THREAD_TEST_CASE(test_closed_write) {
             try {
                 std::rethrow_exception(ep2);
             } catch (std::exception& e2) {
-                BOOST_REQUIRE_EQUAL(std::string(e1.what()), std::string(e2.what()));
+                SEASTAR_BOOST_REQUIRE_EQUAL(std::string(e1.what()), std::string(e2.what()));
                 return;
             }
         }
@@ -2009,7 +2010,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_only_shard0_notify) {
         in.read().get(); // ignore - just want eof
         in.close().get();
 
-        BOOST_CHECK_EQUAL(sstring(buf.begin(), buf.end()), "apa");
+        SEASTAR_BOOST_CHECK_EQUAL(sstring(buf.begin(), buf.end()), "apa");
     }
 }
 
@@ -2018,8 +2019,8 @@ SEASTAR_TEST_CASE(test_tls_cipher_suite_and_protocol_version, *enable_if_with_ne
     co_await certs->set_system_trust();
 
     auto c = co_await tls::connect(certs, co_await google_address(), tls::tls_options{ .server_name = google_name });
-    BOOST_CHECK_EQUAL(co_await tls::get_cipher_suite(c), "TLS_AES_256_GCM_SHA384");
-    BOOST_CHECK_EQUAL(co_await tls::get_protocol_version(c), "TLS1.3");
+    SEASTAR_BOOST_CHECK_EQUAL(co_await tls::get_cipher_suite(c), "TLS_AES_256_GCM_SHA384");
+    SEASTAR_BOOST_CHECK_EQUAL(co_await tls::get_protocol_version(c), "TLS1.3");
 }
 
 SEASTAR_TEST_CASE(test_cipher_suite_and_protocol_version_for_non_tls_connection, *enable_if_with_networking()) {
@@ -2131,7 +2132,7 @@ SEASTAR_THREAD_TEST_CASE(test_send_recv_alloc_limits) {
 
         auto stats_after = memory::stats();
 
-        BOOST_CHECK_EQUAL(stats_after.large_allocations(), stats_before.large_allocations());
+        SEASTAR_BOOST_CHECK_EQUAL(stats_after.large_allocations(), stats_before.large_allocations());
     }
 }
 
@@ -2182,7 +2183,7 @@ SEASTAR_THREAD_TEST_CASE(test_session_close_with_unread_data) {
         BOOST_TEST_MESSAGE(fmt::format("Wrote {} bytes in {:.3f} seconds\n", bytes_sent, delay.count()));
         out.close().handle_exception([] (auto x) {}).get();
         s.shutdown_input();
-        BOOST_CHECK_LT(delay.count(), 1.0);
+        SEASTAR_BOOST_CHECK_LT(delay.count(), 1.0);
     });
 
     seastar::when_all(std::move(c), std::move(s)).discard_result().get();
@@ -2237,7 +2238,7 @@ SEASTAR_THREAD_TEST_CASE(test_send_two_large) {
             bytes_received += buf.size();
         }
 
-        BOOST_CHECK_EQUAL(bytes_received, total_size);
+        SEASTAR_BOOST_CHECK_EQUAL(bytes_received, total_size);
         BOOST_CHECK(std::equal(expected.get(), expected.get() + total_size, received_data.get()));
 
         in.close().get();

--- a/tests/unit/tuple_utils_test.cc
+++ b/tests/unit/tuple_utils_test.cc
@@ -22,6 +22,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <seastar/util/tuple_utils.hh>
+#include "test_comparisons.hh"
 
 #include <boost/test/unit_test.hpp>
 
@@ -45,7 +46,7 @@ BOOST_AUTO_TEST_CASE(for_each) {
         os << e;
     });
 
-    BOOST_REQUIRE_EQUAL(os.str(), "a1005.4");
+    SEASTAR_BOOST_REQUIRE_EQUAL(os.str(), "a1005.4");
 }
 
 namespace {

--- a/tests/unit/uname_test.cc
+++ b/tests/unit/uname_test.cc
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/internal/uname.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar::internal;
 
@@ -31,30 +32,30 @@ BOOST_AUTO_TEST_CASE(test_nowait_aio_fix) {
     auto check = [] (const char* uname) {
         return parse_uname(uname).whitelisted({"5.1", "5.0.8", "4.19.35", "4.14.112"});
     };
-    BOOST_REQUIRE_EQUAL(check("5.1.0"), true);
-    BOOST_REQUIRE_EQUAL(check("5.1.1"), true);
-    BOOST_REQUIRE_EQUAL(check("5.1.1-44.distro"), true);
-    BOOST_REQUIRE_EQUAL(check("5.1.1-44.7.distro"), true);
-    BOOST_REQUIRE_EQUAL(check("5.0.0"), false);
-    BOOST_REQUIRE_EQUAL(check("5.0.7"), false);
-    BOOST_REQUIRE_EQUAL(check("5.0.7-55.el19"), false);
-    BOOST_REQUIRE_EQUAL(check("5.0.8"), true);
-    BOOST_REQUIRE_EQUAL(check("5.0.9"), true);
-    BOOST_REQUIRE_EQUAL(check("5.0.8-200.fedora"), true);
-    BOOST_REQUIRE_EQUAL(check("5.0.9-200.fedora"), true);
-    BOOST_REQUIRE_EQUAL(check("5.2.0"), true);
-    BOOST_REQUIRE_EQUAL(check("5.2.9"), true);
-    BOOST_REQUIRE_EQUAL(check("5.2.9-77.el153"), true);
-    BOOST_REQUIRE_EQUAL(check("6.0.0"), true);
-    BOOST_REQUIRE_EQUAL(check("3.9.0"), false);
-    BOOST_REQUIRE_EQUAL(check("4.19"), false);
-    BOOST_REQUIRE_EQUAL(check("4.19.34"), false);
-    BOOST_REQUIRE_EQUAL(check("4.19.35"), true);
-    BOOST_REQUIRE_EQUAL(check("4.19.36"), true);
-    BOOST_REQUIRE_EQUAL(check("4.20.36"), false);
-    BOOST_REQUIRE_EQUAL(check("4.14.111"), false);
-    BOOST_REQUIRE_EQUAL(check("4.14.112"), true);
-    BOOST_REQUIRE_EQUAL(check("4.14.113"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.1.0"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.1.1"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.1.1-44.distro"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.1.1-44.7.distro"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.0"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.7"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.7-55.el19"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.8"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.9"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.8-200.fedora"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.0.9-200.fedora"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.2.0"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.2.9"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.2.9-77.el153"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("6.0.0"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.9.0"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.19"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.19.34"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.19.35"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.19.36"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.20.36"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.14.111"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.14.112"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("4.14.113"), true);
 }
 
 
@@ -62,15 +63,15 @@ BOOST_AUTO_TEST_CASE(test_xfs_concurrency_fix) {
     auto check = [] (const char* uname) {
         return parse_uname(uname).whitelisted({"3.15", "3.10.0-325.el7"});
     };
-    BOOST_REQUIRE_EQUAL(check("3.15.0"), true);
-    BOOST_REQUIRE_EQUAL(check("5.1.0"), true);
-    BOOST_REQUIRE_EQUAL(check("3.14.0"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.0"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.14"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-325.ubuntu"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-325"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-325.el7"), true);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-326.el7"), true);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-324.el7"), false);
-    BOOST_REQUIRE_EQUAL(check("3.10.0-325.665.el7"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.15.0"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("5.1.0"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.14.0"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.14"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-325.ubuntu"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-325"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-325.el7"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-326.el7"), true);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-324.el7"), false);
+    SEASTAR_BOOST_REQUIRE_EQUAL(check("3.10.0-325.665.el7"), true);
 }

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <filesystem>
+#include "test_comparisons.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -99,7 +100,7 @@ future<> ud_server_client::init_server() {
                 //  verify the client address
                 if (client_path) {
                     socket_address tmmp{unix_domain_addr{*client_path}};
-                    BOOST_REQUIRE_EQUAL(cn_addr, socket_address{unix_domain_addr{*client_path}});
+                    SEASTAR_BOOST_REQUIRE_EQUAL(cn_addr, socket_address{unix_domain_addr{*client_path}});
                 }
 
                 return do_with(cn.input(), cn.output(), [](auto& inp, auto& out) {
@@ -141,7 +142,7 @@ void ud_server_client::client_round() {
     out.write(test_message).get();
     out.flush().get();
     auto bb = inp.read().get();
-    BOOST_REQUIRE_EQUAL(std::string_view(bb.begin(), bb.size()), "+"s+test_message);
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::string_view(bb.begin(), bb.size()), "+"s+test_message);
     inp.close().get();
     out.close().get();
 }
@@ -156,7 +157,7 @@ future<> ud_server_client::run() {
 
 void rm(std::string_view what) {
     auto res = system(fmt::format("rm -f {}", what).c_str());
-    BOOST_REQUIRE_EQUAL(res, 0);
+    SEASTAR_BOOST_REQUIRE_EQUAL(res, 0);
 }
 
 //  testing the various address types, both on the server and on the
@@ -201,11 +202,11 @@ SEASTAR_TEST_CASE(unixdomain_abs_bind_2) {
 
 SEASTAR_TEST_CASE(unixdomain_text) {
     socket_address addr1{unix_domain_addr{"abc"}};
-    BOOST_REQUIRE_EQUAL(format("{}", addr1), "abc");
+    SEASTAR_BOOST_REQUIRE_EQUAL(format("{}", addr1), "abc");
     socket_address addr2{unix_domain_addr{""}};
-    BOOST_REQUIRE_EQUAL(format("{}", addr2), "{unnamed}");
+    SEASTAR_BOOST_REQUIRE_EQUAL(format("{}", addr2), "{unnamed}");
     socket_address addr3{unix_domain_addr{std::string("\0abc", 5)}};
-    BOOST_REQUIRE_EQUAL(format("{}", addr3), "@abc_");
+    SEASTAR_BOOST_REQUIRE_EQUAL(format("{}", addr3), "@abc_");
     return make_ready_future<>();
 }
 
@@ -260,9 +261,9 @@ SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_autobind) {
 
     auto bufs = dgram.get_buffers();
     // POSIX impementation uses single buffer
-    BOOST_REQUIRE_EQUAL(bufs.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bufs.size(), 1);
     string received = internal::to_sstring<sstring>(bufs[0]);
-    BOOST_REQUIRE_EQUAL(received, "hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received, "hello");
 }
 
 SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_named_bound) {
@@ -286,9 +287,9 @@ SEASTAR_THREAD_TEST_CASE(unixdomain_datagram_named_bound) {
     net::udp_datagram dgram = named_receiver.receive().get();
     auto bufs = dgram.get_buffers();
     // POSIX impementation uses single buffer
-    BOOST_REQUIRE_EQUAL(bufs.size(), 1);
+    SEASTAR_BOOST_REQUIRE_EQUAL(bufs.size(), 1);
     string received = internal::to_sstring<sstring>(bufs[0]);
-    BOOST_REQUIRE_EQUAL(received, "hihi");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received, "hihi");
 
     // Try to be nice and remove the temporary directory.
     std::filesystem::remove_all(tmpdir_ptr);

--- a/tests/unit/variant_utils_test.cc
+++ b/tests/unit/variant_utils_test.cc
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <seastar/util/variant_utils.hh>
+#include "test_comparisons.hh"
 
 #include <boost/test/unit_test.hpp>
 
@@ -59,7 +60,7 @@ BOOST_AUTO_TEST_CASE(test_visit_can_return_reference) {
       variant_t{true},
       [](const int& i) -> noncopyable_type& { return t; },
       [](const bool& b) -> noncopyable_type& { return t; });
-    BOOST_REQUIRE_EQUAL(
+    SEASTAR_BOOST_REQUIRE_EQUAL(
       std::addressof(std_visit_ref), std::addressof(ss_visit_ref));
-    BOOST_REQUIRE_EQUAL(std::addressof(t), std::addressof(std_visit_ref));
+    SEASTAR_BOOST_REQUIRE_EQUAL(std::addressof(t), std::addressof(std_visit_ref));
 }

--- a/tests/unit/weak_ptr_test.cc
+++ b/tests/unit/weak_ptr_test.cc
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/core/weak_ptr.hh>
+#include "test_comparisons.hh"
 
 using namespace seastar;
 
@@ -65,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_base_class_weak_ptr) {
 
     auto get_checker = [] (weak_ptr<baseclass> p) {
         return [p = std::move(p)] (bool v) {
-            BOOST_REQUIRE_EQUAL(bool(p), v);
+            SEASTAR_BOOST_REQUIRE_EQUAL(bool(p), v);
         };
     };
 

--- a/tests/unit/websocket_test.cc
+++ b/tests/unit/websocket_test.cc
@@ -10,9 +10,10 @@
 #include <seastar/http/response_parser.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/memory-data-source.hh>
+#include <fmt/ranges.h>
 #include "loopback_socket.hh"
+#include "test_comparisons.hh"
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<seastar::sstring>)
 
 using namespace seastar;
 using namespace seastar::experimental;
@@ -92,7 +93,7 @@ future<> test_websocket_handshake_common(std::string subprotocol) {
         if (it != websocket_accept.end()) {
             websocket_accept.erase(websocket_accept.begin(), it);
         }
-        BOOST_REQUIRE_EQUAL(websocket_accept, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+        SEASTAR_BOOST_REQUIRE_EQUAL(websocket_accept, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
         for (auto& header : resp->_headers) {
             std::cout << header.first << ':' << header.second << std::endl;
         }
@@ -174,7 +175,7 @@ future<> test_websocket_handler_registration_common(std::string subprotocol) {
 
         auto response = input.read_exactly(6).get();
         auto response_str = std::string(response.begin(), response.end());
-        BOOST_REQUIRE_EQUAL(rs_frame, response_str);
+        SEASTAR_BOOST_REQUIRE_EQUAL(rs_frame, response_str);
     });
 }
 
@@ -229,7 +230,7 @@ SEASTAR_TEST_CASE(test_websocket_parser_split) {
             }
 
             SEASTAR_ASSERT(!parser.is_valid());
-            BOOST_REQUIRE_EQUAL(0, parser.result().size());
+            SEASTAR_BOOST_REQUIRE_EQUAL(0, parser.result().size());
 
             std::vector<sstring> expected = {
                 "TEST1",
@@ -237,7 +238,7 @@ SEASTAR_TEST_CASE(test_websocket_parser_split) {
                 "TEST3",
             };
 
-            BOOST_REQUIRE_EQUAL(results, expected);
+            SEASTAR_BOOST_REQUIRE_EQUAL(results, expected);
         }
     });
 }
@@ -294,7 +295,7 @@ SEASTAR_TEST_CASE(test_websocket_client_server) {
 
     co_await client_done.get_future();
 
-    BOOST_REQUIRE_EQUAL(received_data, "hello");
+    SEASTAR_BOOST_REQUIRE_EQUAL(received_data, "hello");
 
     // Shut down cleanly: close client first (sends CLOSE frame), then server
     co_await client_conn.close();


### PR DESCRIPTION
In order for us to be able to eventually drop the deprecated functions, we must alert users that they are deprecated by defaulting to OFF.

Since some tests compare std::vectors which don't have std::ostream formatters, add a wrapper
to funnel printing to a fmt::formatter if available, and fall back to std::ostream if not.