### PR TITLE
net: Remove deprecated make_udp_channel

### DIFF
--- a/include/seastar/core/seastar.hh
+++ b/include/seastar/core/seastar.hh
@@ -154,24 +154,6 @@ future<connected_socket> connect(socket_address sa, socket_address local, transp
 /// \return a \ref socket object that can be used for establishing connections
 socket make_socket();
 
-/// Creates a udp_channel object suitable for sending UDP packets
-///
-/// The channel is not bound to a local address, and thus can only be used
-/// for sending.
-///
-/// \return a \ref net::udp_channel object that can be used for UDP transfers.
-[[deprecated("Use `make_unbound_datagram_channel` instead")]]
-net::udp_channel make_udp_channel();
-
-
-/// Creates a udp_channel object suitable for sending and receiving UDP packets
-///
-/// \param local local address to bind to
-///
-/// \return a \ref net::udp_channel object that can be used for UDP transfers.
-[[deprecated("Use `make_bound_datagram_channel` instead")]]
-net::udp_channel make_udp_channel(const socket_address& local);
-
 /// Creates a datagram_channel object suitable for sending datagrams to
 /// destinations that belong to the provided address family.
 /// Supported address families: AF_INET, AF_INET6 and AF_UNIX.

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -498,9 +498,6 @@ public:
     future<connected_socket> connect(socket_address sa, socket_address = {}, transport proto = transport::TCP);
     virtual ::seastar::socket socket() = 0;
 
-    [[deprecated("Use `make_[un]bound_datagram_channel` instead")]]
-    virtual net::udp_channel make_udp_channel(const socket_address& = {}) = 0;
-
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) = 0;
     virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) = 0;
     virtual future<> initialize() {

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -238,7 +238,6 @@ public:
     explicit posix_network_stack(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator);
     virtual server_socket listen(socket_address sa, listen_options opts) override;
     virtual ::seastar::socket socket() override;
-    virtual net::udp_channel make_udp_channel(const socket_address&) override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
     virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
     static future<std::unique_ptr<network_stack>> create(const program_options::option_group& opts, std::pmr::polymorphic_allocator<char>* allocator=memory::malloc_allocator) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4921,14 +4921,6 @@ socket make_socket() {
     return engine().net().socket();
 }
 
-net::udp_channel make_udp_channel() {
-    return make_unbound_datagram_channel(AF_INET);
-}
-
-net::udp_channel make_udp_channel(const socket_address& local) {
-    return make_bound_datagram_channel(local);
-}
-
 net::datagram_channel make_unbound_datagram_channel(sa_family_t family) {
     return engine().net().make_unbound_datagram_channel(family);
 }

--- a/src/net/native-stack.cc
+++ b/src/net/native-stack.cc
@@ -166,7 +166,6 @@ public:
     explicit native_network_stack(const native_stack_options& opts, std::shared_ptr<device> dev);
     virtual server_socket listen(socket_address sa, listen_options opt) override;
     virtual ::seastar::socket socket() override;
-    virtual udp_channel make_udp_channel(const socket_address& addr) override;
     virtual net::datagram_channel make_unbound_datagram_channel(sa_family_t) override;
     virtual net::datagram_channel make_bound_datagram_channel(const socket_address& local) override;
     virtual future<> initialize() override;
@@ -203,11 +202,6 @@ public:
 };
 
 thread_local promise<std::unique_ptr<network_stack>> native_network_stack::ready_promise;
-
-udp_channel
-native_network_stack::make_udp_channel(const socket_address& addr) {
-    return _inet.get_udp().make_channel(addr);
-}
 
 net::datagram_channel native_network_stack::make_unbound_datagram_channel(sa_family_t family) {
     if (family != AF_INET) {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -1109,17 +1109,6 @@ future<> posix_datagram_channel::send(const socket_address& dst, std::span<tempo
             .then([len, del = std::move(del) ] (size_t size) { SEASTAR_ASSERT(size == len); });
 }
 
-udp_channel
-posix_network_stack::make_udp_channel(const socket_address& addr) {
-    if (!addr.is_unspecified()) {
-        return make_bound_datagram_channel(addr);
-    } else {
-        // Preserve the default behavior of make_udp_channel({}) which is to
-        // create an unbound channel that can be used to send UDP datagrams.
-        return make_unbound_datagram_channel(AF_INET);
-    }
-}
-
 datagram_channel
 posix_network_stack::make_unbound_datagram_channel(sa_family_t family) {
     return datagram_channel(std::make_unique<posix_datagram_channel>(family));


### PR DESCRIPTION
The network_stack::make_udp_channel() virtual method and the free function wrappers were deprecated in October 2023 in favor of make_unbound_datagram_channel() and make_bound_datagram_channel().