### PR TITLE
http: add reserve_connection() for request admission control

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -28,6 +28,7 @@
 #include <seastar/http/retry_strategy.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/util/integrated-length.hh>
 
 namespace bi = boost::intrusive;
@@ -163,6 +164,12 @@ private:
     condition_variable _wait_con;
     util::integrated_length<unsigned, lowres_clock, std::chrono::microseconds> _requests_queued;
     connections_list_t _pool;
+    // Admission slots for in-flight requests, kept in sync with _max_connections.
+    // A caller can reserve a slot (see reserve_connection()) before launching a
+    // request so that no more requests are admitted than there are connections,
+    // applying backpressure to the producer instead of queueing buffer-bearing
+    // requests internally.
+    semaphore _request_slots;
 
     using connection_ptr = seastar::shared_ptr<connection>;
 
@@ -327,6 +334,21 @@ public:
      * \param nr -- the new limit on the number of connections
      */
     future<> set_maximum_connections(unsigned nr);
+
+    /**
+     * \brief Reserve a slot to issue one request
+     *
+     * Resolves once the number of outstanding reservations drops below the
+     * maximum connection count, returning RAII units that must be held for the
+     * whole duration of the request. Holding a reservation guarantees the
+     * subsequent make_request() finds (or can open) a connection without being
+     * queued internally. Callers that launch requests in the background (without
+     * awaiting make_request()) should reserve a slot first so that backpressure
+     * reaches the producer rather than accumulating buffer-bearing requests.
+     *
+     * \param as -- optional abort source to interrupt the wait
+     */
+    future<semaphore_units<>> reserve_connection(abort_source* as = nullptr);
 
     /**
      * \brief Closes the client

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -228,8 +228,16 @@ client::client(std::unique_ptr<connection_factory> f, unsigned max_connections, 
         , _max_connections(max_connections)
         , _max_bytes_to_drain(max_bytes_to_drain)
         , _retry_strategy(std::move(retry_strategy))
+        , _request_slots(max_connections)
 {
     assert(_retry_strategy);
+}
+
+future<semaphore_units<>> client::reserve_connection(abort_source* as) {
+    if (as) {
+        return get_units(_request_slots, 1, *as);
+    }
+    return get_units(_request_slots, 1);
 }
 
 future<client::connection_ptr> client::get_connection(abort_source* as) {
@@ -296,12 +304,16 @@ future<> client::shrink_connections() {
 }
 
 future<> client::set_maximum_connections(unsigned nr) {
+    // Keep the request-admission slots in lock-step with the connection limit so
+    // reserve_connection() always reflects the current capacity.
     if (nr > _max_connections) {
+        _request_slots.signal(nr - _max_connections);
         _max_connections = nr;
         _wait_con.broadcast();
         return make_ready_future<>();
     }
 
+    _request_slots.consume(_max_connections - nr);
     _max_connections = nr;
     return shrink_connections();
 }


### PR DESCRIPTION
Background (fire-and-forget) request submitters currently have no way to apply backpressure to whatever produces their request bodies. When more requests are launched than there are connections, the surplus is parked inside get_connection() on _wait_con while still holding its body buffer, so a fast producer can accumulate an unbounded number of buffer-bearing requests and run the process out of memory.

Add an admission semaphore, _request_slots, sized to _max_connections and kept in lock-step with it in set_maximum_connections(). Expose it through reserve_connection(), which resolves once the number of outstanding reservations drops below the connection limit and returns RAII units that the caller holds for the whole duration of the request. Reserving a slot before launching a background request bounds the in-flight requests to the connection capacity and makes the producer block at the reservation rather than queueing buffer-bearing requests internally.

The change is additive and opt-in: callers that do not reserve see no behavioural change, and the make_request()/get_connection() paths are left untouched.

The intended consumer of reserve_connection() is ScyllaDB's object-storage (S3) client. Its multipart upload sinks issue part uploads as background, fire-and-forget requests, so the connection pool's existing wait-queue never backpressures the producer feeding those parts — surplus requests pile up holding their body buffers. Today the object-storage client bounds this with its own semaphore; with this primitive the sinks will instead reserve_connection() before launching each background part, so admission is gated by actual connection capacity (per connection pool / scheduling group) rather than a separate, hand-tuned limit. This is purely additive and opt-in here; the consumer change lands separately in ScyllaDB.
