### PR TITLE
util: Remove deprecated later() function

### DIFF
--- a/include/seastar/util/later.hh
+++ b/include/seastar/util/later.hh
@@ -73,12 +73,6 @@ future<> maybe_yield() noexcept {
 /// \note This has no effect on I/O polling on other shards.
 future<> check_for_io_immediately() noexcept;
 
-/// \brief Returns a future which is not ready but is scheduled to resolve soon.
-///
-/// \deprecated Use yield() instead, or check_for_io_immediately() if your really need it.
-[[deprecated("Use yield() or check_for_io_immediately()")]]
-future<> later() noexcept;
-
 /// @}
 
 } // namespace seastar

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4994,9 +4994,6 @@ future<> check_for_io_immediately() noexcept {
     return tsk->get_future();
 }
 
-future<> later() noexcept {
-    return check_for_io_immediately();
-}
 
 steady_clock_type::duration reactor::total_idle_time() const {
     return _total_idle;

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -574,7 +574,6 @@ using seastar::produce_be;
 
 // Additional symbols
 using seastar::now;
-using seastar::later;
 using seastar::with_clock;
 using seastar::memory_output_stream;
 using seastar::abort_on_expiry;


### PR DESCRIPTION
The function was deprecated in January 2022 in favor of yield() or check_for_io_immediately().