### PR TITLE
core: add input/output stream copy_n (copies exactly n)

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -617,6 +617,7 @@ public:
         });
     }
 };
+
 /// \endcond
 
 }
@@ -626,6 +627,22 @@ extern template struct internal::stream_copy_consumer<char>;
 template <typename CharType>
 future<> copy(input_stream<CharType>& in, output_stream<CharType>& out) {
     return in.consume(internal::stream_copy_consumer<CharType>(out));
+}
+
+/// \brief copy exactly \c n bytes from the input stream to the output stream
+///
+/// \throws std::runtime_error if the input stream reaches end-of-stream before
+/// \c n bytes have been copied.
+template <typename CharType>
+future<> copy_n(input_stream<CharType>& in, output_stream<CharType>& out, size_t n) {
+    while (n != 0) {
+        auto buf = co_await in.read_up_to(n);
+        if (buf.empty()) {
+            throw std::runtime_error("copy_n: input stream reached end-of-stream before copying the requested number of bytes");
+        }
+        n -= buf.size();
+        co_await out.write(std::move(buf));
+    }
 }
 
 extern template future<> copy<char>(input_stream<char>&, output_stream<char>&);

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -599,6 +599,15 @@ private:
 template <typename CharType>
 future<> copy(input_stream<CharType>&, output_stream<CharType>&);
 
+/*!
+ * \brief copy exactly \c n bytes from the input stream to the output stream
+ *
+ * Throws \c std::runtime_error if the input stream reaches end-of-stream
+ * before \c n bytes have been copied.
+ */
+template <typename CharType>
+future<> copy_n(input_stream<CharType>&, output_stream<CharType>&, size_t n);
+
 }
 
 #include "iostream-impl.hh"

--- a/tests/unit/output_stream_test.cc
+++ b/tests/unit/output_stream_test.cc
@@ -25,6 +25,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/random.hh>
+#include <seastar/util/memory-data-source.hh>
 #include <vector>
 #include <list>
 #include <deque>
@@ -267,6 +268,50 @@ SEASTAR_THREAD_TEST_CASE(test_move_after_batched_write) {
     }
     out.close().get();
     BOOST_REQUIRE_EQUAL(ss.str(), "smth");
+}
+
+namespace {
+
+// Build an input_stream that serves `data` as fixed-size chunks, using the
+// in-tree util::memory_data_source. Multiple chunks exercise copy_n's read
+// loop even for small inputs.
+input_stream<char> make_chunked_input_stream(std::string_view data, size_t chunk = 4) {
+    std::vector<temporary_buffer<char>> bufs;
+    for (size_t i = 0; i < data.size(); i += chunk) {
+        auto sz = std::min(chunk, data.size() - i);
+        bufs.emplace_back(data.data() + i, sz);
+    }
+    return util::as_input_stream(std::move(bufs));
+}
+
+}
+
+SEASTAR_THREAD_TEST_CASE(test_copy_n) {
+    const sstring src = "0123456789abcdef"; // 16 bytes; 4-byte chunks => multi-read
+
+    // copy_n copies exactly n bytes; check counts spanning the chunk boundary,
+    // and that the input retains exactly the unconsumed remainder afterwards.
+    for (size_t n : {size_t(0), size_t(1), size_t(4), size_t(5), size_t(13), src.size()}) {
+        std::stringstream ss;
+        auto in = make_chunked_input_stream(src);
+        auto out = output_stream<char>(testing::memory_data_sink(ss), 8);
+        copy_n(in, out, n).get();
+        out.close().get();
+        BOOST_REQUIRE_EQUAL(ss.str(), std::string(src.data(), n));
+
+        // The input must still have exactly the remaining bytes available.
+        auto rest = in.read_exactly(src.size() - n).get();
+        BOOST_REQUIRE_EQUAL(sstring(rest.get(), rest.size()), src.substr(n));
+    }
+
+    // Requesting more than the stream holds fails (exactly-n contract).
+    {
+        std::stringstream ss;
+        auto in = make_chunked_input_stream(src);
+        auto out = output_stream<char>(testing::memory_data_sink(ss), 8);
+        BOOST_REQUIRE_THROW(copy_n(in, out, src.size() + 1).get(), std::runtime_error);
+        out.close().get();
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_simple_write) {


### PR DESCRIPTION
`copy(input_stream&, output_stream&)` copies an entire input stream to an
output stream, but there is no way to copy a bounded number of bytes.

Add `copy_n(input_stream&, output_stream&, size_t n)` which copies **exactly
n** bytes and throws `std::runtime_error` if the input reaches end-of-stream
before n bytes have been copied. This mirrors `std::copy_n` and seastar's own
`read_exactly`, and keeps the `future<>` return meaningful (success implies
exactly n bytes were copied, rather than a silently truncated count).

It is implemented as a coroutine that reads via `read_up_to()` and writes each
chunk, so larger-than-buffer copies use a single coroutine frame rather than a
chain of `future::then` continuations.

Fixes #962.