### PR TITLE
rpc: replace `_outstanding` unordered_map with log_indexed_container

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -44,6 +44,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/log_indexed_container.hh>
 
 namespace bi = boost::intrusive;
 
@@ -555,7 +556,13 @@ public:
         virtual ~reply_handler() {}
     };
 private:
-    std::unordered_map<id_type, std::unique_ptr<reply_handler_base>> _outstanding;
+    // In-flight reply handlers keyed by message id, using log_indexed_container
+    // to avoid large contiguous rehash allocations.
+    // Note: no_wait verbs consume a message id without inserting a handler;
+    // those ids produce an out-of-range lookup on reply, handled gracefully.
+    using reply_table = log_indexed_container<std::unique_ptr<reply_handler_base>, id_type>;
+
+    reply_table _outstanding;
     socket_address _server_addr, _local_addr;
     client_options _options;
     weak_ptr<client> _parent; // for stream clients

--- a/include/seastar/util/log_indexed_container.hh
+++ b/include/seastar/util/log_indexed_container.hh
@@ -1,0 +1,237 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+#pragma once
+
+#include <concepts>
+#include <optional>
+#include <boost/container/deque.hpp>
+
+#include <seastar/util/assert.hh>
+
+namespace seastar {
+
+/// \brief A container that maps monotonically increasing indices to values,
+/// providing O(1) access by index.
+///
+/// Internally uses a deque of slots indexed by `(index - base_index)`.
+/// Completed/cleared slots are nulled in-place; the front is trimmed lazily
+/// (via trim_front()) to reclaim memory.
+///
+/// For value types that already encode an empty/absent state natively
+/// (raw pointer, unique_ptr, shared_ptr, and similar pointer-like types
+/// that are default-constructible to a null state and convertible to bool),
+/// slots store the value directly using its natural empty state.
+/// For all other types, slots are wrapped in std::optional.
+///
+/// Unlike a hash map, the backing deque grows in fixed-size chunks.
+/// boost::container::deque guarantees that memory blocks are released when
+/// items are popped from the ends, so trim_front() actually reclaims memory
+/// (unlike std::deque in libstdc++, which retains blocks).
+///
+/// The container does not require indices to be inserted in strictly
+/// increasing order. Gaps between occupied slots are allowed.
+/// Out-of-range or absent lookups return nullptr safely.
+///
+/// \tparam T         Value type to store.
+/// \tparam IndexType Integer-like type used as the index (default: size_t).
+///                   Must support: operator-(IndexType) → ptrdiff_t-compatible,
+///                   operator<, and prefix operator++.
+template<typename T, typename IndexType = size_t>
+class log_indexed_container {
+    // Detect pointer-like types that already carry a null/absent state:
+    //   - default-constructs to an "empty" value
+    //   - convertible to bool (true = has value, false = empty)
+    //   - is a raw pointer OR has an element_type member (smart pointer)
+    // Plain integers and enums satisfy the first two but not the third,
+    // so they fall through to optional<T> wrapping as intended.
+    template<typename U>
+    static constexpr bool is_nullable =
+        std::is_default_constructible_v<U> &&
+        requires(const U& u) { { static_cast<bool>(u) } -> std::same_as<bool>; } &&
+        (std::is_pointer_v<U> || requires { typename U::element_type; });
+
+    using slot_t = std::conditional_t<is_nullable<T>, T, std::optional<T>>;
+
+    static bool slot_occupied(const slot_t& s) noexcept {
+        if constexpr (is_nullable<T>) {
+            return static_cast<bool>(s);
+        } else {
+            return s.has_value();
+        }
+    }
+
+    // boost::container::deque releases memory blocks on pop_front/pop_back,
+    // unlike std::deque (libstdc++) which may retain them indefinitely.
+    boost::container::deque<slot_t> _slots;
+    IndexType _base_idx{};
+    size_t _count = 0; // number of occupied (non-empty) slots
+
+public:
+    /// Returns a pointer to the value at the given index,
+    /// or nullptr if the slot is empty or out of range.
+    T* find(IndexType idx) noexcept {
+        if (_slots.empty() || idx < _base_idx) {
+            return nullptr;
+        }
+        auto off = static_cast<size_t>(idx - _base_idx);
+        if (off >= _slots.size()) {
+            return nullptr;
+        }
+        auto& slot = _slots[off];
+        if constexpr (is_nullable<T>) {
+            return slot ? std::addressof(slot) : nullptr;
+        } else {
+            return slot.has_value() ? std::addressof(*slot) : nullptr;
+        }
+    }
+
+    /// Inserts a value at the given index.
+    /// If idx < base_index(), empty slots are prepended to accommodate it.
+    /// The target slot must not already be occupied.
+    /// Returns a reference to the inserted value.
+    T& emplace(IndexType idx, T value) {
+        if (_slots.empty()) {
+            _base_idx = idx;
+            if constexpr (is_nullable<T>) {
+                _slots.push_back(std::move(value));
+            } else {
+                _slots.emplace_back(std::move(value));
+            }
+        } else if (idx < _base_idx) {
+            // New index is before current base: prepend empty slots.
+            auto count = static_cast<size_t>(_base_idx - idx);
+            for (size_t i = 0; i < count; ++i) {
+                _slots.emplace_front();
+            }
+            _base_idx = idx;
+            if constexpr (is_nullable<T>) {
+                _slots.front() = std::move(value);
+            } else {
+                _slots.front().emplace(std::move(value));
+            }
+        } else {
+            auto off = static_cast<size_t>(idx - _base_idx);
+            if (off >= _slots.size()) {
+                // Extend to cover off, default-constructing new slots.
+                _slots.resize(off + 1);
+            }
+            SEASTAR_ASSERT(!slot_occupied(_slots[off]));
+            if constexpr (is_nullable<T>) {
+                _slots[off] = std::move(value);
+            } else {
+                _slots[off].emplace(std::move(value));
+            }
+        }
+        ++_count;
+        auto off = static_cast<size_t>(idx - _base_idx);
+        if constexpr (is_nullable<T>) {
+            return _slots[off];
+        } else {
+            return *_slots[off];
+        }
+    }
+
+    /// Removes and returns the value at the given index.
+    /// Returns a default-constructed T if the slot is absent or empty.
+    T take(IndexType idx) noexcept {
+        if (_slots.empty() || idx < _base_idx) {
+            return T{};
+        }
+        auto off = static_cast<size_t>(idx - _base_idx);
+        if (off >= _slots.size() || !slot_occupied(_slots[off])) {
+            return T{};
+        }
+        T value;
+        if constexpr (is_nullable<T>) {
+            value = std::move(_slots[off]);
+            _slots[off] = T{};
+        } else {
+            value = std::move(*_slots[off]);
+            _slots[off].reset();
+        }
+        --_count;
+        trim_front();
+        return value;
+    }
+
+    /// Clears the slot at the given index. The slot must be occupied.
+    void clear_at(IndexType idx) noexcept {
+        SEASTAR_ASSERT(idx >= _base_idx);
+        auto off = static_cast<size_t>(idx - _base_idx);
+        SEASTAR_ASSERT(off < _slots.size() && slot_occupied(_slots[off]));
+        _slots[off] = slot_t{};
+        --_count;
+    }
+
+    /// Removes empty slots from the front of the deque,
+    /// advancing base_index() accordingly.
+    void trim_front() noexcept {
+        while (!_slots.empty() && !slot_occupied(_slots.front())) {
+            _slots.pop_front();
+            ++_base_idx;
+        }
+    }
+
+    /// Returns true if there are no slots (occupied or gap).
+    [[nodiscard]] bool empty() const noexcept {
+        return _slots.empty();
+    }
+
+    /// Returns the number of occupied (non-empty) slots.
+    [[nodiscard]] size_t size() const noexcept {
+        return _count;
+    }
+
+    /// Returns the base index (the index corresponding to _slots[0]).
+    IndexType base_index() const noexcept {
+        return _base_idx;
+    }
+
+    /// Iterates over all occupied slots, calling f(IndexType, T&) for each.
+    /// The callback may call clear_at() on the current element, but must
+    /// not otherwise modify the container during iteration.
+    /// trim_front() is called automatically after iteration.
+    template<typename F>
+    requires std::invocable<F, IndexType, T&>
+    void for_each(F&& f) {
+        IndexType idx = _base_idx;
+        for (size_t i = 0; i < _slots.size(); ++i, ++idx) {
+            if (slot_occupied(_slots[i])) {
+                if constexpr (is_nullable<T>) {
+                    f(idx, _slots[i]);
+                } else {
+                    f(idx, *_slots[i]);
+                }
+            }
+        }
+        trim_front();
+    }
+
+    /// Clears all slots and resets the base index to IndexType{}.
+    void clear() noexcept {
+        _slots.clear();
+        _base_idx = IndexType{};
+        _count = 0;
+    }
+};
+
+} // namespace seastar

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -805,8 +805,7 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
     }
     if (cancel) {
         cancel->cancel_wait = [this, id] {
-            _outstanding[id]->cancel();
-            _outstanding.erase(id);
+            _outstanding.take(id)->cancel();
         };
         h->pcancel = cancel;
         cancel->wait_back_pointer = &h->pcancel;
@@ -815,8 +814,7 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
 }
 void client::wait_timed_out(id_type id) {
     _stats.timeout++;
-    _outstanding[id]->timeout();
-    _outstanding.erase(id);
+    _outstanding.take(id)->timeout();
 }
 
 future<> client::stop() noexcept {
@@ -996,12 +994,9 @@ future<> client::loop(client_options ops, const socket_address& addr, const sock
                 continue;
             }
             auto&& [msg_id, ht, data] = co_await read_response_frame_compressed(_connected->read_buf);
-            auto it = _outstanding.find(std::abs(msg_id));
             if (!data) {
                 _error = true;
-            } else if (it != _outstanding.end()) {
-                auto handler = std::move(it->second);
-                _outstanding.erase(it);
+            } else if (auto handler = _outstanding.take(std::abs(msg_id))) {
                 (*handler)(*this, msg_id, std::move(data.value()));
                 if (ht) {
                     _stats.delay_samples++;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -321,6 +321,10 @@ seastar_add_test (chunked_fifo
   KIND BOOST
   SOURCES chunked_fifo_test.cc)
 
+seastar_add_test (log_indexed_container
+  KIND BOOST
+  SOURCES log_indexed_container_test.cc)
+
 seastar_add_test (linux_perf_event
   KIND BOOST
   SOURCES linux_perf_event_test.cc ../perf/linux_perf_event.cc)

--- a/tests/unit/log_indexed_container_test.cc
+++ b/tests/unit/log_indexed_container_test.cc
@@ -1,0 +1,246 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+#define BOOST_TEST_MODULE log_indexed_container
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <vector>
+
+#include <seastar/util/log_indexed_container.hh>
+
+using seastar::log_indexed_container;
+
+// ── Tests using int (optional<int> slots) ────────────────────────────────────
+
+BOOST_AUTO_TEST_CASE(test_empty_container) {
+    log_indexed_container<int> c;
+    BOOST_CHECK(c.empty());
+    BOOST_CHECK(c.find(0) == nullptr);
+    BOOST_CHECK(c.find(100) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_and_find) {
+    log_indexed_container<int> c;
+    c.emplace(5, 42);
+    BOOST_CHECK(!c.empty());
+    BOOST_CHECK_EQUAL(c.base_index(), 5u);
+
+    auto* p = c.find(5);
+    BOOST_REQUIRE(p != nullptr);
+    BOOST_CHECK_EQUAL(*p, 42);
+
+    BOOST_CHECK(c.find(4) == nullptr);
+    BOOST_CHECK(c.find(6) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_with_gap) {
+    log_indexed_container<int> c;
+    c.emplace(10, 1);
+    c.emplace(13, 2);
+
+    BOOST_CHECK_EQUAL(*c.find(10), 1);
+    BOOST_CHECK(c.find(11) == nullptr);
+    BOOST_CHECK(c.find(12) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(13), 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_before_base) {
+    log_indexed_container<int> c;
+    c.emplace(5, 50);
+    c.emplace(7, 70);
+
+    // Emplace before the current base index — empty slots prepended.
+    c.emplace(3, 30);
+    BOOST_CHECK_EQUAL(c.base_index(), 3u);
+    BOOST_CHECK_EQUAL(*c.find(3), 30);
+    BOOST_CHECK(c.find(4) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(5), 50);
+    BOOST_CHECK(c.find(6) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(7), 70);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_at_and_trim) {
+    log_indexed_container<int> c;
+    c.emplace(5, 1);
+    c.emplace(6, 2);
+    c.emplace(7, 3);
+
+    c.clear_at(5);
+    c.trim_front();
+    // Front cleared: base_index advances to 6.
+    BOOST_CHECK_EQUAL(c.base_index(), 6u);
+    BOOST_CHECK(c.find(5) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(6), 2);
+
+    c.clear_at(7);
+    c.trim_front();
+    // Index 7 cleared but 6 still at front — no advancement.
+    BOOST_CHECK_EQUAL(c.base_index(), 6u);
+    BOOST_CHECK(c.find(7) == nullptr);
+
+    c.clear_at(6);
+    c.trim_front();
+    // All cleared: container empty.
+    BOOST_CHECK(c.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_at_middle_then_front) {
+    log_indexed_container<int> c;
+    c.emplace(1, 10);
+    c.emplace(2, 20);
+    c.emplace(3, 30);
+
+    // Clear middle — trim stops at front.
+    c.clear_at(2);
+    c.trim_front();
+    BOOST_CHECK_EQUAL(c.base_index(), 1u);
+    BOOST_CHECK(c.find(2) == nullptr);
+
+    // Clear front — trims past the gap to 3.
+    c.clear_at(1);
+    c.trim_front();
+    BOOST_CHECK_EQUAL(c.base_index(), 3u);
+    BOOST_CHECK_EQUAL(*c.find(3), 30);
+}
+
+BOOST_AUTO_TEST_CASE(test_for_each) {
+    log_indexed_container<int> c;
+    c.emplace(2, 20);
+    c.emplace(4, 40);
+    c.emplace(5, 50);
+
+    std::vector<std::pair<size_t, int>> visited;
+    c.for_each([&](size_t idx, int& val) {
+        visited.emplace_back(idx, val);
+    });
+
+    BOOST_REQUIRE_EQUAL(visited.size(), 3u);
+    BOOST_CHECK_EQUAL(visited[0].first, 2u);
+    BOOST_CHECK_EQUAL(visited[0].second, 20);
+    BOOST_CHECK_EQUAL(visited[1].first, 4u);
+    BOOST_CHECK_EQUAL(visited[1].second, 40);
+    BOOST_CHECK_EQUAL(visited[2].first, 5u);
+    BOOST_CHECK_EQUAL(visited[2].second, 50);
+}
+
+BOOST_AUTO_TEST_CASE(test_for_each_with_clear_at) {
+    log_indexed_container<int> c;
+    c.emplace(1, 10);
+    c.emplace(2, 20);
+    c.emplace(3, 30);
+
+    // Clear some entries during iteration.
+    c.for_each([&](size_t idx, int& /*val*/) {
+        if (idx == 1 || idx == 3) {
+            c.clear_at(idx);
+        }
+    });
+
+    // for_each calls trim_front: 1 cleared at front, 2 retained, 3 cleared.
+    BOOST_CHECK(c.find(1) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(2), 20);
+    BOOST_CHECK(c.find(3) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_and_reuse) {
+    log_indexed_container<int> c;
+    c.emplace(10, 1);
+    c.emplace(20, 2);
+
+    c.clear();
+    BOOST_CHECK(c.empty());
+    BOOST_CHECK(c.find(10) == nullptr);
+
+    // Can reuse after clear.
+    c.emplace(5, 99);
+    BOOST_CHECK_EQUAL(*c.find(5), 99);
+}
+
+// ── Tests using unique_ptr<int> (nullable — no optional wrapper) ──────────────
+
+BOOST_AUTO_TEST_CASE(test_move_only_type) {
+    log_indexed_container<std::unique_ptr<int>> c;
+    c.emplace(1, std::make_unique<int>(42));
+
+    auto* p = c.find(1);
+    BOOST_REQUIRE(p != nullptr);
+    BOOST_CHECK_EQUAL(**p, 42);
+
+    c.clear_at(1);
+    c.trim_front();
+    BOOST_CHECK(c.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_unique_ptr_emplace_and_find) {
+    log_indexed_container<std::unique_ptr<int>> c;
+    c.emplace(3, std::make_unique<int>(10));
+    c.emplace(5, std::make_unique<int>(20));
+
+    BOOST_REQUIRE(c.find(3) != nullptr);
+    BOOST_CHECK_EQUAL(*(*c.find(3)), 10);
+    BOOST_CHECK(c.find(4) == nullptr);
+    BOOST_REQUIRE(c.find(5) != nullptr);
+    BOOST_CHECK_EQUAL(*(*c.find(5)), 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_unique_ptr_for_each_with_clear) {
+    log_indexed_container<std::unique_ptr<int>> c;
+    c.emplace(10, std::make_unique<int>(1));
+    c.emplace(11, std::make_unique<int>(2));
+    c.emplace(12, std::make_unique<int>(3));
+
+    std::vector<int> seen;
+    c.for_each([&](size_t idx, std::unique_ptr<int>& val) {
+        seen.push_back(*val);
+        c.clear_at(idx);
+    });
+
+    BOOST_REQUIRE_EQUAL(seen.size(), 3u);
+    BOOST_CHECK_EQUAL(seen[0], 1);
+    BOOST_CHECK_EQUAL(seen[1], 2);
+    BOOST_CHECK_EQUAL(seen[2], 3);
+    BOOST_CHECK(c.empty());
+}
+
+// ── Tests using a custom (non-size_t) IndexType ───────────────────────────────
+
+BOOST_AUTO_TEST_CASE(test_custom_index_type) {
+    // Use int64_t as IndexType — matches the rpc::client id_type use case.
+    log_indexed_container<int, int64_t> c;
+
+    c.emplace(int64_t{1}, 100);
+    c.emplace(int64_t{3}, 300);
+
+    BOOST_CHECK_EQUAL(c.base_index(), int64_t{1});
+    BOOST_REQUIRE(c.find(int64_t{1}) != nullptr);
+    BOOST_CHECK_EQUAL(*c.find(int64_t{1}), 100);
+    BOOST_CHECK(c.find(int64_t{2}) == nullptr);
+    BOOST_REQUIRE(c.find(int64_t{3}) != nullptr);
+    BOOST_CHECK_EQUAL(*c.find(int64_t{3}), 300);
+
+    c.clear_at(int64_t{1});
+    c.trim_front();
+    // Slot for id=1 cleared; trim also skips the null gap at id=2, so base advances to 3.
+    BOOST_CHECK_EQUAL(c.base_index(), int64_t{3});
+    BOOST_REQUIRE(c.find(int64_t{3}) != nullptr);
+    BOOST_CHECK_EQUAL(*c.find(int64_t{3}), 300);
+}


### PR DESCRIPTION
`std::unordered_map<id_type, unique_ptr<reply_handler_base>>` rehashes with a single large contiguous allocation when the number of in-flight requests crosses a bucket threshold. At high concurrency (e.g. 1000 concurrent ALL-consistency reads) this produces >128 KiB allocations, triggering Seastar's large-alloc warning.

Introduce a new generic utility, `log_indexed_container<T, IndexType>` (`include/seastar/util/log_indexed_container.hh`), which maps monotonically increasing integer indices to values without hashing or large contiguous allocations:

  - Backed by `boost::container::deque`, which releases front blocks on `pop_front` (unlike `std::deque` in libstdc++), keeping memory bounded.
  - Stores values in direct index-offset slots, so lookup is O(1).
  - Trims empty slots from the front after each removal, keeping the deque short relative to the concurrency window.
  - Supports any nullable type (raw pointer, `unique_ptr`) natively, and wraps non-nullable types in `std::optional` internally.
  - API: `emplace(idx, value)`, `find(idx)`, `take(idx)`, `clear_at(idx)`, `clear()`, `size()`, `empty()`, `base_index()`.

Replace `_outstanding` with a `log_indexed_container` specialised on `reply_handler_base` `unique_ptr`. RPC message ids are already monotonically increasing per-connection, making them a natural key. Outstanding reply handlers are removed via `take()`. The timer and cancellation callbacks preserve the original invariant that the slot always exists when they fire: the receive path disarms both atomically (no yield point) before returning to the reactor, so a missing slot indicates a bug.

Also add `tests/unit/log_indexed_container_test.cc` with 13 unit tests covering `emplace`, `find`, `take`, `clear_at`, `trim_front`, `base_index` advancement, and a custom index type.

Fixes: SCYLLADB-1541