### PR TITLE
quic: add experimental ngtcp2 transport

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -15,8 +15,18 @@ jobs:
       image: alpine:latest
 
     steps:
+    - name: Install git for checkout
+      run: |
+        apk update
+        apk add --no-cache git
+
     - name: Checkout repository
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+    - name: Checkout ngtcp2 submodule
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git submodule update --init ngtcp2
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -23,11 +23,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-    - name: Checkout ngtcp2 submodule
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git submodule update --init ngtcp2
-
     - name: Install build dependencies
       run: |
         apk update
@@ -49,6 +44,7 @@ jobs:
           lksctp-tools-dev   \
           lz4-dev            \
           numactl-dev        \
+          ngtcp2-dev         \
           openssl            \
           openssl-dev        \
           protobuf-dev       \
@@ -65,7 +61,8 @@ jobs:
         cmake -B build -G Ninja            \
          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
          -DSeastar_LTTNG=OFF               \
-         -DSeastar_DOCS=OFF
+         -DSeastar_DOCS=OFF                \
+         -DSeastar_NGTCP2_PROVIDER=SYSTEM
 
     - name: Build Seastar
       run: |

--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -108,6 +108,7 @@ group "configure.py"
     --c++-standard "$STANDARD"  \
     --compiler "$CPP"           \
     --c-compiler "$CC"          \
+    --ngtcp2-provider system     \
     --mode "$MODE"              \
     "${cook_args[@]}"           \
     "${ccache_opt[@]}"          \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,11 @@ jobs:
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
 
+      - name: Checkout ngtcp2 submodule
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init ngtcp2
+
       - name: Setup ccache
         if: ${{ inputs.enable-ccache }}
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,11 +67,6 @@ jobs:
         with:
           submodules: "${{ contains(inputs.enables, 'dpdk') }}"
 
-      - name: Checkout ngtcp2 submodule
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git submodule update --init ngtcp2
-
       - name: Setup ccache
         if: ${{ inputs.enable-ccache }}
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "dpdk"]
 	path = dpdk
 	url = ../dpdk
+
+[submodule "ngtcp2"]
+	path = ngtcp2
+	url = https://github.com/scylladb-zpp-2025-seastar-quic/ngtcp2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,12 @@ option (Seastar_DPDK
   "Enable DPDK support."
   OFF)
 
+set (Seastar_NGTCP2_PROVIDER
+  "AUTO"
+  CACHE
+  STRING
+  "Select the ngtcp2 provider: AUTO, SYSTEM, or BUNDLED.")
+
 option (Seastar_EXCLUDE_APPS_FROM_ALL
   "When enabled alongside Seastar_APPS, do not build applications by default."
   OFF)
@@ -426,7 +432,7 @@ find_package (ragel 6.10 REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
-find_package (ngtcp2 REQUIRED)
+find_package (ngtcp2 1.14.0 REQUIRED)
 
 cmake_dependent_option (Seastar_LOGGER_COMPILE_TIME_FMT
   "Enable the compile-time {fmt} check when formatting logging messages" ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,7 @@ find_package (ragel 6.10 REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
+find_package (ngtcp2 REQUIRED)
 
 cmake_dependent_option (Seastar_LOGGER_COMPILE_TIME_FMT
   "Enable the compile-time {fmt} check when formatting logging messages" ON
@@ -719,6 +720,10 @@ add_library (seastar
   include/seastar/websocket/client.hh
   include/seastar/websocket/common.hh
   include/seastar/websocket/server.hh
+  include/seastar/quic/quic.hh
+  include/seastar/quic/quic_client.hh
+  include/seastar/quic/quic_server.hh
+  include/seastar/quic/quic_error.hh
   src/core/alien.cc
   src/core/file.cc
   src/core/fair_queue.cc
@@ -815,6 +820,12 @@ add_library (seastar
   src/websocket/common.cc
   src/websocket/client.cc
   src/websocket/server.cc
+  src/quic/quic_command_runtime.cc
+  src/quic/quic_common.cc
+  src/quic/quic_client.cc
+  src/quic/quic_connection_state.cc
+  src/quic/quic_server.cc
+  src/quic/quic_error.cc
   )
 
 if (Seastar_GNUTLS)
@@ -922,6 +933,8 @@ target_link_libraries (seastar
     lz4::lz4
   PRIVATE
     ${CMAKE_DL_LIBS}
+    ngtcp2::ngtcp2
+    GnuTLS::gnutls
     StdAtomic::atomic
     lksctp-tools::lksctp-tools
     protobuf::libprotobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,7 @@ add_library (seastar
   src/quic/quic_client.cc
   src/quic/quic_connection_state.cc
   src/quic/quic_server.cc
+  src/quic/sharded_quic_server.cc
   src/quic/quic_error.cc
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,7 @@ add_library (seastar
   include/seastar/quic/quic.hh
   include/seastar/quic/quic_client.hh
   include/seastar/quic/quic_server.hh
+  include/seastar/quic/sharded_quic_server.hh
   include/seastar/quic/quic_error.hh
   src/core/alien.cc
   src/core/file.cc

--- a/cmake/Findngtcp2.cmake
+++ b/cmake/Findngtcp2.cmake
@@ -1,0 +1,83 @@
+set (NGTCP2_ENABLE_LIB_ONLY
+  ON
+  CACHE
+  BOOL
+  "Build libngtcp2 only")
+
+set (NGTCP2_ENABLE_STATIC_LIB
+  ON
+  CACHE
+  BOOL
+  "Build static lib")
+
+set (NGTCP2_ENABLE_SHARED_LIB
+  OFF
+  CACHE
+  BOOL
+  "Disable shared lib")
+
+set (NGTCP2_ENABLE_GNUTLS
+  ON
+  CACHE
+  BOOL
+  "Enable GnuTLS")
+
+set (NGTCP2_ENABLE_OPENSSL
+  OFF
+  CACHE
+  BOOL
+  "Disable OpenSSL")
+
+set (NGTCP2_DISABLE_TESTS
+  ON
+  CACHE
+  BOOL
+  "Disable tests")
+
+enable_language (C)
+
+set (Cooking_USE_CMAKE_PROJECT_COMMAND ON)
+add_subdirectory (ngtcp2)
+unset (Cooking_USE_CMAKE_PROJECT_COMMAND)
+
+set (NGTCP2_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ngtcp2")
+set (NGTCP2_BIN "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2")
+
+set (ngtcp2_INCLUDE_DIRS
+  "${NGTCP2_SRC}/lib/includes"
+  "${NGTCP2_SRC}/crypto/includes"
+  "${NGTCP2_SRC}/lib"
+  "${NGTCP2_BIN}/lib/includes"
+)
+
+if (TARGET ngtcp2_static AND TARGET ngtcp2_crypto_gnutls_static)
+  add_library (ngtcp2::ngtcp2 INTERFACE IMPORTED)
+
+  set_target_properties(ngtcp2_static PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  set_target_properties(ngtcp2_crypto_gnutls_static PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  set_target_properties (ngtcp2::ngtcp2 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ngtcp2_INCLUDE_DIRS}"
+  )
+
+  target_link_libraries(ngtcp2::ngtcp2
+    INTERFACE
+      ngtcp2_static
+      ngtcp2_crypto_gnutls_static
+  )
+
+  set (ngtcp2_FOUND TRUE)
+else()
+  message (FATAL_ERROR "[ngtcp2] CRITICAL: targets of ngtcp2 library haven't been found!")
+endif()
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (ngtcp2
+  REQUIRED_VARS
+    ngtcp2_FOUND)

--- a/cmake/Findngtcp2.cmake
+++ b/cmake/Findngtcp2.cmake
@@ -1,3 +1,132 @@
+set (ngtcp2_min_version 1.14.0)
+if (ngtcp2_FIND_VERSION AND ngtcp2_FIND_VERSION VERSION_GREATER ngtcp2_min_version)
+  set (ngtcp2_required_version ${ngtcp2_FIND_VERSION})
+else ()
+  set (ngtcp2_required_version ${ngtcp2_min_version})
+endif ()
+
+if (NOT DEFINED Seastar_NGTCP2_PROVIDER)
+  set (Seastar_NGTCP2_PROVIDER AUTO)
+endif ()
+
+if (NOT Seastar_NGTCP2_PROVIDER MATCHES "^(AUTO|SYSTEM|BUNDLED)$")
+  message (FATAL_ERROR
+    "Invalid Seastar_NGTCP2_PROVIDER='${Seastar_NGTCP2_PROVIDER}'. "
+    "Expected AUTO, SYSTEM, or BUNDLED.")
+endif ()
+
+set (ngtcp2_system_found FALSE)
+if (NOT Seastar_NGTCP2_PROVIDER STREQUAL "BUNDLED")
+  find_package (PkgConfig QUIET)
+  if (PkgConfig_FOUND)
+    pkg_check_modules (PC_ngtcp2 QUIET libngtcp2)
+    pkg_check_modules (PC_ngtcp2_crypto_gnutls QUIET libngtcp2_crypto_gnutls)
+  endif ()
+
+  find_library (ngtcp2_LIBRARY
+    NAMES ngtcp2
+    HINTS
+      ${PC_ngtcp2_LIBDIR}
+      ${PC_ngtcp2_LIBRARY_DIRS})
+
+  find_library (ngtcp2_crypto_gnutls_LIBRARY
+    NAMES ngtcp2_crypto_gnutls
+    HINTS
+      ${PC_ngtcp2_crypto_gnutls_LIBDIR}
+      ${PC_ngtcp2_crypto_gnutls_LIBRARY_DIRS})
+
+  find_path (ngtcp2_INCLUDE_DIR
+    NAMES ngtcp2/ngtcp2.h
+    HINTS
+      ${PC_ngtcp2_INCLUDEDIR}
+      ${PC_ngtcp2_INCLUDE_DIRS})
+
+  find_path (ngtcp2_crypto_gnutls_INCLUDE_DIR
+    NAMES ngtcp2/ngtcp2_crypto_gnutls.h
+    HINTS
+      ${PC_ngtcp2_crypto_gnutls_INCLUDEDIR}
+      ${PC_ngtcp2_crypto_gnutls_INCLUDE_DIRS})
+
+  mark_as_advanced (
+    ngtcp2_LIBRARY
+    ngtcp2_crypto_gnutls_LIBRARY
+    ngtcp2_INCLUDE_DIR
+    ngtcp2_crypto_gnutls_INCLUDE_DIR)
+
+  set (ngtcp2_VERSION ${PC_ngtcp2_VERSION})
+
+  if (PC_ngtcp2_FOUND
+      AND PC_ngtcp2_crypto_gnutls_FOUND
+      AND ngtcp2_LIBRARY
+      AND ngtcp2_crypto_gnutls_LIBRARY
+      AND ngtcp2_INCLUDE_DIR
+      AND ngtcp2_crypto_gnutls_INCLUDE_DIR
+      AND NOT PC_ngtcp2_VERSION VERSION_LESS ngtcp2_required_version
+      AND NOT PC_ngtcp2_crypto_gnutls_VERSION VERSION_LESS ngtcp2_required_version)
+    set (ngtcp2_system_found TRUE)
+  endif ()
+endif ()
+
+set (ngtcp2_use_bundled FALSE)
+if (ngtcp2_system_found)
+  set (ngtcp2_LIBRARIES
+    ${ngtcp2_crypto_gnutls_LIBRARY}
+    ${ngtcp2_LIBRARY})
+  set (ngtcp2_INCLUDE_DIRS
+    ${ngtcp2_INCLUDE_DIR}
+    ${ngtcp2_crypto_gnutls_INCLUDE_DIR})
+  list (REMOVE_DUPLICATES ngtcp2_INCLUDE_DIRS)
+
+  if (NOT TARGET ngtcp2::ngtcp2_core)
+    add_library (ngtcp2::ngtcp2_core UNKNOWN IMPORTED)
+
+    set_target_properties (ngtcp2::ngtcp2_core
+      PROPERTIES
+        IMPORTED_LOCATION ${ngtcp2_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${ngtcp2_INCLUDE_DIR})
+  endif ()
+
+  if (NOT TARGET ngtcp2::ngtcp2_crypto_gnutls)
+    add_library (ngtcp2::ngtcp2_crypto_gnutls UNKNOWN IMPORTED)
+
+    set_target_properties (ngtcp2::ngtcp2_crypto_gnutls
+      PROPERTIES
+        IMPORTED_LOCATION ${ngtcp2_crypto_gnutls_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${ngtcp2_crypto_gnutls_INCLUDE_DIR})
+  endif ()
+
+  if (NOT TARGET ngtcp2::ngtcp2)
+    add_library (ngtcp2::ngtcp2 INTERFACE IMPORTED)
+
+    set_target_properties (ngtcp2::ngtcp2
+      PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${ngtcp2_INCLUDE_DIRS}")
+
+    target_link_libraries (ngtcp2::ngtcp2
+      INTERFACE
+        ngtcp2::ngtcp2_crypto_gnutls
+        ngtcp2::ngtcp2_core)
+  endif ()
+
+  set (ngtcp2_FOUND TRUE)
+elseif (NOT Seastar_NGTCP2_PROVIDER STREQUAL "SYSTEM"
+    AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ngtcp2/CMakeLists.txt")
+  set (ngtcp2_use_bundled TRUE)
+else ()
+  set (ngtcp2_FOUND FALSE)
+endif ()
+
+if (NOT ngtcp2_use_bundled)
+  include (FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args (ngtcp2
+    REQUIRED_VARS
+      ngtcp2_FOUND
+    VERSION_VAR
+      ngtcp2_VERSION)
+  return ()
+endif ()
+
 set (NGTCP2_ENABLE_LIB_ONLY
   ON
   CACHE
@@ -71,7 +200,14 @@ if (TARGET ngtcp2_static AND TARGET ngtcp2_crypto_gnutls_static)
       ngtcp2_crypto_gnutls_static
   )
 
+  get_directory_property (ngtcp2_VERSION
+    DIRECTORY ngtcp2
+    DEFINITION PROJECT_VERSION)
+
   set (ngtcp2_FOUND TRUE)
+  if (NOT ngtcp2_FIND_QUIETLY)
+    message (STATUS "Using bundled ngtcp2 ${ngtcp2_VERSION} with the GnuTLS backend")
+  endif ()
 else()
   message (FATAL_ERROR "[ngtcp2] CRITICAL: targets of ngtcp2 library haven't been found!")
 endif()
@@ -80,4 +216,8 @@ include (FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args (ngtcp2
   REQUIRED_VARS
-    ngtcp2_FOUND)
+    ngtcp2_FOUND
+  VERSION_VAR
+    ngtcp2_VERSION
+  FAIL_MESSAGE
+    "Could NOT find ngtcp2 >= ${ngtcp2_required_version} with the GnuTLS backend. Install the system development packages, initialize the ngtcp2 submodule, or select Seastar_NGTCP2_PROVIDER=BUNDLED.")

--- a/configure.py
+++ b/configure.py
@@ -170,6 +170,8 @@ arg_parser.add_argument('--c++-standard', action='store', dest='cpp_standard', d
                         help='C++ standard to build with')
 arg_parser.add_argument('--cook', action='append', dest='cook', default=[],
                         help='Supply this dependency locally for development via `cmake-cooking` (can be repeated)')
+arg_parser.add_argument('--ngtcp2-provider', choices=['auto', 'system', 'bundled'], default='auto',
+                        help='Select the ngtcp2 provider: prefer a system package, require it, or use the bundled submodule')
 arg_parser.add_argument('--verbose', dest='verbose', action='store_true', help='Make configure output more verbose.')
 arg_parser.add_argument('--scheduling-groups-count', action='store', dest='scheduling_groups_count', default='16',
                         help='Number of available scheduling groups in the reactor')
@@ -303,6 +305,7 @@ def configure_mode(mode):
         tr(args.cxx_modules, 'MODULE'),
         tr(args.dpdk, 'DPDK'),
         tr(args.dpdk_machine, 'DPDK_MACHINE'),
+        tr(args.ngtcp2_provider.upper(), 'NGTCP2_PROVIDER'),
         tr(args.hwloc, 'HWLOC', value_when_none='yes'),
         tr(args.io_uring, 'IO_URING', value_when_none=None),
         tr(args.lttng, 'LTTNG', value_when_none='yes'),

--- a/configure.py
+++ b/configure.py
@@ -287,6 +287,7 @@ def configure_mode(mode):
     TRANSLATED_ARGS = [
         '-DCMAKE_BUILD_TYPE={}'.format(MODE_TO_CMAKE_BUILD_TYPE[mode]),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
+        '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_STANDARD={}'.format(args.cpp_standard),
         '-DCMAKE_CXX_COMPILER_LAUNCHER={}'.format(compiler_cache),
         '-DCMAKE_INSTALL_PREFIX={}'.format(args.install_prefix),
@@ -333,9 +334,6 @@ def configure_mode(mode):
 
     # Generate a new build by pointing to the source directory.
     if ingredients_to_cook:
-        # the C compiler is only used when building ingredients.
-        TRANSLATED_ARGS.append(f'-DCMAKE_C_COMPILER={args.cc}')
-
         # We need to use cmake-cooking for some dependencies.
         inclusion_arguments = []
 

--- a/cooking.sh
+++ b/cooking.sh
@@ -265,6 +265,10 @@ cat <<'EOF' > "${build_dir}/Cooking.cmake"
 #
 
 macro (project name)
+  if (Cooking_USE_CMAKE_PROJECT_COMMAND)
+    _project (${name} ${ARGN})
+  endif ()
+
   set (_cooking_dir ${CMAKE_CURRENT_BINARY_DIR}/_cooking)
 
   if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -126,6 +126,12 @@ seastar_add_demo (tutorial_examples
 seastar_add_demo (http_client
   SOURCES http_client_demo.cc)
 
+seastar_add_demo (quic_server
+  SOURCES quic_server_demo.cc)
+
+seastar_add_demo (quic_client
+  SOURCES quic_client_demo.cc)
+
 if (Seastar_MODULE)
   add_executable (hello_cxx_module)
   target_sources (hello_cxx_module

--- a/demos/quic_client_demo.cc
+++ b/demos/quic_client_demo.cc
@@ -1,0 +1,282 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/when_any.hh>
+#include <seastar/quic/quic_client.hh>
+
+#include "../apps/lib/stop_signal.hh"
+
+using namespace seastar;
+using namespace seastar::quic::experimental;
+namespace bpo = boost::program_options;
+
+static socket_address parse_ip_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa6{};
+    sa6.sin6_family = AF_INET6;
+    sa6.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa6.sin6_addr) == 1) {
+        return socket_address(sa6);
+    }
+
+    sockaddr_in sa4{};
+    sa4.sin_family = AF_INET;
+    sa4.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip.c_str(), &sa4.sin_addr) == 1) {
+        return socket_address(sa4);
+    }
+
+    throw std::runtime_error("Invalid IP address: " + ip);
+}
+
+static std::string format_endpoint(const std::string& ip, uint16_t port) {
+    if (ip.find(':') != std::string::npos) {
+        return "[" + ip + "]:" + std::to_string(port);
+    }
+    return ip + ":" + std::to_string(port);
+}
+
+class io_shutdown final {
+public:
+    future<> wait() const {
+        return _done.get_shared_future();
+    }
+
+    void signal() {
+        if (_signaled) {
+            return;
+        }
+        _signaled = true;
+        _done.set_value();
+    }
+
+private:
+    mutable shared_promise<> _done;
+    bool _signaled = false;
+};
+
+static pollable_fd duplicate_stdin() {
+    auto fd = ::dup(STDIN_FILENO);
+    throw_system_error_on(fd == -1, "dup(stdin)");
+    return pollable_fd(file_desc::from_fd(fd));
+}
+
+static future<> receive_loop(lw_shared_ptr<input_stream<char>> input, lw_shared_ptr<io_shutdown> shutdown) {
+    try {
+        while (true) {
+            try {
+                auto chunk = co_await input->read();
+                if (chunk.empty()) {
+                    shutdown->signal();
+                    co_return;
+                }
+                std::cout.write(chunk.get(), static_cast<std::streamsize>(chunk.size()));
+                if (chunk.size() && chunk.get()[chunk.size() - 1] != '\n') {
+                    std::cout << "\n";
+                }
+                std::cout.flush();
+            } catch (const quic_error& e) {
+                if (e.code() == quic_error::closed) {
+                    shutdown->signal();
+                    co_return;
+                }
+                throw;
+            }
+        }
+    } catch (...) {
+        shutdown->signal();
+        throw;
+    }
+}
+
+static future<> input_loop(
+  lw_shared_ptr<output_stream<char>> output,
+  lw_shared_ptr<connection> session,
+  lw_shared_ptr<pollable_fd> stdin_fd,
+  lw_shared_ptr<io_shutdown> shutdown,
+  bool verbose) {
+    char buf[2048];
+    while (session->is_open()) {
+        auto wait_result = co_await when_any(stdin_fd->readable(), shutdown->wait());
+        auto& stdin_ready = std::get<0>(wait_result.futures);
+        auto& shutdown_ready = std::get<1>(wait_result.futures);
+
+        if (shutdown_ready.available()) {
+            shutdown_ready.get();
+            co_return;
+        }
+
+        stdin_ready.get();
+        auto n = co_await stdin_fd->read_some(buf, sizeof(buf));
+        if (n == 0) {
+            if (verbose) {
+                std::cout << "[client] stdin EOF, closing stream output...\n";
+                std::cout.flush();
+            }
+            shutdown->signal();
+            co_await output->close();
+            co_return;
+        }
+        if (verbose) {
+            std::cout << "[client] send bytes=" << n << "\n";
+            std::cout.flush();
+        }
+        co_await output->write(buf, n);
+        co_await output->flush();
+    }
+}
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+      ("address", bpo::value<std::string>()->default_value("::1"), "Server IP address")
+      ("port", bpo::value<uint16_t>()->default_value(4444), "Server UDP port")
+      ("server-name", bpo::value<std::string>()->default_value("localhost"), "TLS server name (SNI)")
+      ("ca", bpo::value<std::string>()->default_value("server.crt"), "PEM CA/certificate file used to verify the server")
+      ("verbose,v", bpo::value<bool>()->default_value(false)->implicit_value(true), "Verbose logging");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        quic_client client;
+        lw_shared_ptr<connection> session;
+        lw_shared_ptr<input_stream<char>> input;
+        lw_shared_ptr<output_stream<char>> output;
+        lw_shared_ptr<pollable_fd> stdin_fd;
+        auto shutdown = make_lw_shared<io_shutdown>();
+        std::exception_ptr error;
+
+        try {
+            auto&& cfg = app.configuration();
+            auto address = cfg["address"].as<std::string>();
+            auto port = cfg["port"].as<uint16_t>();
+            auto server_name = cfg["server-name"].as<std::string>();
+            auto ca_file = cfg["ca"].as<std::string>();
+            auto verbose = cfg["verbose"].as<bool>();
+
+            quic_client_config client_cfg;
+            client_cfg.remote_address = parse_ip_address(address, port);
+            client_cfg.server_name = server_name;
+            if (!ca_file.empty()) {
+                client_cfg.ca_file = ca_file;
+            }
+
+            session = make_lw_shared<connection>(co_await client.connect(std::move(client_cfg)));
+            auto quic_stream = co_await session->open_stream();
+            if (verbose) {
+                std::cout << "[client] opened stream sid=" << quic_stream.id() << "\n";
+                std::cout.flush();
+            }
+            input = make_lw_shared<input_stream<char>>(quic_stream.input());
+            output = make_lw_shared<output_stream<char>>(quic_stream.output());
+            stdin_fd = make_lw_shared<pollable_fd>(duplicate_stdin());
+
+            if (verbose) {
+                std::cout << "[client] connected to " << format_endpoint(address, port) << "\n";
+                std::cout.flush();
+            }
+
+            seastar_apps_lib::stop_signal stop_signal;
+            auto raced = co_await when_any(
+              when_all_succeed(
+                receive_loop(input, shutdown),
+                input_loop(output, session, stdin_fd, shutdown, verbose))
+                .discard_result(),
+              stop_signal.wait().then([session, stdin_fd, shutdown]() {
+                    shutdown->signal();
+                    if (stdin_fd) {
+                        stdin_fd->close();
+                    }
+                    if (session && session->is_open()) {
+                        std::cout << "[client] SIGINT received, closing session...\n";
+                        std::cout.flush();
+                        return session->close();
+                    }
+                    return make_ready_future<>();
+                })
+                .handle_exception([](std::exception_ptr) {}));
+
+            auto io_task = std::move(std::get<0>(raced.futures));
+            auto stop_task = std::move(std::get<1>(raced.futures));
+            if (!io_task.available()) {
+                co_await std::move(io_task);
+            } else {
+                io_task.get();
+            }
+            if (stop_task.available()) {
+                stop_task.get();
+            }
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        shutdown->signal();
+        if (stdin_fd) {
+            stdin_fd->close();
+        }
+        if (session) {
+            try {
+                co_await session->close();
+            } catch (...) {
+            }
+        }
+        if (output) {
+            try {
+                co_await output->close();
+            } catch (...) {
+            }
+        }
+        if (input) {
+            try {
+                co_await input->close();
+            } catch (...) {
+            }
+        }
+
+        try {
+            co_await client.stop();
+        } catch (...) {
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[client] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[client] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+        co_return 0;
+    });
+}

--- a/demos/quic_server_demo.cc
+++ b/demos/quic_server_demo.cc
@@ -31,7 +31,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/quic/quic_server.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/quic/sharded_quic_server.hh>
 
 #include "../apps/lib/stop_signal.hh"
 
@@ -55,13 +56,6 @@ static socket_address parse_ip_address(const std::string& ip, uint16_t port) {
     }
 
     throw std::runtime_error("Invalid IP address: " + ip);
-}
-
-static std::string format_endpoint(const std::string& ip, uint16_t port) {
-    if (ip.find(':') != std::string::npos) {
-        return "[" + ip + "]:" + std::to_string(port);
-    }
-    return ip + ":" + std::to_string(port);
 }
 
 static future<> handle_stream(seastar::quic::experimental::stream quic_stream, bool verbose, uint64_t conn_id, uint64_t stream_no) {
@@ -136,37 +130,6 @@ static future<> handle_session(connection session, bool verbose, uint64_t conn_i
     }
 }
 
-static future<> accept_loop(quic_server& server, gate& sessions, bool verbose) {
-    uint64_t next_conn_id = 1;
-    while (true) {
-        connection session;
-        try {
-            session = co_await server.accept();
-        } catch (const quic_error& e) {
-            if (e.code() == quic_error::closed) {
-                co_return;
-            }
-            throw;
-        }
-        auto conn_id = next_conn_id++;
-        if (verbose) {
-            std::cout << "[server conn#" << conn_id << "] accepted\n";
-            std::cout.flush();
-        }
-
-        (void)with_gate(
-          sessions, [session = std::move(session), verbose, conn_id]() mutable { return handle_session(std::move(session), verbose, conn_id); })
-          .handle_exception([](std::exception_ptr ep) {
-              try {
-                  std::rethrow_exception(ep);
-              } catch (const std::exception& e) {
-                  std::cerr << "[server] connection task failed: " << e.what() << "\n";
-              }
-          })
-          .or_terminate();
-    }
-}
-
 int main(int argc, char** argv) {
     app_template app;
     app.add_options()
@@ -177,9 +140,7 @@ int main(int argc, char** argv) {
       ("verbose,v", bpo::value<bool>()->default_value(false)->implicit_value(true), "Verbose logging");
 
     return app.run(argc, argv, [&app]() -> future<int> {
-        quic_server server;
-        gate sessions;
-        std::optional<future<>> accept_task;
+        sharded_quic_server server;
         std::exception_ptr error;
         bool verbose = false;
 
@@ -197,9 +158,19 @@ int main(int argc, char** argv) {
             server_cfg.key_file = key;
 
             co_await server.start(std::move(server_cfg));
-            accept_task.emplace(accept_loop(server, sessions, verbose));
+            co_await server.serve([verbose] {
+                return [verbose] (connection session) mutable -> future<> {
+                    static thread_local uint64_t next_conn_id = 1;
+                    auto conn_id = (static_cast<uint64_t>(this_shard_id()) << 32) | next_conn_id++;
+                    if (verbose) {
+                        std::cout << "[server shard#" << this_shard_id() << " conn#" << conn_id << "] accepted\n";
+                        std::cout.flush();
+                    }
+                    co_await handle_session(std::move(session), verbose, conn_id);
+                };
+            });
 
-            std::cout << "QUIC server listening on " << format_endpoint(address, port) << "\n";
+            std::cout << "QUIC server listening on " << server.local_address() << "\n";
             std::cout.flush();
 
             seastar_apps_lib::stop_signal stop_signal;
@@ -212,19 +183,6 @@ int main(int argc, char** argv) {
 
         try {
             co_await server.stop();
-        } catch (...) {
-        }
-        if (accept_task) {
-            try {
-                co_await std::move(*accept_task);
-            } catch (...) {
-                if (!error) {
-                    error = std::current_exception();
-                }
-            }
-        }
-        try {
-            co_await sessions.close();
         } catch (...) {
             if (!error) {
                 error = std::current_exception();

--- a/demos/quic_server_demo.cc
+++ b/demos/quic_server_demo.cc
@@ -1,0 +1,246 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <arpa/inet.h>
+
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/quic/quic_server.hh>
+
+#include "../apps/lib/stop_signal.hh"
+
+using namespace seastar;
+using namespace seastar::quic::experimental;
+namespace bpo = boost::program_options;
+
+static socket_address parse_ip_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa6{};
+    sa6.sin6_family = AF_INET6;
+    sa6.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa6.sin6_addr) == 1) {
+        return socket_address(sa6);
+    }
+
+    sockaddr_in sa4{};
+    sa4.sin_family = AF_INET;
+    sa4.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip.c_str(), &sa4.sin_addr) == 1) {
+        return socket_address(sa4);
+    }
+
+    throw std::runtime_error("Invalid IP address: " + ip);
+}
+
+static std::string format_endpoint(const std::string& ip, uint16_t port) {
+    if (ip.find(':') != std::string::npos) {
+        return "[" + ip + "]:" + std::to_string(port);
+    }
+    return ip + ":" + std::to_string(port);
+}
+
+static future<> handle_stream(seastar::quic::experimental::stream quic_stream, bool verbose, uint64_t conn_id, uint64_t stream_no) {
+    try {
+        auto input = quic_stream.input();
+        auto output = quic_stream.output();
+        while (true) {
+            auto chunk = co_await input.read();
+            if (chunk.empty()) {
+                break;
+            }
+            if (verbose) {
+                std::cout << "[server conn#" << conn_id << " stream#" << stream_no << "] recv sid=" << quic_stream.id()
+                          << " bytes=" << chunk.size() << "\n";
+            } else {
+                std::cout.write(chunk.get(), static_cast<std::streamsize>(chunk.size()));
+                if (chunk.size() && chunk.get()[chunk.size() - 1] != '\n') {
+                    std::cout << "\n";
+                }
+            }
+            std::cout.flush();
+            co_await output.write(chunk.get(), chunk.size());
+            co_await output.flush();
+        }
+        co_await output.close();
+        co_await input.close();
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) {
+            std::cerr << "[server conn#" << conn_id << " stream#" << stream_no << "] stream error: " << e.what() << "\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[server conn#" << conn_id << " stream#" << stream_no << "] stream exception: " << e.what() << "\n";
+    }
+}
+
+static future<> handle_session(connection session, bool verbose, uint64_t conn_id) {
+    gate streams;
+    uint64_t next_stream_no = 1;
+    try {
+        while (session.is_open()) {
+            auto quic_stream = co_await session.accept_stream();
+            auto stream_no = next_stream_no++;
+            if (verbose) {
+                std::cout << "[server conn#" << conn_id << "] accepted stream sid=" << quic_stream.id() << "\n";
+                std::cout.flush();
+            }
+            (void)with_gate(streams, [quic_stream = std::move(quic_stream), verbose, conn_id, stream_no]() mutable {
+                return handle_stream(std::move(quic_stream), verbose, conn_id, stream_no);
+            }).handle_exception([](std::exception_ptr ep) {
+                try {
+                    std::rethrow_exception(ep);
+                } catch (const std::exception& e) {
+                    std::cerr << "[server] stream task failed: " << e.what() << "\n";
+                }
+            }).or_terminate();
+        }
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) {
+            std::cerr << "[server conn#" << conn_id << "] connection error: " << e.what() << "\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[server conn#" << conn_id << "] connection exception: " << e.what() << "\n";
+    }
+
+    try {
+        co_await session.close();
+    } catch (...) {
+    }
+    try {
+        co_await streams.close();
+    } catch (...) {
+    }
+}
+
+static future<> accept_loop(quic_server& server, gate& sessions, bool verbose) {
+    uint64_t next_conn_id = 1;
+    while (true) {
+        connection session;
+        try {
+            session = co_await server.accept();
+        } catch (const quic_error& e) {
+            if (e.code() == quic_error::closed) {
+                co_return;
+            }
+            throw;
+        }
+        auto conn_id = next_conn_id++;
+        if (verbose) {
+            std::cout << "[server conn#" << conn_id << "] accepted\n";
+            std::cout.flush();
+        }
+
+        (void)with_gate(
+          sessions, [session = std::move(session), verbose, conn_id]() mutable { return handle_session(std::move(session), verbose, conn_id); })
+          .handle_exception([](std::exception_ptr ep) {
+              try {
+                  std::rethrow_exception(ep);
+              } catch (const std::exception& e) {
+                  std::cerr << "[server] connection task failed: " << e.what() << "\n";
+              }
+          })
+          .or_terminate();
+    }
+}
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+      ("address", bpo::value<std::string>()->default_value("::1"), "Server IP address")
+      ("port", bpo::value<uint16_t>()->default_value(4444), "Server UDP port")
+      ("crt", bpo::value<std::string>()->default_value("server.crt"), "PEM certificate file")
+      ("key,k", bpo::value<std::string>()->default_value("server.key"), "PEM key file")
+      ("verbose,v", bpo::value<bool>()->default_value(false)->implicit_value(true), "Verbose logging");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        quic_server server;
+        gate sessions;
+        std::optional<future<>> accept_task;
+        std::exception_ptr error;
+        bool verbose = false;
+
+        try {
+            auto&& cfg = app.configuration();
+            auto address = cfg["address"].as<std::string>();
+            auto port = cfg["port"].as<uint16_t>();
+            auto crt = cfg["crt"].as<std::string>();
+            auto key = cfg["key"].as<std::string>();
+            verbose = cfg["verbose"].as<bool>();
+
+            quic_server_config server_cfg;
+            server_cfg.listen_address = parse_ip_address(address, port);
+            server_cfg.crt_file = crt;
+            server_cfg.key_file = key;
+
+            co_await server.start(std::move(server_cfg));
+            accept_task.emplace(accept_loop(server, sessions, verbose));
+
+            std::cout << "QUIC server listening on " << format_endpoint(address, port) << "\n";
+            std::cout.flush();
+
+            seastar_apps_lib::stop_signal stop_signal;
+            co_await stop_signal.wait();
+            std::cout << "[server] SIGINT received, disconnecting clients...\n";
+            std::cout.flush();
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        try {
+            co_await server.stop();
+        } catch (...) {
+        }
+        if (accept_task) {
+            try {
+                co_await std::move(*accept_task);
+            } catch (...) {
+                if (!error) {
+                    error = std::current_exception();
+                }
+            }
+        }
+        try {
+            co_await sessions.close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[server] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[server] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+        co_return 0;
+    });
+}

--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -81,6 +81,7 @@ struct stat_data;
 namespace net {
 
 using udp_channel = class datagram_channel;
+struct datagram_channel_options;
 
 }
 
@@ -180,6 +181,16 @@ net::datagram_channel make_unbound_datagram_channel(sa_family_t family);
 /// \return a \ref net::datagram_channel object for sending/receiving datagrams
 /// in a specified address family.
 net::datagram_channel make_bound_datagram_channel(const socket_address& local);
+
+/// Creates a datagram_channel bound according to the supplied options.
+///
+/// \param local local address to bind to
+/// \param opts bound datagram channel options
+///
+/// \return a \ref net::datagram_channel object for sending/receiving datagrams
+net::datagram_channel make_bound_datagram_channel(
+        const socket_address& local,
+        net::datagram_channel_options opts);
 
 /// @}
 

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -166,6 +166,10 @@ public:
 
 using udp_channel = datagram_channel;
 
+struct datagram_channel_options {
+    bool reuse_port = false;
+};
+
 class network_interface_impl;
 
 } /* namespace net */
@@ -499,7 +503,9 @@ public:
     virtual ::seastar::socket socket() = 0;
 
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) = 0;
-    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) = 0;
+    virtual net::datagram_channel make_bound_datagram_channel(
+            const socket_address& local,
+            net::datagram_channel_options opts = {}) = 0;
     virtual future<> initialize() {
         return make_ready_future();
     }

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -166,7 +166,12 @@ public:
 
 using udp_channel = datagram_channel;
 
+/// Options controlling how a bound datagram channel is created.
 struct datagram_channel_options {
+    /// Allow other datagram channels to bind the same local IP endpoint.
+    ///
+    /// This option maps to SO_REUSEPORT on the POSIX network stack. Network
+    /// stacks that do not support port reuse reject the option.
     bool reuse_port = false;
 };
 
@@ -503,9 +508,7 @@ public:
     virtual ::seastar::socket socket() = 0;
 
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) = 0;
-    virtual net::datagram_channel make_bound_datagram_channel(
-            const socket_address& local,
-            net::datagram_channel_options opts = {}) = 0;
+    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) = 0;
     virtual future<> initialize() {
         return make_ready_future();
     }
@@ -528,6 +531,17 @@ public:
      * return by value.
      */
     virtual std::vector<network_interface> network_interfaces();
+
+    /**
+     * Creates a bound datagram channel with implementation-specific options.
+     *
+     * The default implementation preserves compatibility with network stacks
+     * that only implement make_bound_datagram_channel(local), and rejects
+     * options they cannot honor.
+     */
+    virtual net::datagram_channel make_bound_datagram_channel_with_options(
+            const socket_address& local,
+            net::datagram_channel_options opts);
 };
 
 struct network_stack_entry {

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -239,7 +239,9 @@ public:
     virtual server_socket listen(socket_address sa, listen_options opts) override;
     virtual ::seastar::socket socket() override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
-    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
+    virtual net::datagram_channel make_bound_datagram_channel(
+            const socket_address& local,
+            datagram_channel_options opts = {}) override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) {
         return make_ready_future<std::unique_ptr<network_stack>>(std::unique_ptr<network_stack>(new posix_network_stack(opts, allocator)));
     }

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -239,9 +239,10 @@ public:
     virtual server_socket listen(socket_address sa, listen_options opts) override;
     virtual ::seastar::socket socket() override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
-    virtual net::datagram_channel make_bound_datagram_channel(
+    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
+    virtual net::datagram_channel make_bound_datagram_channel_with_options(
             const socket_address& local,
-            datagram_channel_options opts = {}) override;
+            datagram_channel_options opts) override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) {
         return make_ready_future<std::unique_ptr<network_stack>>(std::unique_ptr<network_stack>(new posix_network_stack(opts, allocator)));
     }

--- a/include/seastar/quic/quic.hh
+++ b/include/seastar/quic/quic.hh
@@ -1,0 +1,251 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/api.hh>
+#include <seastar/quic/quic_error.hh>
+
+namespace seastar::quic::experimental {
+
+/// QUIC stream identifier as defined by RFC 9000.
+using stream_id = int64_t;
+
+/// Application-defined QUIC stream or connection error code.
+using application_error_code = uint64_t;
+
+/// Sentinel used internally before ngtcp2 assigns a real stream id.
+inline constexpr stream_id invalid_stream_id = -1;
+
+/// Directionality of a QUIC stream.
+enum class stream_type : uint8_t {
+    bidirectional,
+    unidirectional,
+};
+
+/// Congestion controller selected for new QUIC connections.
+enum class congestion_control_algorithm : uint8_t {
+    reno,
+    cubic,
+    bbr,
+    bbr2,
+};
+
+/// Transport-level knobs passed to ngtcp2 when a connection is created.
+///
+/// The fields mirror ngtcp2 transport settings and parameters. See the ngtcp2
+/// documentation for protocol-level details of each window, payload and PMTUD
+/// option.
+struct transport_config {
+    /// Maximum idle time before the peer may close the connection.
+    std::chrono::nanoseconds max_idle_timeout = std::chrono::seconds{60};
+
+    /// Initial receive window for locally-initiated bidirectional streams.
+    uint64_t initial_max_stream_data_bidi_local = 256 * 1024;
+
+    /// Initial receive window for remotely-initiated bidirectional streams.
+    uint64_t initial_max_stream_data_bidi_remote = 256 * 1024;
+
+    /// Initial receive window for unidirectional streams.
+    uint64_t initial_max_stream_data_uni = 256 * 1024;
+
+    /// Initial connection-wide receive window.
+    uint64_t initial_max_data = 4 * 1024 * 1024;
+
+    /// Maximum number of concurrent bidirectional streams the peer may open.
+    uint64_t initial_max_streams_bidi = 128;
+
+    /// Maximum number of concurrent unidirectional streams the peer may open.
+    uint64_t initial_max_streams_uni = 128;
+
+    /// Maximum UDP payload size this endpoint will transmit.
+    std::optional<size_t> max_tx_udp_payload_size{};
+
+    /// Maximum UDP payload size this endpoint advertises to the peer.
+    std::optional<uint64_t> max_udp_payload_size{};
+
+    /// Initial RTT estimate used before path validation samples are available.
+    std::optional<std::chrono::nanoseconds> initial_rtt{};
+
+    /// Connection-wide auto-tuned flow control window cap.
+    std::optional<uint64_t> max_window{};
+
+    /// Per-stream auto-tuned flow control window cap.
+    std::optional<uint64_t> max_stream_window{};
+
+    /// ACK threshold passed to ngtcp2.
+    std::optional<size_t> ack_thresh{};
+
+    /// Congestion controller override.
+    std::optional<congestion_control_algorithm> congestion_control{};
+
+    /// Disables ngtcp2 transmit UDP payload size shaping.
+    bool disable_tx_udp_payload_size_shaping = false;
+
+    /// Disables path MTU discovery in ngtcp2.
+    bool disable_pmtud = false;
+};
+
+/// Per-connection runtime limits plus transport setup shared by client and server.
+struct connection_options {
+    /// Maximum unsent application bytes buffered by the command runtime.
+    size_t max_pending_send_bytes = 4 * 1024 * 1024;
+
+    /// Maximum unread application bytes buffered across streams.
+    size_t max_pending_receive_bytes = 4 * 1024 * 1024;
+
+    /// QUIC transport parameters and ngtcp2 settings for the connection.
+    transport_config transport{};
+};
+
+/// Options for locally opening a new QUIC stream.
+struct stream_open_options {
+    /// Directionality of the new stream.
+    stream_type type = stream_type::bidirectional;
+};
+
+namespace internal {
+class connection_state;
+}
+
+/// Movable handle to a single QUIC stream.
+class stream final {
+public:
+    /// Constructs an empty stream handle.
+    stream();
+    ~stream();
+
+    stream(stream&&) noexcept;
+    stream& operator=(stream&&) noexcept;
+
+    stream(const stream&) = delete;
+    stream& operator=(const stream&) = delete;
+
+    /// Returns true while at least one usable stream direction remains open.
+    bool is_open() const noexcept;
+
+    /// Returns the ngtcp2 stream id, or invalid_stream_id for an empty handle.
+    stream_id id() const noexcept;
+
+    /// Returns whether this is a bidirectional or unidirectional stream.
+    stream_type type() const noexcept;
+
+    /// Returns true if this endpoint may read bytes from the stream.
+    ///
+    /// This is an open/close capability accessor, not a readiness notification.
+    bool can_read() const noexcept;
+
+    /// Returns true if this endpoint may write bytes to the stream.
+    ///
+    /// This is an open/close capability accessor, not a readiness notification.
+    bool can_write() const noexcept;
+
+    /// Creates an input_stream for the readable side of this stream.
+    input_stream<char> input(connected_socket_input_stream_config cfg = {});
+
+    /// Creates an output_stream for the writable side of this stream.
+    output_stream<char> output(size_t buffer_size = 8192);
+
+    /// Sends FIN for the writable side of this stream.
+    future<> close_output();
+
+    /// Resets the stream with an application error code.
+    future<> reset(application_error_code app_error_code = 0);
+
+    /// Asks the peer to stop sending on the readable side of this stream.
+    future<> stop_sending(application_error_code app_error_code = 0);
+
+    /// Completes after the readable side reaches FIN, reset, or stop-sending shutdown.
+    future<> wait_input_shutdown();
+
+private:
+    class impl;
+    explicit stream(std::unique_ptr<impl> state);
+
+    std::unique_ptr<impl> _impl;
+
+    friend class connection;
+    friend class internal::connection_state;
+    friend connected_socket to_connected_socket(stream&& s);
+};
+
+/// Movable handle to an established QUIC connection.
+class connection final {
+public:
+    /// Constructs an empty connection handle.
+    connection();
+    ~connection();
+
+    connection(connection&&) noexcept;
+    connection& operator=(connection&&) noexcept;
+
+    connection(const connection&) = delete;
+    connection& operator=(const connection&) = delete;
+
+    /// Returns true while the underlying transport accepts new operations.
+    bool is_open() const noexcept;
+
+    /// Returns the local UDP address used by the connection.
+    socket_address local_address() const;
+
+    /// Returns the peer UDP address used by the connection.
+    socket_address peer_address() const;
+
+    /// Returns the ALPN selected by the TLS handshake.
+    sstring selected_alpn() const;
+
+    /// Opens a locally-initiated stream.
+    future<stream> open_stream(stream_open_options options = {});
+
+    /// Waits for the next peer-initiated stream.
+    future<stream> accept_stream();
+
+    /// Closes the connection and its streams.
+    future<> close();
+
+private:
+    class impl;
+    explicit connection(std::unique_ptr<impl> state);
+
+    std::unique_ptr<impl> _impl;
+
+    friend class quic_client;
+    friend class quic_server;
+};
+
+/// Converts a bidirectional QUIC stream into a connected_socket wrapper.
+connected_socket to_connected_socket(stream&& s);
+
+} // namespace seastar::quic::experimental

--- a/include/seastar/quic/quic_client.hh
+++ b/include/seastar/quic/quic_client.hh
@@ -1,0 +1,82 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <seastar/core/sstring.hh>
+#include <seastar/quic/quic.hh>
+
+namespace seastar::quic::experimental {
+
+namespace internal {
+class quic_client_impl;
+}
+
+/// Configuration for a single outbound QUIC connection attempt.
+struct quic_client_config {
+    /// Remote UDP endpoint to connect to.
+    socket_address remote_address;
+
+    /// Local UDP endpoint to bind, or any address in the remote address family.
+    std::optional<socket_address> local_address{};
+
+    /// Server Name Indication value used for TLS certificate validation.
+    sstring server_name = "localhost";
+
+    /// Optional CA bundle used to validate the server certificate.
+    std::optional<sstring> ca_file{};
+
+    /// Non-empty ALPN protocols offered during the TLS handshake.
+    /// The list and each protocol identifier must be non-empty.
+    std::vector<sstring> alpns = {sstring("h3")};
+
+    /// Runtime and transport limits for the resulting connection.
+    connection_options session_options{};
+};
+
+/// Client-side owner of transport state that yields one established connection.
+class quic_client final {
+public:
+    /// Constructs a stopped QUIC client.
+    quic_client();
+    ~quic_client();
+
+    quic_client(quic_client&&) noexcept;
+    quic_client& operator=(quic_client&&) noexcept;
+
+    quic_client(const quic_client&) = delete;
+    quic_client& operator=(const quic_client&) = delete;
+
+    /// Opens a QUIC connection using config.
+    future<connection> connect(quic_client_config config);
+
+    /// Stops background transport work and closes the UDP channel.
+    future<> stop();
+
+private:
+    std::unique_ptr<internal::quic_client_impl> _impl;
+};
+
+} // namespace seastar::quic::experimental

--- a/include/seastar/quic/quic_error.hh
+++ b/include/seastar/quic/quic_error.hh
@@ -1,0 +1,68 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <system_error>
+#include <string>
+#include <type_traits>
+
+namespace seastar::quic::experimental {
+
+/// Error raised by the experimental QUIC transport.
+///
+/// The numeric values are stable within this API and are exposed through
+/// std::system_error::code() using quic_error_category().
+class quic_error final : public std::system_error {
+public:
+    /// Transport-independent QUIC error classes.
+    enum value : uint8_t {
+        none = 0,
+        invalid_argument,
+        invalid_state,
+        io,
+        timeout,
+        protocol,
+        closed,
+        unsupported,
+        internal,
+        backend,
+    };
+
+    /// Constructs a system_error carrying a QUIC error code and optional detail.
+    explicit quic_error(value error, std::string detail = {});
+};
+
+/// Returns the std::error_category used by quic_error.
+const std::error_category& quic_error_category() noexcept;
+
+/// Converts a QUIC error enum to std::error_code.
+std::error_code make_error_code(quic_error::value error) noexcept;
+
+} // namespace seastar::quic::experimental
+
+namespace std {
+
+template <>
+struct is_error_code_enum<seastar::quic::experimental::quic_error::value> : true_type {};
+
+} // namespace std

--- a/include/seastar/quic/quic_server.hh
+++ b/include/seastar/quic/quic_server.hh
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/quic/quic.hh>
 
@@ -31,6 +32,13 @@ namespace seastar::quic::experimental {
 
 namespace internal {
 class quic_server_impl;
+class quic_server_shard;
+
+class quic_packet_router {
+public:
+    virtual ~quic_packet_router() = default;
+    virtual future<> route_quic_packet(unsigned shard, socket_address local_address, socket_address src, temporary_buffer<char> packet) = 0;
+};
 }
 
 /// Listener configuration shared by all connections accepted from this server.
@@ -50,6 +58,9 @@ struct quic_server_config {
 
     /// Runtime and transport limits for accepted connections.
     connection_options session_options{};
+
+    /// Allows multiple UDP sockets to bind the same endpoint for kernel fanout.
+    bool reuse_port = false;
 };
 
 /// Server-side owner of the listening transport and accepted QUIC connections.
@@ -78,6 +89,11 @@ public:
     future<> stop();
 
 private:
+    friend class internal::quic_server_shard;
+
+    void set_packet_router(internal::quic_packet_router* router) noexcept;
+    future<> inject_datagram(socket_address src, temporary_buffer<char> packet);
+
     lw_shared_ptr<internal::quic_server_impl> _impl;
 };
 

--- a/include/seastar/quic/quic_server.hh
+++ b/include/seastar/quic/quic_server.hh
@@ -1,0 +1,84 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/quic/quic.hh>
+
+namespace seastar::quic::experimental {
+
+namespace internal {
+class quic_server_impl;
+}
+
+/// Listener configuration shared by all connections accepted from this server.
+struct quic_server_config {
+    /// Local UDP endpoint to bind.
+    socket_address listen_address;
+
+    /// PEM certificate chain file used by the server TLS session.
+    sstring crt_file;
+
+    /// PEM private key file used by the server TLS session.
+    sstring key_file;
+
+    /// Non-empty ALPN protocols advertised during the TLS handshake.
+    /// The list and each protocol identifier must be non-empty.
+    std::vector<sstring> alpns = {sstring("h3")};
+
+    /// Runtime and transport limits for accepted connections.
+    connection_options session_options{};
+};
+
+/// Server-side owner of the listening transport and accepted QUIC connections.
+class quic_server final {
+public:
+    /// Constructs a stopped QUIC server.
+    quic_server();
+    ~quic_server();
+
+    quic_server(quic_server&&) noexcept;
+    quic_server& operator=(quic_server&&) noexcept;
+
+    quic_server(const quic_server&) = delete;
+    quic_server& operator=(const quic_server&) = delete;
+
+    /// Starts listening for QUIC Initial packets using config.
+    future<> start(quic_server_config config);
+
+    /// Waits for the next connection that completed the QUIC and TLS handshakes.
+    future<connection> accept();
+
+    /// Returns the local UDP endpoint currently used by the server.
+    socket_address local_address() const noexcept;
+
+    /// Stops the listener and all server-owned connections.
+    future<> stop();
+
+private:
+    lw_shared_ptr<internal::quic_server_impl> _impl;
+};
+
+} // namespace seastar::quic::experimental

--- a/include/seastar/quic/quic_server.hh
+++ b/include/seastar/quic/quic_server.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <array>
 #include <vector>
 
 #include <seastar/core/shared_ptr.hh>
@@ -33,6 +34,8 @@ namespace seastar::quic::experimental {
 namespace internal {
 class quic_server_impl;
 class quic_server_shard;
+
+using quic_server_cid_key = std::array<uint8_t, 32>;
 
 class quic_packet_router {
 public:
@@ -58,9 +61,6 @@ struct quic_server_config {
 
     /// Runtime and transport limits for accepted connections.
     connection_options session_options{};
-
-    /// Allows multiple UDP sockets to bind the same endpoint for kernel fanout.
-    bool reuse_port = false;
 };
 
 /// Server-side owner of the listening transport and accepted QUIC connections.
@@ -91,6 +91,10 @@ public:
 private:
     friend class internal::quic_server_shard;
 
+    future<> start_shard(
+            quic_server_config config,
+            internal::quic_server_cid_key cid_key,
+            bool reuse_port);
     void set_packet_router(internal::quic_packet_router* router) noexcept;
     future<> inject_datagram(socket_address src, temporary_buffer<char> packet);
 

--- a/include/seastar/quic/sharded_quic_server.hh
+++ b/include/seastar/quic/sharded_quic_server.hh
@@ -1,0 +1,71 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <seastar/core/future.hh>
+#include <seastar/net/api.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+namespace seastar::quic::experimental {
+
+/// Per-shard QUIC listener using UDP SO_REUSEPORT when the POSIX stack supports it.
+///
+/// The class owns one quic_server instance per shard. Packets are normally
+/// distributed by the kernel receive path. Server-generated connection IDs encode
+/// the owning shard, so packets for established connections that arrive on a
+/// non-owner shard can be forwarded to the shard that owns the connection.
+class sharded_quic_server final {
+public:
+    using accept_handler = noncopyable_function<future<> (connection)>;
+    using accept_handler_factory = std::function<accept_handler ()>;
+
+    sharded_quic_server();
+    ~sharded_quic_server();
+
+    sharded_quic_server(sharded_quic_server&&) noexcept = delete;
+    sharded_quic_server& operator=(sharded_quic_server&&) noexcept = delete;
+
+    sharded_quic_server(const sharded_quic_server&) = delete;
+    sharded_quic_server& operator=(const sharded_quic_server&) = delete;
+
+    /// Starts one listener on each shard.
+    future<> start(quic_server_config config);
+
+    /// Starts per-shard accept loops. The factory is evaluated once on each shard.
+    future<> serve(accept_handler_factory make_handler);
+
+    /// Stops accept loops, listeners, and server-owned connections on every shard.
+    future<> stop();
+
+    /// Returns the local UDP endpoint selected during start().
+    socket_address local_address() const noexcept;
+
+private:
+    class impl;
+    std::unique_ptr<impl> _impl;
+};
+
+} // namespace seastar::quic::experimental

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -40,6 +40,8 @@ debian_packages=(
     libgnutls28-dev
     libhwloc-dev
     liblz4-dev
+    libngtcp2-crypto-gnutls-dev
+    libngtcp2-dev
     libnuma-dev
     libpciaccess-dev
     libprotobuf-dev
@@ -123,6 +125,8 @@ fedora_packages=(
     libasan
     libatomic
     libubsan
+    ngtcp2-crypto-gnutls-devel
+    ngtcp2-devel
     ninja-build
     ragel
     valgrind-devel
@@ -158,6 +162,8 @@ centos9_packages=(
     gcc-toolset-13-libasan-devel
     gcc-toolset-13-libatomic-devel
     gcc-toolset-13-libubsan-devel
+    ngtcp2-crypto-gnutls-devel
+    ngtcp2-devel
     ninja-build
     ragel
 )
@@ -178,6 +184,7 @@ arch_packages=(
     glibc
     gnutls
     hwloc
+    libngtcp2
     libpciaccess
     libtool
     liburing

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4962,6 +4962,12 @@ net::datagram_channel make_bound_datagram_channel(const socket_address& local) {
     return engine().net().make_bound_datagram_channel(local);
 }
 
+net::datagram_channel make_bound_datagram_channel(
+        const socket_address& local,
+        net::datagram_channel_options opts) {
+    return engine().net().make_bound_datagram_channel_with_options(local, opts);
+}
+
 void reactor::add_high_priority_task(task* t) noexcept {
     add_urgent_task(t);
     // break .then() chains

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -167,7 +167,9 @@ public:
     virtual server_socket listen(socket_address sa, listen_options opt) override;
     virtual ::seastar::socket socket() override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
-    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
+    virtual net::datagram_channel make_bound_datagram_channel(
+            const socket_address& local,
+            datagram_channel_options opts = {}) override;
     virtual future<> initialize() override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts) {
         auto ns_opts = dynamic_cast<const native_stack_options*>(&opts);
@@ -211,7 +213,10 @@ net::datagram_channel native_network_stack::make_unbound_datagram_channel(sa_fam
     return _inet.get_udp().make_channel({});
 }
 
-net::datagram_channel native_network_stack::make_bound_datagram_channel(const socket_address& local) {
+net::datagram_channel native_network_stack::make_bound_datagram_channel(const socket_address& local, datagram_channel_options opts) {
+    if (opts.reuse_port) {
+        throw std::runtime_error("SO_REUSEPORT is not supported by the native network stack");
+    }
     return _inet.get_udp().make_channel(local);
 }
 

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -167,9 +167,7 @@ public:
     virtual server_socket listen(socket_address sa, listen_options opt) override;
     virtual ::seastar::socket socket() override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
-    virtual net::datagram_channel make_bound_datagram_channel(
-            const socket_address& local,
-            datagram_channel_options opts = {}) override;
+    virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
     virtual future<> initialize() override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts) {
         auto ns_opts = dynamic_cast<const native_stack_options*>(&opts);
@@ -213,10 +211,7 @@ net::datagram_channel native_network_stack::make_unbound_datagram_channel(sa_fam
     return _inet.get_udp().make_channel({});
 }
 
-net::datagram_channel native_network_stack::make_bound_datagram_channel(const socket_address& local, datagram_channel_options opts) {
-    if (opts.reuse_port) {
-        throw std::runtime_error("SO_REUSEPORT is not supported by the native network stack");
-    }
+net::datagram_channel native_network_stack::make_bound_datagram_channel(const socket_address& local) {
     return _inet.get_udp().make_channel(local);
 }
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -1024,12 +1024,12 @@ private:
         return family == AF_INET || family == AF_INET6;
     }
 
-    static file_desc create_socket(sa_family_t family) {
+    static file_desc create_socket(sa_family_t family, datagram_channel_options opts = {}) {
         file_desc fd = file_desc::socket(family, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
 
         if (is_inet(family)) {
             fd.setsockopt(SOL_IP, IP_PKTINFO, true);
-            if (engine().posix_reuseport_available()) {
+            if (opts.reuse_port) {
                 fd.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1);
             }
         }
@@ -1056,9 +1056,9 @@ public:
 
     /// Creates a channel that is bound to the specified local address. It can be used to
     /// communicate with addresses that belong to the family of \param local.
-    posix_datagram_channel(socket_address local)
+    posix_datagram_channel(socket_address local, datagram_channel_options opts = {})
         : _recv(is_inet(local.family())), _closed(false) {
-        auto fd = create_socket(local.family());
+        auto fd = create_socket(local.family(), opts);
         fd.bind(local.u.sa, local.addr_length);
 
         _address = fd.get_address();
@@ -1110,8 +1110,8 @@ posix_network_stack::make_unbound_datagram_channel(sa_family_t family) {
 }
 
 datagram_channel
-posix_network_stack::make_bound_datagram_channel(const socket_address& local) {
-    return datagram_channel(std::make_unique<posix_datagram_channel>(local));
+posix_network_stack::make_bound_datagram_channel(const socket_address& local, datagram_channel_options opts) {
+    return datagram_channel(std::make_unique<posix_datagram_channel>(local, opts));
 }
 
 bool

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -1110,7 +1110,12 @@ posix_network_stack::make_unbound_datagram_channel(sa_family_t family) {
 }
 
 datagram_channel
-posix_network_stack::make_bound_datagram_channel(const socket_address& local, datagram_channel_options opts) {
+posix_network_stack::make_bound_datagram_channel(const socket_address& local) {
+    return datagram_channel(std::make_unique<posix_datagram_channel>(local));
+}
+
+datagram_channel
+posix_network_stack::make_bound_datagram_channel_with_options(const socket_address& local, datagram_channel_options opts) {
     return datagram_channel(std::make_unique<posix_datagram_channel>(local, opts));
 }
 

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -21,6 +21,7 @@
 
 
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -284,6 +285,15 @@ network_stack::connect(socket_address sa, socket_address local, transport proto)
 
 std::vector<network_interface> network_stack::network_interfaces() {
     return {};
+}
+
+net::datagram_channel network_stack::make_bound_datagram_channel_with_options(
+        const socket_address& local,
+        net::datagram_channel_options opts) {
+    if (opts.reuse_port) {
+        throw std::runtime_error("SO_REUSEPORT is not supported by this network stack");
+    }
+    return make_bound_datagram_channel(local);
 }
 
 void register_net_metrics_for_scheduling_group(

--- a/src/quic/quic_client.cc
+++ b/src/quic/quic_client.cc
@@ -1,0 +1,1447 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <seastar/quic/quic_client.hh>
+
+#include "quic_common.hh"
+#include "quic_impl.hh"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gnutls/crypto.h>
+#include <gnutls/gnutls.h>
+
+#include <ngtcp2/ngtcp2.h>
+#include <ngtcp2/ngtcp2_crypto.h>
+#include <ngtcp2/ngtcp2_crypto_gnutls.h>
+
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/log.hh>
+
+namespace seastar::quic::experimental {
+
+namespace {
+
+constexpr size_t max_udp_payload_size = 65527;
+constexpr size_t default_udp_payload_size = 1200;
+
+static logger quic_client_log("quic_client");
+using quic_message = internal::quic_message;
+
+struct tls_verification_failure {
+    quic_error_code error = quic_error_code::none;
+    sstring detail;
+};
+
+struct rx_event {
+    socket_address src;
+    temporary_buffer<char> packet;
+};
+
+struct client_state;
+void sync_current_path(client_state& st);
+
+// Owns one client-side transport instance: socket, TLS, ngtcp2 state and actor queues.
+struct client_state final : public enable_lw_shared_from_this<client_state>, public internal::connection_transport {
+    quic_client_config cfg{};
+    internal::command_runtime_ptr command_runtime;
+
+    net::datagram_channel channel{};
+    bool channel_ready = false;
+    socket_address local_address{};
+    socket_address remote_address{};
+
+    sockaddr_storage local_ss{};
+    socklen_t local_ss_len = 0;
+    sockaddr_storage remote_ss{};
+    socklen_t remote_ss_len = 0;
+
+    ngtcp2_conn* conn = nullptr;
+    ngtcp2_crypto_conn_ref conn_ref{};
+    gnutls_certificate_credentials_t cred = nullptr;
+    gnutls_session_t tls = nullptr;
+
+    gate task_gate;
+    queue<rx_event> rx_queue{1024};
+    internal::connection_state_ptr connection_state;
+    bool queues_aborted = false;
+    bool stop_requested = false;
+    std::optional<promise<>> handshake_promise;
+    bool handshake_promise_resolved = false;
+
+    bool stopping = false;
+    bool handshake_done = false;
+    size_t tx_payload_limit = default_udp_payload_size;
+    temporary_buffer<char> tx_packet_scratch;
+    std::unordered_map<stream_id, std::deque<internal::transport_command>> blocked_send_commands;
+    std::deque<stream_id> blocked_send_retry_streams;
+    std::unordered_set<stream_id> blocked_send_retry_requested;
+    struct retained_stream_data {
+        uint64_t offset = 0;
+        temporary_buffer<char> payload;
+    };
+    std::unordered_map<stream_id, uint64_t> next_stream_send_offsets;
+    std::unordered_map<stream_id, std::deque<retained_stream_data>> retained_stream_data_by_stream;
+
+    client_state() = default;
+
+    ~client_state() override {
+        // Destruction can happen while user futures still exist; complete them before
+        // releasing TLS/ngtcp2 state.
+        fail_blocked_open_streams(quic_error_code::closed, "client state destroyed");
+        discard_blocked_send();
+        abort_event_queues("client state destroyed");
+        if (command_runtime) {
+            command_runtime->set_command_notifier({});
+        }
+        wake_actor();
+        if (conn) {
+            ngtcp2_conn_del(conn);
+            conn = nullptr;
+        }
+        if (tls) {
+            gnutls_deinit(tls);
+            tls = nullptr;
+        }
+        if (cred) {
+            gnutls_certificate_free_credentials(cred);
+            cred = nullptr;
+        }
+    }
+
+    void fill_path(ngtcp2_path& path) {
+        init_ngtcp2_addr(&path.local, reinterpret_cast<sockaddr*>(&local_ss), local_ss_len);
+        init_ngtcp2_addr(&path.remote, reinterpret_cast<sockaddr*>(&remote_ss), remote_ss_len);
+    }
+
+    bool active() const noexcept {
+        return !stopping && command_runtime;
+    }
+
+    bool transport_active() const noexcept override {
+        return active();
+    }
+
+    bool has_transport_connection() const noexcept override {
+        return conn != nullptr;
+    }
+
+    bool can_retry_blocked_open_streams() const noexcept override {
+        return active() && handshake_done;
+    }
+
+    size_t tx_payload_limit_bytes() const noexcept override {
+        return tx_payload_limit;
+    }
+
+    bool has_blocked_send() const noexcept {
+        return !blocked_send_commands.empty();
+    }
+
+    bool blocked_send_retry_pending() const noexcept {
+        return !blocked_send_retry_streams.empty();
+    }
+
+    bool has_pending_actor_work() const noexcept {
+        // Merge transport, timer and API wakeups into one actor predicate.
+        return stop_requested
+               || (command_runtime && command_runtime->transport_terminal())
+               || !rx_queue.empty()
+               || blocked_send_retry_pending()
+               || (command_runtime && command_runtime->has_pending_commands())
+               || connection_state->tick_pending()
+               || connection_state->has_blocked_open_stream_retry_work();
+    }
+
+    future<> wait_for_actor_wakeup() {
+        // Timer callbacks and stream callbacks share this waiter with the actor.
+        return connection_state->wait_for_actor_wakeup(has_pending_actor_work(), stopping);
+    }
+
+    void wake_actor() {
+        connection_state->wake_actor();
+    }
+
+    void retain_stream_data(stream_id sid, temporary_buffer<char> payload) override {
+        if (sid == invalid_stream_id || payload.empty()) {
+            return;
+        }
+        auto& next_offset = next_stream_send_offsets[sid];
+        auto size = payload.size();
+        // ngtcp2 may split writes, so retention is tracked by stream offset.
+        retained_stream_data_by_stream[sid].push_back(retained_stream_data{
+          .offset = next_offset,
+          .payload = std::move(payload),
+        });
+        next_offset += size;
+    }
+
+    void acked_stream_data(stream_id sid, uint64_t offset, uint64_t datalen) {
+        // ACK ranges may cover partial retained buffers, so trim from the front.
+        auto it = retained_stream_data_by_stream.find(sid);
+        if (it == retained_stream_data_by_stream.end() || !datalen) {
+            return;
+        }
+        auto end = offset + datalen;
+        auto& retained = it->second;
+        while (!retained.empty()) {
+            auto& front = retained.front();
+            auto front_end = front.offset + front.payload.size();
+            if (front_end <= end) {
+                retained.pop_front();
+                continue;
+            }
+            if (front.offset < end) {
+                front.payload.trim_front(static_cast<size_t>(end - front.offset));
+                front.offset = end;
+            }
+            break;
+        }
+        if (retained.empty()) {
+            retained_stream_data_by_stream.erase(it);
+        }
+    }
+
+    void release_stream_data(stream_id sid) {
+        retained_stream_data_by_stream.erase(sid);
+        next_stream_send_offsets.erase(sid);
+    }
+
+    int64_t write_pending_packet(uint8_t* outbuf, size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        // Emit pending transport-only frames such as ACKs and PTO probes.
+        return ngtcp2_conn_write_pkt(conn, &path, &pkt_info, outbuf, outbuf_size, quic_now_ns());
+    }
+
+    internal::transport_stream_write_result write_stream_packet(
+      stream_id sid,
+      const char* data,
+      size_t len,
+      bool fin,
+      uint8_t* outbuf,
+      size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        ngtcp2_vec vec{};
+        ngtcp2_ssize consumed = 0;
+        if (data && len) {
+            vec.base = reinterpret_cast<uint8_t*>(const_cast<char*>(data));
+            vec.len = len;
+        }
+        auto flags = (!len && fin) ? NGTCP2_WRITE_STREAM_FLAG_FIN : 0;
+        auto nwrite = ngtcp2_conn_writev_stream(
+          conn,
+          &path,
+          &pkt_info,
+          outbuf,
+          outbuf_size,
+          &consumed,
+          flags,
+          sid,
+          (data && len) ? &vec : nullptr,
+          (data && len) ? 1 : 0,
+          quic_now_ns());
+        return internal::transport_stream_write_result{
+          .nwrite = nwrite,
+          .consumed = consumed > 0 ? static_cast<size_t>(consumed) : 0,
+        };
+    }
+
+    void complete_send_bytes(size_t len) override {
+        if (command_runtime) {
+            command_runtime->complete_send_bytes(len);
+        }
+    }
+
+    internal::transport_open_stream_result try_open_stream(stream_type type) override {
+        int64_t sid = invalid_stream_id;
+        auto rv = type == stream_type::bidirectional
+                    ? ngtcp2_conn_open_bidi_stream(conn, &sid, nullptr)
+                    : ngtcp2_conn_open_uni_stream(conn, &sid, nullptr);
+        return internal::transport_open_stream_result{
+          .rv = rv,
+          .sid = sid,
+        };
+    }
+
+    int shutdown_stream_write(stream_id sid, application_error_code app_error_code) override {
+        return ngtcp2_conn_shutdown_stream_write(conn, 0, sid, app_error_code);
+    }
+
+    int consume_stream_data(stream_id sid, size_t len) override {
+        if (!conn || !len) {
+            return 0;
+        }
+        auto rv = ngtcp2_conn_extend_max_stream_offset(conn, sid, static_cast<uint64_t>(len));
+        if (rv < 0) {
+            return rv;
+        }
+        ngtcp2_conn_extend_max_offset(conn, static_cast<uint64_t>(len));
+        return 0;
+    }
+
+    int shutdown_stream_read(stream_id sid, application_error_code app_error_code) override {
+        return ngtcp2_conn_shutdown_stream_read(conn, 0, sid, app_error_code);
+    }
+
+    int read_transport_datagram(const socket_address& src, const char* data, size_t len) override {
+        sockaddr_storage remote_ss{};
+        socklen_t remote_ss_len = 0;
+        to_sockaddr_storage(src, remote_ss, remote_ss_len);
+
+        ngtcp2_path path{};
+        init_ngtcp2_addr(&path.local, reinterpret_cast<sockaddr*>(&local_ss), local_ss_len);
+        init_ngtcp2_addr(&path.remote, reinterpret_cast<sockaddr*>(&remote_ss), remote_ss_len);
+        ngtcp2_pkt_info pkt_info{};
+        return ngtcp2_conn_read_pkt(
+          conn,
+          &path,
+          &pkt_info,
+          reinterpret_cast<const uint8_t*>(data),
+          len,
+          quic_now_ns());
+    }
+
+    void sync_transport_path() override {
+        sync_current_path(*this);
+    }
+
+    uint64_t transport_expiry_ns() const noexcept override {
+        return ngtcp2_conn_get_expiry(conn);
+    }
+
+    int handle_transport_expiry(uint64_t now_local) override {
+        return ngtcp2_conn_handle_expiry(conn, now_local);
+    }
+
+    temporary_buffer<char>& tx_packet_buffer() override {
+        return tx_packet_scratch;
+    }
+
+    future<> send_datagram_packet(temporary_buffer<char> packet) override {
+        return send_datagram(quic_client_log, channel, remote_address, std::move(packet));
+    }
+
+    bool can_send_connection_close() const noexcept override {
+        // CONNECTION_CLOSE requires both ngtcp2 state and a live UDP channel.
+        return conn && channel_ready && !channel.is_closed();
+    }
+
+    int64_t write_connection_close_packet(uint8_t* outbuf, size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        ngtcp2_ccerr ccerr{};
+        ngtcp2_ccerr_default(&ccerr);
+        ngtcp2_ccerr_set_application_error(&ccerr, 0, nullptr, 0);
+        return ngtcp2_conn_write_connection_close(
+          conn,
+          &path,
+          &pkt_info,
+          outbuf,
+          outbuf_size,
+          &ccerr,
+          quic_now_ns());
+    }
+
+    void on_stream_write_closed(stream_id sid) override {
+        // Convert ngtcp2 write-side closure into the same state transition as STOP_SENDING.
+        if (!connection_state || !conn) {
+            return;
+        }
+        auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+        connection_state->on_stream_stop_sending(sid, type, peer_initiated, 0, internal::stream_shutdown_side::write);
+    }
+
+    void rearm_transport_timer() override {
+        // ngtcp2 stores absolute expiry; connection_state translates it to Seastar timeouts.
+        if (!connection_state) {
+            return;
+        }
+        if (!conn) {
+            connection_state->cancel_timer();
+            return;
+        }
+        connection_state->rearm_timer_from_expiry(ngtcp2_conn_get_expiry(conn), quic_now_ns(), stopping);
+    }
+
+    void request_close() override {
+        request_stop();
+    }
+
+    void cancel_transport_timer() {
+        if (connection_state) {
+            connection_state->cancel_timer();
+        }
+    }
+
+    void abort_event_queues(const char* why) {
+        // Queue abort wakes receive-side actors that might otherwise wait forever.
+        if (queues_aborted) {
+            return;
+        }
+        queues_aborted = true;
+        auto ex = std::make_exception_ptr(std::runtime_error(why));
+        rx_queue.abort(ex);
+    }
+
+    void resolve_handshake_ready() {
+        if (!handshake_promise || handshake_promise_resolved) {
+            return;
+        }
+        handshake_promise_resolved = true;
+        handshake_promise->set_value();
+    }
+
+    void fail_handshake(std::exception_ptr ex) {
+        if (!handshake_promise || handshake_promise_resolved) {
+            return;
+        }
+        handshake_promise_resolved = true;
+        handshake_promise->set_exception(ex);
+    }
+
+    void complete_open_stream(internal::open_stream_result_ptr result, stream_id sid) override {
+        if (command_runtime) {
+            command_runtime->complete_open_stream(std::move(result), sid);
+        }
+    }
+
+    void fail_open_stream(
+      internal::open_stream_result_ptr result,
+      quic_error_code error,
+      sstring detail) override {
+        if (command_runtime) {
+            command_runtime->fail_open_stream(std::move(result), error, std::move(detail));
+        }
+    }
+
+    bool blocked_open_stream_retry_pending(stream_type type) const noexcept override {
+        return connection_state->blocked_open_stream_retry_pending(type);
+    }
+
+    void defer_blocked_open_stream(internal::transport_command cmd) override {
+        connection_state->defer_blocked_open_stream(std::move(cmd));
+    }
+
+    std::optional<internal::transport_command> pop_blocked_open_stream(stream_type type) override {
+        return connection_state->pop_blocked_open_stream(type);
+    }
+
+    void request_blocked_open_stream_retry(stream_type type) {
+        connection_state->request_blocked_open_stream_retry(type);
+    }
+
+    void defer_blocked_send(internal::transport_command cmd) {
+        blocked_send_commands[cmd.msg.stream].push_back(std::move(cmd));
+    }
+
+    void defer_retried_blocked_send(internal::transport_command cmd) {
+        blocked_send_commands[cmd.msg.stream].push_front(std::move(cmd));
+    }
+
+    bool has_blocked_send_for_stream(stream_id sid) const noexcept {
+        return blocked_send_commands.find(sid) != blocked_send_commands.end();
+    }
+
+    std::optional<internal::transport_command> take_blocked_send() {
+        // Retry streams in request order, skipping entries whose queues were drained.
+        while (!blocked_send_retry_streams.empty()) {
+            auto sid = blocked_send_retry_streams.front();
+            blocked_send_retry_streams.pop_front();
+            blocked_send_retry_requested.erase(sid);
+
+            auto it = blocked_send_commands.find(sid);
+            if (it == blocked_send_commands.end() || it->second.empty()) {
+                continue;
+            }
+
+            auto cmd = std::move(it->second.front());
+            it->second.pop_front();
+            if (it->second.empty()) {
+                blocked_send_commands.erase(it);
+            }
+            return cmd;
+        }
+        return std::nullopt;
+    }
+
+    void request_blocked_send_retry() {
+        // Coalesce retry notifications so one stream has at most one pending retry token.
+        for (auto& [sid, commands] : blocked_send_commands) {
+            if (commands.empty() || blocked_send_retry_requested.contains(sid)) {
+                continue;
+            }
+            blocked_send_retry_requested.insert(sid);
+            blocked_send_retry_streams.push_back(sid);
+        }
+        if (!blocked_send_retry_streams.empty()) {
+            wake_actor();
+        }
+    }
+
+    void request_blocked_send_retry(stream_id sid) {
+        auto it = blocked_send_commands.find(sid);
+        if (it == blocked_send_commands.end() || it->second.empty() || blocked_send_retry_requested.contains(sid)) {
+            return;
+        }
+        blocked_send_retry_requested.insert(sid);
+        blocked_send_retry_streams.push_back(sid);
+        wake_actor();
+    }
+
+    void discard_blocked_send() {
+        // Return unsent byte credit before dropping queued send commands.
+        for (auto& [_, commands] : blocked_send_commands) {
+            for (auto& cmd : commands) {
+                complete_send_bytes(cmd.msg.payload.size());
+            }
+        }
+        blocked_send_commands.clear();
+        blocked_send_retry_streams.clear();
+        blocked_send_retry_requested.clear();
+    }
+
+    void clear_blocked_open_stream_retry(stream_type type) noexcept override {
+        connection_state->clear_blocked_open_stream_retry(type);
+    }
+
+    void fail_blocked_open_streams(quic_error_code error, std::string_view detail) {
+        if (!connection_state) {
+            return;
+        }
+        connection_state->fail_blocked_open_streams(error, detail);
+    }
+
+    void request_stop() {
+        if (stopping || stop_requested) {
+            return;
+        }
+        // Let the actor serialize close packets, timers and queue teardown.
+        stop_requested = true;
+        fail_blocked_open_streams(quic_error_code::closed, "connection closing");
+        cancel_transport_timer();
+        wake_actor();
+    }
+
+    void stop_transport() override {
+        // This is the terminal local cleanup path after the actor decided to stop.
+        quic_client_log.info(
+          "client transport stop: local={} remote={} handshake_done={} channel_ready={}",
+          local_address,
+          remote_address,
+          handshake_done,
+          channel_ready);
+        stopping = true;
+        fail_blocked_open_streams(quic_error_code::closed, "transport stopped");
+        discard_blocked_send();
+        abort_event_queues("client transport stopped");
+        cancel_transport_timer();
+        auto ex = std::make_exception_ptr(quic_error(quic_error_code::closed, "transport stopped"));
+        if (command_runtime) {
+            command_runtime->mark_transport_closed();
+        }
+        if (connection_state) {
+            connection_state->on_transport_closed(ex);
+        }
+        fail_handshake(std::make_exception_ptr(quic_error(quic_error_code::closed, "transport stopped before handshake")));
+        wake_actor();
+        if (channel_ready && !channel.is_closed()) {
+            channel.shutdown_input();
+            channel.shutdown_output();
+        }
+    }
+
+    void fail(quic_error_code err, const sstring& detail) {
+        // Failures bypass graceful close and immediately poison all public surfaces.
+        quic_client_log.error(
+          "client transport failure: error={} detail='{}' local={} remote={} handshake_done={}",
+          to_string(err),
+          detail,
+          local_address,
+          remote_address,
+          handshake_done);
+        stopping = true;
+        fail_blocked_open_streams(err, detail);
+        discard_blocked_send();
+        abort_event_queues("client transport failed");
+        cancel_transport_timer();
+        auto ex = std::make_exception_ptr(quic_error(err, detail));
+        if (command_runtime) {
+            command_runtime->mark_error(err, detail);
+        }
+        if (connection_state) {
+            connection_state->on_transport_closed(ex);
+        }
+        fail_handshake(ex);
+        wake_actor();
+        if (channel_ready && !channel.is_closed()) {
+            channel.shutdown_input();
+            channel.shutdown_output();
+        }
+    }
+
+    void fail_transport(quic_error_code err, sstring detail) override {
+        fail(err, detail);
+    }
+
+    bool actor_active() const noexcept {
+        return active();
+    }
+
+    bool actor_has_pending_work() const noexcept {
+        return has_pending_actor_work();
+    }
+
+    future<> actor_wait_for_wakeup() {
+        return wait_for_actor_wakeup();
+    }
+
+    bool actor_stop_requested() const noexcept {
+        return stop_requested;
+    }
+
+    future<> actor_handle_stop_request() {
+        // This is the last point where the actor owns enough state to close cleanly.
+        co_await internal::send_connection_close(*this);
+        stop_transport();
+    }
+
+    bool actor_transport_terminal() const noexcept {
+        return command_runtime && command_runtime->transport_terminal();
+    }
+
+    future<> actor_handle_transport_terminal() {
+        if (!command_runtime) {
+            co_return;
+        }
+        if (command_runtime->transport_failed()) {
+            fail(command_runtime->transport_error(), command_runtime->transport_error_detail());
+        } else {
+            stop_transport();
+        }
+        co_return;
+    }
+
+    bool actor_has_rx_event() const noexcept {
+        return !rx_queue.empty();
+    }
+
+    future<> actor_handle_next_rx_event() {
+        auto evt = rx_queue.pop();
+        co_await internal::recv_transport_datagram(*this, evt.src, std::move(evt.packet));
+        request_blocked_send_retry();
+    }
+
+    bool actor_has_transport_command() const noexcept {
+        return blocked_send_retry_pending()
+               || (command_runtime && command_runtime->has_pending_commands());
+    }
+
+    future<> actor_handle_next_transport_command() {
+        std::optional<internal::transport_command> cmd;
+        bool retrying_blocked_send = false;
+        // A partially written send must be retried before polling a fresh command to
+        // preserve stream write ordering for that stream.
+        if (blocked_send_retry_pending()) {
+            cmd = take_blocked_send();
+            retrying_blocked_send = cmd.has_value();
+        } else if (!has_blocked_send() && command_runtime) {
+            cmd = command_runtime->poll_command();
+        } else if (command_runtime) {
+            cmd = command_runtime->poll_command();
+        }
+        if (!cmd) {
+            co_return;
+        }
+        if (!retrying_blocked_send
+            && cmd->op == internal::transport_command::kind::send
+            && has_blocked_send_for_stream(cmd->msg.stream)) {
+            // Preserve per-stream write ordering behind an already blocked fragment.
+            auto blocked_stream = cmd->msg.stream;
+            defer_blocked_send(std::move(*cmd));
+            request_blocked_send_retry(blocked_stream);
+            co_return;
+        }
+        auto blocked_stream = cmd->msg.stream;
+        auto blocked = co_await internal::handle_transport_command(*this, std::move(*cmd));
+        if (blocked) {
+            if (retrying_blocked_send) {
+                defer_retried_blocked_send(std::move(*blocked));
+            } else {
+                defer_blocked_send(std::move(*blocked));
+            }
+        } else if (retrying_blocked_send) {
+            request_blocked_send_retry(blocked_stream);
+        }
+    }
+
+    future<> actor_retry_blocked_open_streams() {
+        if (!handshake_done) {
+            co_return;
+        }
+        co_await internal::retry_blocked_open_streams(*this, stream_type::bidirectional);
+        co_await internal::retry_blocked_open_streams(*this, stream_type::unidirectional);
+    }
+
+    bool actor_tick_pending() const noexcept {
+        return connection_state->tick_pending();
+    }
+
+    void actor_clear_tick() noexcept {
+        connection_state->clear_tick();
+    }
+
+    future<> actor_handle_timer_tick() {
+        co_await internal::handle_transport_timer(*this);
+        request_blocked_send_retry();
+    }
+};
+
+void sync_current_path(client_state& st) {
+    // Path migration updates the cached addresses used for later outgoing packets.
+    if (!st.conn) {
+        return;
+    }
+
+    const auto* path = ngtcp2_conn_get_path(st.conn);
+    if (!path) {
+        return;
+    }
+
+    auto local = to_socket_address(path->local);
+    auto remote = to_socket_address(path->remote);
+    if (!local || !remote) {
+        return;
+    }
+
+    if (*local == st.local_address && *remote == st.remote_address) {
+        return;
+    }
+
+    quic_client_log.info("client active path updated: old_local={} old_remote={} new_local={} new_remote={}",
+      st.local_address,
+      st.remote_address,
+      *local,
+      *remote);
+
+    st.local_address = *local;
+    st.remote_address = *remote;
+    to_sockaddr_storage(st.local_address, st.local_ss, st.local_ss_len);
+    to_sockaddr_storage(st.remote_address, st.remote_ss, st.remote_ss_len);
+}
+
+ngtcp2_conn* get_conn(ngtcp2_crypto_conn_ref* ref) {
+    return static_cast<ngtcp2_conn*>(ref->user_data);
+}
+
+void rand_cb(uint8_t* dest, size_t destlen, const ngtcp2_rand_ctx*) {
+    if (!rand_bytes_or_log(quic_client_log, "client", dest, destlen, "ngtcp2 rand callback")) {
+        std::terminate();
+    }
+}
+
+int get_new_connection_id_cb(ngtcp2_conn*, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void*) {
+    cid->datalen = cidlen;
+    if (!rand_bytes_or_log(quic_client_log, "client", cid->data, cidlen, "connection id generation")) {
+        return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    if (!rand_bytes_or_log(quic_client_log, "client", token, NGTCP2_STATELESS_RESET_TOKENLEN, "stateless reset token generation")) {
+        return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    return 0;
+}
+
+int get_path_challenge_data_cb(ngtcp2_conn*, uint8_t* data, void*) {
+    if (!rand_bytes_or_log(quic_client_log, "client", data, 8, "path challenge generation")) {
+        return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    return 0;
+}
+
+sstring selected_alpn_or_empty(gnutls_session_t tls) {
+    gnutls_datum_t selected{};
+    if (gnutls_alpn_get_selected_protocol(tls, &selected) != 0 || !selected.data) {
+        return {};
+    }
+    return {reinterpret_cast<const char*>(selected.data), selected.size};
+}
+
+static sstring certificate_status_to_string(gnutls_session_t tls, unsigned int status) {
+    gnutls_datum_t out{};
+    auto rv = gnutls_certificate_verification_status_print(
+      status, gnutls_certificate_type_get(tls), &out, 0);
+    if (rv < 0) {
+        return sstring("certificate verification failed");
+    }
+    sstring message(reinterpret_cast<const char*>(out.data), out.size);
+    gnutls_free(out.data);
+    while (!message.empty() && (message.back() == '\n' || message.back() == '\r')) {
+        message.resize(message.size() - 1);
+    }
+    return message;
+}
+
+static std::optional<tls_verification_failure> verify_tls_peer_certificate(client_state& st) {
+    // QUIC handshake completion does not imply the certificate chain is acceptable.
+    unsigned int status = 0;
+    auto* hostname = st.cfg.server_name.empty() ? nullptr : st.cfg.server_name.c_str();
+    int rv = gnutls_certificate_verify_peers3(st.tls, hostname, &status);
+    if (rv < 0) {
+        return tls_verification_failure{
+          .error = classify_gnutls_error(rv),
+          .detail = sstring("peer certificate verification failed: ") + sstring(gnutls_error_message(rv)),
+        };
+    }
+    if (status != 0) {
+        return tls_verification_failure{
+          .error = quic_error_code::protocol,
+          .detail = sstring("peer certificate verification failed: ")
+                    + certificate_status_to_string(st.tls, status),
+        };
+    }
+    return std::nullopt;
+}
+
+int handshake_completed_cb(ngtcp2_conn*, void* user_data) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (auto verification_failure = verify_tls_peer_certificate(*st)) {
+        quic_client_log.warn(
+          "client handshake verification failed: error={} detail='{}'",
+          to_string(verification_failure->error),
+          verification_failure->detail);
+        st->fail(verification_failure->error, verification_failure->detail);
+        return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    auto selected_alpn = selected_alpn_or_empty(st->tls);
+    if (selected_alpn.empty()) {
+        constexpr std::string_view detail = "TLS handshake completed without a negotiated ALPN protocol";
+        quic_client_log.warn("client handshake verification failed: detail='{}'", detail);
+        st->fail(quic_error_code::protocol, sstring(detail));
+        return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    st->handshake_done = true;
+    // Publish readiness only after certificate verification and final path sync.
+    sync_current_path(*st);
+    st->command_runtime->mark_transport_ready(st->local_address, st->remote_address, std::move(selected_alpn));
+    st->resolve_handshake_ready();
+    quic_client_log.info("client handshake completed");
+
+    st->wake_actor();
+    st->rearm_transport_timer();
+    return 0;
+}
+
+int begin_path_validation_cb(ngtcp2_conn*, uint32_t, const ngtcp2_path* path, const ngtcp2_path*, void* user_data) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st || !path) {
+        return 0;
+    }
+
+    auto remote = to_socket_address(path->remote);
+    if (remote) {
+        quic_client_log.info("client begin path validation: current_remote={} candidate_remote={}",
+          st->remote_address,
+          *remote);
+    }
+    return 0;
+}
+
+int path_validation_cb(
+  ngtcp2_conn*,
+  uint32_t,
+  const ngtcp2_path* path,
+  const ngtcp2_path* fallback_path,
+  ngtcp2_path_validation_result res,
+  void* user_data) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st) {
+        return 0;
+    }
+
+    auto candidate = path ? to_socket_address(path->remote) : std::nullopt;
+    auto fallback = fallback_path ? to_socket_address(fallback_path->remote) : std::nullopt;
+    quic_client_log.info("client path validation complete: result={} candidate_remote={} fallback_remote={}",
+      res == NGTCP2_PATH_VALIDATION_RESULT_SUCCESS ? "success" : "failure",
+      candidate.value_or(socket_address{}),
+      fallback.value_or(socket_address{}));
+
+    sync_current_path(*st);
+    return 0;
+}
+
+int recv_stream_data_cb(ngtcp2_conn* conn, uint32_t flags, int64_t sid, uint64_t, const uint8_t* data, size_t datalen, void* user_data, void*) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st->connection_state || !st->connection_state->is_open()) {
+        quic_client_log.trace("client drop recv_stream_data: sid={} bytes={} engine_open={}", sid, datalen, st->connection_state && st->connection_state->is_open());
+        return 0;
+    }
+    quic_client_log.trace("client recv_stream_data: sid={} bytes={}", sid, datalen);
+    auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+    auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+    temporary_buffer<char> tb(datalen);
+    if (datalen) {
+        std::memcpy(tb.get_write(), data, datalen);
+    }
+    st->connection_state->on_stream_data(sid, type, peer_initiated, std::move(tb), (flags & NGTCP2_STREAM_DATA_FLAG_FIN) != 0);
+    return 0;
+}
+
+int stream_reset_cb(ngtcp2_conn* conn, int64_t sid, uint64_t, uint64_t app_error_code, void* user_data, void*) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st->connection_state) {
+        return 0;
+    }
+    auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+    auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+    st->connection_state->on_stream_reset(sid, type, peer_initiated, app_error_code);
+    return 0;
+}
+
+int stream_stop_sending_cb(ngtcp2_conn* conn, int64_t sid, uint64_t app_error_code, void* user_data, void*) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st->connection_state) {
+        return 0;
+    }
+    auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+    auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+    st->connection_state->on_stream_stop_sending(sid, type, peer_initiated, app_error_code, internal::stream_shutdown_side::write);
+    return 0;
+}
+
+int stream_close_cb(ngtcp2_conn*, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st || !st->connection_state) {
+        return 0;
+    }
+
+    st->release_stream_data(sid);
+    st->connection_state->on_stream_closed(sid);
+    return 0;
+}
+
+int acked_stream_data_offset_cb(ngtcp2_conn*, int64_t sid, uint64_t offset, uint64_t datalen, void* user_data, void*) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st) {
+        return 0;
+    }
+    st->acked_stream_data(sid, offset, datalen);
+    return 0;
+}
+
+int extend_max_local_streams_bidi_cb(ngtcp2_conn*, uint64_t max_streams, void* user_data) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st) {
+        return 0;
+    }
+    quic_client_log.debug("client local bidi stream capacity extended: max_streams={}", max_streams);
+    st->request_blocked_open_stream_retry(stream_type::bidirectional);
+    return 0;
+}
+
+int extend_max_local_streams_uni_cb(ngtcp2_conn*, uint64_t max_streams, void* user_data) {
+    auto* st = static_cast<client_state*>(user_data);
+    if (!st) {
+        return 0;
+    }
+    quic_client_log.debug("client local uni stream capacity extended: max_streams={}", max_streams);
+    st->request_blocked_open_stream_retry(stream_type::unidirectional);
+    return 0;
+}
+
+void init_tls(client_state& st) {
+    quic_client_log.debug(
+      "client init_tls: server_name='{}' alpn_count={}",
+      st.cfg.server_name,
+      st.cfg.alpns.size());
+    int rv = gnutls_certificate_allocate_credentials(&st.cred);
+    if (rv < 0) {
+        throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+    }
+
+    rv = gnutls_certificate_set_x509_system_trust(st.cred);
+    if (rv < 0) {
+        throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+    }
+    if (st.cfg.ca_file) {
+        rv = gnutls_certificate_set_x509_trust_file(st.cred, st.cfg.ca_file->c_str(), GNUTLS_X509_FMT_PEM);
+        if (rv < 0) {
+            throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+        if (rv == 0) {
+            throw quic_error(
+              quic_error_code::invalid_argument,
+              sstring("no trust anchors loaded from ") + *st.cfg.ca_file);
+        }
+    }
+
+    rv = gnutls_init(&st.tls, GNUTLS_CLIENT | GNUTLS_ENABLE_EARLY_DATA);
+    if (rv < 0) {
+        throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+    }
+
+    rv = gnutls_credentials_set(st.tls, GNUTLS_CRD_CERTIFICATE, st.cred);
+    if (rv < 0) {
+        throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+    }
+
+    rv = gnutls_priority_set_direct(st.tls, "NORMAL:-VERS-ALL:+VERS-TLS1.3", nullptr);
+    if (rv < 0) {
+        throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+    }
+
+    std::vector<gnutls_datum_t> alpns;
+    alpns.reserve(st.cfg.alpns.size());
+    for (const auto& alpn : st.cfg.alpns) {
+        alpns.push_back(gnutls_datum_t{
+          reinterpret_cast<unsigned char*>(const_cast<char*>(alpn.data())),
+          static_cast<unsigned int>(alpn.size()),
+        });
+    }
+    if (!alpns.empty()) {
+        // GnuTLS borrows ALPN buffers for the call only, so the local vector is enough.
+        rv = gnutls_alpn_set_protocols(st.tls, alpns.data(), alpns.size(), GNUTLS_ALPN_MANDATORY);
+        if (rv < 0) {
+            throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+    }
+
+    if (!st.cfg.server_name.empty()) {
+        rv = gnutls_server_name_set(
+          st.tls, GNUTLS_NAME_DNS, st.cfg.server_name.c_str(), st.cfg.server_name.size());
+        if (rv < 0) {
+            throw quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+    }
+
+    rv = ngtcp2_crypto_gnutls_configure_client_session(st.tls);
+    if (rv != 0) {
+        throw quic_error(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+    }
+
+    st.conn_ref.get_conn = get_conn;
+    st.conn_ref.user_data = nullptr;
+    gnutls_session_set_ptr(st.tls, &st.conn_ref);
+    quic_client_log.debug("client TLS initialized");
+}
+
+ngtcp2_cid random_cid(size_t len) {
+    ngtcp2_cid cid{};
+    cid.datalen = len;
+    rand_bytes_or_throw(cid.data, len, "connection id generation");
+    return cid;
+}
+
+void init_client_connection(client_state& st) {
+    const auto& transport_cfg = st.cfg.session_options.transport;
+    if (transport_cfg.max_tx_udp_payload_size) {
+        auto size = *transport_cfg.max_tx_udp_payload_size;
+        if (size < default_udp_payload_size || size > max_udp_payload_size) {
+            throw_quic_error(quic_error_code::invalid_argument, "max_tx_udp_payload_size must be between 1200 and 65527");
+        }
+    }
+    if (transport_cfg.max_udp_payload_size) {
+        auto size = *transport_cfg.max_udp_payload_size;
+        if (size < default_udp_payload_size || size > max_udp_payload_size) {
+            throw_quic_error(quic_error_code::invalid_argument, "max_udp_payload_size must be between 1200 and 65527");
+        }
+    }
+    if (transport_cfg.max_tx_udp_payload_size
+        && transport_cfg.max_udp_payload_size
+        && *transport_cfg.max_tx_udp_payload_size > *transport_cfg.max_udp_payload_size) {
+        throw_quic_error(quic_error_code::invalid_argument, "max_tx_udp_payload_size must be <= max_udp_payload_size");
+    }
+
+    ngtcp2_callbacks callbacks{};
+    callbacks.client_initial = ngtcp2_crypto_client_initial_cb;
+    callbacks.recv_retry = ngtcp2_crypto_recv_retry_cb;
+    callbacks.recv_crypto_data = ngtcp2_crypto_recv_crypto_data_cb;
+    callbacks.encrypt = ngtcp2_crypto_encrypt_cb;
+    callbacks.decrypt = ngtcp2_crypto_decrypt_cb;
+    callbacks.hp_mask = ngtcp2_crypto_hp_mask_cb;
+    callbacks.update_key = ngtcp2_crypto_update_key_cb;
+    callbacks.delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb;
+    callbacks.delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb;
+    callbacks.rand = rand_cb;
+    callbacks.get_new_connection_id = get_new_connection_id_cb;
+    callbacks.get_path_challenge_data = get_path_challenge_data_cb;
+    callbacks.path_validation = path_validation_cb;
+    callbacks.begin_path_validation = begin_path_validation_cb;
+    callbacks.handshake_completed = handshake_completed_cb;
+    callbacks.recv_stream_data = recv_stream_data_cb;
+    callbacks.acked_stream_data_offset = acked_stream_data_offset_cb;
+    callbacks.stream_close = stream_close_cb;
+    callbacks.stream_reset = stream_reset_cb;
+    callbacks.stream_stop_sending = stream_stop_sending_cb;
+    callbacks.extend_max_local_streams_bidi = extend_max_local_streams_bidi_cb;
+    callbacks.extend_max_local_streams_uni = extend_max_local_streams_uni_cb;
+
+    ngtcp2_settings settings{};
+    ngtcp2_settings_default(&settings);
+    settings.initial_ts = quic_now_ns();
+    if (st.cfg.session_options.transport.initial_rtt
+        && *st.cfg.session_options.transport.initial_rtt > std::chrono::nanoseconds::zero()) {
+        settings.initial_rtt = static_cast<uint64_t>(st.cfg.session_options.transport.initial_rtt->count());
+    }
+    if (st.cfg.session_options.transport.max_tx_udp_payload_size) {
+        settings.max_tx_udp_payload_size = *st.cfg.session_options.transport.max_tx_udp_payload_size;
+    }
+    if (st.cfg.session_options.transport.max_window) {
+        settings.max_window = *st.cfg.session_options.transport.max_window;
+    }
+    if (st.cfg.session_options.transport.max_stream_window) {
+        settings.max_stream_window = *st.cfg.session_options.transport.max_stream_window;
+    }
+    if (st.cfg.session_options.transport.ack_thresh) {
+        settings.ack_thresh = *st.cfg.session_options.transport.ack_thresh;
+    }
+    if (auto algo = effective_congestion_control(st.cfg.session_options.transport)) {
+        settings.cc_algo = to_ngtcp2_cc_algo(*algo);
+    }
+    settings.no_tx_udp_payload_size_shaping =
+      st.cfg.session_options.transport.disable_tx_udp_payload_size_shaping ? 1 : 0;
+    settings.no_pmtud = st.cfg.session_options.transport.disable_pmtud ? 1 : 0;
+
+    ngtcp2_transport_params params{};
+    ngtcp2_transport_params_default(&params);
+    params.initial_max_stream_data_bidi_local = effective_initial_receive_window(
+      st.cfg.session_options,
+      st.cfg.session_options.transport.initial_max_stream_data_bidi_local);
+    params.initial_max_stream_data_bidi_remote = effective_initial_receive_window(
+      st.cfg.session_options,
+      st.cfg.session_options.transport.initial_max_stream_data_bidi_remote);
+    params.initial_max_stream_data_uni = effective_initial_receive_window(
+      st.cfg.session_options,
+      st.cfg.session_options.transport.initial_max_stream_data_uni);
+    params.initial_max_data = effective_initial_receive_window(
+      st.cfg.session_options,
+      st.cfg.session_options.transport.initial_max_data);
+    params.initial_max_streams_bidi = st.cfg.session_options.transport.initial_max_streams_bidi;
+    params.initial_max_streams_uni = st.cfg.session_options.transport.initial_max_streams_uni;
+    params.max_idle_timeout = static_cast<uint64_t>(st.cfg.session_options.transport.max_idle_timeout.count());
+    if (st.cfg.session_options.transport.max_udp_payload_size) {
+        params.max_udp_payload_size = *st.cfg.session_options.transport.max_udp_payload_size;
+    }
+    params.disable_active_migration = 1;
+
+    // The client picks the Initial packet CIDs; ngtcp2 rotates them later as needed.
+    auto dcid = random_cid(8);
+    auto scid = random_cid(8);
+
+    ngtcp2_path path{};
+    st.fill_path(path);
+
+    // Create ngtcp2 state before TLS callbacks start producing crypto data.
+    int rv = ngtcp2_conn_client_new(
+      &st.conn,
+      &dcid,
+      &scid,
+      &path,
+      NGTCP2_PROTO_VER_V1,
+      &callbacks,
+      &settings,
+      &params,
+      ngtcp2_mem_for_thread(),
+      &st);
+    if (rv != 0) {
+        throw quic_error(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+    }
+
+    ngtcp2_conn_set_tls_native_handle(st.conn, st.tls);
+    st.conn_ref.user_data = st.conn;
+
+    // Clamp the path-derived payload limit to Seastar's configured maximum.
+    auto payload = ngtcp2_conn_get_path_max_tx_udp_payload_size(st.conn);
+    if (payload == 0) {
+        payload = default_udp_payload_size;
+    }
+    if (payload > max_udp_payload_size) {
+        payload = max_udp_payload_size;
+    }
+    st.tx_payload_limit = payload;
+    quic_client_log.info(
+      "client QUIC connection initialized: local={} remote={} tx_payload_limit={}",
+      st.local_address,
+      st.remote_address,
+      st.tx_payload_limit);
+}
+
+future<> flush_pending_packets_actor(lw_shared_ptr<client_state> st) {
+    co_await internal::flush_pending_transport_packets(*st);
+}
+
+    future<> recv_loop(lw_shared_ptr<client_state> st) {
+    while (st->active()) {
+        net::datagram d(std::unique_ptr<net::datagram_impl>{});
+        try {
+            d = co_await st->channel.receive();
+        } catch (...) {
+            if (st->stopping || !st->command_runtime->is_open()) {
+                co_return;
+            }
+            quic_client_log.error("client recv_loop datagram receive failed");
+            st->fail(quic_error_code::io, "datagram receive failed");
+            co_return;
+        }
+
+        auto src = d.get_src();
+        if (st->rx_queue.full()) {
+            // Drop at the actor boundary instead of blocking the UDP receive loop.
+            quic_client_log.debug("client drop datagram: rx queue full src={}", src);
+            continue;
+        }
+
+        auto pkt = linearize_packet(d.get_buffers());
+        quic_client_log.trace("client recv_loop datagram: src={} bytes={}", src, pkt.size());
+
+        if (!st->rx_queue.push(rx_event{src, std::move(pkt)})) {
+            quic_client_log.debug("client drop datagram: rx queue full after receive src={}", src);
+            continue;
+        }
+        st->wake_actor();
+    }
+}
+
+future<> actor_loop(lw_shared_ptr<client_state> st) {
+    // Bound each pass so a busy QUIC connection yields reactor time.
+    constexpr size_t actor_batch_limit = 64;
+
+    while (st->actor_active()) {
+        if (!st->actor_has_pending_work()) {
+            co_await st->actor_wait_for_wakeup();
+            if (!st->actor_active()) {
+                co_return;
+            }
+        }
+
+        if (st->actor_stop_requested()) {
+            co_await st->actor_handle_stop_request();
+            co_return;
+        }
+
+        if (st->actor_transport_terminal()) {
+            // Surface command-runtime terminal state before processing more work.
+            co_await st->actor_handle_transport_terminal();
+            continue;
+        }
+
+        // Ingress goes first so ACKs, flow control and handshake progress advance.
+        size_t rx_processed = 0;
+        while (st->actor_active()
+               && !st->actor_stop_requested()
+               && st->actor_has_rx_event()
+               && rx_processed < actor_batch_limit) {
+            co_await st->actor_handle_next_rx_event();
+            ++rx_processed;
+        }
+
+        // Application commands use the same fairness budget as datagrams.
+        size_t commands_processed = 0;
+        while (st->actor_active()
+               && !st->actor_stop_requested()
+               && st->actor_has_transport_command()
+               && commands_processed < actor_batch_limit) {
+            co_await st->actor_handle_next_transport_command();
+            ++commands_processed;
+        }
+
+        if (st->actor_active() && !st->actor_stop_requested()) {
+            co_await st->actor_retry_blocked_open_streams();
+        }
+
+        if (st->actor_active() && !st->actor_stop_requested() && st->actor_tick_pending()) {
+            st->actor_clear_tick();
+            co_await st->actor_handle_timer_tick();
+        }
+
+        if (st->actor_active()
+            && !st->actor_stop_requested()
+            && st->actor_has_pending_work()
+            && (rx_processed == actor_batch_limit || commands_processed == actor_batch_limit)) {
+            // Keep a busy connection from monopolizing the reactor when work keeps arriving.
+            co_await seastar::coroutine::maybe_yield();
+        }
+    }
+}
+
+void start_background_tasks(const lw_shared_ptr<client_state>& st) {
+    quic_client_log.debug("client starting background tasks");
+    // Convert uncaught background failures into the normal transport error path.
+    (void)with_gate(st->task_gate, [st] { return actor_loop(st); })
+      .handle_exception([st](std::exception_ptr) {
+          if (st->active()) {
+              st->fail(quic_error_code::io, "actor loop failed");
+          }
+      })
+      .or_terminate();
+    (void)with_gate(st->task_gate, [st] { return recv_loop(st); })
+      .handle_exception([st](std::exception_ptr) {
+          if (st->active()) {
+              st->fail(quic_error_code::io, "receive loop failed");
+          }
+      })
+      .or_terminate();
+}
+
+} // namespace
+
+namespace internal {
+
+class quic_client_impl final {
+public:
+    future<connection_state_ptr> connect(quic_client_config config) {
+        if (_state) {
+            throw_quic_error(quic_error_code::invalid_state, "client is already connected");
+        }
+        validate_alpn_protocols(config.alpns);
+        ensure_gnutls_global();
+        quic_client_log.info(
+          "client connect start: remote={} local={} server_name='{}' alpn_count={}",
+          config.remote_address,
+          config.local_address.value_or(wildcard_address_for_family(config.remote_address.family())),
+          config.server_name,
+          config.alpns.size());
+
+        auto st = make_lw_shared<client_state>();
+        st->cfg = std::move(config);
+        st->command_runtime = make_command_runtime(st->cfg.session_options);
+        st->connection_state = make_connection_state(st->command_runtime, st->cfg.session_options);
+        st->command_runtime->set_command_notifier([raw = st.get()] {
+            // The runtime only posts work; the actor remains the sole transport mutator.
+            raw->wake_actor();
+        });
+        st->remote_address = st->cfg.remote_address;
+        st->handshake_promise.emplace();
+
+        std::exception_ptr init_error;
+        try {
+            validate_ip_socket_address(st->remote_address, "remote_address");
+            auto local = st->cfg.local_address.value_or(wildcard_address_for_family(st->remote_address.family()));
+            validate_ip_socket_address(local, "local_address");
+            if (local.family() != st->remote_address.family()) {
+                throw_quic_error(
+                  quic_error_code::invalid_argument,
+                  "local_address and remote_address must use the same address family");
+            }
+            st->channel = engine().net().make_bound_datagram_channel(local);
+            st->channel_ready = true;
+            st->local_address = st->channel.local_address();
+
+            to_sockaddr_storage(st->local_address, st->local_ss, st->local_ss_len);
+            to_sockaddr_storage(st->remote_address, st->remote_ss, st->remote_ss_len);
+
+            init_tls(*st);
+            init_client_connection(*st);
+
+            // Send the client Initial before starting background receive/actor tasks.
+            co_await flush_pending_packets_actor(st);
+            st->rearm_transport_timer();
+
+            start_background_tasks(st);
+            co_await st->handshake_promise->get_future();
+            _state = st;
+            quic_client_log.info(
+              "client connect initialized: local={} remote={} tx_payload_limit={} alpn='{}'",
+              st->local_address,
+              st->remote_address,
+              st->tx_payload_limit,
+              st->command_runtime->selected_alpn());
+        } catch (const quic_error& e) {
+            quic_client_log.error("client connect failed: code={} detail='{}'", e.code().message(), e.what());
+            init_error = std::current_exception();
+        } catch (...) {
+            quic_client_log.error("client connect failed: unexpected exception");
+            init_error = std::current_exception();
+        }
+
+        if (init_error) {
+            st->stop_transport();
+            co_await st->task_gate.close();
+            std::rethrow_exception(init_error);
+        }
+
+        co_return st->connection_state;
+    }
+
+    future<> stop() {
+        if (!_state) {
+            quic_client_log.debug("client stop ignored: not connected");
+            co_return;
+        }
+        auto st = std::exchange(_state, {});
+        quic_client_log.info("client stop start: local={} remote={}", st->local_address, st->remote_address);
+        st->request_stop();
+        co_await st->task_gate.close();
+        if (st->channel_ready && !st->channel.is_closed()) {
+            st->channel.close();
+        }
+        quic_client_log.info("client stop complete");
+    }
+
+private:
+    lw_shared_ptr<client_state> _state;
+};
+
+} // namespace internal
+
+quic_client::quic_client()
+    : _impl(std::make_unique<internal::quic_client_impl>()) {
+}
+
+quic_client::~quic_client() = default;
+quic_client::quic_client(quic_client&&) noexcept = default;
+quic_client& quic_client::operator=(quic_client&&) noexcept = default;
+
+future<connection> quic_client::connect(quic_client_config config) {
+    quic_client_log.debug("quic_client::connect");
+    auto connection_state = co_await _impl->connect(std::move(config));
+    co_return connection(std::make_unique<connection::impl>(std::move(connection_state)));
+}
+
+future<> quic_client::stop() {
+    quic_client_log.debug("quic_client::stop");
+    co_await _impl->stop();
+}
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_command_runtime.cc
+++ b/src/quic/quic_command_runtime.cc
@@ -1,0 +1,338 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include "quic_impl.hh"
+
+#include <deque>
+#include <exception>
+#include <unordered_map>
+#include <utility>
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/shared_ptr.hh>
+
+namespace seastar::quic::experimental {
+
+namespace {
+
+using transport_command = internal::transport_command;
+
+class queued_command_runtime final : public internal::command_runtime {
+public:
+    explicit queued_command_runtime(connection_options options)
+        : _options(std::move(options)) {
+    }
+
+    bool is_open() const noexcept override {
+        return !_closed && !_closing && _error == quic_error_code::none;
+    }
+
+    socket_address local_address() const override {
+        return _local_address;
+    }
+
+    socket_address peer_address() const override {
+        return _peer_address;
+    }
+
+    sstring selected_alpn() const override {
+        return _selected_alpn;
+    }
+
+    future<> send(internal::quic_message msg) override {
+        const auto limit = _options.max_pending_send_bytes;
+        if (limit && msg.payload.size() > limit) {
+            size_t offset = 0;
+            size_t remaining = msg.payload.size();
+            while (remaining > 0) {
+                auto chunk_size = remaining > limit ? limit : remaining;
+                while (send_requires_wait(chunk_size)) {
+                    throw_if_terminal("send");
+                    co_await _command_space_cv.wait();
+                }
+                throw_if_terminal("send");
+
+                _pending_send_bytes += chunk_size;
+                _commands.emplace_back(transport_command{
+                  .op = transport_command::kind::send,
+                  .msg = internal::quic_message{
+                    .stream = msg.stream,
+                    .payload = msg.payload.share(offset, chunk_size),
+                    .fin = msg.fin && chunk_size == remaining,
+                  },
+                });
+                notify_command_ready();
+                offset += chunk_size;
+                remaining -= chunk_size;
+            }
+            co_return;
+        }
+
+        const auto msg_size = msg.payload.size();
+        while (send_requires_wait(msg_size)) {
+            throw_if_terminal("send");
+            co_await _command_space_cv.wait();
+        }
+        throw_if_terminal("send");
+
+        _pending_send_bytes += msg_size;
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::send,
+          .msg = std::move(msg),
+        });
+        notify_command_ready();
+        co_return;
+    }
+
+    future<stream_id> open_stream(stream_type type) override {
+        throw_if_terminal("open_stream");
+        auto result = make_lw_shared<promise<stream_id>>();
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::open_stream,
+          .type = type,
+          .open_result = result,
+        });
+        notify_command_ready();
+        co_return co_await result->get_future();
+    }
+
+    void complete_send_bytes(size_t len) override {
+        if (!len) {
+            return;
+        }
+        if (len >= _pending_send_bytes) {
+            _pending_send_bytes = 0;
+        } else {
+            _pending_send_bytes -= len;
+        }
+        _command_space_cv.broadcast();
+    }
+
+    void consume_stream_data(stream_id sid, size_t len) override {
+        if (!len || sid == invalid_stream_id || _error != quic_error_code::none || _closed || _closing) {
+            return;
+        }
+        auto [it, inserted] = _pending_consumed_bytes.try_emplace(sid, 0);
+        it->second += len;
+        if (!inserted) {
+            return;
+        }
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::consume_stream_data,
+          .msg = internal::quic_message{
+            .stream = sid,
+          },
+        });
+        notify_command_ready();
+    }
+
+    future<> reset_stream(stream_id sid, application_error_code app_error_code) override {
+        throw_if_terminal("reset_stream");
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::reset_stream,
+          .msg = internal::quic_message{
+            .stream = sid,
+          },
+          .app_error_code = app_error_code,
+        });
+        notify_command_ready();
+        co_return;
+    }
+
+    future<> stop_sending(stream_id sid, application_error_code app_error_code) override {
+        throw_if_terminal("stop_sending");
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::stop_sending,
+          .msg = internal::quic_message{
+            .stream = sid,
+          },
+          .app_error_code = app_error_code,
+        });
+        notify_command_ready();
+        co_return;
+    }
+
+    future<> close() override {
+        if (_closing || _closed) {
+            co_return;
+        }
+        _closing = true;
+        notify_terminal_waiters();
+        _commands.emplace_back(transport_command{
+          .op = transport_command::kind::close_connection,
+        });
+        notify_command_ready();
+        co_return;
+    }
+
+    bool has_pending_commands() const noexcept override {
+        return !_commands.empty();
+    }
+
+    std::optional<transport_command> poll_command() override {
+        if (_commands.empty()) {
+            return std::nullopt;
+        }
+        auto cmd = std::move(_commands.front());
+        _commands.pop_front();
+        if (cmd.op == transport_command::kind::consume_stream_data) {
+            auto it = _pending_consumed_bytes.find(cmd.msg.stream);
+            if (it != _pending_consumed_bytes.end()) {
+                cmd.consumed_bytes = it->second;
+                _pending_consumed_bytes.erase(it);
+            }
+        }
+        return cmd;
+    }
+
+    void set_command_notifier(std::function<void()> notifier) override {
+        _command_notifier = std::move(notifier);
+    }
+
+    void complete_open_stream(internal::open_stream_result_ptr result, stream_id sid) override {
+        if (result) {
+            result->set_value(sid);
+        }
+    }
+
+    void fail_open_stream(internal::open_stream_result_ptr result, quic_error_code error, sstring detail) override {
+        if (result) {
+            result->set_exception(std::make_exception_ptr(quic_error(error, detail)));
+        }
+    }
+
+    void mark_transport_ready(socket_address local, socket_address peer, sstring selected_alpn) override {
+        _local_address = local;
+        _peer_address = peer;
+        _selected_alpn = std::move(selected_alpn);
+    }
+
+    void mark_transport_closed() override {
+        if (_closed) {
+            return;
+        }
+        _closed = true;
+        drain_pending_open_streams(std::make_exception_ptr(quic_error(quic_error_code::closed, "transport closed")));
+        notify_command_ready();
+        notify_terminal_waiters();
+    }
+
+    void mark_error(quic_error_code error, sstring detail) override {
+        if (_error != quic_error_code::none) {
+            return;
+        }
+        _error = error;
+        _error_detail = std::move(detail);
+        _closed = true;
+        drain_pending_open_streams(std::make_exception_ptr(quic_error(_error, _error_detail)));
+        notify_command_ready();
+        notify_terminal_waiters();
+    }
+
+    bool transport_terminal() const noexcept override {
+        return _closed;
+    }
+
+    bool transport_failed() const noexcept override {
+        return _error != quic_error_code::none;
+    }
+
+    quic_error_code transport_error() const noexcept override {
+        return _error;
+    }
+
+    sstring transport_error_detail() const override {
+        return _error_detail;
+    }
+
+private:
+    bool send_requires_wait(size_t msg_size) const noexcept {
+        const auto limit = _options.max_pending_send_bytes;
+        if (!limit) {
+            return false;
+        }
+        if (msg_size > limit) {
+            return _pending_send_bytes != 0;
+        }
+        return _pending_send_bytes > limit - msg_size;
+    }
+
+    void throw_if_terminal(const char* op) const {
+        if (_error != quic_error_code::none) {
+            throw quic_error(_error, sstring(op) + ": " + _error_detail);
+        }
+        if (_closed) {
+            throw quic_error(quic_error_code::closed, sstring(op) + ": transport closed");
+        }
+        if (_closing) {
+            throw quic_error(quic_error_code::closed, sstring(op) + ": connection closing");
+        }
+    }
+
+    void drain_pending_open_streams(std::exception_ptr ex) {
+        for (auto& cmd : _commands) {
+            if (cmd.op == transport_command::kind::open_stream && cmd.open_result) {
+                cmd.open_result->set_exception(ex);
+                cmd.open_result = {};
+            }
+        }
+    }
+
+    void notify_command_ready() {
+        if (_command_notifier) {
+            _command_notifier();
+        }
+    }
+
+    void notify_terminal_waiters() noexcept {
+        _command_space_cv.broadcast();
+    }
+
+    connection_options _options;
+    bool _closing = false;
+    bool _closed = false;
+    quic_error_code _error = quic_error_code::none;
+    sstring _error_detail;
+
+    socket_address _local_address{};
+    socket_address _peer_address{};
+    sstring _selected_alpn;
+
+    std::deque<transport_command> _commands;
+    std::unordered_map<stream_id, size_t> _pending_consumed_bytes;
+    size_t _pending_send_bytes = 0;
+    std::function<void()> _command_notifier;
+
+    condition_variable _command_space_cv;
+};
+
+} // namespace
+
+namespace internal {
+
+command_runtime_ptr make_command_runtime(connection_options options) {
+    return make_shared<queued_command_runtime>(std::move(options));
+}
+
+} // namespace internal
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_common.cc
+++ b/src/quic/quic_common.cc
@@ -1,0 +1,282 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include "quic_common.hh"
+
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+
+#include <gnutls/crypto.h>
+#include <gnutls/gnutls.h>
+
+#include "quic_error_impl.hh"
+
+namespace seastar::quic::experimental {
+
+namespace {
+
+class gnutls_global_guard {
+public:
+    gnutls_global_guard() {
+        gnutls_global_init();
+    }
+
+    ~gnutls_global_guard() {
+        gnutls_global_deinit();
+    }
+};
+
+int try_rand_bytes(uint8_t* dst, size_t len) noexcept {
+    return gnutls_rnd(GNUTLS_RND_RANDOM, dst, len);
+}
+
+[[noreturn]] void throw_random_failure(const char* context, int rv) {
+    throw quic_error(
+      classify_gnutls_error(rv),
+      sstring(context) + ": " + sstring(gnutls_error_message(rv)));
+}
+
+void* mem_malloc(size_t size, void*) {
+    return std::malloc(size);
+}
+
+void mem_free(void* ptr, void*) {
+    std::free(ptr);
+}
+
+void* mem_calloc(size_t n, size_t s, void*) {
+    return std::calloc(n, s);
+}
+
+void* mem_realloc(void* ptr, size_t s, void*) {
+    return std::realloc(ptr, s);
+}
+
+} // namespace
+
+void ensure_gnutls_global() {
+    static gnutls_global_guard guard;
+}
+
+void rand_bytes_or_throw(uint8_t* dst, size_t len, const char* context) {
+    auto rv = try_rand_bytes(dst, len);
+    if (rv < 0) {
+        throw_random_failure(context, rv);
+    }
+}
+
+bool rand_bytes_or_log(logger& log, std::string_view owner, uint8_t* dst, size_t len, const char* context) noexcept {
+    auto rv = try_rand_bytes(dst, len);
+    if (rv >= 0) {
+        return true;
+    }
+    log.error("{} random source failure: context={} detail='{}'", owner, context, gnutls_error_message(rv));
+    return false;
+}
+
+const ngtcp2_mem* ngtcp2_mem_for_thread() {
+    thread_local const ngtcp2_mem mem = {
+      nullptr,
+      mem_malloc,
+      mem_free,
+      mem_calloc,
+      mem_realloc,
+    };
+    return &mem;
+}
+
+void init_ngtcp2_addr(ngtcp2_addr* addr, const sockaddr* sa, size_t len) {
+    addr->addr = const_cast<sockaddr*>(sa);
+    addr->addrlen = static_cast<socklen_t>(len);
+}
+
+void to_sockaddr_storage(const socket_address& sa, sockaddr_storage& out, socklen_t& outlen) {
+    std::memset(&out, 0, sizeof(out));
+    switch (sa.family()) {
+    case AF_INET: {
+        auto in = sa.as_posix_sockaddr_in();
+        std::memcpy(&out, &in, sizeof(in));
+        outlen = sizeof(in);
+        return;
+    }
+    case AF_INET6: {
+        auto in6 = sa.as_posix_sockaddr_in6();
+        std::memcpy(&out, &in6, sizeof(in6));
+        outlen = sizeof(in6);
+        return;
+    }
+    default:
+        throw_quic_error(quic_error_code::invalid_argument, "QUIC requires an IPv4 or IPv6 socket address");
+    }
+}
+
+void validate_ip_socket_address(const socket_address& sa, std::string_view what) {
+    switch (sa.family()) {
+    case AF_INET:
+    case AF_INET6:
+        return;
+    default:
+        throw_quic_error(
+          quic_error_code::invalid_argument,
+          sstring(what) + " must be an IPv4 or IPv6 socket address");
+    }
+}
+
+void validate_alpn_protocols(const std::vector<sstring>& alpns) {
+    if (alpns.empty()) {
+        throw_quic_error(
+          quic_error_code::invalid_argument,
+          "at least one ALPN protocol must be configured");
+    }
+    for (const auto& alpn : alpns) {
+        if (alpn.empty()) {
+            throw_quic_error(
+              quic_error_code::invalid_argument,
+              "ALPN protocol identifiers must not be empty");
+        }
+    }
+}
+
+std::optional<socket_address> to_socket_address(const ngtcp2_addr& addr) {
+    if (!addr.addr || addr.addrlen == 0) {
+        return std::nullopt;
+    }
+
+    auto* sa = reinterpret_cast<const sockaddr*>(addr.addr);
+    switch (sa->sa_family) {
+    case AF_INET: {
+        if (addr.addrlen < sizeof(sockaddr_in)) {
+            return std::nullopt;
+        }
+        sockaddr_in in{};
+        std::memcpy(&in, sa, sizeof(in));
+        return socket_address(in);
+    }
+    case AF_INET6: {
+        if (addr.addrlen < sizeof(sockaddr_in6)) {
+            return std::nullopt;
+        }
+        sockaddr_in6 in6{};
+        std::memcpy(&in6, sa, sizeof(in6));
+        return socket_address(in6);
+    }
+    default:
+        return std::nullopt;
+    }
+}
+
+ngtcp2_tstamp quic_now_ns() noexcept {
+    using namespace std::chrono;
+    return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+socket_address wildcard_address_for_family(sa_family_t family) {
+    switch (family) {
+    case AF_INET: {
+        sockaddr_in sa{};
+        sa.sin_family = AF_INET;
+        return socket_address(sa);
+    }
+    case AF_INET6: {
+        sockaddr_in6 sa{};
+        sa.sin6_family = AF_INET6;
+        return socket_address(sa);
+    }
+    default:
+        throw_quic_error(quic_error_code::invalid_argument, "QUIC requires an IPv4 or IPv6 socket address");
+    }
+}
+
+std::optional<congestion_control_algorithm> effective_congestion_control(const transport_config& cfg) {
+    if (!cfg.congestion_control) {
+        return std::nullopt;
+    }
+    auto algo = *cfg.congestion_control;
+    // ngtcp2 BBR regresses sharply on the small-datagram benchmark profile.
+    if ((algo == congestion_control_algorithm::bbr || algo == congestion_control_algorithm::bbr2)
+        && cfg.max_tx_udp_payload_size
+        && *cfg.max_tx_udp_payload_size <= 4096) {
+        return congestion_control_algorithm::cubic;
+    }
+    return algo;
+}
+
+uint64_t effective_initial_receive_window(const connection_options& options, uint64_t configured) noexcept {
+    if (!options.max_pending_receive_bytes) {
+        return configured;
+    }
+    auto limit = static_cast<uint64_t>(options.max_pending_receive_bytes);
+    return configured < limit ? configured : limit;
+}
+
+future<> send_datagram(logger& log, net::datagram_channel& channel, const socket_address& dst, temporary_buffer<char> packet) {
+    if (packet.empty()) {
+        co_return;
+    }
+    log.trace("udp send datagram: dst={} bytes={}", dst, packet.size());
+    std::array<temporary_buffer<char>, 1> bufs{std::move(packet)};
+    co_await channel.send(dst, std::span<temporary_buffer<char>>(bufs));
+}
+
+temporary_buffer<char> linearize_packet(std::span<temporary_buffer<char>> bufs) {
+    if (bufs.empty()) {
+        return temporary_buffer<char>();
+    }
+    if (bufs.size() == 1) {
+        return std::move(bufs.front());
+    }
+
+    size_t total = 0;
+    for (const auto& b : bufs) {
+        total += b.size();
+    }
+
+    temporary_buffer<char> result(total);
+    char* dst = result.get_write();
+    size_t offset = 0;
+    for (const auto& b : bufs) {
+        std::memcpy(dst + offset, b.get(), b.size());
+        offset += b.size();
+    }
+    return result;
+}
+
+ngtcp2_cc_algo to_ngtcp2_cc_algo(congestion_control_algorithm algo) {
+    switch (algo) {
+    case congestion_control_algorithm::reno:
+        return NGTCP2_CC_ALGO_RENO;
+    case congestion_control_algorithm::cubic:
+        return NGTCP2_CC_ALGO_CUBIC;
+    case congestion_control_algorithm::bbr:
+        return NGTCP2_CC_ALGO_BBR;
+    case congestion_control_algorithm::bbr2:
+#ifdef NGTCP2_CC_ALGO_BBR2
+        return NGTCP2_CC_ALGO_BBR2;
+#else
+        return NGTCP2_CC_ALGO_BBR;
+#endif
+    }
+    return NGTCP2_CC_ALGO_CUBIC;
+}
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_common.hh
+++ b/src/quic/quic_common.hh
@@ -1,0 +1,60 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <ngtcp2/ngtcp2.h>
+
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/api.hh>
+#include <seastar/quic/quic.hh>
+#include <seastar/util/log.hh>
+
+namespace seastar::quic::experimental {
+
+void ensure_gnutls_global();
+void rand_bytes_or_throw(uint8_t* dst, size_t len, const char* context);
+bool rand_bytes_or_log(logger& log, std::string_view owner, uint8_t* dst, size_t len, const char* context) noexcept;
+
+const ngtcp2_mem* ngtcp2_mem_for_thread();
+
+void init_ngtcp2_addr(ngtcp2_addr* addr, const sockaddr* sa, size_t len);
+void to_sockaddr_storage(const socket_address& sa, sockaddr_storage& out, socklen_t& outlen);
+void validate_ip_socket_address(const socket_address& sa, std::string_view what);
+void validate_alpn_protocols(const std::vector<sstring>& alpns);
+std::optional<socket_address> to_socket_address(const ngtcp2_addr& addr);
+
+ngtcp2_tstamp quic_now_ns() noexcept;
+socket_address wildcard_address_for_family(sa_family_t family);
+std::optional<congestion_control_algorithm> effective_congestion_control(const transport_config& cfg);
+uint64_t effective_initial_receive_window(const connection_options& options, uint64_t configured) noexcept;
+future<> send_datagram(logger& log, net::datagram_channel& channel, const socket_address& dst, temporary_buffer<char> packet);
+
+temporary_buffer<char> linearize_packet(std::span<temporary_buffer<char>> bufs);
+ngtcp2_cc_algo to_ngtcp2_cc_algo(congestion_control_algorithm algo);
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_connection_state.cc
+++ b/src/quic/quic_connection_state.cc
@@ -1,0 +1,1382 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include "quic_impl.hh"
+
+#include <chrono>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include <ngtcp2/ngtcp2.h>
+
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/net/stack.hh>
+
+namespace seastar::quic::experimental {
+
+namespace internal {
+
+namespace {
+
+uint64_t transport_now_ns() {
+    using namespace std::chrono;
+    return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+temporary_buffer<char> coalesce_buffers(std::span<temporary_buffer<char>> bufs) {
+    // Seastar output streams can batch fragments; ngtcp2 wants one contiguous span.
+    if (bufs.empty()) {
+        return temporary_buffer<char>();
+    }
+    if (bufs.size() == 1) {
+        return std::move(bufs.front());
+    }
+
+    size_t total = 0;
+    for (const auto& buf : bufs) {
+        total += buf.size();
+    }
+
+    temporary_buffer<char> merged(total);
+    auto* dst = merged.get_write();
+    size_t offset = 0;
+    for (auto& buf : bufs) {
+        std::memcpy(dst + offset, buf.get(), buf.size());
+        offset += buf.size();
+    }
+    return merged;
+}
+
+temporary_buffer<char>& ensure_tx_packet_buffer(connection_transport& transport) {
+    // Reuse one scratch packet buffer per connection to avoid per-packet allocation.
+    auto required = transport.tx_payload_limit_bytes();
+    auto& scratch = transport.tx_packet_buffer();
+    if (scratch.size() < required) {
+        scratch = temporary_buffer<char>(required);
+    }
+    return scratch;
+}
+
+constexpr size_t default_stream_read_queue_fragments = 1024;
+constexpr size_t stream_read_queue_fragment_size_hint = 1024;
+
+size_t make_stream_read_queue_capacity(const connection_options& options) noexcept {
+    // Queue capacity is fragment-based, so derive a conservative fragment count
+    // from the byte budget and keep the default burst allowance.
+    if (!options.max_pending_receive_bytes) {
+        return default_stream_read_queue_fragments;
+    }
+    auto fragments = (options.max_pending_receive_bytes + stream_read_queue_fragment_size_hint - 1)
+                     / stream_read_queue_fragment_size_hint;
+    return fragments + default_stream_read_queue_fragments;
+}
+
+} // namespace
+
+class receive_budget final : public enable_shared_from_this<receive_budget> {
+public:
+    explicit receive_budget(size_t limit)
+        : _limit(limit) {
+    }
+
+    bool try_acquire(size_t size) {
+        // A zero limit means unlimited buffering; nonzero limits are connection-wide.
+        if (!size) {
+            return true;
+        }
+        if (_limit && _pending_bytes + size > _limit) {
+            return false;
+        }
+        _pending_bytes += size;
+        return true;
+    }
+
+    void release(size_t size) {
+        if (!size) {
+            return;
+        }
+        if (size >= _pending_bytes) {
+            _pending_bytes = 0;
+            return;
+        }
+        _pending_bytes -= size;
+    }
+
+private:
+    size_t _limit = 0;
+    size_t _pending_bytes = 0;
+};
+
+// Internal state for a single stream, including its Seastar IO queues and flow control.
+class stream_state final : public enable_shared_from_this<stream_state> {
+    class source_impl;
+    class sink_impl;
+
+public:
+    stream_state(
+      command_runtime_ptr command_runtime,
+      shared_ptr<receive_budget> receive_budget,
+      size_t read_queue_capacity,
+      stream_id sid,
+      stream_type type,
+      bool peer_initiated)
+        : _command_runtime(std::move(command_runtime))
+        , _receive_budget(std::move(receive_budget))
+        , _id(sid)
+        , _type(type)
+        , _can_read(type == stream_type::bidirectional || peer_initiated)
+        // Locally initiated unidirectional streams are write-only; peer-initiated
+        // unidirectional streams are read-only from this endpoint's perspective.
+        , _can_write(type == stream_type::bidirectional || !peer_initiated)
+        , _read_queue(read_queue_capacity) {
+        if (!_can_read) {
+            notify_input_shutdown();
+        }
+    }
+
+    bool is_open() const noexcept {
+        return !_transport_closed
+               && ((_can_read && !_input_shutdown_notified) || (_can_write && !_output_closed));
+    }
+
+    stream_id id() const noexcept {
+        return _id;
+    }
+
+    stream_type type() const noexcept {
+        return _type;
+    }
+
+    bool can_read() const noexcept {
+        return _can_read;
+    }
+
+    bool can_write() const noexcept {
+        return _can_write;
+    }
+
+    bool mark_accepted_for_delivery() noexcept {
+        if (_accepted_for_delivery) {
+            return false;
+        }
+        _accepted_for_delivery = true;
+        return true;
+    }
+
+    input_stream<char> input(connected_socket_input_stream_config cfg);
+    output_stream<char> output(size_t buffer_size);
+
+    future<> close_output();
+    future<> reset(application_error_code app_error_code);
+    future<> stop_sending(application_error_code app_error_code);
+    future<> wait_input_shutdown() {
+        return _input_shutdown.get_shared_future();
+    }
+
+    data_source source(connected_socket_input_stream_config);
+    data_sink sink();
+
+    socket_address local_address() const {
+        return _command_runtime ? _command_runtime->local_address() : socket_address();
+    }
+
+    socket_address peer_address() const {
+        return _command_runtime ? _command_runtime->peer_address() : socket_address();
+    }
+
+    void on_data(temporary_buffer<char> payload, bool fin);
+    void on_reset(application_error_code app_error_code);
+    void on_stop_sending_input(application_error_code app_error_code);
+    void on_stop_sending_output(application_error_code app_error_code);
+    void on_batch_flush_error() noexcept;
+    void on_transport_closed();
+    void on_data_consumed(size_t size);
+
+private:
+    future<> send_one(temporary_buffer<char> payload, bool fin);
+
+    void overload_input(const char* detail) {
+        // Input overload is scoped to this stream; the connection can keep serving
+        // other streams while this reader is failed.
+        if (_input_shutdown_notified) {
+            return;
+        }
+        abort_read_queue(std::make_exception_ptr(quic_error(quic_error_code::io, detail)));
+    }
+
+    bool push_read_fragment(temporary_buffer<char> payload) {
+        const auto payload_size = payload.size();
+        // The receive budget is shared by all streams on this connection, which
+        // keeps one slow consumer from growing memory without bound.
+        if (payload_size && _receive_budget && !_receive_budget->try_acquire(payload_size)) {
+            overload_input("receive queue limit exceeded");
+            return false;
+        }
+        if (_read_queue.push(std::move(payload))) {
+            _queued_read_bytes += payload_size;
+            return true;
+        }
+        if (payload_size && _receive_budget) {
+            _receive_budget->release(payload_size);
+        }
+        overload_input("stream read queue is full");
+        return false;
+    }
+
+    void notify_input_shutdown() {
+        if (_input_shutdown_notified) {
+            return;
+        }
+        _input_shutdown_notified = true;
+        _input_shutdown.set_value();
+    }
+
+    void release_queued_read_bytes() {
+        // Abort paths must return all queued credit because readers will not drain it.
+        if (_queued_read_bytes && _receive_budget) {
+            _receive_budget->release(_queued_read_bytes);
+        }
+        _queued_read_bytes = 0;
+    }
+
+    void release_read_bytes(size_t size) {
+        if (!size) {
+            return;
+        }
+        if (_queued_read_bytes >= size) {
+            _queued_read_bytes -= size;
+        } else {
+            _queued_read_bytes = 0;
+        }
+        if (_receive_budget) {
+            _receive_budget->release(size);
+        }
+    }
+
+    void abort_read_queue(std::exception_ptr ex) {
+        // Abort the queue and complete input shutdown together so waiters agree.
+        release_queued_read_bytes();
+        _read_queue.abort(ex);
+        notify_input_shutdown();
+    }
+
+    command_runtime_ptr _command_runtime;
+    shared_ptr<receive_budget> _receive_budget;
+    stream_id _id = invalid_stream_id;
+    stream_type _type = stream_type::bidirectional;
+    bool _can_read = true;
+    bool _can_write = true;
+
+    queue<temporary_buffer<char>> _read_queue;
+    shared_promise<> _input_shutdown;
+    bool _input_shutdown_notified = false;
+    bool _output_closed = false;
+    bool _transport_closed = false;
+    bool _accepted_for_delivery = false;
+    size_t _queued_read_bytes = 0;
+};
+
+class connection_state::impl {
+public:
+    impl(command_runtime_ptr command_runtime_arg, connection_options options_arg)
+        : command_runtime(std::move(command_runtime_arg))
+        , options(std::move(options_arg))
+        , accepted_streams(1024)
+        , receive_window(make_shared<receive_budget>(options.max_pending_receive_bytes))
+        , stream_read_queue_capacity(make_stream_read_queue_capacity(options)) {
+        _timer.set_callback([this] {
+            // Coalesce timer expirations until the actor processes the pending tick.
+            if (transport_closed || tick_pending) {
+                return;
+            }
+            tick_pending = true;
+            if (!actor_waiter) {
+                return;
+            }
+            auto waiter = std::move(*actor_waiter);
+            actor_waiter.reset();
+            waiter.set_value();
+        });
+    }
+
+    void refill_pending_accepted_streams() {
+        // Transport callbacks may discover streams faster than accept() drains them,
+        // so overflow is retried whenever queue capacity returns.
+        while (!pending_accepted_streams.empty()) {
+            auto st = pending_accepted_streams.front();
+            if (!accepted_streams.push(shared_ptr<stream_state>(st))) {
+                break;
+            }
+            pending_accepted_streams.pop_front();
+        }
+    }
+
+    void enqueue_accepted_stream(const shared_ptr<stream_state>& st) {
+        // Keep stream delivery ordered even when the public accept queue is full.
+        if (!accepted_streams.push(shared_ptr<stream_state>(st))) {
+            pending_accepted_streams.push_back(st);
+        }
+    }
+
+    // Shared state behind the public connection handle.
+    command_runtime_ptr command_runtime;
+    connection_options options;
+    queue<shared_ptr<stream_state>> accepted_streams;
+    std::deque<shared_ptr<stream_state>> pending_accepted_streams;
+    std::unordered_map<stream_id, shared_ptr<stream_state>> streams;
+    shared_ptr<receive_budget> receive_window;
+    size_t stream_read_queue_capacity;
+    bool transport_closed = false;
+
+    std::deque<transport_command> blocked_bidi_open_streams;
+    std::deque<transport_command> blocked_uni_open_streams;
+    std::optional<promise<>> actor_waiter;
+    timer<> _timer;
+    bool tick_pending = false;
+    bool blocked_bidi_open_stream_retry_pending = false;
+    bool blocked_uni_open_stream_retry_pending = false;
+};
+
+future<> stream_state::send_one(temporary_buffer<char> payload, bool fin) {
+    if (!_can_write) {
+        return make_exception_future<>(quic_error(quic_error_code::invalid_state, "stream output is unavailable"));
+    }
+    if (!_command_runtime) {
+        return make_exception_future<>(quic_error(quic_error_code::closed, "stream command runtime is gone"));
+    }
+    if (_transport_closed || (_output_closed && !fin)) {
+        // A final FIN is allowed through the close path; later payload writes fail.
+        return make_exception_future<>(quic_error(quic_error_code::closed, "stream output is closed"));
+    }
+    return _command_runtime->send(internal::quic_message{
+      .stream = _id,
+      .payload = std::move(payload),
+      .fin = fin,
+    });
+}
+
+future<> stream_state::close_output() {
+    if (!_can_write) {
+        throw_quic_error(quic_error_code::invalid_state, "stream output is unavailable");
+    }
+    if (_output_closed) {
+        co_return;
+    }
+    _output_closed = true;
+    co_await send_one(temporary_buffer<char>(), true);
+}
+
+future<> stream_state::reset(application_error_code app_error_code) {
+    if (!_can_write) {
+        throw_quic_error(quic_error_code::invalid_state, "stream output is unavailable");
+    }
+    if (_output_closed) {
+        co_return;
+    }
+    _output_closed = true;
+    if (!_command_runtime) {
+        co_return;
+    }
+    co_await _command_runtime->reset_stream(_id, app_error_code);
+}
+
+future<> stream_state::stop_sending(application_error_code app_error_code) {
+    if (!_can_read) {
+        throw_quic_error(quic_error_code::invalid_state, "stream input is unavailable");
+    }
+    if (_input_shutdown_notified) {
+        co_return;
+    }
+    if (!_command_runtime) {
+        co_return;
+    }
+    // Reflect STOP_SENDING locally before the transport actor emits the frame.
+    abort_read_queue(std::make_exception_ptr(quic_error(quic_error_code::closed, "stop_sending")));
+    co_await _command_runtime->stop_sending(_id, app_error_code);
+}
+
+void stream_state::on_data(temporary_buffer<char> payload, bool fin) {
+    if (_transport_closed || _input_shutdown_notified) {
+        return;
+    }
+    if (!payload.empty() && !push_read_fragment(std::move(payload))) {
+        return;
+    }
+    if (fin) {
+        notify_input_shutdown();
+        // Preserve EOF ordering by queueing the terminal empty fragment after data.
+        (void)push_read_fragment(temporary_buffer<char>());
+    }
+}
+
+void stream_state::on_reset(application_error_code) {
+    abort_read_queue(std::make_exception_ptr(quic_error(quic_error_code::closed, "peer reset stream")));
+}
+
+void stream_state::on_stop_sending_input(application_error_code) {
+    if (!_can_read || _input_shutdown_notified) {
+        return;
+    }
+    abort_read_queue(std::make_exception_ptr(quic_error(quic_error_code::closed, "stop_sending")));
+}
+
+void stream_state::on_stop_sending_output(application_error_code) {
+    if (!_can_write || _output_closed) {
+        return;
+    }
+    _output_closed = true;
+}
+
+void stream_state::on_batch_flush_error() noexcept {
+    _output_closed = true;
+}
+
+void stream_state::on_transport_closed() {
+    if (_transport_closed) {
+        return;
+    }
+    _transport_closed = true;
+    abort_read_queue(std::make_exception_ptr(quic_error(quic_error_code::closed, "transport closed")));
+}
+
+void stream_state::on_data_consumed(size_t size) {
+    if (!size || !_command_runtime || _transport_closed || !_can_read || _input_shutdown_notified) {
+        return;
+    }
+    _command_runtime->consume_stream_data(_id, size);
+}
+
+class stream_state::source_impl final : public data_source_impl {
+public:
+    explicit source_impl(shared_ptr<stream_state> state)
+        : _state(std::move(state)) {
+    }
+
+    future<temporary_buffer<char>> get() override {
+        auto buf = co_await _state->_read_queue.pop_eventually();
+        auto consumed = buf.size();
+        // Empty buffers are EOF markers and do not replenish receive credit.
+        _state->release_read_bytes(consumed);
+        _state->on_data_consumed(consumed);
+        co_return std::move(buf);
+    }
+
+    future<> close() override {
+        // Closing the public input side maps to QUIC STOP_SENDING.
+        return _state->stop_sending(0);
+    }
+
+private:
+    shared_ptr<stream_state> _state;
+};
+
+class stream_state::sink_impl final : public data_sink_impl {
+public:
+    explicit sink_impl(shared_ptr<stream_state> state)
+        : _state(std::move(state)) {
+    }
+
+    future<> put(std::span<temporary_buffer<char>> bufs) override {
+        if (bufs.empty()) {
+            return make_ready_future<>();
+        }
+        return _state->send_one(coalesce_buffers(bufs), false);
+    }
+
+    future<> close() override {
+        return _state->close_output();
+    }
+
+    size_t buffer_size() const noexcept override {
+        return 8192;
+    }
+
+    bool can_batch_flushes() const noexcept override {
+        return true;
+    }
+
+    void on_batch_flush_error() noexcept override {
+        _state->on_batch_flush_error();
+    }
+
+private:
+    shared_ptr<stream_state> _state;
+};
+
+input_stream<char> stream_state::input(connected_socket_input_stream_config cfg) {
+    if (!_can_read) {
+        throw_quic_error(quic_error_code::invalid_state, "stream input is unavailable");
+    }
+    return input_stream<char>(source(cfg));
+}
+
+output_stream<char> stream_state::output(size_t buffer_size) {
+    if (!_can_write) {
+        throw_quic_error(quic_error_code::invalid_state, "stream output is unavailable");
+    }
+    if (_output_closed) {
+        throw_quic_error(quic_error_code::closed, "stream output is closed");
+    }
+    return output_stream<char>(sink(), buffer_size);
+}
+
+data_source stream_state::source(connected_socket_input_stream_config) {
+    if (!_can_read) {
+        throw_quic_error(quic_error_code::invalid_state, "stream input is unavailable");
+    }
+    return data_source(std::make_unique<source_impl>(shared_from_this()));
+}
+
+data_sink stream_state::sink() {
+    if (!_can_write) {
+        throw_quic_error(quic_error_code::invalid_state, "stream output is unavailable");
+    }
+    if (_output_closed) {
+        throw_quic_error(quic_error_code::closed, "stream output is closed");
+    }
+    return data_sink(std::make_unique<sink_impl>(shared_from_this()));
+}
+
+connection_state::connection_state(command_runtime_ptr command_runtime, connection_options options)
+    : _impl(std::make_unique<impl>(std::move(command_runtime), std::move(options))) {
+}
+
+connection_state::~connection_state() = default;
+
+bool connection_state::is_open() const noexcept {
+    return _impl->command_runtime && _impl->command_runtime->is_open();
+}
+
+socket_address connection_state::local_address() const {
+    return _impl->command_runtime ? _impl->command_runtime->local_address() : socket_address();
+}
+
+socket_address connection_state::peer_address() const {
+    return _impl->command_runtime ? _impl->command_runtime->peer_address() : socket_address();
+}
+
+sstring connection_state::selected_alpn() const {
+    return _impl->command_runtime ? _impl->command_runtime->selected_alpn() : sstring();
+}
+
+future<stream> connection_state::open_stream(stream_open_options options) {
+    // Stream state is created after transport credit reserves a concrete id.
+    auto sid = co_await _impl->command_runtime->open_stream(options.type);
+    auto [it, inserted] = _impl->streams.emplace(sid, shared_ptr<stream_state>{});
+    if (inserted || !it->second) {
+        it->second = make_shared<stream_state>(
+          _impl->command_runtime, _impl->receive_window, _impl->stream_read_queue_capacity, sid, options.type, false);
+    }
+    auto st = it->second;
+    co_return stream(std::make_unique<stream::impl>(std::move(st)));
+}
+
+future<stream> connection_state::accept_stream() {
+    _impl->refill_pending_accepted_streams();
+    auto st = co_await _impl->accepted_streams.pop_eventually();
+    _impl->refill_pending_accepted_streams();
+    co_return stream(std::make_unique<stream::impl>(std::move(st)));
+}
+
+future<> connection_state::close() {
+    if (!_impl->command_runtime) {
+        co_return;
+    }
+    co_await _impl->command_runtime->close();
+}
+
+void connection_state::on_stream_data(stream_id sid, stream_type type, bool peer_initiated, temporary_buffer<char> payload, bool fin) {
+    // Transport callbacks can be the first time a peer-initiated stream is seen.
+    auto [it, inserted] = _impl->streams.emplace(sid, shared_ptr<stream_state>{});
+    if (inserted || !it->second) {
+        it->second = make_shared<stream_state>(
+          _impl->command_runtime, _impl->receive_window, _impl->stream_read_queue_capacity, sid, type, peer_initiated);
+    }
+    auto st = it->second;
+    if (peer_initiated && st->mark_accepted_for_delivery()) {
+        // Deliver each peer-initiated stream to accept_stream() exactly once.
+        _impl->enqueue_accepted_stream(st);
+    }
+    st->on_data(std::move(payload), fin);
+}
+
+void connection_state::on_stream_reset(
+  stream_id sid,
+  stream_type type,
+  bool peer_initiated,
+  application_error_code app_error_code) {
+    auto [it, inserted] = _impl->streams.emplace(sid, shared_ptr<stream_state>{});
+    if (inserted || !it->second) {
+        it->second = make_shared<stream_state>(
+          _impl->command_runtime, _impl->receive_window, _impl->stream_read_queue_capacity, sid, type, peer_initiated);
+    }
+    auto st = it->second;
+    if (peer_initiated && st->mark_accepted_for_delivery()) {
+        // Deliver each peer-initiated stream to accept_stream() exactly once.
+        _impl->enqueue_accepted_stream(st);
+    }
+    st->on_reset(app_error_code);
+}
+
+void connection_state::on_stream_stop_sending(
+  stream_id sid,
+  stream_type type,
+  bool peer_initiated,
+  application_error_code app_error_code,
+  stream_shutdown_side shutdown_side) {
+    auto [it, inserted] = _impl->streams.emplace(sid, shared_ptr<stream_state>{});
+    if (inserted || !it->second) {
+        it->second = make_shared<stream_state>(
+          _impl->command_runtime, _impl->receive_window, _impl->stream_read_queue_capacity, sid, type, peer_initiated);
+    }
+    auto st = it->second;
+    if (peer_initiated && st->mark_accepted_for_delivery()) {
+        // Deliver each peer-initiated stream to accept_stream() exactly once.
+        _impl->enqueue_accepted_stream(st);
+    }
+    if (shutdown_side == stream_shutdown_side::write) {
+        st->on_stop_sending_output(app_error_code);
+    } else {
+        st->on_stop_sending_input(app_error_code);
+    }
+}
+
+void connection_state::on_stream_closed(stream_id sid) {
+    _impl->streams.erase(sid);
+}
+
+void connection_state::on_transport_closed(std::exception_ptr ex) {
+    // Fan out one terminal transport error to every public stream surface.
+    if (_impl->transport_closed) {
+        return;
+    }
+    _impl->transport_closed = true;
+    _impl->_timer.cancel();
+    if (!ex) {
+        ex = std::make_exception_ptr(quic_error(quic_error_code::closed, "transport closed"));
+    }
+    _impl->accepted_streams.abort(ex);
+    _impl->pending_accepted_streams.clear();
+    for (auto& [_, st] : _impl->streams) {
+        st->on_transport_closed();
+    }
+    _impl->streams.clear();
+}
+
+future<> connection_state::wait_for_actor_wakeup(bool has_pending_work, bool closing) {
+    // Recheck before sleeping so edge-triggered wakeups cannot be missed.
+    if (has_pending_work || closing) {
+        co_return;
+    }
+    _impl->actor_waiter.emplace();
+    try {
+        co_await _impl->actor_waiter->get_future();
+    } catch (...) {
+    }
+    co_return;
+}
+
+void connection_state::wake_actor() {
+    if (!_impl->actor_waiter) {
+        return;
+    }
+    auto waiter = std::move(*_impl->actor_waiter);
+    _impl->actor_waiter.reset();
+    waiter.set_value();
+}
+
+void connection_state::arm_timer(std::chrono::nanoseconds delay, bool closing) {
+    // Timer ownership stays here so client and server actors use identical expiry logic.
+    if (closing || _impl->transport_closed) {
+        _impl->_timer.cancel();
+        return;
+    }
+    if (delay <= std::chrono::nanoseconds::zero()) {
+        _impl->_timer.cancel();
+        if (_impl->tick_pending) {
+            return;
+        }
+        _impl->tick_pending = true;
+        wake_actor();
+        return;
+    }
+    _impl->_timer.cancel();
+    _impl->_timer.arm(delay);
+}
+
+void connection_state::rearm_timer_from_expiry(uint64_t expiry_ns, uint64_t now_ns, bool closing) {
+    constexpr auto max_timer_sleep = std::chrono::hours(24);
+    if (expiry_ns <= now_ns) {
+        // Expired deadlines are converted into an immediate actor tick.
+        arm_timer(std::chrono::nanoseconds(0), closing);
+        return;
+    }
+    auto wait_ns = expiry_ns - now_ns;
+    auto max_wait_ns = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(max_timer_sleep).count());
+    auto sleep_ns = wait_ns > max_wait_ns ? max_wait_ns : wait_ns;
+    arm_timer(std::chrono::nanoseconds(sleep_ns), closing);
+}
+
+bool connection_state::tick_pending() const noexcept {
+    return _impl->tick_pending;
+}
+
+void connection_state::clear_tick() noexcept {
+    _impl->tick_pending = false;
+}
+
+void connection_state::cancel_timer() noexcept {
+    _impl->_timer.cancel();
+}
+
+void connection_state::defer_blocked_open_stream(transport_command cmd) {
+    // Keep bidi and uni waits separate because ngtcp2 extends their credits separately.
+    auto& q = cmd.type == stream_type::bidirectional
+                ? _impl->blocked_bidi_open_streams
+                : _impl->blocked_uni_open_streams;
+    q.push_back(std::move(cmd));
+}
+
+std::optional<transport_command> connection_state::pop_blocked_open_stream(stream_type type) {
+    auto& q = type == stream_type::bidirectional
+                ? _impl->blocked_bidi_open_streams
+                : _impl->blocked_uni_open_streams;
+    if (q.empty()) {
+        return std::nullopt;
+    }
+    auto cmd = std::move(q.front());
+    q.pop_front();
+    return cmd;
+}
+
+void connection_state::request_blocked_open_stream_retry(stream_type type) {
+    auto& pending = type == stream_type::bidirectional
+                      ? _impl->blocked_bidi_open_stream_retry_pending
+                      : _impl->blocked_uni_open_stream_retry_pending;
+    pending = true;
+    wake_actor();
+}
+
+bool connection_state::blocked_open_stream_retry_pending(stream_type type) const noexcept {
+    return type == stream_type::bidirectional
+             ? _impl->blocked_bidi_open_stream_retry_pending
+             : _impl->blocked_uni_open_stream_retry_pending;
+}
+
+void connection_state::clear_blocked_open_stream_retry(stream_type type) noexcept {
+    auto& pending = type == stream_type::bidirectional
+                      ? _impl->blocked_bidi_open_stream_retry_pending
+                      : _impl->blocked_uni_open_stream_retry_pending;
+    pending = false;
+}
+
+bool connection_state::has_blocked_open_stream_retry_work() const noexcept {
+    return (_impl->blocked_bidi_open_stream_retry_pending && !_impl->blocked_bidi_open_streams.empty())
+           || (_impl->blocked_uni_open_stream_retry_pending && !_impl->blocked_uni_open_streams.empty());
+}
+
+void connection_state::fail_blocked_open_streams(quic_error_code error, std::string_view detail) {
+    // Open-stream promises live above the transport actor and must be completed on teardown.
+    if (!_impl->command_runtime) {
+        _impl->blocked_bidi_open_streams.clear();
+        _impl->blocked_uni_open_streams.clear();
+        _impl->blocked_bidi_open_stream_retry_pending = false;
+        _impl->blocked_uni_open_stream_retry_pending = false;
+        return;
+    }
+
+    auto fail_queue = [this, error, detail] (auto& q) {
+        for (auto& cmd : q) {
+            _impl->command_runtime->fail_open_stream(cmd.open_result, error, sstring(detail));
+        }
+        q.clear();
+    };
+
+    fail_queue(_impl->blocked_bidi_open_streams);
+    fail_queue(_impl->blocked_uni_open_streams);
+    _impl->blocked_bidi_open_stream_retry_pending = false;
+    _impl->blocked_uni_open_stream_retry_pending = false;
+}
+
+future<> flush_pending_transport_packets(connection_transport& transport) {
+    if (!transport.has_transport_connection()) {
+        co_return;
+    }
+
+    auto& outbuf = ensure_tx_packet_buffer(transport);
+    while (transport.transport_active()) {
+        // Drain ACKs, probes and other control frames not tied to an app write.
+        auto nwrite = transport.write_pending_packet(
+          reinterpret_cast<uint8_t*>(outbuf.get_write()),
+          outbuf.size());
+        if (nwrite == 0) {
+            co_return;
+        }
+        if (nwrite < 0) {
+            if (ngtcp2_is_write_more(static_cast<int>(nwrite))) {
+                // ngtcp2 filled internal coalescing state; ask it for the next packet.
+                continue;
+            }
+            if (ngtcp2_is_draining(static_cast<int>(nwrite))) {
+                transport.stop_transport();
+                co_return;
+            }
+            transport.fail_transport(
+              classify_ngtcp2_error(static_cast<int>(nwrite)),
+              ngtcp2_error_message(static_cast<int>(nwrite)));
+            co_return;
+        }
+        co_await transport.send_datagram_packet(outbuf.share(0, static_cast<size_t>(nwrite)));
+    }
+}
+
+namespace {
+
+void complete_send_progress(connection_transport& transport, quic_message& msg, size_t consumed) {
+    if (!consumed) {
+        return;
+    }
+    if (consumed > msg.payload.size()) {
+        consumed = msg.payload.size();
+    }
+    // Retain bytes by stream offset until ngtcp2 reports them acknowledged.
+    transport.retain_stream_data(msg.stream, msg.payload.share(0, consumed));
+    transport.complete_send_bytes(consumed);
+    msg.payload.trim_front(consumed);
+}
+
+void discard_unsent_send_bytes(connection_transport& transport, quic_message& msg) {
+    // Release command-runtime backpressure for bytes ngtcp2 will never consume.
+    if (msg.payload.empty()) {
+        return;
+    }
+    transport.complete_send_bytes(msg.payload.size());
+    msg.payload = temporary_buffer<char>();
+}
+
+} // namespace
+
+future<std::optional<quic_message>> send_stream_message(connection_transport& transport, quic_message msg) {
+    if (!transport.has_transport_connection() || !transport.transport_active() || msg.stream == invalid_stream_id) {
+        discard_unsent_send_bytes(transport, msg);
+        co_return std::nullopt;
+    }
+
+    bool send_fin = msg.fin;
+    auto& outbuf = ensure_tx_packet_buffer(transport);
+
+    while (transport.transport_active()) {
+        const bool remaining = !msg.payload.empty();
+        if (!remaining && !send_fin) {
+            break;
+        }
+
+        auto* ptr = remaining ? msg.payload.get() : nullptr;
+        auto len = remaining ? msg.payload.size() : 0;
+        auto result = transport.write_stream_packet(
+          msg.stream,
+          ptr,
+          len,
+          send_fin,
+          reinterpret_cast<uint8_t*>(outbuf.get_write()),
+          outbuf.size());
+
+        if (result.nwrite < 0) {
+            // Negative write results can still report consumed stream bytes.
+            if (ngtcp2_is_write_more(static_cast<int>(result.nwrite))) {
+                complete_send_progress(transport, msg, result.consumed);
+                co_await flush_pending_transport_packets(transport);
+                continue;
+            }
+            if (ngtcp2_is_draining(static_cast<int>(result.nwrite))) {
+                discard_unsent_send_bytes(transport, msg);
+                transport.stop_transport();
+                co_return std::nullopt;
+            }
+            if (result.nwrite == NGTCP2_ERR_STREAM_DATA_BLOCKED) {
+                complete_send_progress(transport, msg, result.consumed);
+                co_await flush_pending_transport_packets(transport);
+                transport.rearm_transport_timer();
+                // Hand the unsent suffix back to the actor for a later credit retry.
+                msg.fin = send_fin;
+                co_return std::make_optional(std::move(msg));
+            }
+            if (result.nwrite == NGTCP2_ERR_STREAM_SHUT_WR || result.nwrite == NGTCP2_ERR_STREAM_NOT_FOUND) {
+                // Treat peer-side write shutdown as stream-local, not connection-fatal.
+                complete_send_progress(transport, msg, result.consumed);
+                discard_unsent_send_bytes(transport, msg);
+                transport.on_stream_write_closed(msg.stream);
+                co_await flush_pending_transport_packets(transport);
+                transport.rearm_transport_timer();
+                co_return std::nullopt;
+            }
+            discard_unsent_send_bytes(transport, msg);
+            transport.fail_transport(
+              classify_ngtcp2_error(static_cast<int>(result.nwrite)),
+              ngtcp2_error_message(static_cast<int>(result.nwrite)));
+            co_return std::nullopt;
+        }
+        complete_send_progress(transport, msg, result.consumed);
+        if (result.nwrite == 0) {
+            co_await flush_pending_transport_packets(transport);
+            if (result.consumed) {
+                // ngtcp2 consumed stream bytes while only producing control packets.
+                continue;
+            }
+            transport.rearm_transport_timer();
+            msg.fin = send_fin;
+            co_return std::make_optional(std::move(msg));
+        }
+
+        co_await transport.send_datagram_packet(outbuf.share(0, static_cast<size_t>(result.nwrite)));
+        if (send_fin && msg.payload.empty()) {
+            send_fin = false;
+        }
+
+        if (msg.payload.empty() && !send_fin) {
+            break;
+        }
+    }
+
+    if ((!transport.transport_active() || !transport.has_transport_connection())
+        && (!msg.payload.empty() || send_fin)) {
+        discard_unsent_send_bytes(transport, msg);
+        send_fin = false;
+    }
+
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+    msg.fin = false;
+    co_return std::nullopt;
+}
+
+future<bool> open_stream(connection_transport& transport, transport_command cmd) {
+    if (!transport.has_transport_connection() || !cmd.open_result) {
+        co_return false;
+    }
+
+    auto result = transport.try_open_stream(cmd.type);
+    if (result.rv == 0) {
+        // Complete the public promise only after ngtcp2 assigns a concrete id.
+        transport.complete_open_stream(cmd.open_result, result.sid);
+        co_await flush_pending_transport_packets(transport);
+        transport.rearm_transport_timer();
+        co_return false;
+    }
+
+    if (result.rv == NGTCP2_ERR_STREAM_ID_BLOCKED) {
+        // Defer until MAX_STREAMS credit is extended by the peer.
+        transport.defer_blocked_open_stream(std::move(cmd));
+        co_await flush_pending_transport_packets(transport);
+        transport.rearm_transport_timer();
+        co_return true;
+    }
+
+    auto error = classify_ngtcp2_error(result.rv);
+    auto detail = ngtcp2_error_message(result.rv);
+    transport.fail_open_stream(cmd.open_result, error, detail);
+    transport.fail_transport(error, detail);
+    co_return false;
+}
+
+future<> consume_stream_data(connection_transport& transport, stream_id sid, size_t len) {
+    if (!transport.has_transport_connection() || sid == invalid_stream_id || !len) {
+        co_return;
+    }
+
+    auto rv = transport.consume_stream_data(sid, len);
+    if (rv < 0) {
+        transport.fail_transport(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        co_return;
+    }
+
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+}
+
+future<> reset_stream(connection_transport& transport, stream_id sid, application_error_code app_error_code) {
+    if (!transport.has_transport_connection()) {
+        co_return;
+    }
+    auto rv = transport.shutdown_stream_write(sid, app_error_code);
+    if (rv < 0) {
+        transport.fail_transport(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        co_return;
+    }
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+}
+
+future<> stop_sending(connection_transport& transport, stream_id sid, application_error_code app_error_code) {
+    if (!transport.has_transport_connection()) {
+        co_return;
+    }
+    auto rv = transport.shutdown_stream_read(sid, app_error_code);
+    if (rv < 0) {
+        transport.fail_transport(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        co_return;
+    }
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+}
+
+future<> retry_blocked_open_streams(connection_transport& transport, stream_type type) {
+    if (!transport.can_retry_blocked_open_streams() || !transport.blocked_open_stream_retry_pending(type)) {
+        co_return;
+    }
+
+    transport.clear_blocked_open_stream_retry(type);
+    // Retry deferred opens until the queue drains or credit is exhausted again.
+    while (transport.can_retry_blocked_open_streams()) {
+        auto cmd = transport.pop_blocked_open_stream(type);
+        if (!cmd) {
+            co_return;
+        }
+        auto blocked = co_await open_stream(transport, std::move(*cmd));
+        if (blocked) {
+            co_return;
+        }
+    }
+}
+
+future<std::optional<transport_command>> handle_transport_command(connection_transport& transport, transport_command cmd) {
+    // Returning a command means only that this specific operation is blocked and
+    // should be requeued by the owning actor.
+    switch (cmd.op) {
+    case transport_command::kind::send: {
+        auto blocked = co_await send_stream_message(transport, std::move(cmd.msg));
+        if (blocked) {
+            cmd.msg = std::move(*blocked);
+            co_return std::make_optional(std::move(cmd));
+        }
+        break;
+    }
+    case transport_command::kind::open_stream:
+        (void)co_await open_stream(transport, std::move(cmd));
+        break;
+    case transport_command::kind::consume_stream_data:
+        co_await consume_stream_data(transport, cmd.msg.stream, cmd.consumed_bytes);
+        break;
+    case transport_command::kind::reset_stream:
+        co_await reset_stream(transport, cmd.msg.stream, cmd.app_error_code);
+        break;
+    case transport_command::kind::stop_sending:
+        co_await stop_sending(transport, cmd.msg.stream, cmd.app_error_code);
+        break;
+    case transport_command::kind::close_connection:
+        transport.request_close();
+        break;
+    }
+    co_return std::nullopt;
+}
+
+future<> recv_transport_datagram(connection_transport& transport, const socket_address& src, temporary_buffer<char> pkt) {
+    if (!transport.transport_active() || !transport.has_transport_connection()) {
+        co_return;
+    }
+
+    auto rv = transport.read_transport_datagram(src, pkt.get(), pkt.size());
+    if (rv < 0) {
+        if (ngtcp2_is_draining(rv)) {
+            transport.stop_transport();
+            co_return;
+        }
+        transport.fail_transport(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        co_return;
+    }
+
+    // Packet processing can update the active path used for replies.
+    transport.sync_transport_path();
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+}
+
+future<> handle_transport_timer(connection_transport& transport) {
+    if (!transport.transport_active() || !transport.has_transport_connection()) {
+        co_return;
+    }
+
+    auto now_local = transport_now_ns();
+    // ngtcp2 uses the same expiry hook for PTO, loss recovery and idle timeout.
+    if (transport.transport_expiry_ns() <= now_local) {
+        auto rv = transport.handle_transport_expiry(now_local);
+        if (rv < 0) {
+            if (ngtcp2_is_idle_close(rv) || ngtcp2_is_draining(rv)) {
+                transport.stop_transport();
+                co_return;
+            }
+            transport.fail_transport(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+            co_return;
+        }
+    }
+
+    co_await flush_pending_transport_packets(transport);
+    transport.rearm_transport_timer();
+}
+
+future<> send_connection_close(connection_transport& transport) {
+    if (!transport.can_send_connection_close()) {
+        // Once the connection or datagram channel is gone, no close packet can be sent.
+        co_return;
+    }
+
+    auto& outbuf = ensure_tx_packet_buffer(transport);
+    auto nwrite = transport.write_connection_close_packet(
+      reinterpret_cast<uint8_t*>(outbuf.get_write()),
+      outbuf.size());
+    if (nwrite == 0) {
+        co_return;
+    }
+    if (nwrite < 0) {
+        // Draining and idle-close already mean the peer does not need a new close frame.
+        if (!ngtcp2_is_draining(static_cast<int>(nwrite)) && !ngtcp2_is_idle_close(static_cast<int>(nwrite))) {
+            transport.fail_transport(
+              classify_ngtcp2_error(static_cast<int>(nwrite)),
+              ngtcp2_error_message(static_cast<int>(nwrite)));
+        }
+        co_return;
+    }
+
+    co_await transport.send_datagram_packet(outbuf.share(0, static_cast<size_t>(nwrite)));
+}
+
+connection_state_ptr make_connection_state(command_runtime_ptr command_runtime, connection_options options) {
+    return make_shared<connection_state>(std::move(command_runtime), std::move(options));
+}
+
+} // namespace internal
+
+namespace {
+
+class quic_connected_socket_impl final : public net::connected_socket_impl {
+public:
+    explicit quic_connected_socket_impl(shared_ptr<internal::stream_state> state)
+        : _state(std::move(state)) {
+    }
+
+    data_source source() override {
+        return _state->source({});
+    }
+
+    data_source source(connected_socket_input_stream_config cfg) override {
+        return _state->source(cfg);
+    }
+
+    data_sink sink() override {
+        return _state->sink();
+    }
+
+    void shutdown_input() override {
+        (void)_state->stop_sending(0).handle_exception([] (std::exception_ptr) {
+        });
+    }
+
+    void shutdown_output() override {
+        (void)_state->close_output().handle_exception([] (std::exception_ptr) {
+        });
+    }
+
+    void set_nodelay(bool) override {
+    }
+
+    bool get_nodelay() const override {
+        return true;
+    }
+
+    void set_keepalive(bool) override {
+    }
+
+    bool get_keepalive() const override {
+        return false;
+    }
+
+    void set_keepalive_parameters(const net::keepalive_params&) override {
+    }
+
+    net::keepalive_params get_keepalive_parameters() const override {
+        return net::tcp_keepalive_params{std::chrono::seconds(0), std::chrono::seconds(0), 0};
+    }
+
+    void set_sockopt(int, int, const void*, size_t) override {
+    }
+
+    int get_sockopt(int, int, void*, size_t) const override {
+        return 0;
+    }
+
+    socket_address local_address() const noexcept override {
+        return _state->local_address();
+    }
+
+    socket_address remote_address() const noexcept override {
+        return _state->peer_address();
+    }
+
+    future<> wait_input_shutdown() override {
+        return _state->wait_input_shutdown();
+    }
+
+private:
+    shared_ptr<internal::stream_state> _state;
+};
+
+} // namespace
+
+stream::stream() = default;
+stream::~stream() = default;
+stream::stream(stream&&) noexcept = default;
+stream& stream::operator=(stream&&) noexcept = default;
+
+stream::stream(std::unique_ptr<impl> state)
+    : _impl(std::move(state)) {
+}
+
+bool stream::is_open() const noexcept {
+    return _impl && _impl->state && _impl->state->is_open();
+}
+
+bool stream::can_read() const noexcept {
+    return _impl && _impl->state && _impl->state->can_read();
+}
+
+bool stream::can_write() const noexcept {
+    return _impl && _impl->state && _impl->state->can_write();
+}
+
+stream_id stream::id() const noexcept {
+    return (_impl && _impl->state) ? _impl->state->id() : invalid_stream_id;
+}
+
+stream_type stream::type() const noexcept {
+    return (_impl && _impl->state) ? _impl->state->type() : stream_type::bidirectional;
+}
+
+input_stream<char> stream::input(connected_socket_input_stream_config cfg) {
+    if (!_impl || !_impl->state) {
+        throw_quic_error(quic_error_code::invalid_state, "stream state is null");
+    }
+    return _impl->state->input(cfg);
+}
+
+output_stream<char> stream::output(size_t buffer_size) {
+    if (!_impl || !_impl->state) {
+        throw_quic_error(quic_error_code::invalid_state, "stream state is null");
+    }
+    return _impl->state->output(buffer_size);
+}
+
+future<> stream::close_output() {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<>(quic_error(quic_error_code::invalid_state, "stream state is null"));
+    }
+    return _impl->state->close_output();
+}
+
+future<> stream::reset(application_error_code app_error_code) {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<>(quic_error(quic_error_code::invalid_state, "stream state is null"));
+    }
+    return _impl->state->reset(app_error_code);
+}
+
+future<> stream::stop_sending(application_error_code app_error_code) {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<>(quic_error(quic_error_code::invalid_state, "stream state is null"));
+    }
+    return _impl->state->stop_sending(app_error_code);
+}
+
+future<> stream::wait_input_shutdown() {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<>(quic_error(quic_error_code::invalid_state, "stream state is null"));
+    }
+    return _impl->state->wait_input_shutdown();
+}
+
+connection::connection() = default;
+connection::~connection() = default;
+connection::connection(connection&&) noexcept = default;
+connection& connection::operator=(connection&&) noexcept = default;
+
+connection::connection(std::unique_ptr<impl> state)
+    : _impl(std::move(state)) {
+}
+
+bool connection::is_open() const noexcept {
+    return _impl && _impl->state && _impl->state->is_open();
+}
+
+socket_address connection::local_address() const {
+    return (_impl && _impl->state) ? _impl->state->local_address() : socket_address();
+}
+
+socket_address connection::peer_address() const {
+    return (_impl && _impl->state) ? _impl->state->peer_address() : socket_address();
+}
+
+sstring connection::selected_alpn() const {
+    return (_impl && _impl->state) ? _impl->state->selected_alpn() : sstring();
+}
+
+future<stream> connection::open_stream(stream_open_options options) {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<stream>(quic_error(quic_error_code::invalid_state, "connection state is null"));
+    }
+    return _impl->state->open_stream(options);
+}
+
+future<stream> connection::accept_stream() {
+    if (!_impl || !_impl->state) {
+        return make_exception_future<stream>(quic_error(quic_error_code::invalid_state, "connection state is null"));
+    }
+    return _impl->state->accept_stream();
+}
+
+future<> connection::close() {
+    if (!_impl || !_impl->state) {
+        co_return;
+    }
+    co_await _impl->state->close();
+}
+
+connected_socket to_connected_socket(stream&& s) {
+    if (!s._impl || !s._impl->state) {
+        throw_quic_error(quic_error_code::invalid_state, "stream state is null");
+    }
+    auto state = std::move(s._impl->state);
+    if (!state->can_read() || !state->can_write()) {
+        throw_quic_error(quic_error_code::invalid_state, "connected_socket requires a bidirectional stream");
+    }
+    return connected_socket(std::make_unique<quic_connected_socket_impl>(std::move(state)));
+}
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_error.cc
+++ b/src/quic/quic_error.cc
@@ -1,0 +1,156 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include "quic_error_impl.hh"
+
+#include <system_error>
+#include <utility>
+
+#include <ngtcp2/ngtcp2.h>
+
+#include <gnutls/gnutls.h>
+
+namespace seastar::quic::experimental {
+
+const char* to_string(quic_error_code error) noexcept {
+    switch (error) {
+    case quic_error_code::none:
+        return "none";
+    case quic_error_code::invalid_argument:
+        return "invalid_argument";
+    case quic_error_code::invalid_state:
+        return "invalid_state";
+    case quic_error_code::io:
+        return "io";
+    case quic_error_code::timeout:
+        return "timeout";
+    case quic_error_code::protocol:
+        return "protocol";
+    case quic_error_code::closed:
+        return "closed";
+    case quic_error_code::unsupported:
+        return "unsupported";
+    case quic_error_code::internal:
+        return "internal";
+    case quic_error_code::backend:
+        return "backend";
+    }
+    return "unknown";
+}
+
+namespace {
+
+class quic_error_category_impl final : public std::error_category {
+public:
+    const char* name() const noexcept override {
+        return "seastar.quic";
+    }
+
+    std::string message(int ev) const override {
+        return to_string(static_cast<quic_error_code>(ev));
+    }
+};
+
+std::system_error make_quic_system_error(quic_error_code error, std::string detail) {
+    auto code = make_error_code(error);
+    if (detail.empty()) {
+        return std::system_error(code);
+    }
+    return std::system_error(code, std::move(detail));
+}
+
+} // namespace
+
+const std::error_category& quic_error_category() noexcept {
+    static const quic_error_category_impl category;
+    return category;
+}
+
+std::error_code make_error_code(quic_error_code error) noexcept {
+    return {static_cast<int>(error), quic_error_category()};
+}
+
+quic_error::quic_error(quic_error_code error, std::string detail)
+    : std::system_error(make_quic_system_error(error, std::move(detail))) {
+}
+
+[[noreturn]] void throw_quic_error(quic_error_code error, std::string_view detail) {
+    throw quic_error(error, std::string(detail));
+}
+
+quic_error_code classify_ngtcp2_error(int code) noexcept {
+    if (code == 0) {
+        return quic_error_code::none;
+    }
+    if (code == NGTCP2_ERR_DRAINING) {
+        return quic_error_code::closed;
+    }
+    if (code == NGTCP2_ERR_IDLE_CLOSE) {
+        return quic_error_code::timeout;
+    }
+    if (code == NGTCP2_ERR_WRITE_MORE) {
+        return quic_error_code::none;
+    }
+    if (code == NGTCP2_ERR_INVALID_ARGUMENT) {
+        return quic_error_code::invalid_argument;
+    }
+    if (code == NGTCP2_ERR_PROTO) {
+        return quic_error_code::protocol;
+    }
+    return quic_error_code::backend;
+}
+
+quic_error_code classify_gnutls_error(int code) noexcept {
+    if (code >= 0) {
+        return quic_error_code::none;
+    }
+    if (code == GNUTLS_E_AGAIN || code == GNUTLS_E_INTERRUPTED) {
+        return quic_error_code::io;
+    }
+#ifdef GNUTLS_E_TIMEDOUT
+    if (code == GNUTLS_E_TIMEDOUT) {
+        return quic_error_code::timeout;
+    }
+#endif
+    return quic_error_code::backend;
+}
+
+bool ngtcp2_is_write_more(int code) noexcept {
+    return code == NGTCP2_ERR_WRITE_MORE;
+}
+
+bool ngtcp2_is_draining(int code) noexcept {
+    return code == NGTCP2_ERR_DRAINING;
+}
+
+bool ngtcp2_is_idle_close(int code) noexcept {
+    return code == NGTCP2_ERR_IDLE_CLOSE;
+}
+
+std::string ngtcp2_error_message(int code) {
+    return ngtcp2_strerror(code);
+}
+
+std::string gnutls_error_message(int code) {
+    return gnutls_strerror(code);
+}
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_error_impl.hh
+++ b/src/quic/quic_error_impl.hh
@@ -1,0 +1,47 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <seastar/quic/quic_error.hh>
+
+namespace seastar::quic::experimental {
+
+using quic_error_code = quic_error::value;
+
+const char* to_string(quic_error_code error) noexcept;
+
+[[noreturn]] void throw_quic_error(quic_error_code error, std::string_view detail = {});
+
+quic_error_code classify_ngtcp2_error(int code) noexcept;
+quic_error_code classify_gnutls_error(int code) noexcept;
+
+bool ngtcp2_is_write_more(int code) noexcept;
+bool ngtcp2_is_draining(int code) noexcept;
+bool ngtcp2_is_idle_close(int code) noexcept;
+
+std::string ngtcp2_error_message(int code);
+std::string gnutls_error_message(int code);
+
+} // namespace seastar::quic::experimental

--- a/src/quic/quic_impl.hh
+++ b/src/quic/quic_impl.hh
@@ -1,0 +1,266 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include "quic_error_impl.hh"
+
+#include <seastar/quic/quic.hh>
+
+namespace seastar::quic::experimental {
+
+namespace internal {
+class stream_state;
+class connection_state;
+
+using stream_state_ptr = shared_ptr<stream_state>;
+using connection_state_ptr = shared_ptr<connection_state>;
+}
+
+class stream::impl {
+public:
+    explicit impl(internal::stream_state_ptr state)
+        : state(std::move(state)) {
+    }
+
+    internal::stream_state_ptr state;
+};
+
+class connection::impl {
+public:
+    explicit impl(internal::connection_state_ptr state)
+        : state(std::move(state)) {
+    }
+
+    internal::connection_state_ptr state;
+};
+
+} // namespace seastar::quic::experimental
+
+namespace seastar::quic::experimental::internal {
+
+class command_runtime;
+class stream_state;
+class connection_state;
+
+using command_runtime_ptr = shared_ptr<command_runtime>;
+using stream_state_ptr = shared_ptr<stream_state>;
+using connection_state_ptr = shared_ptr<connection_state>;
+using open_stream_result_ptr = lw_shared_ptr<promise<stream_id>>;
+
+// Payload scheduled by the command runtime to be written by the transport.
+struct quic_message {
+    stream_id stream = invalid_stream_id;
+    temporary_buffer<char> payload;
+    bool fin = false;
+};
+
+enum class stream_shutdown_side : uint8_t {
+    // Stop delivering bytes to the local reader.
+    read,
+    // Stop accepting bytes from the local writer.
+    write,
+};
+
+// Commands emitted by the command runtime and executed by the transport-facing actor loop.
+struct transport_command {
+    enum class kind : uint8_t {
+        // Write stream bytes, optionally carrying FIN.
+        send,
+        // Allocate a locally initiated QUIC stream id.
+        open_stream,
+        // Return receive credit after the application consumes data.
+        consume_stream_data,
+        // Abort the local write side with RESET_STREAM.
+        reset_stream,
+        // Ask the peer to stop sending on the local read side.
+        stop_sending,
+        // Start connection shutdown from the transport actor.
+        close_connection,
+    };
+
+    kind op = kind::send;
+    quic_message msg;
+    stream_type type = stream_type::bidirectional;
+    size_t consumed_bytes = 0;
+    application_error_code app_error_code = 0;
+    open_stream_result_ptr open_result;
+};
+
+// Bridge between the public stream API and the transport actor.
+class command_runtime {
+// The runtime owns user-facing promises and queues; the actor owns ngtcp2.
+public:
+    virtual ~command_runtime() = default;
+
+    virtual bool is_open() const noexcept = 0;
+    virtual socket_address local_address() const = 0;
+    virtual socket_address peer_address() const = 0;
+    virtual sstring selected_alpn() const = 0;
+
+    virtual future<> send(quic_message msg) = 0;
+    virtual future<stream_id> open_stream(stream_type type) = 0;
+    virtual void complete_send_bytes(size_t len) = 0;
+    virtual void consume_stream_data(stream_id sid, size_t len) = 0;
+    virtual future<> reset_stream(stream_id sid, application_error_code app_error_code) = 0;
+    virtual future<> stop_sending(stream_id sid, application_error_code app_error_code) = 0;
+    virtual future<> close() = 0;
+
+    virtual bool has_pending_commands() const noexcept = 0;
+    virtual std::optional<transport_command> poll_command() = 0;
+    virtual void set_command_notifier(std::function<void()> notifier) = 0;
+    virtual void complete_open_stream(open_stream_result_ptr result, stream_id sid) = 0;
+    virtual void fail_open_stream(open_stream_result_ptr result, quic_error_code error, sstring detail) = 0;
+    virtual void mark_transport_ready(socket_address local, socket_address peer, sstring selected_alpn) = 0;
+    virtual void mark_transport_closed() = 0;
+    virtual void mark_error(quic_error_code error, sstring detail) = 0;
+    virtual bool transport_terminal() const noexcept = 0;
+    virtual bool transport_failed() const noexcept = 0;
+    virtual quic_error_code transport_error() const noexcept = 0;
+    virtual sstring transport_error_detail() const = 0;
+};
+
+struct transport_stream_write_result {
+    int64_t nwrite = 0;
+    size_t consumed = 0;
+};
+
+struct transport_open_stream_result {
+    int rv = 0;
+    stream_id sid = invalid_stream_id;
+};
+
+// Base class for client/server transport operations shared by common helpers.
+class connection_transport {
+public:
+    virtual ~connection_transport() = default;
+
+    virtual bool transport_active() const noexcept = 0;
+    virtual bool has_transport_connection() const noexcept = 0;
+    virtual bool can_retry_blocked_open_streams() const noexcept = 0;
+    virtual size_t tx_payload_limit_bytes() const noexcept = 0;
+
+    virtual int64_t write_pending_packet(uint8_t* outbuf, size_t outbuf_size) = 0;
+    virtual transport_stream_write_result write_stream_packet(
+      stream_id sid,
+      const char* data,
+      size_t len,
+      bool fin,
+      uint8_t* outbuf,
+      size_t outbuf_size) = 0;
+    virtual transport_open_stream_result try_open_stream(stream_type type) = 0;
+    virtual void retain_stream_data(stream_id sid, temporary_buffer<char> payload) = 0;
+    virtual void complete_send_bytes(size_t len) = 0;
+    virtual int consume_stream_data(stream_id sid, size_t len) = 0;
+    virtual int shutdown_stream_write(stream_id sid, application_error_code app_error_code) = 0;
+    virtual int shutdown_stream_read(stream_id sid, application_error_code app_error_code) = 0;
+    virtual int read_transport_datagram(const socket_address& src, const char* data, size_t len) = 0;
+    virtual void sync_transport_path() = 0;
+    virtual uint64_t transport_expiry_ns() const noexcept = 0;
+    virtual int handle_transport_expiry(uint64_t now_ns) = 0;
+    virtual temporary_buffer<char>& tx_packet_buffer() = 0;
+
+    virtual future<> send_datagram_packet(temporary_buffer<char> packet) = 0;
+    virtual bool can_send_connection_close() const noexcept = 0;
+    virtual int64_t write_connection_close_packet(uint8_t* outbuf, size_t outbuf_size) = 0;
+    virtual void on_stream_write_closed(stream_id sid) = 0;
+    virtual void rearm_transport_timer() = 0;
+    virtual void request_close() = 0;
+    virtual void stop_transport() = 0;
+    virtual void fail_transport(quic_error_code error, sstring detail) = 0;
+
+    virtual void complete_open_stream(open_stream_result_ptr result, stream_id sid) = 0;
+    virtual void fail_open_stream(open_stream_result_ptr result, quic_error_code error, sstring detail) = 0;
+    virtual void defer_blocked_open_stream(transport_command cmd) = 0;
+    virtual std::optional<transport_command> pop_blocked_open_stream(stream_type type) = 0;
+    virtual bool blocked_open_stream_retry_pending(stream_type type) const noexcept = 0;
+    virtual void clear_blocked_open_stream_retry(stream_type type) noexcept = 0;
+
+};
+
+class connection_state {
+public:
+    explicit connection_state(command_runtime_ptr runtime, connection_options options = {});
+    ~connection_state();
+
+    connection_state(const connection_state&) = delete;
+    connection_state& operator=(const connection_state&) = delete;
+
+    bool is_open() const noexcept;
+    socket_address local_address() const;
+    socket_address peer_address() const;
+    sstring selected_alpn() const;
+
+    future<stream> open_stream(stream_open_options options = {});
+    future<stream> accept_stream();
+    future<> close();
+
+    void on_stream_data(stream_id sid, stream_type type, bool peer_initiated, temporary_buffer<char> payload, bool fin);
+    void on_stream_reset(stream_id sid, stream_type type, bool peer_initiated, application_error_code app_error_code);
+    void on_stream_stop_sending(
+      stream_id sid,
+      stream_type type,
+      bool peer_initiated,
+      application_error_code app_error_code,
+      stream_shutdown_side shutdown_side);
+    void on_stream_closed(stream_id sid);
+    void on_transport_closed(std::exception_ptr ex);
+
+    future<> wait_for_actor_wakeup(bool has_pending_work, bool closing);
+    void wake_actor();
+
+    bool tick_pending() const noexcept;
+    void clear_tick() noexcept;
+
+    void arm_timer(std::chrono::nanoseconds delay, bool closing);
+    void rearm_timer_from_expiry(uint64_t expiry_ns, uint64_t now_ns, bool closing);
+    void cancel_timer() noexcept;
+
+    void defer_blocked_open_stream(transport_command cmd);
+    std::optional<transport_command> pop_blocked_open_stream(stream_type type);
+    void request_blocked_open_stream_retry(stream_type type);
+    bool blocked_open_stream_retry_pending(stream_type type) const noexcept;
+    void clear_blocked_open_stream_retry(stream_type type) noexcept;
+    bool has_blocked_open_stream_retry_work() const noexcept;
+    void fail_blocked_open_streams(quic_error_code error, std::string_view detail);
+
+private:
+    class impl;
+    std::unique_ptr<impl> _impl;
+};
+
+connection_state_ptr make_connection_state(command_runtime_ptr runtime, connection_options options = {});
+
+future<> flush_pending_transport_packets(connection_transport& transport);
+future<std::optional<quic_message>> send_stream_message(connection_transport& transport, quic_message msg);
+future<bool> open_stream(connection_transport& transport, transport_command cmd);
+future<> consume_stream_data(connection_transport& transport, stream_id sid, size_t len);
+future<> reset_stream(connection_transport& transport, stream_id sid, application_error_code app_error_code);
+future<> stop_sending(connection_transport& transport, stream_id sid, application_error_code app_error_code);
+future<> retry_blocked_open_streams(connection_transport& transport, stream_type type);
+future<std::optional<transport_command>> handle_transport_command(connection_transport& transport, transport_command cmd);
+future<> recv_transport_datagram(connection_transport& transport, const socket_address& src, temporary_buffer<char> pkt);
+future<> handle_transport_timer(connection_transport& transport);
+future<> send_connection_close(connection_transport& transport);
+
+command_runtime_ptr make_command_runtime(connection_options options = {});
+
+} // namespace seastar::quic::experimental::internal

--- a/src/quic/quic_server.cc
+++ b/src/quic/quic_server.cc
@@ -54,6 +54,7 @@
 #include <seastar/core/queue.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/util/log.hh>
@@ -63,11 +64,52 @@ namespace seastar::quic::experimental {
 namespace {
 
 constexpr size_t max_cid_len = 20;
-constexpr size_t server_short_cid_len = 8;
+constexpr size_t server_short_cid_len = 16;
+constexpr size_t server_cid_shard_prefix_len = 2;
+constexpr size_t server_cid_generation_attempts = 16;
 constexpr size_t max_udp_payload_size = 65527;
 constexpr size_t default_udp_payload_size = 1200;
 
 static logger quic_server_log("quic_server");
+
+bool encode_current_shard_in_server_cid(uint8_t* data, size_t len) noexcept {
+    if (len < server_cid_shard_prefix_len) {
+        return true;
+    }
+    auto shard = this_shard_id();
+    if (shard > std::numeric_limits<uint16_t>::max()) {
+        return false;
+    }
+    data[0] = static_cast<uint8_t>((shard >> 8) & 0xffu);
+    data[1] = static_cast<uint8_t>(shard & 0xffu);
+    return true;
+}
+
+bool rand_server_cid_or_log(uint8_t* dest, size_t len, const char* detail) {
+    if (!rand_bytes_or_log(quic_server_log, "server", dest, len, detail)) {
+        return false;
+    }
+    return encode_current_shard_in_server_cid(dest, len);
+}
+
+void rand_server_cid_or_throw(uint8_t* dest, size_t len, const char* detail) {
+    rand_bytes_or_throw(dest, len, detail);
+    if (!encode_current_shard_in_server_cid(dest, len)) {
+        throw_quic_error(quic_error_code::unsupported, "too many shards to encode in QUIC connection id");
+    }
+}
+
+std::optional<unsigned> shard_from_server_cid(const uint8_t* cid, size_t len) noexcept {
+    if (len != server_short_cid_len || len < server_cid_shard_prefix_len) {
+        return std::nullopt;
+    }
+    auto shard = (static_cast<unsigned>(cid[0]) << 8) | static_cast<unsigned>(cid[1]);
+    if (shard >= this_smp_shard_count()) {
+        return std::nullopt;
+    }
+    return shard;
+}
+
 using transport_command = internal::transport_command;
 using quic_message = internal::quic_message;
 
@@ -757,7 +799,9 @@ public:
             throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
         }
 
-        _channel = engine().net().make_bound_datagram_channel(_cfg.listen_address);
+        _channel = engine().net().make_bound_datagram_channel(
+          _cfg.listen_address,
+          net::datagram_channel_options{.reuse_port = _cfg.reuse_port});
         _channel_ready = true;
         _listen_address = _channel.local_address();
         _started = true;
@@ -971,6 +1015,50 @@ private:
     }
 
     friend struct server_connection;
+    friend class seastar::quic::experimental::quic_server;
+
+    bool has_mapped_dcid(const uint8_t* cid, size_t len) const {
+        return _by_dcid.find(cid_key(cid, len)) != _by_dcid.end();
+    }
+
+    bool generate_server_cid_or_log(ngtcp2_cid& cid, size_t cidlen, const char* detail) const {
+        if (cidlen != server_short_cid_len) {
+            quic_server_log.warn("server refused to generate unexpected connection id length: requested={} expected={}",
+              cidlen, server_short_cid_len);
+            return false;
+        }
+
+        cid.datalen = cidlen;
+        for (size_t attempt = 0; attempt != server_cid_generation_attempts; ++attempt) {
+            if (!rand_server_cid_or_log(cid.data, cidlen, detail)) {
+                return false;
+            }
+            if (!has_mapped_dcid(cid.data, cid.datalen)) {
+                return true;
+            }
+            quic_server_log.debug("server generated duplicate connection id; retrying attempt={}", attempt + 1);
+        }
+
+        quic_server_log.warn("server failed to generate a unique connection id after {} attempts", server_cid_generation_attempts);
+        return false;
+    }
+
+    void generate_server_cid_or_throw(ngtcp2_cid& cid, size_t cidlen, const char* detail) const {
+        if (cidlen != server_short_cid_len) {
+            throw_quic_error(quic_error_code::internal, "unexpected QUIC connection id length requested");
+        }
+
+        cid.datalen = cidlen;
+        for (size_t attempt = 0; attempt != server_cid_generation_attempts; ++attempt) {
+            rand_server_cid_or_throw(cid.data, cidlen, detail);
+            if (!has_mapped_dcid(cid.data, cid.datalen)) {
+                return;
+            }
+            quic_server_log.debug("server generated duplicate connection id; retrying attempt={}", attempt + 1);
+        }
+
+        throw_quic_error(quic_error_code::internal, "failed to generate a unique QUIC connection id");
+    }
 
     static ngtcp2_conn* get_conn(ngtcp2_crypto_conn_ref* ref) {
         return static_cast<ngtcp2_conn*>(ref->user_data);
@@ -982,9 +1070,10 @@ private:
         }
     }
 
-    static int get_new_connection_id_cb(ngtcp2_conn*, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void*) {
-        cid->datalen = cidlen;
-        if (!rand_bytes_or_log(quic_server_log, "server", cid->data, cidlen, "connection id generation")) {
+    static int get_new_connection_id_cb(ngtcp2_conn*, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void* user_data) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        auto* server = conn ? conn->server_impl() : nullptr;
+        if (!server || !server->generate_server_cid_or_log(*cid, cidlen, "connection id generation")) {
             return NGTCP2_ERR_CALLBACK_FAILURE;
         }
         if (!rand_bytes_or_log(quic_server_log, "server", token, NGTCP2_STATELESS_RESET_TOKENLEN, "stateless reset token generation")) {
@@ -1271,8 +1360,7 @@ private:
 
         // Mint a server CID used to route later packets for this connection.
         ngtcp2_cid scid{};
-        scid.datalen = server_short_cid_len;
-        rand_bytes_or_throw(scid.data, scid.datalen, "connection id generation");
+        generate_server_cid_or_throw(scid, server_short_cid_len, "connection id generation");
 
         ngtcp2_callbacks callbacks{};
         callbacks.recv_client_initial = ngtcp2_crypto_recv_client_initial_cb;
@@ -1348,6 +1436,10 @@ private:
         if (_cfg.session_options.transport.max_udp_payload_size) {
             params.max_udp_payload_size = *_cfg.session_options.transport.max_udp_payload_size;
         }
+        // Sharded listeners route server-generated CIDs back to the owning
+        // shard if SO_REUSEPORT delivers a later packet elsewhere. Active
+        // migration is still disabled; the forwarding path handles rebinding,
+        // not deliberate peer migration to a new path.
         params.disable_active_migration = 1;
 
         ngtcp2_path path{};
@@ -1472,9 +1564,7 @@ private:
         }
     }
 
-    future<> handle_datagram(net::datagram d) {
-        auto src = d.get_src();
-        auto pkt = linearize_packet(d.get_buffers());
+    future<> handle_packet(socket_address src, temporary_buffer<char> pkt, bool allow_forward) {
         const auto* data = reinterpret_cast<const uint8_t*>(pkt.get());
         const size_t len = pkt.size();
         quic_server_log.trace("server received datagram: src={} bytes={}", src, len);
@@ -1495,6 +1585,15 @@ private:
         if (!conn) {
             // Unknown short-header packets cannot create server state; only Initial can.
             if (!parsed.long_header || parsed.long_type != quic_long_type::initial) {
+                if (allow_forward && _packet_router) {
+                    auto owner = shard_from_server_cid(parsed.dcid.data(), parsed.dcid_len);
+                    if (owner && *owner != this_shard_id()) {
+                        quic_server_log.debug("server forward datagram: src={} owner_shard={} current_shard={}",
+                          src, *owner, this_shard_id());
+                        co_await _packet_router->route_quic_packet(*owner, _listen_address, src, std::move(pkt));
+                        co_return;
+                    }
+                }
                 quic_server_log.debug("server drop datagram: unknown DCID and not Initial src={} long_header={} long_type={}",
                   src, parsed.long_header, static_cast<unsigned>(parsed.long_type));
                 co_return;
@@ -1519,6 +1618,18 @@ private:
         }
         conn->wake_actor();
         co_return;
+    }
+
+    void set_packet_router(internal::quic_packet_router* router) noexcept {
+        _packet_router = router;
+    }
+
+    future<> inject_datagram(socket_address src, temporary_buffer<char> pkt) {
+        co_await handle_packet(src, std::move(pkt), false);
+    }
+
+    future<> handle_datagram(net::datagram d) {
+        co_await handle_packet(d.get_src(), linearize_packet(d.get_buffers()), true);
     }
 
     future<> receive_loop() {
@@ -1555,6 +1666,7 @@ private:
     gate _task_gate;
     future<> _send_tail = make_ready_future<>();
     condition_variable _accept_cv;
+    internal::quic_packet_router* _packet_router = nullptr;
     std::deque<connection_state_ptr> _accepted;
     std::unordered_map<std::string, conn_ptr> _by_dcid;
     std::vector<conn_ptr> _conns;
@@ -1693,6 +1805,16 @@ future<connection> quic_server::accept() {
 
 socket_address quic_server::local_address() const noexcept {
     return _impl ? _impl->listen_address() : socket_address{};
+}
+
+void quic_server::set_packet_router(internal::quic_packet_router* router) noexcept {
+    if (_impl) {
+        _impl->set_packet_router(router);
+    }
+}
+
+future<> quic_server::inject_datagram(socket_address src, temporary_buffer<char> packet) {
+    co_await _impl->inject_datagram(src, std::move(packet));
 }
 
 future<> quic_server::stop() {

--- a/src/quic/quic_server.cc
+++ b/src/quic/quic_server.cc
@@ -64,8 +64,10 @@ namespace seastar::quic::experimental {
 namespace {
 
 constexpr size_t max_cid_len = 20;
-constexpr size_t server_short_cid_len = 16;
+constexpr size_t server_short_cid_len = max_cid_len;
 constexpr size_t server_cid_shard_prefix_len = 2;
+constexpr size_t server_cid_auth_tag_len = 8;
+constexpr size_t server_cid_authenticated_len = server_short_cid_len - server_cid_auth_tag_len;
 constexpr size_t server_cid_generation_attempts = 16;
 constexpr size_t max_udp_payload_size = 65527;
 constexpr size_t default_udp_payload_size = 1200;
@@ -85,22 +87,63 @@ bool encode_current_shard_in_server_cid(uint8_t* data, size_t len) noexcept {
     return true;
 }
 
-bool rand_server_cid_or_log(uint8_t* dest, size_t len, const char* detail) {
-    if (!rand_bytes_or_log(quic_server_log, "server", dest, len, detail)) {
+bool authenticate_server_cid(
+        const internal::quic_server_cid_key& key,
+        const uint8_t* cid,
+        size_t len) noexcept {
+    if (len != server_short_cid_len) {
         return false;
     }
-    return encode_current_shard_in_server_cid(dest, len);
-}
 
-void rand_server_cid_or_throw(uint8_t* dest, size_t len, const char* detail) {
-    rand_bytes_or_throw(dest, len, detail);
-    if (!encode_current_shard_in_server_cid(dest, len)) {
-        throw_quic_error(quic_error_code::unsupported, "too many shards to encode in QUIC connection id");
+    std::array<uint8_t, 32> digest{};
+    auto rv = gnutls_hmac_fast(
+      GNUTLS_MAC_SHA256,
+      key.data(),
+      key.size(),
+      cid,
+      server_cid_authenticated_len,
+      digest.data());
+    if (rv < 0) {
+        return false;
     }
+    return gnutls_memcmp(
+             cid + server_cid_authenticated_len,
+             digest.data(),
+             server_cid_auth_tag_len)
+           == 0;
 }
 
-std::optional<unsigned> shard_from_server_cid(const uint8_t* cid, size_t len) noexcept {
-    if (len != server_short_cid_len || len < server_cid_shard_prefix_len) {
+bool seal_server_cid(
+        const internal::quic_server_cid_key& key,
+        uint8_t* cid,
+        size_t len) noexcept {
+    if (len != server_short_cid_len || !encode_current_shard_in_server_cid(cid, len)) {
+        return false;
+    }
+
+    std::array<uint8_t, 32> digest{};
+    auto rv = gnutls_hmac_fast(
+      GNUTLS_MAC_SHA256,
+      key.data(),
+      key.size(),
+      cid,
+      server_cid_authenticated_len,
+      digest.data());
+    if (rv < 0) {
+        return false;
+    }
+    std::memcpy(
+      cid + server_cid_authenticated_len,
+      digest.data(),
+      server_cid_auth_tag_len);
+    return true;
+}
+
+std::optional<unsigned> shard_from_server_cid(
+        const internal::quic_server_cid_key& key,
+        const uint8_t* cid,
+        size_t len) noexcept {
+    if (!authenticate_server_cid(key, cid, len)) {
         return std::nullopt;
     }
     auto shard = (static_cast<unsigned>(cid[0]) << 8) | static_cast<unsigned>(cid[1]);
@@ -773,11 +816,19 @@ public:
         cleanup_resources();
     }
 
-    future<> start(quic_server_config cfg) {
+    future<> start(
+            quic_server_config cfg,
+            bool reuse_port,
+            std::optional<quic_server_cid_key> cid_key) {
         if (_started) {
             throw_quic_error(quic_error_code::invalid_state, "server already started");
         }
         ensure_gnutls_global();
+        if (cid_key) {
+            _cid_key = std::move(*cid_key);
+        } else {
+            rand_bytes_or_throw(_cid_key.data(), _cid_key.size(), "server CID routing key generation");
+        }
         validate_ip_socket_address(cfg.listen_address, "listen_address");
         validate_alpn_protocols(cfg.alpns);
         quic_server_log.info(
@@ -799,9 +850,9 @@ public:
             throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
         }
 
-        _channel = engine().net().make_bound_datagram_channel(
+        _channel = make_bound_datagram_channel(
           _cfg.listen_address,
-          net::datagram_channel_options{.reuse_port = _cfg.reuse_port});
+          net::datagram_channel_options{.reuse_port = reuse_port});
         _channel_ready = true;
         _listen_address = _channel.local_address();
         _started = true;
@@ -1030,7 +1081,11 @@ private:
 
         cid.datalen = cidlen;
         for (size_t attempt = 0; attempt != server_cid_generation_attempts; ++attempt) {
-            if (!rand_server_cid_or_log(cid.data, cidlen, detail)) {
+            if (!rand_bytes_or_log(quic_server_log, "server", cid.data, cidlen, detail)) {
+                return false;
+            }
+            if (!seal_server_cid(_cid_key, cid.data, cidlen)) {
+                quic_server_log.warn("server failed to authenticate generated connection id");
                 return false;
             }
             if (!has_mapped_dcid(cid.data, cid.datalen)) {
@@ -1050,7 +1105,13 @@ private:
 
         cid.datalen = cidlen;
         for (size_t attempt = 0; attempt != server_cid_generation_attempts; ++attempt) {
-            rand_server_cid_or_throw(cid.data, cidlen, detail);
+            rand_bytes_or_throw(cid.data, cidlen, detail);
+            if (!seal_server_cid(_cid_key, cid.data, cidlen)) {
+                if (this_shard_id() > std::numeric_limits<uint16_t>::max()) {
+                    throw_quic_error(quic_error_code::unsupported, "too many shards to encode in QUIC connection id");
+                }
+                throw_quic_error(quic_error_code::internal, "failed to authenticate generated QUIC connection id");
+            }
             if (!has_mapped_dcid(cid.data, cid.datalen)) {
                 return;
             }
@@ -1586,7 +1647,7 @@ private:
             // Unknown short-header packets cannot create server state; only Initial can.
             if (!parsed.long_header || parsed.long_type != quic_long_type::initial) {
                 if (allow_forward && _packet_router) {
-                    auto owner = shard_from_server_cid(parsed.dcid.data(), parsed.dcid_len);
+                    auto owner = shard_from_server_cid(_cid_key, parsed.dcid.data(), parsed.dcid_len);
                     if (owner && *owner != this_shard_id()) {
                         quic_server_log.debug("server forward datagram: src={} owner_shard={} current_shard={}",
                           src, *owner, this_shard_id());
@@ -1655,6 +1716,7 @@ private:
     }
 
     quic_server_config _cfg{};
+    quic_server_cid_key _cid_key{};
     gnutls_certificate_credentials_t _cred = nullptr;
     net::datagram_channel _channel{};
     bool _channel_ready = false;
@@ -1794,7 +1856,14 @@ quic_server& quic_server::operator=(quic_server&&) noexcept = default;
 
 future<> quic_server::start(quic_server_config config) {
     quic_server_log.debug("quic_server::start");
-    co_await _impl->start(std::move(config));
+    co_await _impl->start(std::move(config), false, std::nullopt);
+}
+
+future<> quic_server::start_shard(
+        quic_server_config config,
+        internal::quic_server_cid_key cid_key,
+        bool reuse_port) {
+    co_await _impl->start(std::move(config), reuse_port, std::move(cid_key));
 }
 
 future<connection> quic_server::accept() {

--- a/src/quic/quic_server.cc
+++ b/src/quic/quic_server.cc
@@ -1,0 +1,1703 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <seastar/quic/quic_server.hh>
+
+#include "quic_common.hh"
+#include "quic_impl.hh"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <deque>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gnutls/crypto.h>
+#include <gnutls/gnutls.h>
+
+#include <ngtcp2/ngtcp2.h>
+#include <ngtcp2/ngtcp2_crypto.h>
+#include <ngtcp2/ngtcp2_crypto_gnutls.h>
+
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/weak_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/log.hh>
+
+namespace seastar::quic::experimental {
+
+namespace {
+
+constexpr size_t max_cid_len = 20;
+constexpr size_t server_short_cid_len = 8;
+constexpr size_t max_udp_payload_size = 65527;
+constexpr size_t default_udp_payload_size = 1200;
+
+static logger quic_server_log("quic_server");
+using transport_command = internal::transport_command;
+using quic_message = internal::quic_message;
+
+std::string cid_key(const uint8_t* data, size_t len) {
+    // CIDs are opaque bytes; std::string is used here only as a binary map key.
+    return std::string(reinterpret_cast<const char*>(data), len);
+}
+
+enum class quic_long_type : uint8_t {
+    initial = 0,
+    zero_rtt = 1,
+    handshake = 2,
+    retry = 3,
+};
+
+struct dcid_parse_result {
+    bool ok = false;
+    bool long_header = false;
+    quic_long_type long_type = quic_long_type::initial;
+    std::array<uint8_t, max_cid_len> dcid{};
+    size_t dcid_len = 0;
+};
+
+dcid_parse_result parse_dcid(const uint8_t* pkt, size_t len, size_t short_dcid_len) {
+    // Parse just enough of the packet header to route it without decrypting it.
+    dcid_parse_result result{};
+    if (len < 1) {
+        return result;
+    }
+
+    const uint8_t long_header = (pkt[0] & 0x80u) != 0;
+    result.long_header = long_header;
+    if (long_header) {
+        if (len < 1 + 4 + 1) {
+            return result;
+        }
+
+        result.long_type = static_cast<quic_long_type>((pkt[0] >> 4) & 0x03u);
+        size_t off = 1 + 4;
+        const uint8_t cid_len = pkt[off++];
+        if (cid_len > result.dcid.size() || off + cid_len > len) {
+            return result;
+        }
+
+        std::memcpy(result.dcid.data(), pkt + off, cid_len);
+        result.dcid_len = cid_len;
+        result.ok = true;
+        return result;
+    }
+
+    if (len < 1 + short_dcid_len) {
+        return result;
+    }
+    std::memcpy(result.dcid.data(), pkt + 1, short_dcid_len);
+    result.dcid_len = short_dcid_len;
+    result.ok = true;
+    return result;
+}
+
+struct conn_rx_event {
+    socket_address src;
+    temporary_buffer<char> packet;
+};
+
+struct server_connection;
+void sync_current_path(server_connection& conn);
+
+// Per-peer server-side transport state created after the first Initial packet.
+struct server_connection final : public enable_lw_shared_from_this<server_connection>, public internal::connection_transport {
+    weak_ptr<internal::quic_server_impl> server;
+    internal::command_runtime_ptr command_runtime;
+    internal::connection_state_ptr connection_state;
+
+    ngtcp2_conn* conn = nullptr;
+    ngtcp2_crypto_conn_ref conn_ref{};
+    gnutls_session_t tls = nullptr;
+
+    socket_address peer{};
+    sockaddr_storage local_ss{};
+    socklen_t local_ss_len = 0;
+    sockaddr_storage peer_ss{};
+    socklen_t peer_ss_len = 0;
+
+    queue<conn_rx_event> rx_queue{1024};
+    bool queues_aborted = false;
+    bool unregistered = false;
+    bool stop_requested = false;
+    std::optional<quic_error_code> stop_error;
+    sstring stop_error_detail;
+
+    bool closing = false;
+    bool handshake_done = false;
+    bool accepted_to_listener = false;
+    size_t tx_payload_limit = default_udp_payload_size;
+    temporary_buffer<char> tx_packet_scratch;
+    std::unordered_map<stream_id, std::deque<transport_command>> blocked_send_commands;
+    std::deque<stream_id> blocked_send_retry_streams;
+    std::unordered_set<stream_id> blocked_send_retry_requested;
+    struct retained_stream_data {
+        uint64_t offset = 0;
+        temporary_buffer<char> payload;
+    };
+    std::unordered_map<stream_id, uint64_t> next_stream_send_offsets;
+    std::unordered_map<stream_id, std::deque<retained_stream_data>> retained_stream_data_by_stream;
+    std::unordered_set<std::string> mapped_dcids;
+
+    server_connection() = default;
+
+    ~server_connection() override {
+        // Complete pending user promises before tearing down ngtcp2-owned callbacks.
+        fail_blocked_open_streams(quic_error_code::closed, "server connection destroyed");
+        discard_blocked_send();
+        abort_event_queues("server connection destroyed");
+        if (command_runtime) {
+            command_runtime->set_command_notifier({});
+        }
+        wake_actor();
+        if (conn) {
+            ngtcp2_conn_del(conn);
+            conn = nullptr;
+        }
+        if (tls) {
+            gnutls_deinit(tls);
+            tls = nullptr;
+        }
+    }
+
+    void fill_path(ngtcp2_path& path) {
+        init_ngtcp2_addr(&path.local, reinterpret_cast<sockaddr*>(&local_ss), local_ss_len);
+        init_ngtcp2_addr(&path.remote, reinterpret_cast<sockaddr*>(&peer_ss), peer_ss_len);
+    }
+
+    internal::quic_server_impl* server_impl() const noexcept {
+        return server.get();
+    }
+
+    bool transport_active() const noexcept override {
+        return active();
+    }
+
+    bool has_transport_connection() const noexcept override {
+        return conn != nullptr;
+    }
+
+    bool can_retry_blocked_open_streams() const noexcept override {
+        // Server streams can open as soon as the connection is active; no client-side
+        // handshake promise gate is needed here.
+        return active() && !stop_requested;
+    }
+
+    size_t tx_payload_limit_bytes() const noexcept override {
+        return tx_payload_limit;
+    }
+
+    bool has_blocked_send() const noexcept {
+        return !blocked_send_commands.empty();
+    }
+
+    bool blocked_send_retry_pending() const noexcept {
+        return !blocked_send_retry_streams.empty();
+    }
+
+    bool has_pending_actor_work() const noexcept {
+        // Keep the server actor wake predicate aligned with the client actor.
+        return stop_requested
+               || (command_runtime && command_runtime->transport_terminal())
+               || !rx_queue.empty()
+               || blocked_send_retry_pending()
+               || (command_runtime && command_runtime->has_pending_commands())
+               || connection_state->tick_pending()
+               || connection_state->has_blocked_open_stream_retry_work();
+    }
+
+    future<> wait_for_actor_wakeup() {
+        // Shared connection state owns wakeups from timers and stream callbacks.
+        return connection_state->wait_for_actor_wakeup(has_pending_actor_work(), closing);
+    }
+
+    void wake_actor() {
+        connection_state->wake_actor();
+    }
+
+    void retain_stream_data(stream_id sid, temporary_buffer<char> payload) override {
+        if (sid == invalid_stream_id || payload.empty()) {
+            return;
+        }
+        auto& next_offset = next_stream_send_offsets[sid];
+        auto size = payload.size();
+        // Retain sent bytes until ACK callbacks retire them by stream offset.
+        retained_stream_data_by_stream[sid].push_back(retained_stream_data{
+          .offset = next_offset,
+          .payload = std::move(payload),
+        });
+        next_offset += size;
+    }
+
+    void acked_stream_data(stream_id sid, uint64_t offset, uint64_t datalen) {
+        // ACK callbacks retire retained buffers by byte range, not by send command.
+        auto it = retained_stream_data_by_stream.find(sid);
+        if (it == retained_stream_data_by_stream.end() || !datalen) {
+            return;
+        }
+        auto end = offset + datalen;
+        auto& retained = it->second;
+        while (!retained.empty()) {
+            auto& front = retained.front();
+            auto front_end = front.offset + front.payload.size();
+            if (front_end <= end) {
+                retained.pop_front();
+                continue;
+            }
+            if (front.offset < end) {
+                front.payload.trim_front(static_cast<size_t>(end - front.offset));
+                front.offset = end;
+            }
+            break;
+        }
+        if (retained.empty()) {
+            retained_stream_data_by_stream.erase(it);
+        }
+    }
+
+    void release_stream_data(stream_id sid) {
+        retained_stream_data_by_stream.erase(sid);
+        next_stream_send_offsets.erase(sid);
+    }
+
+    int64_t write_pending_packet(uint8_t* outbuf, size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        // Flush transport-only frames even when no application write is pending.
+        return ngtcp2_conn_write_pkt(conn, &path, &pkt_info, outbuf, outbuf_size, quic_now_ns());
+    }
+
+    internal::transport_stream_write_result write_stream_packet(
+      stream_id sid,
+      const char* data,
+      size_t len,
+      bool fin,
+      uint8_t* outbuf,
+      size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        ngtcp2_vec vec{};
+        ngtcp2_ssize consumed = 0;
+        if (data && len) {
+            vec.base = reinterpret_cast<uint8_t*>(const_cast<char*>(data));
+            vec.len = len;
+        }
+        auto flags = (!len && fin) ? NGTCP2_WRITE_STREAM_FLAG_FIN : 0;
+        auto nwrite = ngtcp2_conn_writev_stream(
+          conn,
+          &path,
+          &pkt_info,
+          outbuf,
+          outbuf_size,
+          &consumed,
+          flags,
+          sid,
+          (data && len) ? &vec : nullptr,
+          (data && len) ? 1 : 0,
+          quic_now_ns());
+        return internal::transport_stream_write_result{
+          .nwrite = nwrite,
+          .consumed = consumed > 0 ? static_cast<size_t>(consumed) : 0,
+        };
+    }
+
+    void complete_send_bytes(size_t len) override {
+        if (command_runtime) {
+            command_runtime->complete_send_bytes(len);
+        }
+    }
+
+    internal::transport_open_stream_result try_open_stream(stream_type type) override {
+        int64_t sid = invalid_stream_id;
+        auto rv = type == stream_type::bidirectional
+                    ? ngtcp2_conn_open_bidi_stream(conn, &sid, nullptr)
+                    : ngtcp2_conn_open_uni_stream(conn, &sid, nullptr);
+        return internal::transport_open_stream_result{
+          .rv = rv,
+          .sid = sid,
+        };
+    }
+
+    int shutdown_stream_write(stream_id sid, application_error_code app_error_code) override {
+        return ngtcp2_conn_shutdown_stream_write(conn, 0, sid, app_error_code);
+    }
+
+    int consume_stream_data(stream_id sid, size_t len) override {
+        if (!conn || !len) {
+            return 0;
+        }
+        auto rv = ngtcp2_conn_extend_max_stream_offset(conn, sid, static_cast<uint64_t>(len));
+        if (rv < 0) {
+            return rv;
+        }
+        ngtcp2_conn_extend_max_offset(conn, static_cast<uint64_t>(len));
+        return 0;
+    }
+
+    int shutdown_stream_read(stream_id sid, application_error_code app_error_code) override {
+        return ngtcp2_conn_shutdown_stream_read(conn, 0, sid, app_error_code);
+    }
+
+    int read_transport_datagram(const socket_address& src, const char* data, size_t len) override {
+        sockaddr_storage peer_addr_ss{};
+        socklen_t peer_addr_ss_len = 0;
+        to_sockaddr_storage(src, peer_addr_ss, peer_addr_ss_len);
+
+        ngtcp2_path path{};
+        init_ngtcp2_addr(&path.local, reinterpret_cast<sockaddr*>(&local_ss), local_ss_len);
+        init_ngtcp2_addr(&path.remote, reinterpret_cast<sockaddr*>(&peer_addr_ss), peer_addr_ss_len);
+        ngtcp2_pkt_info pkt_info{};
+        return ngtcp2_conn_read_pkt(
+          conn,
+          &path,
+          &pkt_info,
+          reinterpret_cast<const uint8_t*>(data),
+          len,
+          quic_now_ns());
+    }
+
+    void sync_transport_path() override {
+        sync_current_path(*this);
+    }
+
+    uint64_t transport_expiry_ns() const noexcept override {
+        return ngtcp2_conn_get_expiry(conn);
+    }
+
+    int handle_transport_expiry(uint64_t now_local) override {
+        return ngtcp2_conn_handle_expiry(conn, now_local);
+    }
+
+    temporary_buffer<char>& tx_packet_buffer() override {
+        return tx_packet_scratch;
+    }
+
+    future<> send_datagram_packet(temporary_buffer<char> packet) override;
+
+    bool can_send_connection_close() const noexcept override;
+
+    int64_t write_connection_close_packet(uint8_t* outbuf, size_t outbuf_size) override {
+        ngtcp2_path path{};
+        fill_path(path);
+        ngtcp2_pkt_info pkt_info{};
+        ngtcp2_ccerr ccerr{};
+        ngtcp2_ccerr_default(&ccerr);
+        ngtcp2_ccerr_set_application_error(&ccerr, 0, nullptr, 0);
+        return ngtcp2_conn_write_connection_close(
+          conn,
+          &path,
+          &pkt_info,
+          outbuf,
+          outbuf_size,
+          &ccerr,
+          quic_now_ns());
+    }
+
+    void on_stream_write_closed(stream_id sid) override {
+        if (!connection_state || !conn) {
+            return;
+        }
+        auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+        connection_state->on_stream_stop_sending(sid, type, peer_initiated, 0, internal::stream_shutdown_side::write);
+    }
+
+    void rearm_transport_timer() override {
+        // Store timer state in connection_state so callbacks can wake the actor.
+        if (!connection_state) {
+            return;
+        }
+        if (!conn) {
+            connection_state->cancel_timer();
+            return;
+        }
+        connection_state->rearm_timer_from_expiry(ngtcp2_conn_get_expiry(conn), quic_now_ns(), closing);
+    }
+
+    void request_close() override {
+        request_stop();
+    }
+
+    void cancel_transport_timer() {
+        if (connection_state) {
+            connection_state->cancel_timer();
+        }
+    }
+
+    void abort_event_queues(const char* why) {
+        if (queues_aborted) {
+            return;
+        }
+        queues_aborted = true;
+        auto ex = std::make_exception_ptr(std::runtime_error(why));
+        rx_queue.abort(ex);
+    }
+
+    void complete_open_stream(internal::open_stream_result_ptr result, stream_id sid) override {
+        if (command_runtime) {
+            command_runtime->complete_open_stream(std::move(result), sid);
+        }
+    }
+
+    void fail_open_stream(
+      internal::open_stream_result_ptr result,
+      quic_error_code error,
+      sstring detail) override {
+        if (command_runtime) {
+            command_runtime->fail_open_stream(std::move(result), error, std::move(detail));
+        }
+    }
+
+    bool blocked_open_stream_retry_pending(stream_type type) const noexcept override {
+        return connection_state->blocked_open_stream_retry_pending(type);
+    }
+
+    void defer_blocked_open_stream(transport_command cmd) override {
+        connection_state->defer_blocked_open_stream(std::move(cmd));
+    }
+
+    std::optional<transport_command> pop_blocked_open_stream(stream_type type) override {
+        return connection_state->pop_blocked_open_stream(type);
+    }
+
+    void request_blocked_open_stream_retry(stream_type type) {
+        connection_state->request_blocked_open_stream_retry(type);
+    }
+
+    void defer_blocked_send(transport_command cmd) {
+        blocked_send_commands[cmd.msg.stream].push_back(std::move(cmd));
+    }
+
+    void defer_retried_blocked_send(transport_command cmd) {
+        blocked_send_commands[cmd.msg.stream].push_front(std::move(cmd));
+    }
+
+    bool has_blocked_send_for_stream(stream_id sid) const noexcept {
+        return blocked_send_commands.find(sid) != blocked_send_commands.end();
+    }
+
+    std::optional<transport_command> take_blocked_send() {
+        while (!blocked_send_retry_streams.empty()) {
+            auto sid = blocked_send_retry_streams.front();
+            blocked_send_retry_streams.pop_front();
+            blocked_send_retry_requested.erase(sid);
+
+            auto it = blocked_send_commands.find(sid);
+            if (it == blocked_send_commands.end() || it->second.empty()) {
+                continue;
+            }
+
+            auto cmd = std::move(it->second.front());
+            it->second.pop_front();
+            if (it->second.empty()) {
+                blocked_send_commands.erase(it);
+            }
+            return cmd;
+        }
+        return std::nullopt;
+    }
+
+    void request_blocked_send_retry() {
+        for (auto& [sid, commands] : blocked_send_commands) {
+            if (commands.empty() || blocked_send_retry_requested.contains(sid)) {
+                continue;
+            }
+            blocked_send_retry_requested.insert(sid);
+            blocked_send_retry_streams.push_back(sid);
+        }
+        if (!blocked_send_retry_streams.empty()) {
+            wake_actor();
+        }
+    }
+
+    void request_blocked_send_retry(stream_id sid) {
+        auto it = blocked_send_commands.find(sid);
+        if (it == blocked_send_commands.end() || it->second.empty() || blocked_send_retry_requested.contains(sid)) {
+            return;
+        }
+        blocked_send_retry_requested.insert(sid);
+        blocked_send_retry_streams.push_back(sid);
+        wake_actor();
+    }
+
+    void discard_blocked_send() {
+        for (auto& [_, commands] : blocked_send_commands) {
+            for (auto& cmd : commands) {
+                complete_send_bytes(cmd.msg.payload.size());
+            }
+        }
+        blocked_send_commands.clear();
+        blocked_send_retry_streams.clear();
+        blocked_send_retry_requested.clear();
+    }
+
+    void clear_blocked_open_stream_retry(stream_type type) noexcept override {
+        connection_state->clear_blocked_open_stream_retry(type);
+    }
+
+    void fail_blocked_open_streams(quic_error_code error, std::string_view detail) {
+        if (!connection_state) {
+            return;
+        }
+        connection_state->fail_blocked_open_streams(error, detail);
+    }
+
+    void request_stop() {
+        // Public close requests only schedule actor work; cleanup happens later.
+        if (closing || stop_requested) {
+            return;
+        }
+        stop_requested = true;
+        fail_blocked_open_streams(quic_error_code::closed, "server connection stopping");
+        cancel_transport_timer();
+        wake_actor();
+    }
+
+    bool active() const noexcept;
+    bool actor_active() const noexcept {
+        return active();
+    }
+    bool actor_has_pending_work() const noexcept {
+        return has_pending_actor_work();
+    }
+    future<> actor_wait_for_wakeup() {
+        return wait_for_actor_wakeup();
+    }
+    bool actor_stop_requested() const noexcept {
+        return stop_requested;
+    }
+    future<> actor_handle_stop_request();
+    bool actor_transport_terminal() const noexcept {
+        return command_runtime && command_runtime->transport_terminal();
+    }
+    future<> actor_handle_transport_terminal() {
+        if (!command_runtime) {
+            co_return;
+        }
+        if (command_runtime->transport_failed()) {
+            fail(command_runtime->transport_error(), command_runtime->transport_error_detail());
+        } else {
+            stop_transport();
+        }
+        co_return;
+    }
+    bool actor_has_rx_event() const noexcept {
+        return !rx_queue.empty();
+    }
+    future<> actor_handle_next_rx_event();
+    bool actor_has_transport_command() const noexcept {
+        return blocked_send_retry_pending()
+               || (command_runtime && command_runtime->has_pending_commands());
+    }
+    future<> actor_handle_next_transport_command() {
+        // This mirrors the client command path so common helpers can stay transport-agnostic.
+        std::optional<transport_command> cmd;
+        bool retrying_blocked_send = false;
+        // Retry a blocked send before taking a new command so the connection keeps
+        // its original send ordering for that stream.
+        if (blocked_send_retry_pending()) {
+            cmd = take_blocked_send();
+            retrying_blocked_send = cmd.has_value();
+        } else if (!has_blocked_send() && command_runtime) {
+            cmd = command_runtime->poll_command();
+        } else if (command_runtime) {
+            cmd = command_runtime->poll_command();
+        }
+        if (!cmd) {
+            co_return;
+        }
+        if (!retrying_blocked_send
+            && cmd->op == transport_command::kind::send
+            && has_blocked_send_for_stream(cmd->msg.stream)) {
+            auto blocked_stream = cmd->msg.stream;
+            defer_blocked_send(std::move(*cmd));
+            request_blocked_send_retry(blocked_stream);
+            co_return;
+        }
+        auto blocked_stream = cmd->msg.stream;
+        auto blocked = co_await internal::handle_transport_command(*this, std::move(*cmd));
+        if (blocked) {
+            if (retrying_blocked_send) {
+                defer_retried_blocked_send(std::move(*blocked));
+            } else {
+                defer_blocked_send(std::move(*blocked));
+            }
+        } else if (retrying_blocked_send) {
+            request_blocked_send_retry(blocked_stream);
+        }
+    }
+    future<> actor_retry_blocked_open_streams() {
+        co_await internal::retry_blocked_open_streams(*this, stream_type::bidirectional);
+        co_await internal::retry_blocked_open_streams(*this, stream_type::unidirectional);
+    }
+    bool actor_tick_pending() const noexcept {
+        return connection_state->tick_pending();
+    }
+    void actor_clear_tick() noexcept {
+        connection_state->clear_tick();
+    }
+    future<> actor_handle_timer_tick();
+    void stop_transport() override;
+    void fail(quic_error_code error, const sstring& detail);
+    void fail_transport(quic_error_code error, sstring detail) override;
+};
+
+using conn_ptr = lw_shared_ptr<server_connection>;
+
+void sync_current_path(server_connection& conn) {
+    // Path migration updates the cached peer address used for later sends.
+    if (!conn.conn) {
+        return;
+    }
+
+    const auto* path = ngtcp2_conn_get_path(conn.conn);
+    if (!path) {
+        return;
+    }
+
+    auto local = to_socket_address(path->local);
+    auto remote = to_socket_address(path->remote);
+    if (!local || !remote) {
+        return;
+    }
+
+    auto old_local = to_socket_address(ngtcp2_addr{
+      reinterpret_cast<ngtcp2_sockaddr*>(&conn.local_ss),
+      static_cast<ngtcp2_socklen>(conn.local_ss_len),
+    });
+
+    if ((!old_local || *local == *old_local) && *remote == conn.peer) {
+        return;
+    }
+
+    quic_server_log.info("server active path updated: old_local={} old_remote={} new_local={} new_remote={}",
+      old_local.value_or(socket_address{}),
+      conn.peer,
+      *local,
+      *remote);
+
+    conn.peer = *remote;
+    to_sockaddr_storage(*local, conn.local_ss, conn.local_ss_len);
+    to_sockaddr_storage(conn.peer, conn.peer_ss, conn.peer_ss_len);
+}
+
+} // namespace
+
+namespace internal {
+
+// Owns the listener socket and tracks the set of active server-side connections.
+class quic_server_impl final : public enable_lw_shared_from_this<quic_server_impl>, public weakly_referencable<quic_server_impl> {
+public:
+    quic_server_impl() = default;
+    ~quic_server_impl() {
+        request_stop_detached();
+        cleanup_resources();
+    }
+
+    future<> start(quic_server_config cfg) {
+        if (_started) {
+            throw_quic_error(quic_error_code::invalid_state, "server already started");
+        }
+        ensure_gnutls_global();
+        validate_ip_socket_address(cfg.listen_address, "listen_address");
+        validate_alpn_protocols(cfg.alpns);
+        quic_server_log.info(
+          "server start: listen={} crt_file='{}' key_file='{}' alpn_count={}",
+          cfg.listen_address,
+          cfg.crt_file,
+          cfg.key_file,
+          cfg.alpns.size());
+
+        _cfg = std::move(cfg);
+        int rv = gnutls_certificate_allocate_credentials(&_cred);
+        if (rv < 0) {
+            throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+
+        rv = gnutls_certificate_set_x509_key_file(
+          _cred, _cfg.crt_file.c_str(), _cfg.key_file.c_str(), GNUTLS_X509_FMT_PEM);
+        if (rv < 0) {
+            throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+
+        _channel = engine().net().make_bound_datagram_channel(_cfg.listen_address);
+        _channel_ready = true;
+        _listen_address = _channel.local_address();
+        _started = true;
+        _stopping = false;
+        quic_server_log.info("server listening on {}", _listen_address);
+
+        auto self = shared_from_this();
+        (void)with_gate(_task_gate, [self] { return self->receive_loop(); })
+          .handle_exception([self](std::exception_ptr) {
+              if (!self->_stopping) {
+                  quic_server_log.error("server receive loop failed");
+                  self->_stopping = true;
+                  self->_accept_cv.broadcast();
+              }
+          })
+          .or_terminate();
+        co_return;
+    }
+
+    future<connection_state_ptr> accept() {
+        if (!_started) {
+            throw_quic_error(quic_error_code::invalid_state, "server is not started");
+        }
+        quic_server_log.debug("server accept wait: pending_accepted={} active_conns={}", _accepted.size(), _conns.size());
+
+        while (_accepted.empty()) {
+            if (_stopping) {
+                throw_quic_error(quic_error_code::closed, "server stopped");
+            }
+            co_await _accept_cv.wait();
+        }
+
+        auto connection_state = std::move(_accepted.front());
+        _accepted.pop_front();
+        quic_server_log.info("server accept ready: pending_accepted={} active_conns={}", _accepted.size(), _conns.size());
+        co_return connection_state;
+    }
+
+    future<> stop() {
+        if (!_started) {
+            quic_server_log.debug("server stop ignored: not started");
+            co_return;
+        }
+
+        quic_server_log.info(
+          "server stop start: listen={} active_conns={} pending_accepted={} mapped_dcids={}",
+          _listen_address,
+          _conns.size(),
+          _accepted.size(),
+          _by_dcid.size());
+        request_stop();
+
+        co_await _task_gate.close();
+
+        cleanup_resources();
+        _started = false;
+        _stopping = false;
+        quic_server_log.info("server stop complete");
+    }
+
+    bool stopping() const noexcept {
+        return _stopping;
+    }
+
+    void request_stop() noexcept {
+        request_stop_impl(false);
+    }
+
+    void request_stop_detached() noexcept {
+        request_stop_impl(true);
+    }
+
+private:
+    void request_stop_impl(bool detached) noexcept {
+        if (!_started || _stopping) {
+            return;
+        }
+
+        if (detached) {
+            quic_server_log.warn("quic_server destroyed or orphaned without awaiting stop(); shutting down detached");
+        }
+        _stopping = true;
+        _accept_cv.broadcast();
+
+        auto conns_copy = _conns;
+        for (auto& conn : conns_copy) {
+            conn->stop_transport();
+        }
+
+        if (_channel_ready && !_channel.is_closed()) {
+            try {
+                _channel.shutdown_input();
+            } catch (...) {
+            }
+        }
+    }
+
+public:
+    net::datagram_channel& channel() {
+        return _channel;
+    }
+
+    future<> send_datagram_packet(const socket_address& dst, temporary_buffer<char> packet) {
+        if (packet.empty()) {
+            return make_ready_future<>();
+        }
+
+        promise<> done;
+        auto result = done.get_future();
+
+        _send_tail = std::move(_send_tail).then_wrapped(
+          [this, dst, packet = std::move(packet), done = std::move(done)] (future<> previous) mutable {
+              try {
+                  previous.get();
+              } catch (...) {
+                  quic_server_log.debug("server udp send chain observed previous send failure");
+              }
+
+              return send_datagram(quic_server_log, _channel, dst, std::move(packet))
+                .then_wrapped([done = std::move(done)] (future<> send_result) mutable {
+                    try {
+                        send_result.get();
+                        done.set_value();
+                    } catch (...) {
+                        done.set_exception(std::current_exception());
+                    }
+                    return make_ready_future<>();
+                });
+          });
+
+        return result;
+    }
+
+    void map_dcid(const conn_ptr& conn, const uint8_t* cid, size_t len) {
+        // Multiple DCIDs can route to the same connection during migration/rotation.
+        auto key = cid_key(cid, len);
+        _by_dcid[key] = conn;
+        conn->mapped_dcids.insert(std::move(key));
+        quic_server_log.debug("server map DCID: len={} total_mapped={} conn_mapped={}", len, _by_dcid.size(), conn->mapped_dcids.size());
+    }
+
+    void unmap_dcid(const conn_ptr& conn, const uint8_t* cid, size_t len) {
+        auto key = cid_key(cid, len);
+        auto it = _by_dcid.find(key);
+        if (it != _by_dcid.end() && it->second == conn) {
+            _by_dcid.erase(it);
+        }
+        conn->mapped_dcids.erase(key);
+        quic_server_log.debug("server unmap DCID: len={} total_mapped={} conn_mapped={}", len, _by_dcid.size(), conn->mapped_dcids.size());
+    }
+
+    void unregister_connection(const conn_ptr& conn) {
+        // Idempotent unregister lets failure, stop and actor-abort paths converge.
+        if (!conn || conn->unregistered) {
+            return;
+        }
+        conn->unregistered = true;
+        quic_server_log.info("server unregister connection: peer={} mapped_dcids={} active_conns_before={}", conn->peer, conn->mapped_dcids.size(), _conns.size());
+        for (const auto& key : conn->mapped_dcids) {
+            auto it = _by_dcid.find(key);
+            if (it != _by_dcid.end() && it->second == conn) {
+                _by_dcid.erase(it);
+            }
+        }
+        conn->mapped_dcids.clear();
+
+        _conns.erase(std::remove(_conns.begin(), _conns.end(), conn), _conns.end());
+        quic_server_log.info("server connection unregistered: active_conns={} mapped_dcids={}", _conns.size(), _by_dcid.size());
+    }
+
+    void enqueue_accepted_session(const connection_state_ptr& connection_state) {
+        // Listener accept observes handshake-ready connections, not raw Initial packets.
+        _accepted.push_back(connection_state);
+        quic_server_log.debug("server queued accepted session: pending_accepted={}", _accepted.size());
+        _accept_cv.signal();
+    }
+
+    gnutls_certificate_credentials_t credentials() const {
+        return _cred;
+    }
+
+    const quic_server_config& config() const {
+        return _cfg;
+    }
+
+    const socket_address& listen_address() const {
+        return _listen_address;
+    }
+
+private:
+    void cleanup_resources() noexcept {
+        if (_channel_ready && !_channel.is_closed()) {
+            try {
+                _channel.shutdown_output();
+            } catch (...) {
+            }
+            try {
+                _channel.close();
+            } catch (...) {
+            }
+        }
+
+        _conns.clear();
+        _by_dcid.clear();
+        _accepted.clear();
+        if (_cred) {
+            gnutls_certificate_free_credentials(_cred);
+            _cred = nullptr;
+        }
+        _channel_ready = false;
+    }
+
+    friend struct server_connection;
+
+    static ngtcp2_conn* get_conn(ngtcp2_crypto_conn_ref* ref) {
+        return static_cast<ngtcp2_conn*>(ref->user_data);
+    }
+
+    static void rand_cb(uint8_t* dest, size_t len, const ngtcp2_rand_ctx*) {
+        if (!rand_bytes_or_log(quic_server_log, "server", dest, len, "ngtcp2 rand callback")) {
+            std::terminate();
+        }
+    }
+
+    static int get_new_connection_id_cb(ngtcp2_conn*, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void*) {
+        cid->datalen = cidlen;
+        if (!rand_bytes_or_log(quic_server_log, "server", cid->data, cidlen, "connection id generation")) {
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+        }
+        if (!rand_bytes_or_log(quic_server_log, "server", token, NGTCP2_STATELESS_RESET_TOKENLEN, "stateless reset token generation")) {
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+        }
+        return 0;
+    }
+
+    static int get_path_challenge_data_cb(ngtcp2_conn*, uint8_t* data, void*) {
+        if (!rand_bytes_or_log(quic_server_log, "server", data, 8, "path challenge generation")) {
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+        }
+        return 0;
+    }
+
+    static sstring selected_alpn_or_empty(gnutls_session_t tls) {
+        gnutls_datum_t selected{};
+        if (gnutls_alpn_get_selected_protocol(tls, &selected) != 0 || !selected.data) {
+            return {};
+        }
+        return {reinterpret_cast<const char*>(selected.data), selected.size};
+    }
+
+    static int handshake_completed_cb(ngtcp2_conn*, void* user_data) {
+        // Accept queues see the connection only after TLS and QUIC handshakes complete.
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !conn->command_runtime) {
+            return 0;
+        }
+        auto selected_alpn = selected_alpn_or_empty(conn->tls);
+        if (selected_alpn.empty()) {
+            constexpr std::string_view detail = "TLS handshake completed without a negotiated ALPN protocol";
+            quic_server_log.warn("server handshake verification failed: peer={} detail='{}'", conn->peer, detail);
+            conn->fail(quic_error_code::protocol, sstring(detail));
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+        }
+        auto server = conn->server_impl();
+        conn->handshake_done = true;
+        sync_current_path(*conn);
+        conn->command_runtime->mark_transport_ready(
+          to_socket_address(ngtcp2_conn_get_path(conn->conn)->local).value_or(
+            server ? server->listen_address() : socket_address{}),
+          conn->peer,
+          std::move(selected_alpn));
+        if (!conn->accepted_to_listener && server && conn->connection_state) {
+            conn->accepted_to_listener = true;
+            server->enqueue_accepted_session(conn->connection_state);
+        }
+        quic_server_log.info("server handshake completed: peer={} alpn='{}'", conn->peer, conn->command_runtime->selected_alpn());
+        conn->wake_actor();
+        conn->rearm_transport_timer();
+        return 0;
+    }
+
+    static int begin_path_validation_cb(ngtcp2_conn*, uint32_t, const ngtcp2_path* path, const ngtcp2_path*, void* user_data) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !path) {
+            return 0;
+        }
+
+        auto remote = to_socket_address(path->remote);
+        if (remote) {
+            quic_server_log.info("server begin path validation: peer={} candidate_remote={}", conn->peer, *remote);
+        }
+        return 0;
+    }
+
+    static int path_validation_cb(
+      ngtcp2_conn*,
+      uint32_t,
+      const ngtcp2_path* path,
+      const ngtcp2_path* fallback_path,
+      ngtcp2_path_validation_result res,
+      void* user_data) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn) {
+            return 0;
+        }
+
+        auto candidate = path ? to_socket_address(path->remote) : std::nullopt;
+        auto fallback = fallback_path ? to_socket_address(fallback_path->remote) : std::nullopt;
+        quic_server_log.info("server path validation complete: peer={} result={} candidate_remote={} fallback_remote={}",
+          conn->peer,
+          res == NGTCP2_PATH_VALIDATION_RESULT_SUCCESS ? "success" : "failure",
+          candidate.value_or(socket_address{}),
+          fallback.value_or(socket_address{}));
+
+        sync_current_path(*conn);
+        return 0;
+    }
+
+    static int dcid_status_cb(ngtcp2_conn*, ngtcp2_connection_id_status_type type, uint64_t, const ngtcp2_cid* cid, const uint8_t*, void* user_data) {
+        // ngtcp2 tells us when a routed DCID becomes usable or retired.
+        auto* conn = static_cast<server_connection*>(user_data);
+        auto server = conn ? conn->server_impl() : nullptr;
+        if (!conn || !server || !cid) {
+            return 0;
+        }
+        auto self = conn->shared_from_this();
+        if (type == NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE) {
+            quic_server_log.debug("server dcid activate: peer={} len={}", conn->peer, cid->datalen);
+            server->map_dcid(self, cid->data, cid->datalen);
+        } else if (type == NGTCP2_CONNECTION_ID_STATUS_TYPE_DEACTIVATE) {
+            quic_server_log.debug("server dcid deactivate: peer={} len={}", conn->peer, cid->datalen);
+            server->unmap_dcid(self, cid->data, cid->datalen);
+        }
+        return 0;
+    }
+
+    static int recv_stream_data_cb(ngtcp2_conn* ngconn, uint32_t flags, int64_t sid, uint64_t, const uint8_t* data, size_t datalen, void* user_data, void*) {
+        // Stream callbacks translate ngtcp2 ids into the public connection_state model.
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !conn->connection_state || !conn->connection_state->is_open()) {
+            quic_server_log.trace("server drop recv_stream_data: sid={} bytes={} conn_valid={} engine_open={}",
+              sid, datalen, conn != nullptr, conn && conn->connection_state && conn->connection_state->is_open());
+            return 0;
+        }
+        quic_server_log.trace("server recv_stream_data: peer={} sid={} bytes={}", conn->peer, sid, datalen);
+        auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(ngconn, sid);
+        temporary_buffer<char> tb(datalen);
+        if (datalen) {
+            std::memcpy(tb.get_write(), data, datalen);
+        }
+        conn->connection_state->on_stream_data(sid, type, peer_initiated, std::move(tb), (flags & NGTCP2_STREAM_DATA_FLAG_FIN) != 0);
+        return 0;
+    }
+
+    static int stream_reset_cb(ngtcp2_conn* ngconn, int64_t sid, uint64_t, uint64_t app_error_code, void* user_data, void*) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !conn->connection_state) {
+            return 0;
+        }
+        auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(ngconn, sid);
+        conn->connection_state->on_stream_reset(sid, type, peer_initiated, app_error_code);
+        return 0;
+    }
+
+    static int stream_stop_sending_cb(ngtcp2_conn* ngconn, int64_t sid, uint64_t app_error_code, void* user_data, void*) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !conn->connection_state) {
+            return 0;
+        }
+        auto type = ngtcp2_is_bidi_stream(sid) ? stream_type::bidirectional : stream_type::unidirectional;
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(ngconn, sid);
+        conn->connection_state->on_stream_stop_sending(sid, type, peer_initiated, app_error_code, stream_shutdown_side::write);
+        return 0;
+    }
+
+    static int stream_close_cb(ngtcp2_conn*, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn || !conn->connection_state) {
+            return 0;
+        }
+
+        conn->release_stream_data(sid);
+        conn->connection_state->on_stream_closed(sid);
+        return 0;
+    }
+
+    static int acked_stream_data_offset_cb(ngtcp2_conn*, int64_t sid, uint64_t offset, uint64_t datalen, void* user_data, void*) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn) {
+            return 0;
+        }
+        conn->acked_stream_data(sid, offset, datalen);
+        return 0;
+    }
+
+    static int extend_max_local_streams_bidi_cb(ngtcp2_conn*, uint64_t max_streams, void* user_data) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn) {
+            return 0;
+        }
+        quic_server_log.debug("server local bidi stream capacity extended: peer={} max_streams={}", conn->peer, max_streams);
+        conn->request_blocked_open_stream_retry(stream_type::bidirectional);
+        return 0;
+    }
+
+    static int extend_max_local_streams_uni_cb(ngtcp2_conn*, uint64_t max_streams, void* user_data) {
+        auto* conn = static_cast<server_connection*>(user_data);
+        if (!conn) {
+            return 0;
+        }
+        quic_server_log.debug("server local uni stream capacity extended: peer={} max_streams={}", conn->peer, max_streams);
+        conn->request_blocked_open_stream_retry(stream_type::unidirectional);
+        return 0;
+    }
+
+    gnutls_session_t make_tls_session(server_connection& conn) const {
+        gnutls_session_t tls = nullptr;
+        int rv = gnutls_init(&tls, GNUTLS_SERVER | GNUTLS_ENABLE_EARLY_DATA);
+        if (rv < 0) {
+            throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+        rv = gnutls_credentials_set(tls, GNUTLS_CRD_CERTIFICATE, _cred);
+        if (rv < 0) {
+            gnutls_deinit(tls);
+            throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+        rv = gnutls_priority_set_direct(tls, "NORMAL:-VERS-ALL:+VERS-TLS1.3", nullptr);
+        if (rv < 0) {
+            gnutls_deinit(tls);
+            throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+        }
+
+        std::vector<gnutls_datum_t> alpns;
+        alpns.reserve(_cfg.alpns.size());
+        for (const auto& alpn : _cfg.alpns) {
+            alpns.push_back(gnutls_datum_t{
+              reinterpret_cast<unsigned char*>(const_cast<char*>(alpn.data())),
+              static_cast<unsigned int>(alpn.size()),
+            });
+        }
+        if (!alpns.empty()) {
+            rv = gnutls_alpn_set_protocols(tls, alpns.data(), alpns.size(), GNUTLS_ALPN_MANDATORY);
+            if (rv < 0) {
+                gnutls_deinit(tls);
+                throw_quic_error(classify_gnutls_error(rv), gnutls_error_message(rv));
+            }
+        }
+
+        rv = ngtcp2_crypto_gnutls_configure_server_session(tls);
+        if (rv != 0) {
+            gnutls_deinit(tls);
+            throw_quic_error(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        }
+
+        conn.conn_ref.get_conn = get_conn;
+        conn.conn_ref.user_data = nullptr;
+        gnutls_session_set_ptr(tls, &conn.conn_ref);
+        return tls;
+    }
+
+    conn_ptr init_connection(const socket_address& peer, const uint8_t* pkt, size_t pkt_len) {
+        quic_server_log.info("server init_connection: peer={} first_packet_bytes={}", peer, pkt_len);
+        const auto& transport_cfg = _cfg.session_options.transport;
+        if (transport_cfg.max_tx_udp_payload_size) {
+            auto size = *transport_cfg.max_tx_udp_payload_size;
+            if (size < default_udp_payload_size || size > max_udp_payload_size) {
+                throw_quic_error(quic_error_code::invalid_argument, "max_tx_udp_payload_size must be between 1200 and 65527");
+            }
+        }
+        if (transport_cfg.max_udp_payload_size) {
+            auto size = *transport_cfg.max_udp_payload_size;
+            if (size < default_udp_payload_size || size > max_udp_payload_size) {
+                throw_quic_error(quic_error_code::invalid_argument, "max_udp_payload_size must be between 1200 and 65527");
+            }
+        }
+        if (transport_cfg.max_tx_udp_payload_size
+            && transport_cfg.max_udp_payload_size
+            && *transport_cfg.max_tx_udp_payload_size > *transport_cfg.max_udp_payload_size) {
+            throw_quic_error(quic_error_code::invalid_argument, "max_tx_udp_payload_size must be <= max_udp_payload_size");
+        }
+        auto conn = make_lw_shared<server_connection>();
+        conn->server = weak_from_this();
+        conn->command_runtime = make_command_runtime(_cfg.session_options);
+        conn->connection_state = make_connection_state(conn->command_runtime, _cfg.session_options);
+        conn->command_runtime->set_command_notifier([raw = conn.get()] {
+            raw->wake_actor();
+        });
+        conn->peer = peer;
+        to_sockaddr_storage(_listen_address, conn->local_ss, conn->local_ss_len);
+        to_sockaddr_storage(peer, conn->peer_ss, conn->peer_ss_len);
+        conn->tls = make_tls_session(*conn);
+
+        // Decode the Initial CIDs before creating server-side ngtcp2 state.
+        ngtcp2_version_cid vc{};
+        int rv = ngtcp2_pkt_decode_version_cid(&vc, pkt, pkt_len, NGTCP2_MAX_CIDLEN);
+        if (rv < 0) {
+            throw_quic_error(quic_error_code::protocol, "failed to decode Initial CID");
+        }
+
+        // The client's source CID becomes our destination CID for this connection.
+        ngtcp2_cid dcid{};
+        dcid.datalen = vc.scidlen;
+        std::memcpy(dcid.data, vc.scid, vc.scidlen);
+
+        // Preserve the original destination CID for transport parameters.
+        ngtcp2_cid odcid{};
+        odcid.datalen = vc.dcidlen;
+        std::memcpy(odcid.data, vc.dcid, vc.dcidlen);
+
+        // Mint a server CID used to route later packets for this connection.
+        ngtcp2_cid scid{};
+        scid.datalen = server_short_cid_len;
+        rand_bytes_or_throw(scid.data, scid.datalen, "connection id generation");
+
+        ngtcp2_callbacks callbacks{};
+        callbacks.recv_client_initial = ngtcp2_crypto_recv_client_initial_cb;
+        callbacks.recv_retry = ngtcp2_crypto_recv_retry_cb;
+        callbacks.recv_crypto_data = ngtcp2_crypto_recv_crypto_data_cb;
+        callbacks.encrypt = ngtcp2_crypto_encrypt_cb;
+        callbacks.decrypt = ngtcp2_crypto_decrypt_cb;
+        callbacks.hp_mask = ngtcp2_crypto_hp_mask_cb;
+        callbacks.update_key = ngtcp2_crypto_update_key_cb;
+        callbacks.delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb;
+        callbacks.delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb;
+        callbacks.rand = rand_cb;
+        callbacks.get_new_connection_id = get_new_connection_id_cb;
+        callbacks.get_path_challenge_data = get_path_challenge_data_cb;
+        callbacks.path_validation = path_validation_cb;
+        callbacks.begin_path_validation = begin_path_validation_cb;
+        callbacks.handshake_completed = handshake_completed_cb;
+        callbacks.dcid_status = dcid_status_cb;
+        callbacks.recv_stream_data = recv_stream_data_cb;
+        callbacks.acked_stream_data_offset = acked_stream_data_offset_cb;
+        callbacks.stream_close = stream_close_cb;
+        callbacks.stream_reset = stream_reset_cb;
+        callbacks.stream_stop_sending = stream_stop_sending_cb;
+        callbacks.extend_max_local_streams_bidi = extend_max_local_streams_bidi_cb;
+        callbacks.extend_max_local_streams_uni = extend_max_local_streams_uni_cb;
+
+        // Settings tune local behavior; transport parameters are peer-visible.
+        ngtcp2_settings settings{};
+        ngtcp2_settings_default(&settings);
+        settings.initial_ts = quic_now_ns();
+        if (_cfg.session_options.transport.initial_rtt
+            && *_cfg.session_options.transport.initial_rtt > std::chrono::nanoseconds::zero()) {
+            settings.initial_rtt = static_cast<uint64_t>(_cfg.session_options.transport.initial_rtt->count());
+        }
+        if (_cfg.session_options.transport.max_tx_udp_payload_size) {
+            settings.max_tx_udp_payload_size = *_cfg.session_options.transport.max_tx_udp_payload_size;
+        }
+        if (_cfg.session_options.transport.max_window) {
+            settings.max_window = *_cfg.session_options.transport.max_window;
+        }
+        if (_cfg.session_options.transport.max_stream_window) {
+            settings.max_stream_window = *_cfg.session_options.transport.max_stream_window;
+        }
+        if (_cfg.session_options.transport.ack_thresh) {
+            settings.ack_thresh = *_cfg.session_options.transport.ack_thresh;
+        }
+        if (auto algo = effective_congestion_control(_cfg.session_options.transport)) {
+            settings.cc_algo = to_ngtcp2_cc_algo(*algo);
+        }
+        settings.no_tx_udp_payload_size_shaping =
+          _cfg.session_options.transport.disable_tx_udp_payload_size_shaping ? 1 : 0;
+        settings.no_pmtud = _cfg.session_options.transport.disable_pmtud ? 1 : 0;
+
+        ngtcp2_transport_params params{};
+        ngtcp2_transport_params_default(&params);
+        params.original_dcid_present = 1;
+        params.original_dcid = odcid;
+        params.initial_max_stream_data_bidi_local = effective_initial_receive_window(
+          _cfg.session_options,
+          _cfg.session_options.transport.initial_max_stream_data_bidi_local);
+        params.initial_max_stream_data_bidi_remote = effective_initial_receive_window(
+          _cfg.session_options,
+          _cfg.session_options.transport.initial_max_stream_data_bidi_remote);
+        params.initial_max_stream_data_uni = effective_initial_receive_window(
+          _cfg.session_options,
+          _cfg.session_options.transport.initial_max_stream_data_uni);
+        params.initial_max_data = effective_initial_receive_window(
+          _cfg.session_options,
+          _cfg.session_options.transport.initial_max_data);
+        params.initial_max_streams_bidi = _cfg.session_options.transport.initial_max_streams_bidi;
+        params.initial_max_streams_uni = _cfg.session_options.transport.initial_max_streams_uni;
+        params.max_idle_timeout = static_cast<uint64_t>(_cfg.session_options.transport.max_idle_timeout.count());
+        if (_cfg.session_options.transport.max_udp_payload_size) {
+            params.max_udp_payload_size = *_cfg.session_options.transport.max_udp_payload_size;
+        }
+        params.disable_active_migration = 1;
+
+        ngtcp2_path path{};
+        conn->fill_path(path);
+        rv = ngtcp2_conn_server_new(
+          &conn->conn,
+          &dcid,
+          &scid,
+          &path,
+          NGTCP2_PROTO_VER_V1,
+          &callbacks,
+          &settings,
+          &params,
+          ngtcp2_mem_for_thread(),
+          conn.get());
+        if (rv != 0) {
+            throw_quic_error(classify_ngtcp2_error(rv), ngtcp2_error_message(rv));
+        }
+
+        ngtcp2_conn_set_tls_native_handle(conn->conn, conn->tls);
+        conn->conn_ref.user_data = conn->conn;
+
+        auto payload = ngtcp2_conn_get_path_max_tx_udp_payload_size(conn->conn);
+        if (payload == 0) {
+            payload = default_udp_payload_size;
+        }
+        if (payload > max_udp_payload_size) {
+            payload = max_udp_payload_size;
+        }
+        conn->tx_payload_limit = payload;
+
+        // Route both the original and freshly issued CIDs to this connection.
+        map_dcid(conn, odcid.data, odcid.datalen);
+        map_dcid(conn, scid.data, scid.datalen);
+        _conns.push_back(conn);
+        quic_server_log.info(
+          "server connection initialized: peer={} tx_payload_limit={} active_conns={} odcid_len={} scid_len={}",
+          conn->peer,
+          conn->tx_payload_limit,
+          _conns.size(),
+          odcid.datalen,
+          scid.datalen);
+
+        auto self = shared_from_this();
+        // Unexpected actor failures are reported through normal connection state.
+        (void)with_gate(_task_gate, [self, conn] { return conn_actor_loop(conn); })
+          .handle_exception([self, conn](std::exception_ptr) {
+              conn->closing = true;
+              conn->abort_event_queues("server actor loop failed");
+              if (conn->command_runtime && conn->command_runtime->is_open()) {
+                  conn->command_runtime->mark_error(quic_error_code::io, "server actor loop failed");
+              }
+              if (auto server = conn->server_impl()) {
+                  server->unregister_connection(conn);
+              }
+          })
+          .or_terminate();
+        return conn;
+    }
+
+    static future<> flush_pending_packets_actor(conn_ptr conn) {
+        co_await flush_pending_transport_packets(*conn);
+    }
+
+    static future<> conn_actor_loop(conn_ptr conn) {
+        // Match the client-side batch bound for fairness across hot connections.
+        constexpr size_t actor_batch_limit = 64;
+
+        while (conn->actor_active()) {
+            if (!conn->actor_has_pending_work()) {
+                co_await conn->actor_wait_for_wakeup();
+                if (!conn->actor_active()) {
+                    co_return;
+                }
+            }
+
+            if (conn->actor_stop_requested()) {
+                co_await conn->actor_handle_stop_request();
+                co_return;
+            }
+
+            if (conn->actor_transport_terminal()) {
+                // Reconcile terminal command-runtime state before more I/O work.
+                co_await conn->actor_handle_transport_terminal();
+                continue;
+            }
+
+            size_t rx_processed = 0;
+            while (conn->actor_active()
+                   && !conn->actor_stop_requested()
+                   && conn->actor_has_rx_event()
+                   && rx_processed < actor_batch_limit) {
+                co_await conn->actor_handle_next_rx_event();
+                ++rx_processed;
+            }
+
+            size_t commands_processed = 0;
+            while (conn->actor_active()
+                   && !conn->actor_stop_requested()
+                   && conn->actor_has_transport_command()
+                   && commands_processed < actor_batch_limit) {
+                co_await conn->actor_handle_next_transport_command();
+                ++commands_processed;
+            }
+
+            if (conn->actor_active() && !conn->actor_stop_requested()) {
+                co_await conn->actor_retry_blocked_open_streams();
+            }
+
+            if (conn->actor_active() && !conn->actor_stop_requested() && conn->actor_tick_pending()) {
+                conn->actor_clear_tick();
+                co_await conn->actor_handle_timer_tick();
+            }
+
+            if (conn->actor_active()
+                && !conn->actor_stop_requested()
+                && conn->actor_has_pending_work()
+                && (rx_processed == actor_batch_limit || commands_processed == actor_batch_limit)) {
+                // Yield between batches so one busy peer does not starve other work.
+                co_await seastar::coroutine::maybe_yield();
+            }
+        }
+    }
+
+    future<> handle_datagram(net::datagram d) {
+        auto src = d.get_src();
+        auto pkt = linearize_packet(d.get_buffers());
+        const auto* data = reinterpret_cast<const uint8_t*>(pkt.get());
+        const size_t len = pkt.size();
+        quic_server_log.trace("server received datagram: src={} bytes={}", src, len);
+
+        auto parsed = parse_dcid(data, len, server_short_cid_len);
+        // Routing happens by DCID before any per-connection ngtcp2 state sees the packet.
+        if (!parsed.ok) {
+            quic_server_log.debug("server drop datagram: failed to parse DCID src={} bytes={}", src, len);
+            co_return;
+        }
+
+        conn_ptr conn;
+        auto it = _by_dcid.find(cid_key(parsed.dcid.data(), parsed.dcid_len));
+        if (it != _by_dcid.end()) {
+            conn = it->second;
+        }
+
+        if (!conn) {
+            // Unknown short-header packets cannot create server state; only Initial can.
+            if (!parsed.long_header || parsed.long_type != quic_long_type::initial) {
+                quic_server_log.debug("server drop datagram: unknown DCID and not Initial src={} long_header={} long_type={}",
+                  src, parsed.long_header, static_cast<unsigned>(parsed.long_type));
+                co_return;
+            }
+            try {
+                conn = init_connection(src, data, len);
+            } catch (...) {
+                quic_server_log.warn("server failed to initialize connection from Initial packet: src={} bytes={}", src, len);
+                co_return;
+            }
+        }
+
+        if (!conn || conn->closing) {
+            quic_server_log.debug("server drop datagram: conn missing/closing src={}", src);
+            co_return;
+        }
+
+        if (!conn->rx_queue.push(conn_rx_event{src, std::move(pkt)})) {
+            // Per-connection queues bound memory even if one peer sends faster than its actor.
+            quic_server_log.debug("server drop datagram: rx queue full src={} peer={}", src, conn->peer);
+            co_return;
+        }
+        conn->wake_actor();
+        co_return;
+    }
+
+    future<> receive_loop() {
+        while (!_stopping) {
+            try {
+                auto d = co_await _channel.receive();
+                co_await handle_datagram(std::move(d));
+            } catch (...) {
+                if (_stopping) {
+                    co_return;
+                }
+                quic_server_log.error("server receive_loop channel receive failed");
+                _stopping = true;
+                _accept_cv.broadcast();
+
+                auto conns_copy = _conns;
+                for (auto& conn : conns_copy) {
+                    conn->fail(quic_error_code::io, "server receive_loop channel receive failed");
+                }
+                co_return;
+            }
+        }
+    }
+
+    quic_server_config _cfg{};
+    gnutls_certificate_credentials_t _cred = nullptr;
+    net::datagram_channel _channel{};
+    bool _channel_ready = false;
+    socket_address _listen_address{};
+
+    bool _started = false;
+    bool _stopping = false;
+
+    gate _task_gate;
+    future<> _send_tail = make_ready_future<>();
+    condition_variable _accept_cv;
+    std::deque<connection_state_ptr> _accepted;
+    std::unordered_map<std::string, conn_ptr> _by_dcid;
+    std::vector<conn_ptr> _conns;
+};
+
+} // namespace internal
+
+bool server_connection::active() const noexcept {
+    return !closing && command_runtime && server;
+}
+
+future<> server_connection::send_datagram_packet(temporary_buffer<char> packet) {
+    auto* srv = server_impl();
+    if (!srv) {
+        co_return;
+    }
+    co_await srv->send_datagram_packet(peer, std::move(packet));
+}
+
+bool server_connection::can_send_connection_close() const noexcept {
+    auto* srv = server_impl();
+    return conn && srv && !srv->channel().is_closed();
+}
+
+future<> server_connection::actor_handle_next_rx_event() {
+    auto evt = rx_queue.pop();
+    co_await internal::recv_transport_datagram(*this, evt.src, std::move(evt.packet));
+    request_blocked_send_retry();
+}
+
+future<> server_connection::actor_handle_stop_request() {
+    auto self = shared_from_this();
+    auto stop_error_local = stop_error;
+    // Snapshot the terminal reason before cleanup clears actor-visible state.
+    auto stop_error_detail_local = stop_error_detail;
+    stop_requested = false;
+    discard_blocked_send();
+
+    // Send the close frame from the actor while transport state is still owned here.
+    co_await internal::send_connection_close(*this);
+
+    closing = true;
+    abort_event_queues(stop_error_local ? "server connection failed" : "server connection stopped");
+    if (command_runtime && command_runtime->is_open()) {
+        if (stop_error_local) {
+            command_runtime->mark_error(*stop_error_local, stop_error_detail_local);
+        } else {
+            command_runtime->mark_transport_closed();
+        }
+    }
+    if (connection_state) {
+        if (stop_error_local) {
+            connection_state->on_transport_closed(std::make_exception_ptr(quic_error(*stop_error_local, stop_error_detail_local)));
+        } else {
+            connection_state->on_transport_closed(std::make_exception_ptr(quic_error(quic_error_code::closed, "server connection stopped")));
+        }
+    }
+    if (auto* srv = server_impl()) {
+        srv->unregister_connection(self);
+    }
+}
+
+future<> server_connection::actor_handle_timer_tick() {
+    co_await internal::handle_transport_timer(*this);
+    request_blocked_send_retry();
+}
+
+void server_connection::stop_transport() {
+    quic_server_log.info("server connection request stop: peer={} closing={} mapped_dcids={}", peer, closing, mapped_dcids.size());
+    if (closing || stop_requested) {
+        return;
+    }
+    // Defer final cleanup to the actor so shutdown paths share one sequence.
+    stop_requested = true;
+    fail_blocked_open_streams(quic_error_code::closed, "server connection stopped");
+    discard_blocked_send();
+    if (connection_state) {
+        connection_state->on_transport_closed(std::make_exception_ptr(quic_error(quic_error_code::closed, "server connection stopped")));
+    }
+    cancel_transport_timer();
+    wake_actor();
+}
+
+void server_connection::fail(quic_error_code error, const sstring& detail) {
+    quic_server_log.error(
+      "server connection failure: peer={} error={} detail='{}' closing={} mapped_dcids={}",
+      peer,
+      to_string(error),
+      detail,
+      closing,
+      mapped_dcids.size());
+    if (closing) {
+        return;
+    }
+    if (!stop_error) {
+        // Keep the first failure as the one surfaced during actor shutdown.
+        stop_error = error;
+        stop_error_detail = detail;
+    }
+    fail_blocked_open_streams(error, detail);
+    discard_blocked_send();
+    if (connection_state) {
+        connection_state->on_transport_closed(std::make_exception_ptr(quic_error(error, detail)));
+    }
+    cancel_transport_timer();
+    stop_requested = true;
+    wake_actor();
+}
+
+void server_connection::fail_transport(quic_error_code error, sstring detail) {
+    fail(error, detail);
+}
+
+quic_server::quic_server()
+    : _impl(make_lw_shared<internal::quic_server_impl>()) {
+}
+
+quic_server::~quic_server() {
+    if (_impl) {
+        _impl->request_stop_detached();
+    }
+}
+quic_server::quic_server(quic_server&&) noexcept = default;
+quic_server& quic_server::operator=(quic_server&&) noexcept = default;
+
+future<> quic_server::start(quic_server_config config) {
+    quic_server_log.debug("quic_server::start");
+    co_await _impl->start(std::move(config));
+}
+
+future<connection> quic_server::accept() {
+    quic_server_log.debug("quic_server::accept");
+    auto connection_state = co_await _impl->accept();
+    co_return connection(std::make_unique<connection::impl>(std::move(connection_state)));
+}
+
+socket_address quic_server::local_address() const noexcept {
+    return _impl ? _impl->listen_address() : socket_address{};
+}
+
+future<> quic_server::stop() {
+    quic_server_log.debug("quic_server::stop");
+    co_await _impl->stop();
+}
+
+} // namespace seastar::quic::experimental

--- a/src/quic/sharded_quic_server.cc
+++ b/src/quic/sharded_quic_server.cc
@@ -41,6 +41,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/util/log.hh>
 
+#include "quic_common.hh"
 #include "quic_error_impl.hh"
 
 namespace seastar::quic::experimental {
@@ -78,7 +79,7 @@ bool is_bind_conflict(std::exception_ptr ep) noexcept {
             std::rethrow_exception(ep);
         }
     } catch (const std::system_error& e) {
-        return e.code().value() == EADDRINUSE || e.code().value() == EADDRNOTAVAIL;
+        return e.code().value() == EADDRINUSE;
     } catch (...) {
     }
     return false;
@@ -109,14 +110,27 @@ thread_local std::unordered_map<socket_address, quic_server_shard*> quic_server_
 
 class quic_server_shard final : public quic_packet_router {
 public:
-    future<> start(quic_server_config config) {
+    future<> start(quic_server_config config, quic_server_cid_key cid_key) {
         if (_started) {
             throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server shard already started");
         }
         _server.set_packet_router(this);
-        co_await _server.start(std::move(config));
+        try {
+            co_await _server.start_shard(
+              std::move(config),
+              std::move(cid_key),
+              this_smp_shard_count() > 1);
+        } catch (...) {
+            _server.set_packet_router(nullptr);
+            throw;
+        }
         _local_address = _server.local_address();
-        quic_server_shards[_local_address] = this;
+        auto registration = quic_server_shards.emplace(_local_address, this);
+        if (!registration.second) {
+            _server.set_packet_router(nullptr);
+            co_await _server.stop();
+            throw_quic_error(quic_error_code::invalid_state, "another sharded QUIC server is already registered on this endpoint");
+        }
         _registered = true;
         _started = true;
     }
@@ -264,7 +278,9 @@ public:
             throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server already started");
         }
 
-        config.reuse_port = this_smp_shard_count() > 1;
+        ensure_gnutls_global();
+        internal::quic_server_cid_key cid_key{};
+        rand_bytes_or_throw(cid_key.data(), cid_key.size(), "sharded server CID routing key generation");
 
         co_await _shards->start();
         _shards_started = true;
@@ -272,9 +288,9 @@ public:
         std::exception_ptr error;
         try {
             if (socket_address_port(config.listen_address) == 0) {
-                co_await start_with_ephemeral_port(std::move(config));
+                co_await start_with_ephemeral_port(std::move(config), cid_key);
             } else {
-                co_await start_on_all_shards(std::move(config));
+                co_await start_on_all_shards(std::move(config), cid_key);
             }
             _started = true;
         } catch (...) {
@@ -372,9 +388,11 @@ private:
     }
 
 private:
-    future<> start_with_ephemeral_port(quic_server_config config) {
-        co_await _shards->invoke_on(0, [config] (internal::quic_server_shard& shard) mutable {
-            return shard.start(std::move(config));
+    future<> start_with_ephemeral_port(
+            quic_server_config config,
+            internal::quic_server_cid_key cid_key) {
+        co_await _shards->invoke_on(0, [config, cid_key] (internal::quic_server_shard& shard) mutable {
+            return shard.start(std::move(config), std::move(cid_key));
         });
 
         auto local = co_await _shards->invoke_on(0, [] (internal::quic_server_shard& shard) {
@@ -384,14 +402,16 @@ private:
         set_socket_address_port(config.listen_address, socket_address_port(local));
 
         auto remaining_shards = std::views::iota(1u, this_smp_shard_count());
-        co_await _shards->invoke_on(remaining_shards, [config = std::move(config)] (internal::quic_server_shard& shard) mutable {
-            return shard.start(config);
+        co_await _shards->invoke_on(remaining_shards, [config = std::move(config), cid_key] (internal::quic_server_shard& shard) mutable {
+            return shard.start(config, cid_key);
         });
     }
 
-    future<> start_on_all_shards(quic_server_config config) {
-        co_await _shards->invoke_on_all([config] (internal::quic_server_shard& shard) mutable {
-            return shard.start(config);
+    future<> start_on_all_shards(
+            quic_server_config config,
+            internal::quic_server_cid_key cid_key) {
+        co_await _shards->invoke_on_all([config, cid_key] (internal::quic_server_shard& shard) mutable {
+            return shard.start(config, cid_key);
         });
         _local_address = co_await _shards->invoke_on(0, [] (internal::quic_server_shard& shard) {
             return make_ready_future<socket_address>(shard.local_address());

--- a/src/quic/sharded_quic_server.cc
+++ b/src/quic/sharded_quic_server.cc
@@ -1,0 +1,431 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <seastar/quic/sharded_quic_server.hh>
+
+#include <arpa/inet.h>
+#include <errno.h>
+
+#include <exception>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/deleter.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/internal/run_in_background.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/log.hh>
+
+#include "quic_error_impl.hh"
+
+namespace seastar::quic::experimental {
+namespace {
+
+logger sharded_quic_server_log("sharded_quic_server");
+
+uint16_t socket_address_port(const socket_address& address) noexcept {
+    switch (address.family()) {
+    case AF_INET:
+        return ntohs(address.as_posix_sockaddr_in().sin_port);
+    case AF_INET6:
+        return ntohs(address.as_posix_sockaddr_in6().sin6_port);
+    default:
+        return 0;
+    }
+}
+
+void set_socket_address_port(socket_address& address, uint16_t port) noexcept {
+    switch (address.family()) {
+    case AF_INET:
+        address.as_posix_sockaddr_in().sin_port = htons(port);
+        break;
+    case AF_INET6:
+        address.as_posix_sockaddr_in6().sin6_port = htons(port);
+        break;
+    default:
+        break;
+    }
+}
+
+bool is_bind_conflict(std::exception_ptr ep) noexcept {
+    try {
+        if (ep) {
+            std::rethrow_exception(ep);
+        }
+    } catch (const std::system_error& e) {
+        return e.code().value() == EADDRINUSE || e.code().value() == EADDRNOTAVAIL;
+    } catch (...) {
+    }
+    return false;
+}
+
+using forwarded_packet_ptr = foreign_ptr<std::unique_ptr<temporary_buffer<char>>>;
+
+temporary_buffer<char> make_shard_local_packet(forwarded_packet_ptr packet) {
+    if (!packet) {
+        return temporary_buffer<char>();
+    }
+    if (packet.get_owner_shard() == this_shard_id()) {
+        return std::move(*packet);
+    }
+    auto* data = packet->get_write();
+    auto size = packet->size();
+    auto deleter = make_object_deleter(std::move(packet));
+    return temporary_buffer<char>(data, size, std::move(deleter));
+}
+
+} // namespace
+
+namespace internal {
+
+class quic_server_shard;
+
+thread_local std::unordered_map<socket_address, quic_server_shard*> quic_server_shards;
+
+class quic_server_shard final : public quic_packet_router {
+public:
+    future<> start(quic_server_config config) {
+        if (_started) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server shard already started");
+        }
+        _server.set_packet_router(this);
+        co_await _server.start(std::move(config));
+        _local_address = _server.local_address();
+        quic_server_shards[_local_address] = this;
+        _registered = true;
+        _started = true;
+    }
+
+    future<> serve(sharded_quic_server::accept_handler handler) {
+        if (!_started) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server shard is not started");
+        }
+        if (_accept_task) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server shard is already serving");
+        }
+
+        _handler = std::move(handler);
+        _accept_task.emplace(accept_loop());
+        co_return;
+    }
+
+    future<> stop() {
+        if (!_started && !_accept_task) {
+            co_return;
+        }
+
+        unregister_router();
+        _server.set_packet_router(nullptr);
+
+        std::exception_ptr error;
+        try {
+            co_await _server.stop();
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        if (_accept_task) {
+            try {
+                co_await std::move(*_accept_task);
+            } catch (...) {
+                if (!error) {
+                    error = std::current_exception();
+                }
+            }
+            _accept_task.reset();
+        }
+
+        try {
+            co_await _connections.close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+
+        _handler = {};
+        _started = false;
+
+        if (error) {
+            std::rethrow_exception(error);
+        }
+    }
+
+    socket_address local_address() const noexcept {
+        return _server.local_address();
+    }
+
+    future<> route_quic_packet(unsigned shard, socket_address local_address, socket_address src, temporary_buffer<char> packet) override {
+        if (shard >= this_smp_shard_count()) {
+            co_return;
+        }
+        auto forwarded = make_foreign(std::make_unique<temporary_buffer<char>>(std::move(packet)));
+        co_await smp::submit_to(shard, [local_address, src, packet = std::move(forwarded)] () mutable {
+            auto it = quic_server_shards.find(local_address);
+            if (it == quic_server_shards.end() || !it->second) {
+                sharded_quic_server_log.debug("drop forwarded QUIC datagram: no server registered on shard {} for {}", this_shard_id(), local_address);
+                return make_ready_future<>();
+            }
+            return it->second->inject_datagram(src, make_shard_local_packet(std::move(packet)));
+        });
+    }
+
+    future<> inject_datagram(socket_address src, temporary_buffer<char> packet) {
+        co_await _server.inject_datagram(src, std::move(packet));
+    }
+
+private:
+    void unregister_router() noexcept {
+        if (!_registered) {
+            return;
+        }
+        auto it = quic_server_shards.find(_local_address);
+        if (it != quic_server_shards.end() && it->second == this) {
+            quic_server_shards.erase(it);
+        }
+        _registered = false;
+    }
+
+    future<> accept_loop() {
+        while (true) {
+            connection session;
+            try {
+                session = co_await _server.accept();
+            } catch (const quic_error& e) {
+                if (e.code() == quic_error_code::closed) {
+                    co_return;
+                }
+                throw;
+            }
+
+            (void)with_gate(_connections, [this, session = std::move(session)] () mutable {
+                return _handler(std::move(session));
+            }).handle_exception([] (std::exception_ptr ep) {
+                try {
+                    std::rethrow_exception(ep);
+                } catch (const std::exception& e) {
+                    sharded_quic_server_log.warn("accepted QUIC session handler failed on shard {}: {}", this_shard_id(), e.what());
+                } catch (...) {
+                    sharded_quic_server_log.warn("accepted QUIC session handler failed on shard {}", this_shard_id());
+                }
+            }).or_terminate();
+        }
+    }
+
+private:
+    quic_server _server;
+    gate _connections;
+    sharded_quic_server::accept_handler _handler;
+    std::optional<future<>> _accept_task;
+    socket_address _local_address;
+    bool _registered = false;
+    bool _started = false;
+};
+
+} // namespace internal
+
+class sharded_quic_server::impl final {
+public:
+    impl()
+      : _shards(std::make_unique<sharded<internal::quic_server_shard>>()) {
+    }
+
+    ~impl() {
+        request_stop_detached();
+    }
+
+    future<> start(quic_server_config config) {
+        if (_started || _shards_started) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server already started");
+        }
+
+        config.reuse_port = this_smp_shard_count() > 1;
+
+        co_await _shards->start();
+        _shards_started = true;
+
+        std::exception_ptr error;
+        try {
+            if (socket_address_port(config.listen_address) == 0) {
+                co_await start_with_ephemeral_port(std::move(config));
+            } else {
+                co_await start_on_all_shards(std::move(config));
+            }
+            _started = true;
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        if (error) {
+            try {
+                co_await _shards->stop();
+            } catch (...) {
+            }
+            _shards_started = false;
+            if (this_smp_shard_count() > 1 && is_bind_conflict(error)) {
+                throw_quic_error(quic_error_code::unsupported, "sharded QUIC server requires UDP SO_REUSEPORT for multi-shard bind");
+            }
+            std::rethrow_exception(error);
+        }
+    }
+
+    future<> serve(sharded_quic_server::accept_handler_factory make_handler) {
+        if (!_started) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server is not started");
+        }
+        if (_serving) {
+            throw_quic_error(quic_error_code::invalid_state, "sharded QUIC server is already serving");
+        }
+
+        std::exception_ptr error;
+        try {
+            co_await _shards->invoke_on_all([make_handler = std::move(make_handler)] (internal::quic_server_shard& shard) mutable {
+                return shard.serve(make_handler());
+            });
+            _serving = true;
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        if (error) {
+            co_await stop();
+            std::rethrow_exception(error);
+        }
+    }
+
+    future<> stop() {
+        if (!_shards_started) {
+            co_return;
+        }
+
+        std::exception_ptr error;
+        try {
+            co_await _shards->stop();
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        _started = false;
+        _serving = false;
+        _shards_started = false;
+        _local_address = socket_address{};
+
+        if (error) {
+            std::rethrow_exception(error);
+        }
+    }
+
+    socket_address local_address() const noexcept {
+        return _local_address;
+    }
+
+private:
+    void request_stop_detached() noexcept {
+        if (!_shards_started || !_shards) {
+            return;
+        }
+
+        sharded_quic_server_log.warn("sharded_quic_server destroyed without awaiting stop(); shutting down detached");
+        auto shards = std::move(_shards);
+        _started = false;
+        _serving = false;
+        _shards_started = false;
+        _local_address = socket_address{};
+
+        auto cleanup = shards->stop()
+          .handle_exception([] (std::exception_ptr ep) {
+              try {
+                  std::rethrow_exception(ep);
+              } catch (const std::exception& e) {
+                  sharded_quic_server_log.warn("detached sharded QUIC server stop failed: {}", e.what());
+              } catch (...) {
+                  sharded_quic_server_log.warn("detached sharded QUIC server stop failed");
+              }
+          })
+          .finally([shards = std::move(shards)] {});
+        seastar::internal::run_in_background(std::move(cleanup));
+    }
+
+private:
+    future<> start_with_ephemeral_port(quic_server_config config) {
+        co_await _shards->invoke_on(0, [config] (internal::quic_server_shard& shard) mutable {
+            return shard.start(std::move(config));
+        });
+
+        auto local = co_await _shards->invoke_on(0, [] (internal::quic_server_shard& shard) {
+            return make_ready_future<socket_address>(shard.local_address());
+        });
+        _local_address = local;
+        set_socket_address_port(config.listen_address, socket_address_port(local));
+
+        auto remaining_shards = std::views::iota(1u, this_smp_shard_count());
+        co_await _shards->invoke_on(remaining_shards, [config = std::move(config)] (internal::quic_server_shard& shard) mutable {
+            return shard.start(config);
+        });
+    }
+
+    future<> start_on_all_shards(quic_server_config config) {
+        co_await _shards->invoke_on_all([config] (internal::quic_server_shard& shard) mutable {
+            return shard.start(config);
+        });
+        _local_address = co_await _shards->invoke_on(0, [] (internal::quic_server_shard& shard) {
+            return make_ready_future<socket_address>(shard.local_address());
+        });
+    }
+
+private:
+    std::unique_ptr<sharded<internal::quic_server_shard>> _shards;
+    socket_address _local_address;
+    bool _started = false;
+    bool _serving = false;
+    bool _shards_started = false;
+};
+
+sharded_quic_server::sharded_quic_server()
+  : _impl(std::make_unique<impl>()) {
+}
+
+sharded_quic_server::~sharded_quic_server() = default;
+
+future<> sharded_quic_server::start(quic_server_config config) {
+    return _impl->start(std::move(config));
+}
+
+future<> sharded_quic_server::serve(accept_handler_factory make_handler) {
+    return _impl->serve(std::move(make_handler));
+}
+
+future<> sharded_quic_server::stop() {
+    return _impl->stop();
+}
+
+socket_address sharded_quic_server::local_address() const noexcept {
+    return _impl->local_address();
+}
+
+} // namespace seastar::quic::experimental

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -490,6 +490,11 @@ seastar_add_test (program_options
 seastar_add_test (proxy_protocol
   SOURCES proxy_protocol_test.cc)
 
+seastar_add_test (quic
+  SOURCES quic_test.cc
+  LIBRARIES ngtcp2::ngtcp2
+  DEPENDS testcrt)
+
 seastar_add_test (queue
   SOURCES queue_test.cc)
 

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -69,40 +69,6 @@ SEASTAR_TEST_CASE(udp_packet_test) {
     });
 }
 
-SEASTAR_TEST_CASE(udp_bound_channel_rejects_duplicate_bind_without_reuse_port) {
-    return async([] {
-        auto first = make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0}));
-        auto local = first.local_address();
-
-        bool duplicate_failed = false;
-        try {
-            auto second = make_bound_datagram_channel(local);
-            second.close();
-        } catch (...) {
-            duplicate_failed = true;
-        }
-
-        first.close();
-        BOOST_REQUIRE(duplicate_failed);
-    });
-}
-
-SEASTAR_TEST_CASE(udp_bound_channel_allows_duplicate_bind_with_reuse_port) {
-    return async([] {
-        auto first = engine().net().make_bound_datagram_channel(
-          make_ipv4_address({0x7f000001, 0}),
-          net::datagram_channel_options{.reuse_port = true});
-        auto local = first.local_address();
-
-        auto second = engine().net().make_bound_datagram_channel(
-          local,
-          net::datagram_channel_options{.reuse_port = true});
-
-        second.close();
-        first.close();
-    });
-}
-
 SEASTAR_TEST_CASE(tcp_packet_test) {
     if (!check_ipv6_support()) {
         return make_ready_future<>();
@@ -159,4 +125,3 @@ SEASTAR_TEST_CASE(ipv6_equal_test) {
 
     return make_ready_future();
 }
-

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -69,6 +69,40 @@ SEASTAR_TEST_CASE(udp_packet_test) {
     });
 }
 
+SEASTAR_TEST_CASE(udp_bound_channel_rejects_duplicate_bind_without_reuse_port) {
+    return async([] {
+        auto first = make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0}));
+        auto local = first.local_address();
+
+        bool duplicate_failed = false;
+        try {
+            auto second = make_bound_datagram_channel(local);
+            second.close();
+        } catch (...) {
+            duplicate_failed = true;
+        }
+
+        first.close();
+        BOOST_REQUIRE(duplicate_failed);
+    });
+}
+
+SEASTAR_TEST_CASE(udp_bound_channel_allows_duplicate_bind_with_reuse_port) {
+    return async([] {
+        auto first = engine().net().make_bound_datagram_channel(
+          make_ipv4_address({0x7f000001, 0}),
+          net::datagram_channel_options{.reuse_port = true});
+        auto local = first.local_address();
+
+        auto second = engine().net().make_bound_datagram_channel(
+          local,
+          net::datagram_channel_options{.reuse_port = true});
+
+        second.close();
+        first.close();
+    });
+}
+
 SEASTAR_TEST_CASE(tcp_packet_test) {
     if (!check_ipv6_support()) {
         return make_ready_future<>();

--- a/tests/unit/quic_test.cc
+++ b/tests/unit/quic_test.cc
@@ -76,9 +76,9 @@ constexpr int ngtcp2_err_stream_id_blocked = NGTCP2_ERR_STREAM_ID_BLOCKED;
 constexpr int ngtcp2_err_draining = NGTCP2_ERR_DRAINING;
 constexpr int ngtcp2_err_stream_shut_wr = NGTCP2_ERR_STREAM_SHUT_WR;
 
-constexpr size_t test_server_cid_len = 16;
+constexpr size_t test_server_cid_len = 20;
 
-temporary_buffer<char> make_short_header_packet_for_shard(unsigned shard) {
+temporary_buffer<char> make_forged_short_header_packet_for_shard(unsigned shard) {
     temporary_buffer<char> packet(test_server_cid_len + 8);
     std::fill_n(packet.get_write(), packet.size(), char{0x5a});
     packet.get_write()[0] = 0x40;
@@ -92,13 +92,13 @@ future<> send_udp_packet(net::datagram_channel& channel, socket_address dst, tem
     co_await channel.send(dst, std::span<temporary_buffer<char>>(datagram));
 }
 
-future<> send_udp_packets(
+future<> send_forged_udp_packets(
   net::datagram_channel& channel,
   socket_address dst,
   unsigned owner_shard,
   size_t packet_count) {
     for (size_t packet_index = 0; packet_index < packet_count; ++packet_index) {
-        co_await send_udp_packet(channel, dst, make_short_header_packet_for_shard(owner_shard));
+        co_await send_udp_packet(channel, dst, make_forged_short_header_packet_for_shard(owner_shard));
         co_await seastar::coroutine::maybe_yield();
     }
 }
@@ -1291,7 +1291,7 @@ SEASTAR_TEST_CASE(test_sharded_quic_server_keeps_connection_alive_after_wrong_sh
     }
 }
 
-SEASTAR_TEST_CASE(test_sharded_quic_server_stop_races_with_forwarded_packets) {
+SEASTAR_TEST_CASE(test_sharded_quic_server_ignores_forged_routing_cids_during_stop) {
     if (this_smp_shard_count() < 2) {
         BOOST_TEST_MESSAGE("skipping cross-shard QUIC shutdown race test: at least two shards are required");
         co_return;
@@ -1326,16 +1326,16 @@ SEASTAR_TEST_CASE(test_sharded_quic_server_stop_races_with_forwarded_packets) {
       server.local_address(), accepted_shards, owner_shard, wrong_shard);
     channels[0].close();
 
-    // This source port is known to land on shard 1, while the synthetic CID
-    // names shard 0 as owner. Keep sending while stop() unregisters shard 0.
+    // This source port is known to land on shard 1. The synthetic CID names
+    // shard 0 but has no valid routing tag, so it must not be forwarded.
     for (unsigned warmup = 0; warmup < 8; ++warmup) {
         co_await send_udp_packet(
-          channels[1], server.local_address(), make_short_header_packet_for_shard(owner_shard));
+          channels[1], server.local_address(), make_forged_short_header_packet_for_shard(owner_shard));
     }
     co_await sleep(std::chrono::milliseconds(10));
 
     constexpr size_t packet_count = 512;
-    auto forwards = send_udp_packets(
+    auto forwards = send_forged_udp_packets(
       channels[1], server.local_address(), owner_shard, packet_count);
     auto stop_future = server.stop();
     co_await std::move(forwards);

--- a/tests/unit/quic_test.cc
+++ b/tests/unit/quic_test.cc
@@ -20,10 +20,16 @@
  * Copyright (C) 2026 ScyllaDB Ltd.
  */
 
+#include <arpa/inet.h>
+
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <deque>
 #include <limits>
+#include <memory>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -33,17 +39,24 @@
 #include <gnutls/gnutls.h>
 #include <ngtcp2/ngtcp2.h>
 
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/queue.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/net/api.hh>
 #include <seastar/quic/quic.hh>
 #include <seastar/quic/quic_client.hh>
 #include <seastar/quic/quic_server.hh>
+#include <seastar/quic/sharded_quic_server.hh>
 #include <seastar/testing/test_case.hh>
 
 #include "quic/quic_common.hh"
@@ -62,6 +75,231 @@ constexpr int ngtcp2_err_stream_data_blocked = NGTCP2_ERR_STREAM_DATA_BLOCKED;
 constexpr int ngtcp2_err_stream_id_blocked = NGTCP2_ERR_STREAM_ID_BLOCKED;
 constexpr int ngtcp2_err_draining = NGTCP2_ERR_DRAINING;
 constexpr int ngtcp2_err_stream_shut_wr = NGTCP2_ERR_STREAM_SHUT_WR;
+
+constexpr size_t test_server_cid_len = 16;
+
+temporary_buffer<char> make_short_header_packet_for_shard(unsigned shard) {
+    temporary_buffer<char> packet(test_server_cid_len + 8);
+    std::fill_n(packet.get_write(), packet.size(), char{0x5a});
+    packet.get_write()[0] = 0x40;
+    packet.get_write()[1] = static_cast<char>((shard >> 8) & 0xffu);
+    packet.get_write()[2] = static_cast<char>(shard & 0xffu);
+    return packet;
+}
+
+future<> send_udp_packet(net::datagram_channel& channel, socket_address dst, temporary_buffer<char> packet) {
+    std::array<temporary_buffer<char>, 1> datagram{std::move(packet)};
+    co_await channel.send(dst, std::span<temporary_buffer<char>>(datagram));
+}
+
+future<> send_udp_packets(
+  net::datagram_channel& channel,
+  socket_address dst,
+  unsigned owner_shard,
+  size_t packet_count) {
+    for (size_t packet_index = 0; packet_index < packet_count; ++packet_index) {
+        co_await send_udp_packet(channel, dst, make_short_header_packet_for_shard(owner_shard));
+        co_await seastar::coroutine::maybe_yield();
+    }
+}
+
+class accepted_shard_observer final {
+public:
+    future<> record(unsigned shard) {
+        if (this_shard_id() == _observer_shard) {
+            return _accepted.push_eventually(std::move(shard));
+        }
+        return smp::submit_to(_observer_shard, [this, shard] () mutable {
+            return _accepted.push_eventually(std::move(shard));
+        });
+    }
+
+    future<unsigned> wait_for_accept() {
+        return with_timeout(
+          std::chrono::steady_clock::now() + std::chrono::seconds(2),
+          _accepted.pop_eventually());
+    }
+
+private:
+    const unsigned _observer_shard = this_shard_id();
+    queue<unsigned> _accepted{1};
+};
+
+struct handler_factory_probe {
+    unsigned calls = 0;
+};
+
+future<unsigned> connect_from_source_and_get_shard(
+  socket_address server_address,
+  socket_address source_address,
+  accepted_shard_observer& accepted_shards) {
+    quic_client client;
+    std::optional<connection> session;
+    std::exception_ptr error;
+    unsigned shard = 0;
+
+    try {
+        quic_client_config client_cfg;
+        client_cfg.remote_address = server_address;
+        client_cfg.local_address = source_address;
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+
+        shard = co_await accepted_shards.wait_for_accept();
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+    co_return shard;
+}
+
+future<std::array<net::datagram_channel, 2>> make_udp_channels_for_shards(
+  socket_address server_address,
+  accepted_shard_observer& accepted_shards,
+  unsigned first_shard,
+  unsigned second_shard) {
+    std::array<std::optional<socket_address>, 2> selected;
+
+    for (unsigned attempt = 0; attempt < 128 && (!selected[0] || !selected[1]); ++attempt) {
+        auto port_probe = make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0}));
+        auto candidate = port_probe.local_address();
+        port_probe.close();
+
+        auto shard = co_await connect_from_source_and_get_shard(server_address, candidate, accepted_shards);
+        if (shard == first_shard && !selected[0]) {
+            selected[0] = candidate;
+        } else if (shard == second_shard && !selected[1]) {
+            selected[1] = candidate;
+        }
+    }
+
+    if (!selected[0] || !selected[1]) {
+        throw std::runtime_error("could not find UDP source ports hashing to both requested shards");
+    }
+
+    co_return std::array<net::datagram_channel, 2>{
+      make_bound_datagram_channel(*selected[0]),
+      make_bound_datagram_channel(*selected[1]),
+    };
+}
+
+class rebinding_quic_proxy final {
+public:
+    rebinding_quic_proxy(
+      socket_address server_address,
+      net::datagram_channel owner_backend,
+      net::datagram_channel wrong_backend)
+      : _server_address(server_address)
+      , _front(make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0})))
+      , _owner_backend(std::move(owner_backend))
+      , _wrong_backend(std::move(wrong_backend)) {
+    }
+
+    socket_address local_address() const {
+        return _front.local_address();
+    }
+
+    void start() {
+        _tasks.push_back(relay_client_packets());
+        _tasks.push_back(relay_server_packets(_owner_backend));
+        _tasks.push_back(relay_server_packets(_wrong_backend));
+    }
+
+    void use_wrong_shard() noexcept {
+        _use_wrong_backend = true;
+    }
+
+    future<> stop() {
+        if (_stopping) {
+            co_return;
+        }
+        _stopping = true;
+        _front.shutdown_input();
+        _owner_backend.shutdown_input();
+        _wrong_backend.shutdown_input();
+
+        auto tasks = co_await when_all(_tasks.begin(), _tasks.end());
+        _tasks.clear();
+        for (auto& task : tasks) {
+            task.get();
+        }
+
+        _front.close();
+        _owner_backend.close();
+        _wrong_backend.close();
+    }
+
+private:
+    future<> relay_client_packets() {
+        try {
+            while (!_stopping) {
+                auto datagram = co_await _front.receive();
+                if (_stopping) {
+                    co_return;
+                }
+                _client_address = datagram.get_src();
+                auto packet = linearize_packet(datagram.get_buffers());
+                auto& backend = _use_wrong_backend ? _wrong_backend : _owner_backend;
+                co_await send_udp_packet(backend, _server_address, std::move(packet));
+            }
+        } catch (...) {
+            if (!_stopping) {
+                throw;
+            }
+        }
+    }
+
+    future<> relay_server_packets(net::datagram_channel& backend) {
+        try {
+            while (!_stopping) {
+                auto datagram = co_await backend.receive();
+                if (_stopping) {
+                    co_return;
+                }
+                if (!_client_address) {
+                    continue;
+                }
+                auto packet = linearize_packet(datagram.get_buffers());
+                co_await send_udp_packet(_front, *_client_address, std::move(packet));
+            }
+        } catch (...) {
+            if (!_stopping) {
+                throw;
+            }
+        }
+    }
+
+private:
+    socket_address _server_address;
+    net::datagram_channel _front;
+    net::datagram_channel _owner_backend;
+    net::datagram_channel _wrong_backend;
+    std::optional<socket_address> _client_address;
+    std::vector<future<>> _tasks;
+    bool _use_wrong_backend = false;
+    bool _stopping = false;
+};
 
 class fake_connection_transport final : public quic_internal::connection_transport {
 public:
@@ -361,6 +599,17 @@ socket_address allocate_loopback_quic_address() {
     auto address = probe.local_address();
     probe.close();
     return address;
+}
+
+uint16_t quic_socket_address_port(const socket_address& address) {
+    switch (address.family()) {
+    case AF_INET:
+        return ntohs(address.as_posix_sockaddr_in().sin_port);
+    case AF_INET6:
+        return ntohs(address.as_posix_sockaddr_in6().sin6_port);
+    default:
+        return 0;
+    }
 }
 
 future<> echo_quic_stream(quic_stream stream) {
@@ -898,6 +1147,416 @@ SEASTAR_TEST_CASE(test_quic_server_rejects_empty_alpn_configuration) {
 
         require_quic_future_exception(server.start(std::move(cfg)), quic_error::invalid_argument);
     });
+}
+
+
+future<> quic_echo_client_round_trip(socket_address server_address, sstring payload) {
+    quic_client client;
+    std::optional<connection> session;
+    std::exception_ptr error;
+
+    try {
+        quic_client_config client_cfg;
+        client_cfg.remote_address = server_address;
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+        co_await quic_echo_round_trip(*session, std::move(payload));
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_keeps_connection_alive_after_wrong_shard_delivery) {
+    if (this_smp_shard_count() < 2) {
+        BOOST_TEST_MESSAGE("skipping cross-shard QUIC rebinding test: at least two shards are required");
+        co_return;
+    }
+
+    constexpr unsigned owner_shard = 0;
+    constexpr unsigned wrong_shard = 1;
+    sharded_quic_server server;
+    quic_client client;
+    std::optional<connection> session;
+    std::unique_ptr<rebinding_quic_proxy> proxy;
+    accepted_shard_observer accepted_shards;
+    std::exception_ptr error;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        co_await server.start(std::move(server_cfg));
+
+        co_await server.serve([&accepted_shards] {
+            return [&accepted_shards] (connection session) mutable -> future<> {
+                co_await accepted_shards.record(this_shard_id());
+                try {
+                    while (true) {
+                        auto stream = co_await session.accept_stream();
+                        co_await echo_quic_stream(std::move(stream));
+                    }
+                } catch (const quic_error& e) {
+                    if (e.code() != quic_error_code::closed) {
+                        throw;
+                    }
+                }
+            };
+        });
+
+        auto backends = co_await make_udp_channels_for_shards(
+          server.local_address(), accepted_shards, owner_shard, wrong_shard);
+        proxy = std::make_unique<rebinding_quic_proxy>(
+          server.local_address(),
+          std::move(backends[0]),
+          std::move(backends[1]));
+        proxy->start();
+
+        quic_client_config client_cfg;
+        client_cfg.remote_address = proxy->local_address();
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+
+        auto accepted_shard = co_await accepted_shards.wait_for_accept();
+        BOOST_REQUIRE_EQUAL(accepted_shard, owner_shard);
+        co_await quic_echo_round_trip(*session, "before rebinding");
+
+        proxy->use_wrong_shard();
+        co_await with_timeout(
+          std::chrono::steady_clock::now() + std::chrono::seconds(5),
+          quic_echo_round_trip(*session, "after wrong-shard delivery"));
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+    if (proxy) {
+        try {
+            co_await proxy->stop();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_stop_races_with_forwarded_packets) {
+    if (this_smp_shard_count() < 2) {
+        BOOST_TEST_MESSAGE("skipping cross-shard QUIC shutdown race test: at least two shards are required");
+        co_return;
+    }
+
+    sharded_quic_server server;
+    quic_server_config server_cfg;
+    server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+    server_cfg.crt_file = "test.crt";
+    server_cfg.key_file = "test.key";
+    co_await server.start(std::move(server_cfg));
+
+    accepted_shard_observer accepted_shards;
+    co_await server.serve([&accepted_shards] {
+        return [&accepted_shards] (connection session) mutable -> future<> {
+            co_await accepted_shards.record(this_shard_id());
+            try {
+                while (true) {
+                    co_await session.accept_stream();
+                }
+            } catch (const quic_error& e) {
+                if (e.code() != quic_error_code::closed) {
+                    throw;
+                }
+            }
+        };
+    });
+
+    constexpr unsigned owner_shard = 0;
+    constexpr unsigned wrong_shard = 1;
+    auto channels = co_await make_udp_channels_for_shards(
+      server.local_address(), accepted_shards, owner_shard, wrong_shard);
+    channels[0].close();
+
+    // This source port is known to land on shard 1, while the synthetic CID
+    // names shard 0 as owner. Keep sending while stop() unregisters shard 0.
+    for (unsigned warmup = 0; warmup < 8; ++warmup) {
+        co_await send_udp_packet(
+          channels[1], server.local_address(), make_short_header_packet_for_shard(owner_shard));
+    }
+    co_await sleep(std::chrono::milliseconds(10));
+
+    constexpr size_t packet_count = 512;
+    auto forwards = send_udp_packets(
+      channels[1], server.local_address(), owner_shard, packet_count);
+    auto stop_future = server.stop();
+    co_await std::move(forwards);
+    channels[1].close();
+    co_await std::move(stop_future);
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_creates_handler_on_every_shard) {
+    sharded_quic_server server;
+    sharded<handler_factory_probe> factory_probes;
+    bool factory_probes_started = false;
+    std::exception_ptr error;
+
+    try {
+        co_await factory_probes.start();
+        factory_probes_started = true;
+
+        quic_server_config server_cfg;
+        server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        co_await server.start(std::move(server_cfg));
+
+        co_await server.serve([&factory_probes] {
+            ++factory_probes.local().calls;
+            return [] (connection session) mutable -> future<> {
+                co_await session.close();
+            };
+        });
+
+        auto called_once_on_every_shard = co_await factory_probes.map_reduce0(
+          [] (const handler_factory_probe& probe) {
+              return probe.calls == 1;
+          },
+          true,
+          [] (bool lhs, bool rhs) {
+              return lhs && rhs;
+          });
+        BOOST_REQUIRE(called_once_on_every_shard);
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+    if (factory_probes_started) {
+        try {
+            co_await factory_probes.stop();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_enforces_lifecycle_and_restarts) {
+    sharded_quic_server server;
+    auto make_handler = [] {
+        return [] (connection session) mutable -> future<> {
+            co_await session.close();
+        };
+    };
+    auto make_config = [] {
+        quic_server_config cfg;
+        cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        cfg.crt_file = "test.crt";
+        cfg.key_file = "test.key";
+        return cfg;
+    };
+
+    require_quic_future_exception(server.serve(make_handler), quic_error::invalid_state);
+
+    co_await server.start(make_config());
+    BOOST_REQUIRE_NE(quic_socket_address_port(server.local_address()), 0);
+    require_quic_future_exception(server.start(make_config()), quic_error::invalid_state);
+
+    co_await server.serve(make_handler);
+    require_quic_future_exception(server.serve(make_handler), quic_error::invalid_state);
+
+    co_await server.stop();
+    co_await server.stop();
+
+    co_await server.start(make_config());
+    BOOST_REQUIRE_NE(quic_socket_address_port(server.local_address()), 0);
+    co_await server.serve(make_handler);
+    co_await server.stop();
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_echoes_connections) {
+    sharded_quic_server server;
+    std::exception_ptr error;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        co_await server.start(std::move(server_cfg));
+
+        auto server_address = server.local_address();
+        BOOST_REQUIRE_EQUAL(server_address.family(), AF_INET);
+        BOOST_REQUIRE_NE(quic_socket_address_port(server_address), 0);
+
+        co_await server.serve([] {
+            return [] (connection session) mutable -> future<> {
+                try {
+                    auto quic_stream = co_await session.accept_stream();
+                    co_await echo_quic_stream(std::move(quic_stream));
+                } catch (const quic_error& e) {
+                    if (e.code() != quic_error::closed) {
+                        throw;
+                    }
+                }
+            };
+        });
+
+        auto client_count = std::max(4u, this_smp_shard_count() * 2u);
+        std::vector<future<>> clients;
+        clients.reserve(client_count);
+        for (unsigned i = 0; i < client_count; ++i) {
+            clients.push_back(quic_echo_client_round_trip(server_address, format("sharded echo {}", i)));
+        }
+        co_await when_all_succeed(clients.begin(), clients.end());
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_destructor_stops_detached) {
+    {
+        sharded_quic_server server;
+
+        quic_server_config server_cfg;
+        server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        co_await server.start(std::move(server_cfg));
+    }
+
+    co_await sleep(std::chrono::milliseconds{100});
+}
+
+SEASTAR_TEST_CASE(test_sharded_quic_server_destructor_stops_detached_with_active_session) {
+    quic_client client;
+    std::optional<connection> session;
+    std::exception_ptr error;
+
+    try {
+        {
+            sharded_quic_server server;
+
+            quic_server_config server_cfg;
+            server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+            server_cfg.crt_file = "test.crt";
+            server_cfg.key_file = "test.key";
+            co_await server.start(std::move(server_cfg));
+
+            auto server_address = server.local_address();
+            co_await server.serve([] {
+                return [] (connection session) mutable -> future<> {
+                    co_await sleep(std::chrono::milliseconds{200});
+                    try {
+                        co_await session.close();
+                    } catch (...) {
+                    }
+                };
+            });
+
+            quic_client_config client_cfg;
+            client_cfg.remote_address = server_address;
+            client_cfg.server_name = "test.scylladb.org";
+            client_cfg.ca_file = "test.crt";
+            session.emplace(co_await client.connect(std::move(client_cfg)));
+            co_await sleep(std::chrono::milliseconds{25});
+        }
+
+        co_await sleep(std::chrono::milliseconds{300});
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+        }
+    }
+
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
 }
 
 SEASTAR_TEST_CASE(test_quic_connection_metadata_tracks_transport_ready) {

--- a/tests/unit/quic_test.cc
+++ b/tests/unit/quic_test.cc
@@ -1,0 +1,2116 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+#include <array>
+#include <deque>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <gnutls/gnutls.h>
+#include <ngtcp2/ngtcp2.h>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/net/api.hh>
+#include <seastar/quic/quic.hh>
+#include <seastar/quic/quic_client.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/testing/test_case.hh>
+
+#include "quic/quic_common.hh"
+#include "quic/quic_error_impl.hh"
+#include "quic/quic_impl.hh"
+
+using namespace seastar;
+using namespace seastar::quic::experimental;
+namespace quic_internal = seastar::quic::experimental::internal;
+using quic_stream = seastar::quic::experimental::stream;
+
+namespace {
+
+constexpr int ngtcp2_err_write_more = NGTCP2_ERR_WRITE_MORE;
+constexpr int ngtcp2_err_stream_data_blocked = NGTCP2_ERR_STREAM_DATA_BLOCKED;
+constexpr int ngtcp2_err_stream_id_blocked = NGTCP2_ERR_STREAM_ID_BLOCKED;
+constexpr int ngtcp2_err_draining = NGTCP2_ERR_DRAINING;
+constexpr int ngtcp2_err_stream_shut_wr = NGTCP2_ERR_STREAM_SHUT_WR;
+
+class fake_connection_transport final : public quic_internal::connection_transport {
+public:
+    fake_connection_transport() = default;
+    ~fake_connection_transport() override = default;
+
+    bool active = true;
+    bool has_connection = true;
+    bool retry_blocked_open_streams = false;
+    bool bidi_retry_pending = false;
+    bool uni_retry_pending = false;
+    bool can_close = false;
+    size_t consume_calls = 0;
+    size_t completed_send_bytes = 0;
+    size_t stream_write_calls = 0;
+    size_t write_pending_calls = 0;
+    size_t send_datagram_calls = 0;
+    size_t rearm_calls = 0;
+    size_t open_stream_calls = 0;
+    size_t complete_open_stream_calls = 0;
+    size_t fail_open_stream_calls = 0;
+    size_t deferred_open_stream_calls = 0;
+    size_t reset_stream_calls = 0;
+    size_t stop_sending_calls = 0;
+    size_t stream_write_closed_calls = 0;
+    size_t request_close_calls = 0;
+    size_t stop_transport_calls = 0;
+    size_t read_datagram_calls = 0;
+    size_t sync_path_calls = 0;
+    size_t timer_expiry_calls = 0;
+    size_t write_connection_close_calls = 0;
+    size_t clear_bidi_retry_calls = 0;
+    size_t clear_uni_retry_calls = 0;
+    stream_id consumed_sid = invalid_stream_id;
+    size_t consumed_len = 0;
+    stream_id reset_sid = invalid_stream_id;
+    stream_id stop_sending_sid = invalid_stream_id;
+    stream_id write_closed_sid = invalid_stream_id;
+    application_error_code reset_error = 0;
+    application_error_code stop_sending_error = 0;
+    stream_id completed_open_sid = invalid_stream_id;
+    int consume_result = 0;
+    int reset_result = 0;
+    int stop_sending_result = 0;
+    int read_datagram_result = 0;
+    int timer_expiry_result = 0;
+    uint64_t expiry_ns = 0;
+    int64_t connection_close_result = 0;
+    temporary_buffer<char> tx_buffer = temporary_buffer<char>(128);
+    std::deque<quic_internal::transport_stream_write_result> stream_write_results;
+    std::deque<quic_internal::transport_open_stream_result> open_stream_results;
+    std::deque<int64_t> pending_packet_results;
+    std::deque<quic_internal::transport_command> deferred_bidi_open_streams;
+    std::deque<quic_internal::transport_command> deferred_uni_open_streams;
+
+    bool transport_active() const noexcept override {
+        return active;
+    }
+
+    bool has_transport_connection() const noexcept override {
+        return has_connection;
+    }
+
+    bool can_retry_blocked_open_streams() const noexcept override {
+        return retry_blocked_open_streams;
+    }
+
+    size_t tx_payload_limit_bytes() const noexcept override {
+        return 1200;
+    }
+
+    int64_t write_pending_packet(uint8_t*, size_t) override {
+        ++write_pending_calls;
+        if (!pending_packet_results.empty()) {
+            auto result = pending_packet_results.front();
+            pending_packet_results.pop_front();
+            return result;
+        }
+        return 0;
+    }
+
+    quic_internal::transport_stream_write_result write_stream_packet(
+      stream_id,
+      const char*,
+      size_t,
+      bool,
+      uint8_t*,
+      size_t) override {
+        ++stream_write_calls;
+        if (!stream_write_results.empty()) {
+            auto result = stream_write_results.front();
+            stream_write_results.pop_front();
+            return result;
+        }
+        return {};
+    }
+
+    quic_internal::transport_open_stream_result try_open_stream(stream_type) override {
+        ++open_stream_calls;
+        if (!open_stream_results.empty()) {
+            auto result = open_stream_results.front();
+            open_stream_results.pop_front();
+            return result;
+        }
+        return {};
+    }
+
+    void complete_send_bytes(size_t len) override {
+        completed_send_bytes += len;
+    }
+
+    void retain_stream_data(stream_id, temporary_buffer<char>) override {
+    }
+
+    int consume_stream_data(stream_id sid, size_t len) override {
+        ++consume_calls;
+        consumed_sid = sid;
+        consumed_len = len;
+        return consume_result;
+    }
+
+    int shutdown_stream_write(stream_id sid, application_error_code app_error_code) override {
+        ++reset_stream_calls;
+        reset_sid = sid;
+        reset_error = app_error_code;
+        return reset_result;
+    }
+
+    int shutdown_stream_read(stream_id sid, application_error_code app_error_code) override {
+        ++stop_sending_calls;
+        stop_sending_sid = sid;
+        stop_sending_error = app_error_code;
+        return stop_sending_result;
+    }
+
+    int read_transport_datagram(const socket_address&, const char*, size_t) override {
+        ++read_datagram_calls;
+        return read_datagram_result;
+    }
+
+    void sync_transport_path() override {
+        ++sync_path_calls;
+    }
+
+    uint64_t transport_expiry_ns() const noexcept override {
+        return expiry_ns;
+    }
+
+    int handle_transport_expiry(uint64_t) override {
+        ++timer_expiry_calls;
+        return timer_expiry_result;
+    }
+
+    temporary_buffer<char>& tx_packet_buffer() override {
+        return tx_buffer;
+    }
+
+    future<> send_datagram_packet(temporary_buffer<char>) override {
+        ++send_datagram_calls;
+        return make_ready_future<>();
+    }
+
+    bool can_send_connection_close() const noexcept override {
+        return can_close;
+    }
+
+    int64_t write_connection_close_packet(uint8_t*, size_t) override {
+        ++write_connection_close_calls;
+        return connection_close_result;
+    }
+
+    void on_stream_write_closed(stream_id sid) override {
+        ++stream_write_closed_calls;
+        write_closed_sid = sid;
+    }
+
+    void rearm_transport_timer() override {
+        ++rearm_calls;
+    }
+
+    void request_close() override {
+        ++request_close_calls;
+    }
+
+    void stop_transport() override {
+        ++stop_transport_calls;
+        active = false;
+    }
+
+    void fail_transport(quic_error_code error, sstring detail) override {
+        last_error = error;
+        last_error_detail = std::move(detail);
+    }
+
+    void complete_open_stream(quic_internal::open_stream_result_ptr result, stream_id sid) override {
+        ++complete_open_stream_calls;
+        completed_open_sid = sid;
+        if (result) {
+            result->set_value(sid);
+        }
+    }
+
+    void fail_open_stream(quic_internal::open_stream_result_ptr result, quic_error_code error, sstring detail) override {
+        ++fail_open_stream_calls;
+        open_stream_error = error;
+        open_stream_error_detail = detail;
+        if (result) {
+            result->set_exception(std::make_exception_ptr(quic_error(error, std::string(detail))));
+        }
+    }
+
+    void defer_blocked_open_stream(quic_internal::transport_command cmd) override {
+        ++deferred_open_stream_calls;
+        auto& q = cmd.type == stream_type::bidirectional
+                    ? deferred_bidi_open_streams
+                    : deferred_uni_open_streams;
+        q.push_back(std::move(cmd));
+    }
+
+    std::optional<quic_internal::transport_command> pop_blocked_open_stream(stream_type type) override {
+        auto& q = type == stream_type::bidirectional
+                    ? deferred_bidi_open_streams
+                    : deferred_uni_open_streams;
+        if (q.empty()) {
+            return std::nullopt;
+        }
+        auto cmd = std::move(q.front());
+        q.pop_front();
+        return cmd;
+    }
+
+    bool blocked_open_stream_retry_pending(stream_type type) const noexcept override {
+        return type == stream_type::bidirectional ? bidi_retry_pending : uni_retry_pending;
+    }
+
+    void clear_blocked_open_stream_retry(stream_type type) noexcept override {
+        if (type == stream_type::bidirectional) {
+            ++clear_bidi_retry_calls;
+            bidi_retry_pending = false;
+        } else {
+            ++clear_uni_retry_calls;
+            uni_retry_pending = false;
+        }
+    }
+
+    std::optional<quic_error_code> last_error;
+    sstring last_error_detail;
+    std::optional<quic_error_code> open_stream_error;
+    sstring open_stream_error_detail;
+};
+
+quic_internal::quic_message make_message(stream_id sid, std::string_view payload, bool fin = false) {
+    return quic_internal::quic_message{
+      .stream = sid,
+      .payload = temporary_buffer<char>::copy_of(payload),
+      .fin = fin,
+    };
+}
+
+template <typename Func>
+void require_quic_error(Func&& func, quic_error_code error) {
+    try {
+        func();
+        BOOST_FAIL("expected quic_error");
+    } catch (const quic_error& e) {
+        BOOST_REQUIRE(e.code() == error);
+    }
+}
+
+template <typename Future>
+void require_quic_future_exception(Future&& fut, quic_error_code error) {
+    try {
+        std::forward<Future>(fut).get();
+        BOOST_FAIL("expected quic_error");
+    } catch (const quic_error& e) {
+        BOOST_REQUIRE(e.code() == error);
+    }
+}
+
+quic_stream open_stream_from_engine(
+  const quic_internal::command_runtime_ptr& runtime,
+  const quic_internal::connection_state_ptr& engine,
+  stream_id sid,
+  stream_type type) {
+    auto opened = engine->open_stream(stream_open_options{.type = type});
+    auto cmd = runtime->poll_command();
+    BOOST_REQUIRE(cmd.has_value());
+    BOOST_REQUIRE(cmd->op == quic_internal::transport_command::kind::open_stream);
+    BOOST_REQUIRE(cmd->open_result);
+    BOOST_REQUIRE(cmd->type == type);
+    runtime->complete_open_stream(cmd->open_result, sid);
+    return opened.get();
+}
+
+socket_address allocate_loopback_quic_address() {
+    auto probe = make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0}));
+    auto address = probe.local_address();
+    probe.close();
+    return address;
+}
+
+future<> echo_quic_stream(quic_stream stream) {
+    auto input = stream.input();
+    auto output = stream.output();
+    while (true) {
+        auto chunk = co_await input.read();
+        if (chunk.empty()) {
+            break;
+        }
+        co_await output.write(std::move(chunk));
+        co_await output.flush();
+    }
+    co_await output.close();
+    co_await input.close();
+}
+
+future<> run_quic_echo_session(quic_server& server, size_t streams_to_accept) {
+    auto session = co_await server.accept();
+    std::vector<future<>> stream_tasks;
+    stream_tasks.reserve(streams_to_accept);
+    for (size_t i = 0; i < streams_to_accept; ++i) {
+        stream_tasks.push_back(echo_quic_stream(co_await session.accept_stream()));
+    }
+    co_await when_all_succeed(stream_tasks.begin(), stream_tasks.end());
+}
+
+future<> quic_echo_round_trip(connection& session, sstring payload) {
+    auto quic_stream = co_await session.open_stream();
+    auto input = quic_stream.input();
+    auto output = quic_stream.output();
+
+    co_await output.write(payload);
+    co_await output.close();
+
+    auto echoed = co_await input.read_exactly(payload.size());
+    BOOST_REQUIRE_EQUAL(to_sstring(std::move(echoed)), payload);
+
+    auto eof = co_await input.read();
+    BOOST_REQUIRE(eof.empty());
+    co_await input.close();
+}
+
+std::array<char, 4> make_frame_header(size_t size) {
+    BOOST_REQUIRE_LE(size, std::numeric_limits<uint32_t>::max());
+    uint32_t value = static_cast<uint32_t>(size);
+    return {
+      static_cast<char>((value >> 24) & 0xff),
+      static_cast<char>((value >> 16) & 0xff),
+      static_cast<char>((value >> 8) & 0xff),
+      static_cast<char>(value & 0xff),
+    };
+}
+
+uint32_t parse_frame_header(const temporary_buffer<char>& header) {
+    BOOST_REQUIRE_EQUAL(header.size(), 4);
+    const auto* p = reinterpret_cast<const unsigned char*>(header.get());
+    return (static_cast<uint32_t>(p[0]) << 24)
+           | (static_cast<uint32_t>(p[1]) << 16)
+           | (static_cast<uint32_t>(p[2]) << 8)
+           | static_cast<uint32_t>(p[3]);
+}
+
+future<sstring> read_quic_frame(input_stream<char>& input) {
+    auto header = co_await input.read_exactly(4);
+    auto size = parse_frame_header(header);
+    auto payload = co_await input.read_exactly(size);
+    BOOST_REQUIRE_EQUAL(payload.size(), size);
+    co_return to_sstring(std::move(payload));
+}
+
+future<> write_quic_frame(output_stream<char>& output, const sstring& payload) {
+    auto header = make_frame_header(payload.size());
+    co_await output.write(header.data(), header.size());
+    co_await output.write(payload);
+    co_await output.flush();
+}
+
+future<> echo_quic_frame(quic_stream stream) {
+    auto input = stream.input();
+    auto output = stream.output();
+    auto payload = co_await read_quic_frame(input);
+    co_await write_quic_frame(output, payload);
+}
+
+future<> run_quic_framed_echo_session(connection& session, size_t streams_to_accept) {
+    std::vector<future<>> stream_tasks;
+    stream_tasks.reserve(streams_to_accept);
+    for (size_t i = 0; i < streams_to_accept; ++i) {
+        stream_tasks.push_back(echo_quic_frame(co_await session.accept_stream()));
+    }
+    co_await when_all_succeed(stream_tasks.begin(), stream_tasks.end());
+}
+
+future<> quic_framed_round_trip(connection& session, sstring payload) {
+    auto stream = co_await session.open_stream();
+    auto input = stream.input();
+    auto output = stream.output();
+
+    co_await write_quic_frame(output, payload);
+
+    auto response = co_await read_quic_frame(input);
+    BOOST_REQUIRE_EQUAL(response, payload);
+}
+
+sstring make_large_quic_payload(size_t size) {
+    sstring payload;
+    payload.resize(size);
+    for (size_t i = 0; i < size; ++i) {
+        payload[i] = static_cast<char>('a' + (i % 26));
+    }
+    return payload;
+}
+
+connection_options large_payload_options() {
+    connection_options options;
+    options.max_pending_send_bytes = 32 * 1024 * 1024;
+    options.max_pending_receive_bytes = 32 * 1024 * 1024;
+    options.transport.initial_max_stream_data_bidi_local = 16 * 1024 * 1024;
+    options.transport.initial_max_stream_data_bidi_remote = 16 * 1024 * 1024;
+    options.transport.initial_max_stream_data_uni = 16 * 1024 * 1024;
+    options.transport.initial_max_data = 64 * 1024 * 1024;
+    return options;
+}
+
+future<> require_quic_handshake_rejected(
+  sstring server_name,
+  sstring ca_file,
+  std::vector<sstring> client_alpns,
+  std::vector<sstring> server_alpns = {sstring("h3")},
+  std::optional<quic_error_code> expected_error = quic_error::protocol) {
+    quic_server server;
+    quic_client client;
+    std::optional<connection> session;
+    std::exception_ptr error;
+    bool rejected = false;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        server_cfg.alpns = std::move(server_alpns);
+        co_await server.start(std::move(server_cfg));
+
+        quic_client_config client_cfg;
+        client_cfg.remote_address = server.local_address();
+        client_cfg.server_name = std::move(server_name);
+        client_cfg.ca_file = std::move(ca_file);
+        client_cfg.alpns = std::move(client_alpns);
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+    } catch (const quic_error& e) {
+        rejected = true;
+        if (expected_error && e.code() != *expected_error) {
+            error = std::current_exception();
+        }
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+    BOOST_REQUIRE(rejected);
+}
+
+} // namespace
+
+SEASTAR_TEST_CASE(test_quic_default_public_objects_are_safe) {
+    return seastar::async([] {
+        quic_stream s;
+        BOOST_REQUIRE(!s.is_open());
+        BOOST_REQUIRE_EQUAL(s.id(), invalid_stream_id);
+        BOOST_REQUIRE(s.type() == stream_type::bidirectional);
+        BOOST_REQUIRE(!s.can_read());
+        BOOST_REQUIRE(!s.can_write());
+        require_quic_error([&s] { (void)s.input(); }, quic_error::invalid_state);
+        require_quic_error([&s] { (void)s.output(); }, quic_error::invalid_state);
+        require_quic_future_exception(s.close_output(), quic_error::invalid_state);
+        require_quic_future_exception(s.reset(), quic_error::invalid_state);
+        require_quic_future_exception(s.stop_sending(), quic_error::invalid_state);
+        require_quic_future_exception(s.wait_input_shutdown(), quic_error::invalid_state);
+        require_quic_error([s = std::move(s)]() mutable { (void)to_connected_socket(std::move(s)); }, quic_error::invalid_state);
+
+        connection c;
+        BOOST_REQUIRE(!c.is_open());
+        require_quic_future_exception(c.open_stream(), quic_error::invalid_state);
+        require_quic_future_exception(c.accept_stream(), quic_error::invalid_state);
+        c.close().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_client_server_echoes_concurrent_streams_on_one_connection) {
+    auto address = allocate_loopback_quic_address();
+    std::vector<sstring> messages = {
+      "first request",
+      "second request with a longer payload",
+      "third request",
+      "fourth request on the same connection",
+      "fifth request",
+    };
+
+    quic_server server;
+    quic_client client;
+    std::optional<connection> session;
+    std::optional<future<>> server_task;
+    std::exception_ptr error;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = address;
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        co_await server.start(std::move(server_cfg));
+        server_task.emplace(run_quic_echo_session(server, messages.size()));
+
+        quic_client_config client_cfg;
+        client_cfg.remote_address = address;
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+
+        std::vector<future<>> client_tasks;
+        client_tasks.reserve(messages.size());
+        for (auto& message : messages) {
+            client_tasks.push_back(quic_echo_round_trip(*session, message));
+        }
+        co_await when_all_succeed(client_tasks.begin(), client_tasks.end());
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (server_task) {
+        try {
+            co_await std::move(*server_task);
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_quic_client_server_handles_concurrent_framed_requests_on_one_connection) {
+    auto address = allocate_loopback_quic_address();
+    std::vector<sstring> messages = {
+      "aaa",
+      make_large_quic_payload(128 * 1024),
+      make_large_quic_payload(1024 * 1024),
+      "bbbbb",
+      make_large_quic_payload(2 * 1024 * 1024),
+      "cc",
+      make_large_quic_payload(4 * 1024 * 1024),
+      "dddddd",
+    };
+
+    quic_server server;
+    quic_client client;
+    std::optional<connection> session;
+    std::optional<connection> server_session;
+    std::optional<future<>> server_task;
+    std::exception_ptr error;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = address;
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        server_cfg.session_options = large_payload_options();
+        co_await server.start(std::move(server_cfg));
+        auto server_accept = server.accept();
+
+        quic_client_config client_cfg;
+        client_cfg.remote_address = address;
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        client_cfg.session_options = large_payload_options();
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+        server_session.emplace(co_await std::move(server_accept));
+        server_task.emplace(run_quic_framed_echo_session(*server_session, messages.size()));
+
+        std::vector<future<>> client_tasks;
+        client_tasks.reserve(messages.size());
+        for (auto& message : messages) {
+            client_tasks.push_back(quic_framed_round_trip(*session, message));
+        }
+        co_await when_all_succeed(client_tasks.begin(), client_tasks.end());
+        co_await std::move(*server_task);
+        server_task.reset();
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (server_session) {
+        try {
+            co_await server_session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (server_task) {
+        try {
+            co_await std::move(*server_task);
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_quic_client_server_handles_large_framed_request) {
+    auto address = allocate_loopback_quic_address();
+    auto message = make_large_quic_payload(8 * 1024 * 1024);
+
+    quic_server server;
+    quic_client client;
+    std::optional<connection> session;
+    std::optional<connection> server_session;
+    std::optional<future<>> server_task;
+    std::exception_ptr error;
+
+    try {
+        quic_server_config server_cfg;
+        server_cfg.listen_address = address;
+        server_cfg.crt_file = "test.crt";
+        server_cfg.key_file = "test.key";
+        server_cfg.session_options = large_payload_options();
+        co_await server.start(std::move(server_cfg));
+        auto server_accept = server.accept();
+
+        quic_client_config client_cfg;
+        client_cfg.remote_address = address;
+        client_cfg.server_name = "test.scylladb.org";
+        client_cfg.ca_file = "test.crt";
+        client_cfg.session_options = large_payload_options();
+        session.emplace(co_await client.connect(std::move(client_cfg)));
+        server_session.emplace(co_await std::move(server_accept));
+        server_task.emplace(run_quic_framed_echo_session(*server_session, 1));
+
+        co_await quic_framed_round_trip(*session, message);
+        co_await std::move(*server_task);
+        server_task.reset();
+    } catch (...) {
+        error = std::current_exception();
+    }
+
+    if (session) {
+        try {
+            co_await session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (server_session) {
+        try {
+            co_await server_session->close();
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    try {
+        co_await client.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    try {
+        co_await server.stop();
+    } catch (...) {
+        if (!error) {
+            error = std::current_exception();
+        }
+    }
+
+    if (server_task) {
+        try {
+            co_await std::move(*server_task);
+        } catch (...) {
+            if (!error) {
+                error = std::current_exception();
+            }
+        }
+    }
+
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+SEASTAR_TEST_CASE(test_quic_client_rejects_certificate_for_wrong_server_name) {
+    return require_quic_handshake_rejected(
+      "wrong.scylladb.org", "test.crt", {sstring("h3")});
+}
+
+SEASTAR_TEST_CASE(test_quic_client_rejects_untrusted_server_certificate) {
+    return require_quic_handshake_rejected(
+      "test.scylladb.org", "other.crt", {sstring("h3")});
+}
+
+SEASTAR_TEST_CASE(test_quic_handshake_rejects_missing_common_alpn) {
+    return require_quic_handshake_rejected(
+      "test.scylladb.org",
+      "test.crt",
+      {sstring("custom-client-protocol")},
+      {sstring("h3")},
+      std::nullopt);
+}
+
+SEASTAR_TEST_CASE(test_quic_client_rejects_empty_alpn_configuration) {
+    return seastar::async([] {
+        quic_client client;
+        quic_client_config cfg;
+        cfg.remote_address = make_ipv4_address({0x7f000001, 4433});
+        cfg.alpns.clear();
+
+        require_quic_future_exception(client.connect(std::move(cfg)), quic_error::invalid_argument);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_client_rejects_empty_alpn_identifier) {
+    return seastar::async([] {
+        quic_client client;
+        quic_client_config cfg;
+        cfg.remote_address = make_ipv4_address({0x7f000001, 4433});
+        cfg.alpns = {sstring()};
+
+        require_quic_future_exception(client.connect(std::move(cfg)), quic_error::invalid_argument);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_server_rejects_empty_alpn_configuration) {
+    return seastar::async([] {
+        quic_server server;
+        quic_server_config cfg;
+        cfg.listen_address = make_ipv4_address({0x7f000001, 0});
+        cfg.crt_file = "unused.crt";
+        cfg.key_file = "unused.key";
+        cfg.alpns.clear();
+
+        require_quic_future_exception(server.start(std::move(cfg)), quic_error::invalid_argument);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_connection_metadata_tracks_transport_ready) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+        auto local = socket_address(ipv4_addr("127.0.0.1", 1111));
+        auto peer = socket_address(ipv4_addr("127.0.0.1", 2222));
+
+        runtime->mark_transport_ready(local, peer, "h3");
+
+        BOOST_REQUIRE(engine->is_open());
+        BOOST_REQUIRE_EQUAL(engine->local_address(), local);
+        BOOST_REQUIRE_EQUAL(engine->peer_address(), peer);
+        BOOST_REQUIRE_EQUAL(engine->selected_alpn(), "h3");
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_open_stream_exposes_directional_capabilities) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        auto bidi = open_stream_from_engine(runtime, engine, 0, stream_type::bidirectional);
+        BOOST_REQUIRE(bidi.is_open());
+        BOOST_REQUIRE_EQUAL(bidi.id(), 0);
+        BOOST_REQUIRE(bidi.type() == stream_type::bidirectional);
+        BOOST_REQUIRE(bidi.can_read());
+        BOOST_REQUIRE(bidi.can_write());
+        (void)bidi.input();
+        (void)bidi.output();
+
+        auto uni = open_stream_from_engine(runtime, engine, 2, stream_type::unidirectional);
+        BOOST_REQUIRE(uni.is_open());
+        BOOST_REQUIRE_EQUAL(uni.id(), 2);
+        BOOST_REQUIRE(uni.type() == stream_type::unidirectional);
+        BOOST_REQUIRE(!uni.can_read());
+        BOOST_REQUIRE(uni.can_write());
+        require_quic_error([&uni] { (void)uni.input(); }, quic_error::invalid_state);
+        (void)uni.output();
+        require_quic_error([uni = std::move(uni)]() mutable { (void)to_connected_socket(std::move(uni)); }, quic_error::invalid_state);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_accept_stream_exposes_peer_directional_capabilities_once) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(5, stream_type::unidirectional, true, temporary_buffer<char>("abc", 3), false);
+        engine->on_stream_data(5, stream_type::unidirectional, true, temporary_buffer<char>("def", 3), false);
+
+        auto accepted = engine->accept_stream().get();
+        BOOST_REQUIRE(accepted.is_open());
+        BOOST_REQUIRE_EQUAL(accepted.id(), 5);
+        BOOST_REQUIRE(accepted.type() == stream_type::unidirectional);
+        BOOST_REQUIRE(accepted.can_read());
+        BOOST_REQUIRE(!accepted.can_write());
+        (void)accepted.input();
+        require_quic_error([&accepted] { (void)accepted.output(); }, quic_error::invalid_state);
+
+        auto second_accept = engine->accept_stream();
+        BOOST_REQUIRE(!second_accept.available());
+        engine->on_transport_closed(std::make_exception_ptr(quic_error(quic_error::closed, "done")));
+        require_quic_future_exception(std::move(second_accept), quic_error::closed);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_pending_accept_completes_when_peer_stream_arrives) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        auto pending_accept = engine->accept_stream();
+        BOOST_REQUIRE(!pending_accept.available());
+
+        engine->on_stream_data(7, stream_type::bidirectional, true, temporary_buffer<char>("hello", 5), false);
+
+        auto accepted = pending_accept.get();
+        BOOST_REQUIRE(accepted.is_open());
+        BOOST_REQUIRE_EQUAL(accepted.id(), 7);
+        BOOST_REQUIRE(accepted.type() == stream_type::bidirectional);
+        BOOST_REQUIRE(accepted.can_read());
+        BOOST_REQUIRE(accepted.can_write());
+
+        auto input = accepted.input();
+        auto chunk = input.read_exactly(5).get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "hello");
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_peer_stream_data_is_buffered_before_accept) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(9, stream_type::bidirectional, true, temporary_buffer<char>("abc", 3), false);
+        engine->on_stream_data(9, stream_type::bidirectional, true, temporary_buffer<char>("def", 3), false);
+
+        auto accepted = engine->accept_stream().get();
+        BOOST_REQUIRE_EQUAL(accepted.id(), 9);
+
+        auto input = accepted.input();
+        auto payload = input.read_exactly(6).get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(payload)), "abcdef");
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_fin_completes_input_shutdown_and_eof) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(7, stream_type::bidirectional, true, temporary_buffer<char>("ping", 4), true);
+        auto accepted = engine->accept_stream().get();
+        auto shutdown = accepted.wait_input_shutdown();
+        BOOST_REQUIRE(shutdown.available());
+        shutdown.get();
+
+        auto input = accepted.input();
+        auto chunk = input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "ping");
+        auto eof = input.read().get();
+        BOOST_REQUIRE(eof.empty());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_stream_close_reset_and_stop_sending_queue_commands) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        auto output_stream = open_stream_from_engine(runtime, engine, 9, stream_type::bidirectional);
+        output_stream.close_output().get();
+        auto close_cmd = runtime->poll_command();
+        BOOST_REQUIRE(close_cmd.has_value());
+        BOOST_REQUIRE(close_cmd->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(close_cmd->msg.stream, 9);
+        BOOST_REQUIRE(close_cmd->msg.payload.empty());
+        BOOST_REQUIRE(close_cmd->msg.fin);
+        require_quic_error([&output_stream] { (void)output_stream.output(); }, quic_error::closed);
+
+        auto reset_stream = open_stream_from_engine(runtime, engine, 11, stream_type::bidirectional);
+        reset_stream.reset(123).get();
+        auto reset_cmd = runtime->poll_command();
+        BOOST_REQUIRE(reset_cmd.has_value());
+        BOOST_REQUIRE(reset_cmd->op == quic_internal::transport_command::kind::reset_stream);
+        BOOST_REQUIRE_EQUAL(reset_cmd->msg.stream, 11);
+        BOOST_REQUIRE_EQUAL(reset_cmd->app_error_code, 123);
+
+        engine->on_stream_data(13, stream_type::bidirectional, true, temporary_buffer<char>("payload", 7), false);
+        auto input_stream = engine->accept_stream().get();
+        input_stream.stop_sending(77).get();
+        auto stop_cmd = runtime->poll_command();
+        BOOST_REQUIRE(stop_cmd.has_value());
+        BOOST_REQUIRE(stop_cmd->op == quic_internal::transport_command::kind::stop_sending);
+        BOOST_REQUIRE_EQUAL(stop_cmd->msg.stream, 13);
+        BOOST_REQUIRE_EQUAL(stop_cmd->app_error_code, 77);
+        require_quic_future_exception(input_stream.input().read(), quic_error::closed);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_peer_reset_aborts_stream_input) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(14, stream_type::bidirectional, true, temporary_buffer<char>("payload", 7), false);
+        auto accepted = engine->accept_stream().get();
+        auto input = accepted.input();
+        auto chunk = input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "payload");
+
+        auto shutdown = accepted.wait_input_shutdown();
+        BOOST_REQUIRE(!shutdown.available());
+
+        engine->on_stream_reset(14, stream_type::bidirectional, true, 1234);
+
+        shutdown.get();
+        require_quic_future_exception(input.read(), quic_error::closed);
+        BOOST_REQUIRE(accepted.is_open());
+        (void)accepted.output();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_peer_stop_sending_closes_stream_output) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        auto opened = open_stream_from_engine(runtime, engine, 16, stream_type::bidirectional);
+        BOOST_REQUIRE(opened.can_write());
+        (void)opened.output();
+
+        engine->on_stream_stop_sending(
+          16,
+          stream_type::bidirectional,
+          false,
+          4321,
+          quic_internal::stream_shutdown_side::write);
+
+        require_quic_error([&opened] { (void)opened.output(); }, quic_error::closed);
+        opened.close_output().get();
+        BOOST_REQUIRE(!runtime->poll_command().has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_peer_stop_sending_read_aborts_stream_input) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(18, stream_type::bidirectional, true, temporary_buffer<char>("payload", 7), false);
+        auto accepted = engine->accept_stream().get();
+        auto input = accepted.input();
+        auto chunk = input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "payload");
+
+        auto shutdown = accepted.wait_input_shutdown();
+        BOOST_REQUIRE(!shutdown.available());
+
+        engine->on_stream_stop_sending(
+          18,
+          stream_type::bidirectional,
+          true,
+          5678,
+          quic_internal::stream_shutdown_side::read);
+
+        shutdown.get();
+        require_quic_future_exception(input.read(), quic_error::closed);
+        BOOST_REQUIRE(accepted.is_open());
+        (void)accepted.output();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_connected_socket_wraps_bidirectional_stream) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+        auto local = socket_address(ipv4_addr("127.0.0.1", 3333));
+        auto peer = socket_address(ipv4_addr("127.0.0.1", 4444));
+        runtime->mark_transport_ready(local, peer, "h3");
+
+        engine->on_stream_data(15, stream_type::bidirectional, true, temporary_buffer<char>("hello", 5), false);
+        auto accepted = engine->accept_stream().get();
+        auto sock = to_connected_socket(std::move(accepted));
+
+        BOOST_REQUIRE_EQUAL(sock.local_address(), local);
+        BOOST_REQUIRE_EQUAL(sock.remote_address(), peer);
+        BOOST_REQUIRE(sock.get_nodelay());
+        BOOST_REQUIRE(!sock.get_keepalive());
+
+        auto input = sock.input();
+        auto chunk = input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "hello");
+        auto consume_cmd = runtime->poll_command();
+        BOOST_REQUIRE(consume_cmd.has_value());
+        BOOST_REQUIRE(consume_cmd->op == quic_internal::transport_command::kind::consume_stream_data);
+        BOOST_REQUIRE_EQUAL(consume_cmd->msg.stream, 15);
+
+        sock.shutdown_output();
+        auto close_cmd = runtime->poll_command();
+        BOOST_REQUIRE(close_cmd.has_value());
+        BOOST_REQUIRE(close_cmd->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE(close_cmd->msg.fin);
+
+        auto shutdown = sock.wait_input_shutdown();
+        BOOST_REQUIRE(!shutdown.available());
+        sock.shutdown_input();
+        shutdown.get();
+        auto stop_cmd = runtime->poll_command();
+        BOOST_REQUIRE(stop_cmd.has_value());
+        BOOST_REQUIRE(stop_cmd->op == quic_internal::transport_command::kind::stop_sending);
+        BOOST_REQUIRE_EQUAL(stop_cmd->msg.stream, 15);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_connection_close_terminates_pending_accept_and_open) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        auto pending_accept = engine->accept_stream();
+        auto pending_open = engine->open_stream();
+        BOOST_REQUIRE(!pending_accept.available());
+        BOOST_REQUIRE(!pending_open.available());
+
+        engine->close().get();
+        BOOST_REQUIRE(!engine->is_open());
+
+        runtime->mark_transport_closed();
+        engine->on_transport_closed(std::make_exception_ptr(quic_error(quic_error::closed, "transport closed")));
+
+        require_quic_future_exception(std::move(pending_accept), quic_error::closed);
+        require_quic_future_exception(std::move(pending_open), quic_error::closed);
+
+        auto open_cmd = runtime->poll_command();
+        BOOST_REQUIRE(open_cmd.has_value());
+        BOOST_REQUIRE(open_cmd->op == quic_internal::transport_command::kind::open_stream);
+        BOOST_REQUIRE(!open_cmd->open_result);
+
+        auto close_cmd = runtime->poll_command();
+        BOOST_REQUIRE(close_cmd.has_value());
+        BOOST_REQUIRE(close_cmd->op == quic_internal::transport_command::kind::close_connection);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_stream_closed_detaches_old_handle_from_reused_stream_id) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(22, stream_type::bidirectional, true, temporary_buffer<char>("old", 3), false);
+        auto old_stream = engine->accept_stream().get();
+        auto old_input = old_stream.input();
+        auto old_chunk = old_input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(old_chunk)), "old");
+        auto old_consume_cmd = runtime->poll_command();
+        BOOST_REQUIRE(old_consume_cmd.has_value());
+        BOOST_REQUIRE(old_consume_cmd->op == quic_internal::transport_command::kind::consume_stream_data);
+
+        engine->on_stream_closed(22);
+        engine->on_stream_data(22, stream_type::bidirectional, true, temporary_buffer<char>("new", 3), true);
+
+        auto new_stream = engine->accept_stream().get();
+        BOOST_REQUIRE_EQUAL(new_stream.id(), 22);
+        auto new_input = new_stream.input();
+        auto new_chunk = new_input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(new_chunk)), "new");
+        BOOST_REQUIRE(new_input.read().get().empty());
+
+        old_stream.close_output().get();
+        auto close_cmd = runtime->poll_command();
+        BOOST_REQUIRE(close_cmd.has_value());
+        BOOST_REQUIRE(close_cmd->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(close_cmd->msg.stream, 22);
+        BOOST_REQUIRE(close_cmd->msg.fin);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_transport_close_aborts_pending_accept_and_existing_streams) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        engine->on_stream_data(17, stream_type::bidirectional, true, temporary_buffer<char>("payload", 7), false);
+        auto accepted = engine->accept_stream().get();
+        auto input = accepted.input();
+        auto pending_accept = engine->accept_stream();
+
+        engine->on_transport_closed(std::make_exception_ptr(quic_error(quic_error::closed, "transport closed")));
+
+        require_quic_future_exception(std::move(pending_accept), quic_error::closed);
+        require_quic_future_exception(input.read(), quic_error::closed);
+        BOOST_REQUIRE(!accepted.is_open());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_receive_budget_accepts_payload_at_limit) {
+    return seastar::async([] {
+        connection_options options;
+        options.max_pending_receive_bytes = 4;
+        auto runtime = quic_internal::make_command_runtime(options);
+        auto engine = quic_internal::make_connection_state(runtime, options);
+
+        engine->on_stream_data(20, stream_type::bidirectional, true, temporary_buffer<char>("ping", 4), false);
+
+        BOOST_REQUIRE(!runtime->transport_failed());
+        auto accepted = engine->accept_stream().get();
+        auto input = accepted.input();
+        auto chunk = input.read().get();
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "ping");
+
+        auto consume_cmd = runtime->poll_command();
+        BOOST_REQUIRE(consume_cmd.has_value());
+        BOOST_REQUIRE(consume_cmd->op == quic_internal::transport_command::kind::consume_stream_data);
+        BOOST_REQUIRE_EQUAL(consume_cmd->msg.stream, 20);
+        BOOST_REQUIRE_EQUAL(consume_cmd->consumed_bytes, 4);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_receive_budget_failure_stops_only_stream_input) {
+    return seastar::async([] {
+        connection_options options;
+        options.max_pending_receive_bytes = 4;
+        auto runtime = quic_internal::make_command_runtime(options);
+        auto engine = quic_internal::make_connection_state(runtime, options);
+
+        engine->on_stream_data(19, stream_type::bidirectional, true, temporary_buffer<char>("hello", 5), false);
+
+        BOOST_REQUIRE(!runtime->transport_failed());
+        auto accepted = engine->accept_stream().get();
+        require_quic_future_exception(accepted.input().read(), quic_error::io);
+        BOOST_REQUIRE(!runtime->poll_command().has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_receive_flow_control_window_is_capped_by_pending_receive_budget) {
+    return seastar::async([] {
+        connection_options options;
+        options.max_pending_receive_bytes = 4096;
+        options.transport.initial_max_stream_data_bidi_local = 1 << 20;
+        options.transport.initial_max_stream_data_bidi_remote = 1 << 19;
+        options.transport.initial_max_stream_data_uni = 1 << 18;
+        options.transport.initial_max_data = 1 << 21;
+
+        BOOST_REQUIRE_EQUAL(
+          effective_initial_receive_window(options, options.transport.initial_max_stream_data_bidi_local),
+          options.max_pending_receive_bytes);
+        BOOST_REQUIRE_EQUAL(
+          effective_initial_receive_window(options, options.transport.initial_max_stream_data_bidi_remote),
+          options.max_pending_receive_bytes);
+        BOOST_REQUIRE_EQUAL(
+          effective_initial_receive_window(options, options.transport.initial_max_stream_data_uni),
+          options.max_pending_receive_bytes);
+        BOOST_REQUIRE_EQUAL(
+          effective_initial_receive_window(options, options.transport.initial_max_data),
+          options.max_pending_receive_bytes);
+
+        options.transport.initial_max_data = 2048;
+        BOOST_REQUIRE_EQUAL(
+          effective_initial_receive_window(options, options.transport.initial_max_data),
+          options.transport.initial_max_data);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_accept_stream_queue_overflow_defers_delivery) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto engine = quic_internal::make_connection_state(runtime);
+
+        for (stream_id sid = 0; sid < 1025; ++sid) {
+            engine->on_stream_data(sid, stream_type::unidirectional, true, temporary_buffer<char>(), false);
+        }
+
+        BOOST_REQUIRE(!runtime->transport_failed());
+
+        for (stream_id sid = 0; sid < 1025; ++sid) {
+            auto accepted = engine->accept_stream().get();
+            BOOST_REQUIRE_EQUAL(accepted.id(), sid);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_runtime_close_and_error_drain_pending_open_streams) {
+    return seastar::async([] {
+        auto runtime = quic_internal::make_command_runtime();
+        auto open = runtime->open_stream(stream_type::bidirectional);
+        BOOST_REQUIRE(!open.available());
+
+        runtime->mark_transport_closed();
+
+        require_quic_future_exception(std::move(open), quic_error::closed);
+        require_quic_future_exception(runtime->send(make_message(1, "x")), quic_error::closed);
+
+        auto failed_runtime = quic_internal::make_command_runtime();
+        auto failed_open = failed_runtime->open_stream(stream_type::bidirectional);
+        failed_runtime->mark_error(quic_error::protocol, "bad packet");
+        require_quic_future_exception(std::move(failed_open), quic_error::protocol);
+        require_quic_future_exception(failed_runtime->open_stream(stream_type::bidirectional), quic_error::protocol);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_reading_stream_queues_consumed_credit) {
+    return seastar::async([] {
+        auto command_runtime = quic_internal::make_command_runtime();
+        auto connection_state = quic_internal::make_connection_state(command_runtime);
+
+        connection_state->on_stream_data(
+          0,
+          stream_type::bidirectional,
+          true,
+          temporary_buffer<char>("ping", 4),
+          false);
+
+        auto accepted = connection_state->accept_stream().get();
+        auto input = accepted.input();
+        auto chunk = input.read().get();
+
+        BOOST_REQUIRE_EQUAL(to_sstring(std::move(chunk)), "ping");
+
+        auto cmd = command_runtime->poll_command();
+        BOOST_REQUIRE(cmd.has_value());
+        BOOST_REQUIRE(cmd->op == quic_internal::transport_command::kind::consume_stream_data);
+        BOOST_REQUIRE_EQUAL(cmd->msg.stream, 0);
+        BOOST_REQUIRE_EQUAL(cmd->consumed_bytes, 4);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_consume_stream_command_updates_transport_credit) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::consume_stream_data;
+        cmd.msg.stream = 7;
+        cmd.consumed_bytes = 64;
+
+        quic_internal::handle_transport_command(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE_EQUAL(transport.consume_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.consumed_sid, 7);
+        BOOST_REQUIRE_EQUAL(transport.consumed_len, 64);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_backpressure_waits_for_transport_consumption) {
+    return seastar::async([] {
+        connection_options options;
+        options.max_pending_send_bytes = 4;
+
+        auto command_runtime = quic_internal::make_command_runtime(options);
+        command_runtime->send(make_message(0, "ping")).get();
+
+        auto first = command_runtime->poll_command();
+        BOOST_REQUIRE(first.has_value());
+        BOOST_REQUIRE(first->op == quic_internal::transport_command::kind::send);
+
+        auto blocked_send = command_runtime->send(make_message(0, "x"));
+        BOOST_REQUIRE(!blocked_send.available());
+
+        command_runtime->complete_send_bytes(first->msg.payload.size());
+        blocked_send.get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_backpressure_chunks_single_large_send) {
+    return seastar::async([] {
+        connection_options options;
+        options.max_pending_send_bytes = 4;
+
+        auto command_runtime = quic_internal::make_command_runtime(options);
+        auto oversized_send = command_runtime->send(make_message(0, "hello", true));
+        BOOST_REQUIRE(!oversized_send.available());
+
+        auto first = command_runtime->poll_command();
+        BOOST_REQUIRE(first.has_value());
+        BOOST_REQUIRE(first->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(to_sstring(first->msg.payload.share()), "hell");
+        BOOST_REQUIRE(!first->msg.fin);
+        BOOST_REQUIRE(!command_runtime->poll_command().has_value());
+
+        command_runtime->complete_send_bytes(first->msg.payload.size());
+        oversized_send.get();
+
+        auto second = command_runtime->poll_command();
+        BOOST_REQUIRE(second.has_value());
+        BOOST_REQUIRE(second->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(to_sstring(second->msg.payload.share()), "o");
+        BOOST_REQUIRE(second->msg.fin);
+        BOOST_REQUIRE(!command_runtime->poll_command().has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_consume_stream_data_coalesces_pending_credit) {
+    return seastar::async([] {
+        auto command_runtime = quic_internal::make_command_runtime(connection_options{});
+
+        command_runtime->consume_stream_data(7, 4);
+        command_runtime->consume_stream_data(7, 5);
+
+        auto cmd = command_runtime->poll_command();
+        BOOST_REQUIRE(cmd.has_value());
+        BOOST_REQUIRE(cmd->op == quic_internal::transport_command::kind::consume_stream_data);
+        BOOST_REQUIRE_EQUAL(cmd->msg.stream, 7);
+        BOOST_REQUIRE_EQUAL(cmd->consumed_bytes, 9);
+        BOOST_REQUIRE(!command_runtime->poll_command().has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_defers_remaining_payload_when_blocked) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_write_more,
+          .consumed = 3,
+        });
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = 0,
+          .consumed = 0,
+        });
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::send;
+        cmd.msg = make_message(9, "hello");
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE(blocked.has_value());
+        BOOST_REQUIRE(blocked->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(blocked->msg.stream, 9);
+        BOOST_REQUIRE_EQUAL(to_sstring(blocked->msg.payload.share()), "lo");
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 3);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_calls, 2);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 2);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_retry_completes_deferred_payload) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_write_more,
+          .consumed = 3,
+        });
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = 0,
+          .consumed = 0,
+        });
+
+        quic_internal::transport_command first_cmd;
+        first_cmd.op = quic_internal::transport_command::kind::send;
+        first_cmd.msg = make_message(11, "hello");
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(first_cmd)).get();
+        BOOST_REQUIRE(blocked.has_value());
+
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = 17,
+          .consumed = 2,
+        });
+
+        auto resumed = quic_internal::handle_transport_command(transport, std::move(*blocked)).get();
+
+        BOOST_REQUIRE(!resumed.has_value());
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_calls, 3);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 3);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 2);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_defers_payload_when_stream_flow_control_blocks) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_stream_data_blocked,
+          .consumed = 0,
+        });
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::send;
+        cmd.msg = make_message(13, "hello");
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE(blocked.has_value());
+        BOOST_REQUIRE(blocked->op == quic_internal::transport_command::kind::send);
+        BOOST_REQUIRE_EQUAL(blocked->msg.stream, 13);
+        BOOST_REQUIRE_EQUAL(to_sstring(blocked->msg.payload.share()), "hello");
+        BOOST_REQUIRE(!blocked->msg.fin);
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 0);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_retry_fin_completes_without_duplicate_write) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_stream_data_blocked,
+          .consumed = 0,
+        });
+
+        quic_internal::transport_command first_cmd;
+        first_cmd.op = quic_internal::transport_command::kind::send;
+        first_cmd.msg = make_message(17, "hello", true);
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(first_cmd)).get();
+        BOOST_REQUIRE(blocked.has_value());
+        BOOST_REQUIRE(blocked->msg.fin);
+        BOOST_REQUIRE_EQUAL(to_sstring(blocked->msg.payload.share()), "hello");
+
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = 19,
+          .consumed = 5,
+        });
+
+        auto resumed = quic_internal::handle_transport_command(transport, std::move(*blocked)).get();
+
+        BOOST_REQUIRE(!resumed.has_value());
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_calls, 2);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 2);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 2);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_open_stream_command_completes_result) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.open_stream_results.push_back(quic_internal::transport_open_stream_result{
+          .rv = 0,
+          .sid = 21,
+        });
+
+        auto result = make_lw_shared<promise<stream_id>>();
+        auto result_future = result->get_future();
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::open_stream;
+        cmd.type = stream_type::bidirectional;
+        cmd.open_result = result;
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE_EQUAL(result_future.get(), 21);
+        BOOST_REQUIRE_EQUAL(transport.open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.complete_open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.completed_open_sid, 21);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+        BOOST_REQUIRE(!transport.open_stream_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_open_stream_command_failure_propagates_error) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.open_stream_results.push_back(quic_internal::transport_open_stream_result{
+          .rv = NGTCP2_ERR_PROTO,
+          .sid = invalid_stream_id,
+        });
+
+        auto result = make_lw_shared<promise<stream_id>>();
+        auto result_future = result->get_future();
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::open_stream;
+        cmd.type = stream_type::bidirectional;
+        cmd.open_result = result;
+
+        auto blocked = quic_internal::handle_transport_command(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE_EQUAL(transport.open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.fail_open_stream_calls, 1);
+        BOOST_REQUIRE(transport.open_stream_error.has_value());
+        BOOST_REQUIRE(*transport.open_stream_error == quic_error::protocol);
+        BOOST_REQUIRE(!transport.open_stream_error_detail.empty());
+        BOOST_REQUIRE(transport.last_error.has_value());
+        BOOST_REQUIRE(*transport.last_error == quic_error::protocol);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 0);
+
+        try {
+            (void)result_future.get();
+            BOOST_FAIL("expected open_stream to fail");
+        } catch (const quic_error& e) {
+            BOOST_REQUIRE(e.code() == quic_error::protocol);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_open_stream_command_defers_when_stream_id_blocked) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.open_stream_results.push_back(quic_internal::transport_open_stream_result{
+          .rv = ngtcp2_err_stream_id_blocked,
+          .sid = invalid_stream_id,
+        });
+
+        auto result = make_lw_shared<promise<stream_id>>();
+        auto result_future = result->get_future();
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::open_stream;
+        cmd.type = stream_type::unidirectional;
+        cmd.open_result = result;
+
+        auto blocked = quic_internal::open_stream(transport, std::move(cmd)).get();
+
+        BOOST_REQUIRE(blocked);
+        BOOST_REQUIRE(!result_future.available());
+        BOOST_REQUIRE_EQUAL(transport.open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.deferred_open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.deferred_uni_open_streams.size(), 1);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_retry_blocked_open_streams_completes_deferred_stream) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.retry_blocked_open_streams = true;
+        transport.bidi_retry_pending = true;
+        transport.open_stream_results.push_back(quic_internal::transport_open_stream_result{
+          .rv = 0,
+          .sid = 23,
+        });
+
+        auto result = make_lw_shared<promise<stream_id>>();
+        auto result_future = result->get_future();
+
+        quic_internal::transport_command cmd;
+        cmd.op = quic_internal::transport_command::kind::open_stream;
+        cmd.type = stream_type::bidirectional;
+        cmd.open_result = result;
+        transport.defer_blocked_open_stream(std::move(cmd));
+
+        quic_internal::retry_blocked_open_streams(transport, stream_type::bidirectional).get();
+
+        BOOST_REQUIRE(!transport.bidi_retry_pending);
+        BOOST_REQUIRE_EQUAL(transport.clear_bidi_retry_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.complete_open_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(result_future.get(), 23);
+        BOOST_REQUIRE(transport.deferred_bidi_open_streams.empty());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_draining_stops_transport_and_completes_bytes) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_draining,
+          .consumed = 0,
+        });
+
+        auto blocked = quic_internal::send_stream_message(transport, make_message(25, "hello")).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE(!transport.active);
+        BOOST_REQUIRE_EQUAL(transport.stop_transport_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_stream_closed_discards_payload_without_transport_failure) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = ngtcp2_err_stream_shut_wr,
+          .consumed = 2,
+        });
+
+        auto blocked = quic_internal::send_stream_message(transport, make_message(27, "hello")).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_closed_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.write_closed_sid, 27);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_backend_error_fails_transport) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.stream_write_results.push_back(quic_internal::transport_stream_write_result{
+          .nwrite = NGTCP2_ERR_CALLBACK_FAILURE,
+          .consumed = 1,
+        });
+
+        auto blocked = quic_internal::send_stream_message(transport, make_message(29, "hello")).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE(transport.last_error.has_value());
+        BOOST_REQUIRE(*transport.last_error == quic_error::backend);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_send_command_without_connection_discards_payload) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.has_connection = false;
+
+        auto blocked = quic_internal::send_stream_message(transport, make_message(31, "hello", true)).get();
+
+        BOOST_REQUIRE(!blocked.has_value());
+        BOOST_REQUIRE_EQUAL(transport.completed_send_bytes, 5);
+        BOOST_REQUIRE_EQUAL(transport.stream_write_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 0);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_reset_stop_and_close_transport_commands) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+
+        quic_internal::transport_command reset_cmd;
+        reset_cmd.op = quic_internal::transport_command::kind::reset_stream;
+        reset_cmd.msg.stream = 33;
+        reset_cmd.app_error_code = 1001;
+        quic_internal::handle_transport_command(transport, std::move(reset_cmd)).get();
+
+        BOOST_REQUIRE_EQUAL(transport.reset_stream_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.reset_sid, 33);
+        BOOST_REQUIRE_EQUAL(transport.reset_error, 1001);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+
+        quic_internal::transport_command stop_cmd;
+        stop_cmd.op = quic_internal::transport_command::kind::stop_sending;
+        stop_cmd.msg.stream = 35;
+        stop_cmd.app_error_code = 1002;
+        quic_internal::handle_transport_command(transport, std::move(stop_cmd)).get();
+
+        BOOST_REQUIRE_EQUAL(transport.stop_sending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.stop_sending_sid, 35);
+        BOOST_REQUIRE_EQUAL(transport.stop_sending_error, 1002);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 2);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 2);
+
+        quic_internal::transport_command close_cmd;
+        close_cmd.op = quic_internal::transport_command::kind::close_connection;
+        quic_internal::handle_transport_command(transport, std::move(close_cmd)).get();
+
+        BOOST_REQUIRE_EQUAL(transport.request_close_calls, 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_transport_command_failures_mark_transport_error) {
+    return seastar::async([] {
+        fake_connection_transport consume_transport;
+        consume_transport.consume_result = NGTCP2_ERR_PROTO;
+        quic_internal::consume_stream_data(consume_transport, 37, 16).get();
+        BOOST_REQUIRE_EQUAL(consume_transport.consume_calls, 1);
+        BOOST_REQUIRE(consume_transport.last_error.has_value());
+        BOOST_REQUIRE(*consume_transport.last_error == quic_error::protocol);
+        BOOST_REQUIRE_EQUAL(consume_transport.write_pending_calls, 0);
+        BOOST_REQUIRE_EQUAL(consume_transport.rearm_calls, 0);
+
+        fake_connection_transport reset_transport;
+        reset_transport.reset_result = NGTCP2_ERR_PROTO;
+        quic_internal::reset_stream(reset_transport, 39, 1).get();
+        BOOST_REQUIRE_EQUAL(reset_transport.reset_stream_calls, 1);
+        BOOST_REQUIRE(reset_transport.last_error.has_value());
+        BOOST_REQUIRE(*reset_transport.last_error == quic_error::protocol);
+
+        fake_connection_transport stop_transport;
+        stop_transport.stop_sending_result = NGTCP2_ERR_PROTO;
+        quic_internal::stop_sending(stop_transport, 41, 1).get();
+        BOOST_REQUIRE_EQUAL(stop_transport.stop_sending_calls, 1);
+        BOOST_REQUIRE(stop_transport.last_error.has_value());
+        BOOST_REQUIRE(*stop_transport.last_error == quic_error::protocol);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_flush_pending_packet_error_marks_transport_error) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.pending_packet_results.push_back(NGTCP2_ERR_PROTO);
+
+        quic_internal::flush_pending_transport_packets(transport).get();
+
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.stop_transport_calls, 0);
+        BOOST_REQUIRE(transport.last_error.has_value());
+        BOOST_REQUIRE(*transport.last_error == quic_error::protocol);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_recv_datagram_success_and_draining_paths) {
+    return seastar::async([] {
+        auto peer = socket_address(ipv4_addr("127.0.0.1", 5555));
+
+        fake_connection_transport transport;
+        quic_internal::recv_transport_datagram(transport, peer, temporary_buffer<char>("pkt", 3)).get();
+        BOOST_REQUIRE_EQUAL(transport.read_datagram_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.sync_path_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(transport.rearm_calls, 1);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+
+        fake_connection_transport draining_transport;
+        draining_transport.read_datagram_result = ngtcp2_err_draining;
+        quic_internal::recv_transport_datagram(draining_transport, peer, temporary_buffer<char>("pkt", 3)).get();
+        BOOST_REQUIRE_EQUAL(draining_transport.read_datagram_calls, 1);
+        BOOST_REQUIRE_EQUAL(draining_transport.stop_transport_calls, 1);
+        BOOST_REQUIRE(!draining_transport.active);
+        BOOST_REQUIRE_EQUAL(draining_transport.sync_path_calls, 0);
+
+        fake_connection_transport failed_transport;
+        failed_transport.read_datagram_result = NGTCP2_ERR_PROTO;
+        quic_internal::recv_transport_datagram(failed_transport, peer, temporary_buffer<char>("pkt", 3)).get();
+        BOOST_REQUIRE_EQUAL(failed_transport.read_datagram_calls, 1);
+        BOOST_REQUIRE_EQUAL(failed_transport.sync_path_calls, 0);
+        BOOST_REQUIRE_EQUAL(failed_transport.write_pending_calls, 0);
+        BOOST_REQUIRE_EQUAL(failed_transport.rearm_calls, 0);
+        BOOST_REQUIRE(failed_transport.last_error.has_value());
+        BOOST_REQUIRE(*failed_transport.last_error == quic_error::protocol);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_connection_close_not_sent_when_transport_cannot_close) {
+    return seastar::async([] {
+        fake_connection_transport transport;
+        transport.can_close = false;
+
+        quic_internal::send_connection_close(transport).get();
+
+        BOOST_REQUIRE_EQUAL(transport.write_connection_close_calls, 0);
+        BOOST_REQUIRE_EQUAL(transport.send_datagram_calls, 0);
+        BOOST_REQUIRE(!transport.last_error.has_value());
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_timer_and_connection_close_helpers) {
+    return seastar::async([] {
+        fake_connection_transport timer_transport;
+        timer_transport.expiry_ns = 0;
+        quic_internal::handle_transport_timer(timer_transport).get();
+        BOOST_REQUIRE_EQUAL(timer_transport.timer_expiry_calls, 1);
+        BOOST_REQUIRE_EQUAL(timer_transport.write_pending_calls, 1);
+        BOOST_REQUIRE_EQUAL(timer_transport.rearm_calls, 1);
+
+        fake_connection_transport idle_close_transport;
+        idle_close_transport.expiry_ns = 0;
+        idle_close_transport.timer_expiry_result = NGTCP2_ERR_IDLE_CLOSE;
+        quic_internal::handle_transport_timer(idle_close_transport).get();
+        BOOST_REQUIRE_EQUAL(idle_close_transport.timer_expiry_calls, 1);
+        BOOST_REQUIRE_EQUAL(idle_close_transport.stop_transport_calls, 1);
+        BOOST_REQUIRE(!idle_close_transport.active);
+
+        fake_connection_transport close_transport;
+        close_transport.can_close = true;
+        close_transport.connection_close_result = 17;
+        quic_internal::send_connection_close(close_transport).get();
+        BOOST_REQUIRE_EQUAL(close_transport.write_connection_close_calls, 1);
+        BOOST_REQUIRE_EQUAL(close_transport.send_datagram_calls, 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_error_strings_and_exception_details) {
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::none), "none");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::invalid_argument), "invalid_argument");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::invalid_state), "invalid_state");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::io), "io");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::timeout), "timeout");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::protocol), "protocol");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::closed), "closed");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::unsupported), "unsupported");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::internal), "internal");
+    BOOST_REQUIRE_EQUAL(to_string(quic_error::backend), "backend");
+    BOOST_REQUIRE_EQUAL(to_string(static_cast<quic_error_code>(999)), "unknown");
+
+    quic_error plain(quic_error::closed);
+    BOOST_REQUIRE(plain.code() == quic_error::closed);
+    BOOST_REQUIRE_EQUAL(std::string(plain.what()), "closed");
+
+    quic_error detailed(quic_error::protocol, "bad packet");
+    BOOST_REQUIRE(detailed.code() == quic_error::protocol);
+    BOOST_REQUIRE_EQUAL(std::string(detailed.what()), "bad packet: protocol");
+    BOOST_REQUIRE(plain.code().category() == quic_error_category());
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_quic_error_classification_helpers) {
+    BOOST_REQUIRE(classify_ngtcp2_error(0) == quic_error::none);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_DRAINING) == quic_error::closed);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_IDLE_CLOSE) == quic_error::timeout);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_WRITE_MORE) == quic_error::none);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_INVALID_ARGUMENT) == quic_error::invalid_argument);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_PROTO) == quic_error::protocol);
+    BOOST_REQUIRE(classify_ngtcp2_error(NGTCP2_ERR_CALLBACK_FAILURE) == quic_error::backend);
+
+    BOOST_REQUIRE(ngtcp2_is_write_more(NGTCP2_ERR_WRITE_MORE));
+    BOOST_REQUIRE(!ngtcp2_is_write_more(NGTCP2_ERR_PROTO));
+    BOOST_REQUIRE(ngtcp2_is_draining(NGTCP2_ERR_DRAINING));
+    BOOST_REQUIRE(!ngtcp2_is_draining(NGTCP2_ERR_PROTO));
+    BOOST_REQUIRE(ngtcp2_is_idle_close(NGTCP2_ERR_IDLE_CLOSE));
+    BOOST_REQUIRE(!ngtcp2_is_idle_close(NGTCP2_ERR_PROTO));
+
+    BOOST_REQUIRE(classify_gnutls_error(0) == quic_error::none);
+    BOOST_REQUIRE(classify_gnutls_error(GNUTLS_E_AGAIN) == quic_error::io);
+    BOOST_REQUIRE(classify_gnutls_error(GNUTLS_E_INTERRUPTED) == quic_error::io);
+#ifdef GNUTLS_E_TIMEDOUT
+    BOOST_REQUIRE(classify_gnutls_error(GNUTLS_E_TIMEDOUT) == quic_error::timeout);
+#endif
+    BOOST_REQUIRE(classify_gnutls_error(GNUTLS_E_INVALID_REQUEST) == quic_error::backend);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_quic_socket_address_round_trip_ipv4_and_ipv6) {
+    auto check_round_trip = [] (socket_address original) {
+        validate_ip_socket_address(original, "test_address");
+
+        sockaddr_storage storage{};
+        socklen_t storage_len = 0;
+        to_sockaddr_storage(original, storage, storage_len);
+
+        ngtcp2_addr addr{};
+        init_ngtcp2_addr(&addr, reinterpret_cast<const sockaddr*>(&storage), storage_len);
+
+        auto converted = to_socket_address(addr);
+        BOOST_REQUIRE(converted.has_value());
+        BOOST_REQUIRE_EQUAL(*converted, original);
+    };
+
+    check_round_trip(socket_address(ipv4_addr("127.0.0.1", 1234)));
+    check_round_trip(socket_address(ipv6_addr("::1", 5678)));
+
+    ngtcp2_addr empty{};
+    BOOST_REQUIRE(!to_socket_address(empty).has_value());
+
+    sockaddr_storage short_storage{};
+    auto* short_ipv4 = reinterpret_cast<sockaddr_in*>(&short_storage);
+    short_ipv4->sin_family = AF_INET;
+    ngtcp2_addr short_addr{};
+    init_ngtcp2_addr(&short_addr, reinterpret_cast<const sockaddr*>(&short_storage), sizeof(sockaddr_in) - 1);
+    BOOST_REQUIRE(!to_socket_address(short_addr).has_value());
+
+    sockaddr_storage unsupported_storage{};
+    auto* unsupported = reinterpret_cast<sockaddr*>(&unsupported_storage);
+    unsupported->sa_family = AF_UNIX;
+    ngtcp2_addr unsupported_addr{};
+    init_ngtcp2_addr(&unsupported_addr, unsupported, sizeof(sockaddr));
+    BOOST_REQUIRE(!to_socket_address(unsupported_addr).has_value());
+
+    socket_address unspecified;
+    require_quic_error([&] { validate_ip_socket_address(unspecified, "test_address"); }, quic_error::invalid_argument);
+    require_quic_error([&] {
+        sockaddr_storage storage{};
+        socklen_t storage_len = 0;
+        to_sockaddr_storage(unspecified, storage, storage_len);
+    }, quic_error::invalid_argument);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_quic_linearize_packet_and_congestion_control_mapping) {
+    std::array<temporary_buffer<char>, 0> empty{};
+    auto empty_result = linearize_packet(std::span<temporary_buffer<char>>(empty));
+    BOOST_REQUIRE(empty_result.empty());
+
+    std::array<temporary_buffer<char>, 1> single{
+      temporary_buffer<char>::copy_of(std::string_view("abc")),
+    };
+    auto single_result = linearize_packet(std::span<temporary_buffer<char>>(single));
+    BOOST_REQUIRE_EQUAL(to_sstring(std::move(single_result)), "abc");
+
+    std::array<temporary_buffer<char>, 3> chunks{
+      temporary_buffer<char>::copy_of(std::string_view("ab")),
+      temporary_buffer<char>::copy_of(std::string_view("cd")),
+      temporary_buffer<char>::copy_of(std::string_view("ef")),
+    };
+    auto merged = linearize_packet(std::span<temporary_buffer<char>>(chunks));
+    BOOST_REQUIRE_EQUAL(to_sstring(std::move(merged)), "abcdef");
+
+    BOOST_REQUIRE(to_ngtcp2_cc_algo(congestion_control_algorithm::reno) == NGTCP2_CC_ALGO_RENO);
+    BOOST_REQUIRE(to_ngtcp2_cc_algo(congestion_control_algorithm::cubic) == NGTCP2_CC_ALGO_CUBIC);
+    BOOST_REQUIRE(to_ngtcp2_cc_algo(congestion_control_algorithm::bbr) == NGTCP2_CC_ALGO_BBR);
+#ifdef NGTCP2_CC_ALGO_BBR2
+    BOOST_REQUIRE(to_ngtcp2_cc_algo(congestion_control_algorithm::bbr2) == NGTCP2_CC_ALGO_BBR2);
+#else
+    BOOST_REQUIRE(to_ngtcp2_cc_algo(congestion_control_algorithm::bbr2) == NGTCP2_CC_ALGO_BBR);
+#endif
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_quic_client_stop_without_connect_is_noop) {
+    return seastar::async([] {
+        quic_client client;
+        client.stop().get();
+        client.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_client_rejects_invalid_remote_address_family) {
+    return seastar::async([] {
+        quic_client client;
+        quic_client_config cfg;
+        cfg.remote_address = socket_address();
+
+        require_quic_future_exception(client.connect(std::move(cfg)), quic_error::invalid_argument);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_server_stop_without_start_is_noop) {
+    return seastar::async([] {
+        quic_server server;
+        server.stop().get();
+        server.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_server_accept_before_start_fails) {
+    return seastar::async([] {
+        quic_server server;
+        require_quic_future_exception(server.accept(), quic_error::invalid_state);
+    });
+}
+
+SEASTAR_TEST_CASE(test_quic_server_rejects_invalid_listen_address_family) {
+    return seastar::async([] {
+        quic_server server;
+        quic_server_config cfg;
+        cfg.listen_address = socket_address();
+        cfg.crt_file = "unused.crt";
+        cfg.key_file = "unused.key";
+
+        require_quic_future_exception(server.start(std::move(cfg)), quic_error::invalid_argument);
+    });
+}

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -40,7 +40,9 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/posix-stack.hh>
 #include <stdexcept>
+#include <system_error>
 
+#include <cerrno>
 #include <optional>
 #include <tuple>
 #include <future>
@@ -89,6 +91,41 @@ std::pmr::polymorphic_allocator<char> allocator{&malloc_allocator};
 
 SEASTAR_TEST_CASE(socket_allocation_test) {
     return echo_server_loop().finally([](){ engine().exit((malloc_allocator.allocs == malloc_allocator.frees) ? 0 : 1); });
+}
+
+SEASTAR_TEST_CASE(udp_bound_channel_rejects_duplicate_bind_without_reuse_port) {
+    return async([] {
+        auto first = make_bound_datagram_channel(make_ipv4_address({0x7f000001, 0}));
+        auto local = first.local_address();
+
+        bool duplicate_failed = false;
+        try {
+            auto second = make_bound_datagram_channel(local);
+            second.close();
+        } catch (const std::system_error& e) {
+            BOOST_REQUIRE_EQUAL(e.code().value(), EADDRINUSE);
+            duplicate_failed = true;
+        }
+
+        first.close();
+        BOOST_REQUIRE(duplicate_failed);
+    });
+}
+
+SEASTAR_TEST_CASE(udp_bound_channel_allows_duplicate_bind_with_reuse_port) {
+    return async([] {
+        auto first = make_bound_datagram_channel(
+          make_ipv4_address({0x7f000001, 0}),
+          net::datagram_channel_options{.reuse_port = true});
+        auto local = first.local_address();
+
+        auto second = make_bound_datagram_channel(
+          local,
+          net::datagram_channel_options{.reuse_port = true});
+
+        second.close();
+        first.close();
+    });
 }
 
 SEASTAR_TEST_CASE(socket_skip_test) {


### PR DESCRIPTION
Add an experimental QUIC transport backed by ngtcp2 and GnuTLS.

The series adds a bundled ngtcp2 build, exposes an ngtcp2::ngtcp2
CMake target, and initializes the ngtcp2 submodule in CI. The DPDK
submodule checkout remains limited to DPDK-enabled builds.

The new API lives under seastar::quic::experimental and provides
client and server endpoints, connections, bidirectional and
unidirectional streams, transport configuration, QUIC errors, and
conversion of bidirectional streams to connected_socket.

Each connection owns its ngtcp2 and TLS state and drives it from a
single async loop that handles received packets, timer expiry, stream
commands, and connection shutdown.

Also add QUIC client/server demos and unit coverage for the public API,
stream lifecycle, flow control, blocked sends, blocked stream opens,
packet handling, close paths, error classification, and socket address
conversion.