### PR TITLE
sstring: Remove deprecated reset() method

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -527,17 +527,6 @@ public:
         return u.internal.size == 0;
     }
 
-    // Deprecated March 2020.
-    [[deprecated("Use = {}")]]
-    void reset() noexcept {
-        if (is_external()) {
-            std::free(u.external.str);
-        }
-        u.internal.size = 0;
-        if (NulTerminate) {
-            u.internal.str[0] = '\0';
-        }
-    }
     temporary_buffer<char_type> release() && {
         if (is_external()) {
             auto ptr = u.external.str;


### PR DESCRIPTION
The method was deprecated in March 2020 in favor of assigning default value with = {}.