### PR TITLE
rpc: tune _outstanding map to reduce rehash allocations

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -950,6 +950,9 @@ client::metrics::~metrics() {
 client::client(const logger& l, void* s, client_options ops, socket socket, const socket_address& addr, const socket_address& local)
         : rpc::connection(l, s), _socket(std::move(socket)), _server_addr(addr), _local_addr(local), _options(ops), _metrics(*this)
 {
+    // Reduce rehash frequency and keep per-rehash allocations small to avoid oversized allocations.
+    _outstanding.max_load_factor(8);
+    _outstanding.reserve(4096);
     _socket.set_reuseaddr(ops.reuseaddr);
     // Run client in the background.
     // Communicate result via _stopped.


### PR DESCRIPTION
## Problem

The `_outstanding` `unordered_map` in `rpc::client` uses the default `load_factor` of 1. Under sustained RPC load, every power-of-two boundary triggers a rehash that doubles the backing array. At ~16K entries the array crosses the 128KB single-allocation threshold, causing oversized-allocation warnings in memory-constrained environments.

## Fix

Two adjustments in the primary `client` constructor (all three delegating constructors pick this up automatically):

- `max_load_factor(8)`: 8 entries per bucket reduces rehash frequency by 8× and keeps the backing array at ~32KB for 4K buckets (8 entries × 4K buckets × 8-byte pointer)
- `reserve(4096)`: avoids early rehashes during typical RPC bursts at connection start

This is the same approach used for similar maps elsewhere in the codebase.

## Notes

A follow-up ticket will evaluate structural alternatives (e.g. a chunked/log-indexed map) once there is empirical evidence of further gain.

Fixes: SCYLLADB-1541