### PR TITLE
core: fix output_stream move to reset moved-from state

### DIFF
--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -47,6 +47,7 @@
 #include <memory>
 #include <optional>
 #include <variant>
+#include <utility>
 #include <vector>
 
 namespace bi = boost::intrusive;
@@ -503,9 +504,38 @@ public:
         : _fd(std::move(fd)), _buffer_size(size), _trim_to_size(opts.trim_to_size), _batch_flushes(opts.batch_flushes && _fd.can_batch_flushes()) {}
     output_stream(data_sink fd) noexcept
         : _fd(std::move(fd)), _buffer_size(_fd.buffer_size()), _trim_to_size(true) {}
-    output_stream(output_stream&&) noexcept = default;
+    output_stream(output_stream&& o) noexcept
+        : _fd(std::move(o._fd))
+        , _buf(std::move(o._buf))
+        , _zc_bufs(std::move(o._zc_bufs))
+        , _buffer_size(std::exchange(o._buffer_size, 0))
+        , _end(std::exchange(o._end, 0))
+        , _zc_len(std::exchange(o._zc_len, 0))
+        , _trim_to_size(std::exchange(o._trim_to_size, false))
+        , _batch_flushes(std::exchange(o._batch_flushes, false))
+        , _in_batch(std::exchange(o._in_batch, std::nullopt))
+        , _flush(std::exchange(o._flush, false))
+        , _flushing(std::exchange(o._flushing, false))
+        , _ex(std::move(o._ex))
+    {}
     [[deprecated("Output stream cannot be move-assigned, consider move-constructing the target in place")]]
-    output_stream& operator=(output_stream&&) noexcept = default;
+    output_stream& operator=(output_stream&& o) noexcept {
+        if (this != &o) {
+            _fd = std::move(o._fd);
+            _buf = std::move(o._buf);
+            _zc_bufs = std::move(o._zc_bufs);
+            _buffer_size = std::exchange(o._buffer_size, 0);
+            _end = std::exchange(o._end, 0);
+            _zc_len = std::exchange(o._zc_len, 0);
+            _trim_to_size = std::exchange(o._trim_to_size, false);
+            _batch_flushes = std::exchange(o._batch_flushes, false);
+            _in_batch = std::exchange(o._in_batch, std::nullopt);
+            _flush = std::exchange(o._flush, false);
+            _flushing = std::exchange(o._flushing, false);
+            _ex = std::move(o._ex);
+        }
+        return *this;
+    }
     ~output_stream() {
         if (_batch_flushes) {
             SEASTAR_ASSERT(!_in_batch && "Was this stream properly closed?");

--- a/tests/unit/output_stream_test.cc
+++ b/tests/unit/output_stream_test.cc
@@ -257,6 +257,18 @@ SEASTAR_THREAD_TEST_CASE(test_flush_on_empty_buffer_does_not_push_empty_packet_d
     BOOST_REQUIRE(ss.str().empty());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_move_after_batched_write) {
+    std::stringstream ss;
+    output_stream<char> out;
+    {
+        auto out2 = output_stream<char>(testing::memory_data_sink(ss), 8);
+        out2.write(sstring("smth")).get();
+        out = std::move(out2);
+    }
+    out.close().get();
+    BOOST_REQUIRE_EQUAL(ss.str(), "smth");
+}
+
 SEASTAR_THREAD_TEST_CASE(test_simple_write) {
     std::stringstream ss;
     auto out = output_stream<char>(testing::memory_data_sink(ss), 8);


### PR DESCRIPTION
`output_stream`'s move constructor and move assignment were defaulted.
A defaulted move leaves the moved-from `_in_batch` (a `std::optional`)
engaged, and the scalar members (`_end`, `_zc_len`, `_batch_flushes`)
unchanged, so the moved-from object's destructor trips:

```
SEASTAR_ASSERT(!_in_batch && "Was this stream properly closed?")
```

as in:

```c++
output_stream<char> out;
{
    output_stream<char> out2 = ...;
    co_await out2.write("smth");
    out = std::move(out2);
} // assertion fires when out2 is destroyed
```

Define the move constructor and move assignment explicitly, using
`std::exchange` to reset the state-bearing members of the moved-from
object so its destructor runs cleanly.

Fixes #2959.