### PR TITLE
util: Remove deprecated disable_failure_guard

### DIFF
--- a/include/seastar/util/alloc_failure_injector.hh
+++ b/include/seastar/util/alloc_failure_injector.hh
@@ -109,10 +109,6 @@ alloc_failure_injector& local_failure_injector() {
 #endif
 
 
-struct [[deprecated("Use scoped_critical_section instead")]] disable_failure_guard {
-    scoped_critical_alloc_section cs;
-};
-
 /// \brief Marks a point in code which should be considered for failure injection.
 inline
 void on_alloc_point() {


### PR DESCRIPTION
The struct was deprecated in November 2020 in favor of scoped_critical_alloc_section.