### PR TITLE
core: sleep_abortable propagates custom abort exception when already aborted

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -213,8 +213,15 @@ public:
 
     /// Returns the default exception type (\ref abort_requested_exception) for this abort source.
     /// Overridable by derived classes.
+    ///
+    /// The same exception_ptr object is returned on every call, so callers can
+    /// compare an abort exception (\ref abort_requested_exception_ptr) against
+    /// it by identity to tell whether an abort used the default exception or a
+    /// caller-supplied one. Overrides should preserve this property by likewise
+    /// returning a stable object.
     virtual std::exception_ptr get_default_exception() const noexcept {
-        return make_exception_ptr(abort_requested_exception());
+        static const thread_local std::exception_ptr ex = make_exception_ptr(abort_requested_exception());
+        return ex;
     }
 };
 

--- a/include/seastar/core/sleep.hh
+++ b/include/seastar/core/sleep.hh
@@ -77,12 +77,16 @@ future<> sleep_abortable(typename Clock::duration dur);
 extern template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration);
 extern template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration);
 
-/// Returns a future which completes after a specified time has elapsed
-/// or throws \ref sleep_aborted exception if the sleep is aborted.
+/// Returns a future which completes after a specified time has elapsed,
+/// or returns a failed future immediately if the sleep is aborted via \p as.
+///
+/// If the abort carried a custom exception (via \ref abort_source::request_abort_ex),
+/// the returned future is failed with that exception; otherwise it is failed
+/// with \ref sleep_aborted.
 ///
 /// \param dur minimum amount of time before the returned future becomes
 ///            ready.
-/// \param as the \ref abort_source that eventually notifies that the sleep
+/// \param as the \ref abort_source that can be used to notify that the sleep
 ///            should be aborted.
 /// \return A \ref future which becomes ready when the sleep duration elapses.
 template <typename Clock = steady_clock_type>

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -111,7 +111,16 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as) {
                 sc = std::move(*sc_opt);
                 tmr.arm(dur);
             } else {
-                done.set_exception(sleep_aborted());
+                // Try to preserve a custom exception if one was provided, relying on
+                // comparing the exception pointers. This relies on get_default_exception
+                // always providing a pointer to the same exception object.
+                // See scylladb/seastar#3452.
+                const auto& ex = as.abort_requested_exception_ptr();
+                if (ex != as.get_default_exception()) {
+                    done.set_exception(ex);
+                } else {
+                    done.set_exception(sleep_aborted());
+                }
             }
         }
     };

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -197,6 +197,17 @@ SEASTAR_THREAD_TEST_CASE(test_sleep_abortable_already_aborted_with_exception) {
     });
 }
 
+// Companion to the above: when the already-aborted source carries no custom
+// exception (plain request_abort), sleep_abortable still fails with
+// sleep_aborted, matching the during-sleep path. See scylladb/seastar#3452.
+SEASTAR_THREAD_TEST_CASE(test_sleep_abortable_already_aborted_no_exception) {
+    abort_source as;
+    as.request_abort();
+    auto f = sleep_abortable(10s, as);
+
+    BOOST_REQUIRE_THROW(f.get(), sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {
     auto as = std::make_unique<abort_source>();
     int aborted = 0;

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <exception>
+#include <string_view>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -178,6 +179,22 @@ SEASTAR_THREAD_TEST_CASE(test_sleep_abortable_with_exception) {
         caught_exception = true;
     }
     BOOST_REQUIRE(caught_exception);
+}
+
+// Regression test for scylladb/seastar#3452: when the abort_source is already
+// aborted before sleep_abortable subscribes, the custom abort exception must
+// still be propagated, just as it is when the abort lands during the sleep.
+SEASTAR_THREAD_TEST_CASE(test_sleep_abortable_already_aborted_with_exception) {
+    abort_source as;
+    auto expected_message = "expected";
+    // Abort the source *before* calling sleep_abortable, so subscribe() returns
+    // a disengaged optional and the already-aborted fast path is taken.
+    as.request_abort_ex(std::runtime_error(expected_message));
+    auto f = sleep_abortable(10s, as);
+
+    BOOST_REQUIRE_EXCEPTION(f.get(), std::runtime_error, [&] (const std::runtime_error& e) {
+        return e.what() == std::string_view(expected_message);
+    });
 }
 
 SEASTAR_THREAD_TEST_CASE(test_destroy_with_moved_subscriptions) {


### PR DESCRIPTION
## Problem

`sleep_abortable(dur, abort_source&)` had two abort paths that disagreed on the
exception the returned future fails with:

- **Abort *during* the sleep**: the subscriber callback propagates the exception
  supplied via `abort_source::request_abort_ex(...)`, so a custom exception is
  preserved.
- **Source *already aborted* before `sleep_abortable` subscribes**: `subscribe()`
  returns a disengaged `optimized_optional` (the subscription is built but never
  linked), so the `else` fast path ran and always fabricated a fresh
  `sleep_aborted`, **discarding** the exception the `abort_source` already
  stored.

So whether a custom abort exception survived depended on a race with the moment
`sleep_abortable` subscribed.

## Fix

Make the already-aborted fast path mirror the during-sleep path: propagate the
caller-supplied exception when one was given, otherwise fall back to
`sleep_aborted`.

To distinguish "caller supplied an exception" from "default abort" on the fast
path, `abort_source::get_default_exception()` now returns a stable (per-shard)
shared `exception_ptr`. A plain `request_abort()` stores that same object, so
`sleep_abortable` can tell a caller-supplied exception apart by comparing the
stored abort exception against it by identity. A plain `request_abort()` still
yields `sleep_aborted` exactly as before.

## Behavior

| Abort | Exception |
|-------|-----------|
| `request_abort_ex(custom)` during sleep | `custom` |
| `request_abort_ex(custom)` already aborted | `custom` (previously `sleep_aborted` — the bug) |
| `request_abort()` during sleep | `sleep_aborted` |
| `request_abort()` already aborted | `sleep_aborted` (unchanged) |

## Tests

Added to `tests/unit/abort_source_test.cc`:

- `test_sleep_abortable_already_aborted_with_exception` — custom exception is
  propagated on the already-aborted path (fails before the fix).
- `test_sleep_abortable_already_aborted_no_exception` — a plain abort still
  yields `sleep_aborted`.

Fixes #3452
