### PR TITLE
seastar_test: Fix nested exception unpacking with ex. future return

### DIFF
--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -74,8 +74,7 @@ add_exception_message(const std::exception* ep, bool rec, char *out, char *end) 
     return loc;
 }
 
-[[noreturn]]
-static void repackage_exception_and_rethrow(const std::exception* ep) {
+static future<> repackage_exception_and_rethrow(const std::exception* ep) {
     // Note: using a static buffer for formatting, same as boost::test code,
     // so we make it less prone to fail in failure handling for OOM
     // situations etc.
@@ -83,7 +82,7 @@ static void repackage_exception_and_rethrow(const std::exception* ep) {
     static char buf[REPORT_ERROR_BUFFER_SIZE];
 
     auto loc = add_exception_message(ep, false, buf, buf + sizeof(buf) - 1);
-    boost:: BOOST_TEST_I_THROW(boost::execution_exception(boost::execution_exception::cpp_exception_error, buf, loc));
+    return make_exception_future<>(boost::execution_exception(boost::execution_exception::cpp_exception_error, buf, loc));
 }
 
 void seastar_test::run() {
@@ -95,17 +94,19 @@ void seastar_test::run() {
 
     set_abort_on_internal_error(true);
 
-    global_test_runner().run_sync([this] {
+    global_test_runner().run_sync([this]() -> future<> {
         // #3165 - do exception catch here already, and package
         // the info into an execution_exception, potentially including
         // nestedness etc.
-        try {
-            return run_test_case();
-        } catch (std::exception& e) {
-            repackage_exception_and_rethrow(&e);
-        } catch (...) {
-            repackage_exception_and_rethrow(nullptr);
-        }
+        return futurize_invoke(std::bind(&seastar_test::run_test_case, this)).handle_exception([](std::exception_ptr e) {
+            try {
+                std::rethrow_exception(e);
+            } catch (std::exception& e) {
+                return repackage_exception_and_rethrow(&e);
+            } catch (...) {
+                return repackage_exception_and_rethrow(nullptr);
+            }
+        });
     });
 }
 

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -167,14 +167,27 @@ SEASTAR_TEST_CASE(test_nested_throw_helper) {
     return make_ready_future<>();
 }
 
-// Cannot be a SEASTAR_TEST_CASE, because of recursion of seastar::test::run.
-BOOST_AUTO_TEST_CASE(test_nested_throw) {
+// Dummy test that on its own does nothing.
+SEASTAR_TEST_CASE(test_nested_exception_future_helper) {
+    try {
+        return test_nested_throw_helper_instance.run_test_case();
+    } catch (...) {
+        return make_exception_future<>(std::current_exception());
+    }
+}
+
+template<typename T>
+void exception_message_check_helper(const T& instance) {
     // make helper throw its nested test failure
     do_throw = true;
+    auto def = defer([]() noexcept {
+        do_throw = false;
+    });
+
     try {
         // fake "normal" test invoke. This will push the test into the main
         // runner etc. The exception will be thrown.
-        const_cast<test_nested_throw_helper&>(test_nested_throw_helper_instance).run();
+        const_cast<T&>(instance).run();
     } catch (boost::execution_exception& e) {
         // Should get a cpp exception failure
         BOOST_REQUIRE_EQUAL(e.code(), boost::execution_exception::error_code::cpp_exception_error);
@@ -183,5 +196,15 @@ BOOST_AUTO_TEST_CASE(test_nested_throw) {
         // Should have the outer message
         BOOST_REQUIRE(e.what().find("Message 2") != std::string::npos);
     }
+}
+
+// Cannot be a SEASTAR_TEST_CASE, because of recursion of seastar::test::run.
+BOOST_AUTO_TEST_CASE(test_nested_throw) {
+    exception_message_check_helper(test_nested_throw_helper_instance);
+}
+
+// Cannot be a SEASTAR_TEST_CASE, because of recursion of seastar::test::run.
+BOOST_AUTO_TEST_CASE(test_nested_throw_return_exception_future) {
+    exception_message_check_helper(test_nested_exception_future_helper_instance);
 }
 


### PR DESCRIPTION
Fixes: #3458

The workaround fix in 7039ebc to make boost tests print nested exception info only works for test cases where the exception is in fact thrown from the case, but not when the exception is delivered as an exception future.

This patch fixes this by simply turning all exception handling in run_sync into future-based and repackage the exception as such. Also saves an extra throw

Added unit test for this case as well.