### PR TITLE
http/client: add per-HTTP-method I/O statistics

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -21,8 +21,11 @@
 
 #pragma once
 
+#include <array>
+#include <chrono>
 #include <boost/intrusive/list.hpp>
 #include <seastar/net/api.hh>
+#include <seastar/http/common.hh>
 #include <seastar/http/connection_factory.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/http/retry_strategy.hh>
@@ -42,6 +45,33 @@ namespace http {
 class client;
 struct request;
 struct reply;
+
+/**
+ * \brief Per-HTTP-method I/O statistics
+ *
+ * Counters are accumulated for the lifetime of the owning \ref client and
+ * cover all requests of a single \ref httpd::operation_type.
+ */
+struct http_method_stats {
+    /// Number of completed requests (both successful and failed)
+    uint64_t ops = 0;
+    /// Number of retry attempts performed across all requests
+    uint64_t retries = 0;
+    /// Cumulative request latency; divide by \ref ops to get the average
+    std::chrono::duration<double> latency{0};
+};
+
+/**
+ * \brief Per-method HTTP client statistics, indexed by \ref httpd::operation_type
+ */
+class client_stats {
+    static constexpr size_t num_methods = httpd::operation_type::NUM_OPERATION;
+    std::array<http_method_stats, num_methods> methods{};
+public:
+    http_method_stats& operator[](httpd::operation_type method) { return methods[method]; }
+
+    const http_method_stats& operator[](httpd::operation_type method) const { return methods[method]; }
+};
 
 namespace internal {
 
@@ -163,6 +193,7 @@ private:
     condition_variable _wait_con;
     util::integrated_length<unsigned, lowres_clock, std::chrono::microseconds> _requests_queued;
     connections_list_t _pool;
+    http::client_stats _http_stats;
 
     using connection_ptr = seastar::shared_ptr<connection>;
 
@@ -180,6 +211,7 @@ private:
 
     future<> maybe_retry_request(std::exception_ptr ex,
                                  unsigned retry_count,
+                                 httpd::operation_type method,
                                  const request& req,
                                  reply_handler& handle,
                                  const retry_strategy& strategy,
@@ -374,6 +406,15 @@ public:
      */
     const auto& integrated_requests_queued() const noexcept {
         return _requests_queued;
+    }
+
+    /**
+     * \brief Returns the per-method HTTP statistics
+     *
+     * This is a container holding per-method I/O statistics indexed by operation type.
+     */
+    const http::client_stats& get_stats() const noexcept {
+        return _http_stats;
     }
 };
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -31,6 +31,7 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/http/client.hh>
+#include <seastar/http/common.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/http/response_parser.hh>
@@ -343,20 +344,22 @@ future<> client::make_request(const request& req, reply_handler& handle, std::op
 
 future<> client::maybe_retry_request(std::exception_ptr ex,
                                      unsigned retry_count,
+                                     httpd::operation_type method,
                                      const request& req,
                                      reply_handler& handle,
                                      const retry_strategy& strategy,
                                      std::optional<reply::status_type> expected,
                                      abort_source* as) {
-    return strategy.should_retry(ex, retry_count).then([this, ex = std::move(ex), retry_count, &req, &handle, &strategy, as, expected](bool retry) mutable {
+    return strategy.should_retry(ex, retry_count).then([this, ex = std::move(ex), retry_count, method, &req, &handle, &strategy, as, expected](bool retry) mutable {
         if (!retry) {
             return make_exception_future<>(std::move(ex));
         }
+        ++_http_stats[method].retries;
         return with_new_connection([this, &req, &handle, as, expected](connection& con) {
                                        return do_make_request(con, req, handle, as, expected);
                                    },
-                                   as).handle_exception([this, retry_count, &req, &handle, &strategy, as, expected](std::exception_ptr ex) {
-            return maybe_retry_request(std::move(ex), retry_count + 1, req, handle, strategy, expected, as);
+                                   as).handle_exception([this, retry_count, method, &req, &handle, &strategy, as, expected](std::exception_ptr ex) {
+            return maybe_retry_request(std::move(ex), retry_count + 1, method, req, handle, strategy, expected, as);
         });
     });
 }
@@ -370,13 +373,18 @@ future<> client::make_request(const request& req, reply_handler& handle, const r
     } catch (...) {
         return current_exception_as_future();
     }
+    auto method = httpd::str2type(req._method);
+    ++_http_stats[method].ops;
+    auto start = lowres_clock::now();
     return with_connection([this, &req, &handle, as, expected] (connection& con) {
         return do_make_request(con, req, handle, as, expected);
-    }, as).handle_exception([this, &req, &handle, &strategy, as, expected] (std::exception_ptr ex) {
+    }, as).handle_exception([this, method, &req, &handle, &strategy, as, expected] (std::exception_ptr ex) {
         if (as && as->abort_requested()) {
             return make_exception_future<>(as->abort_requested_exception_ptr());
         }
-        return maybe_retry_request(std::move(ex), 0, req, handle, strategy, expected, as);
+        return maybe_retry_request(std::move(ex), 0, method, req, handle, strategy, expected, as);
+    }).finally([this, method, start] {
+        _http_stats[method].latency += std::chrono::duration<double>(lowres_clock::now() - start);
     });
 }
 


### PR DESCRIPTION
### Problem

Users of the seastar HTTP client have no built-in way to observe per-method I/O activity (request counts, retries, latency). Today every consumer that wants this visibility has to wrap the client and re-implement its own tracking, which is duplicated work and easy to get wrong (e.g. missing the retry path, or only counting one verb).

### Changes

The HTTP `client` now tracks per-HTTP-method statistics directly:

- A new `http::http_method_stats` struct holds `ops`, `retries`, and accumulated `latency` (as `std::chrono::duration<double>`).
- A new `http::client_stats` container holds an `std::array<http_method_stats, NUM_OPERATION>` indexed by `httpd::operation_type`, with `operator[]` overloads for ergonomic access.
- `client::make_request` resolves the verb via `httpd::str2type`, increments `ops`, and accumulates wall-clock latency in a `.finally()` block using `lowres_clock`.
- `client::maybe_retry_request` takes the resolved `operation_type` as an extra argument and increments `retries` whenever the retry strategy decides to retry.
- A `const get_stats()` accessor exposes the container so callers can read counters without owning any tracking code.

This keeps the wiring entirely inside the client — no API break for existing callers of `make_request`, no behavior change on the success/failure paths beyond the counter updates.
