### PR TITLE
reactor: Remove deprecated cpu_id() method

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -661,8 +661,6 @@ public:
 
     network_stack& net() { return *_network_stack; }
 
-    [[deprecated("Use this_shard_id")]]
-    shard_id cpu_id() const;
 
     /// \returns Returns the `smp` instance which owns this reactor.
     const seastar::smp& smp() const noexcept;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -198,10 +198,6 @@ namespace seastar {
 
 seastar::logger seastar_logger("seastar");
 
-shard_id reactor::cpu_id() const {
-    SEASTAR_ASSERT(_id == this_shard_id());
-    return _id;
-}
 
 void reactor::update_shares_for_queues(internal::priority_class pc, uint32_t shares) {
     for (auto&& q : _io_queues) {


### PR DESCRIPTION
The method was deprecated in April 2020 in favor of this_shard_id().