### PR TITLE
io_tester: disambiguate sstring streaming to YAML::Emitter

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -648,7 +648,7 @@ private:
 
     void emit_one_metrics(YAML::Emitter& out, sstring m_name, bool check_class_metrics = true) {
         if (auto v = get_one_metrics(m_name, check_class_metrics); v.has_value()) {
-            out << YAML::Key << m_name << YAML::Value << *v;
+            out << YAML::Key << std::string(m_name) << YAML::Value << *v;
         }
     }
 
@@ -1206,7 +1206,7 @@ public:
     future<> emit_results(YAML::Emitter& out) {
         return _finished.wait(_cl.size()).then([this, &out] {
             for (auto& cl: _cl) {
-                out << YAML::Key << cl->name();
+                out << YAML::Key << std::string(cl->name());
                 out << YAML::BeginMap;
                 cl->emit_results(out);
                 out << YAML::EndMap;


### PR DESCRIPTION
## Problem

The Alpine Linux CI build fails to compile `apps/io_tester/io_tester.cc`:

```
io_tester.cc:651:30: error: ambiguous overload for 'operator<<'
  (operand types are 'YAML::Emitter' and 'seastar::sstring')
```
(also at `io_tester.cc:1209`)

## Cause

Newer `yaml-cpp` (>= 0.8.0, now on the Alpine CI image) ships an
`operator<<(Emitter&, const std::string_view&)` overload alongside the
existing `const std::string&` one. `seastar::sstring` is implicitly
convertible to **both** `std::string` and `std::string_view`, so
streaming an `sstring` directly into a `YAML::Emitter` is ambiguous.

The source lines are old (2021 and 2025) and unchanged; the breakage is
purely from the yaml-cpp package upgrade in the CI image, so it affects
`master` independently of any in-flight PR.

## Fix

Explicitly convert to `std::string` at the two affected call sites. The
`std::string` overload has always existed in yaml-cpp, so this stays
correct on older versions too (unlike a `std::string_view` cast, which
would break older toolchains that lack that overload).