### PR TITLE
http: follow WHATWG spec for invalid percent-encoded sequences

### DIFF
--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -30,21 +30,32 @@ namespace internal {
 
 namespace {
 
+bool is_hex_digit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
 short hex_to_byte(char c) {
-    if (c >='a' && c <= 'z') {
+    if (c >= 'a' && c <= 'f') {
         return c - 'a' + 10;
-    } else if (c >='A' && c <= 'Z') {
+    } else if (c >= 'A' && c <= 'F') {
         return c - 'A' + 10;
+    } else if (c >= '0' && c <= '9') {
+        return c - '0';
     }
-    return c - '0';
+    return -1;
 }
 
 /**
- * Convert a hex encoded 2 bytes substring to char
+ * Convert a hex encoded 2 bytes substring to char.
+ * Returns -1 if either character is not a valid hex digit.
  */
-char hexstr_to_char(std::string_view in, size_t from) {
-
-    return static_cast<char>(hex_to_byte(in[from]) * 16 + hex_to_byte(in[from + 1]));
+short hexstr_to_char(std::string_view in, size_t from) {
+    auto hi = hex_to_byte(in[from]);
+    auto lo = hex_to_byte(in[from + 1]);
+    if (hi < 0 || lo < 0) {
+        return -1;
+    }
+    return static_cast<short>(hi * 16 + lo);
 }
 
 bool should_encode(char c) {
@@ -65,11 +76,11 @@ bool decode(bool replace_plus, std::string_view in, sstring& out) {
     sstring buff(in.length(), 0);
     for (size_t i = 0; i < in.length(); ++i) {
         if (in[i] == '%') {
-            if (i + 3 <= in.size()) {
-                buff[pos++] = hexstr_to_char(in, i + 1);
+            if (i + 2 < in.size() && is_hex_digit(in[i + 1]) && is_hex_digit(in[i + 2])) {
+                buff[pos++] = static_cast<char>(hexstr_to_char(in, i + 1));
                 i += 2;
             } else {
-                return false;
+                buff[pos++] = '%';
             }
         } else if (replace_plus && in[i] == '+') {
             buff[pos++] = ' ';

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -249,6 +249,12 @@ SEASTAR_TEST_CASE(test_decode_url) {
     const auto& a = req.get_query_param_array("a");
     auto expected_a = std::vector<sstring>{"!", "#$#"};
     BOOST_REQUIRE(a == expected_a);
+    req._url = "/a?q=%25%s%1G";
+    req.parse_query_param();
+    BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "%%s%1G");
+    req._url = "/a?q=%2g";
+    req.parse_query_param();
+    BOOST_REQUIRE_EQUAL(req.get_query_param("q"), "%2g");
     return make_ready_future<>();
 }
 
@@ -259,13 +265,13 @@ SEASTAR_TEST_CASE(test_decode_path) {
     req.param.set("param2", "/same%2Ba%2Bb");
     req.param.set("param3", "/another_param");
     req.param.set("param4", "/yet%20another");
-    req.param.set("invalid_param", "/%2");
+    req.param.set("incomplete_escape", "/%2");
 
     BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "a+b");
     BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "same+a+b");
     BOOST_REQUIRE_EQUAL(req.get_path_param("param3"), "another_param");
     BOOST_REQUIRE_EQUAL(req.get_path_param("param4"), "yet another");
-    BOOST_REQUIRE_EQUAL(req.get_path_param("invalid_param"), "");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("incomplete_escape"), "%2");
     BOOST_REQUIRE_EQUAL(req.get_path_param("missing_param"), "");
     return make_ready_future<>();
 }

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -276,6 +276,36 @@ SEASTAR_TEST_CASE(test_decode_path) {
     return make_ready_future<>();
 }
 
+// Exhaustive table of WHATWG percent-decoding edge cases, exercised directly
+// against url_decode/path_decode. Both always succeed now: an invalid or
+// incomplete escape is emitted literally rather than failing the decode.
+SEASTAR_TEST_CASE(test_url_decode_edge_cases) {
+    struct { std::string_view in; std::string_view url; std::string_view path; } cases[] = {
+        // input            url_decode (+ -> space)   path_decode (+ kept)
+        {"",                "",                        ""},
+        {"abc",             "abc",                     "abc"},
+        {"%41",             "A",                       "A"},
+        {"%4a",             "J",                       "J"},        // lower-case hex
+        {"%4A",             "J",                       "J"},        // upper-case hex
+        {"a+b",             "a b",                     "a+b"},      // '+' only decoded by url_decode
+        {"%2g",             "%2g",                     "%2g"},      // bad 2nd nibble -> literal
+        {"%g2",             "%g2",                     "%g2"},      // bad 1st nibble -> literal
+        {"%gg",             "%gg",                     "%gg"},
+        {"%",               "%",                       "%"},        // trailing '%'
+        {"%2",              "%2",                      "%2"},       // trailing single hex digit
+        {"%%41",            "%A",                      "%A"},       // literal '%' then a real escape
+        {"%25%s%1G",        "%%s%1G",                  "%%s%1G"},   // WHATWG spec example
+    };
+    for (auto& c : cases) {
+        sstring out;
+        BOOST_REQUIRE(seastar::http::internal::url_decode(c.in, out));
+        BOOST_REQUIRE_EQUAL(out, sstring(c.url));
+        BOOST_REQUIRE(seastar::http::internal::path_decode(c.in, out));
+        BOOST_REQUIRE_EQUAL(out, sstring(c.path));
+    }
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_routes) {
     handl* h1 = new handl();
     handl* h2 = new handl();


### PR DESCRIPTION
`url_decode`/`path_decode` treat any `%` followed by two characters as
a hex escape. Two problems follow from that:

- `hex_to_byte` accepted `a`-`z`/`A`-`Z` as hex digits, so e.g. `%2g`
  decoded to a bogus byte instead of being left alone.
- An incomplete trailing escape (`%` or `%X` at the end of input)
  caused the whole decode to fail.

Neither matches the URL Standard, which says a percent-encoded byte is
`%` followed by two ASCII hex digits; if that is not the case, the `%`
is emitted literally and parsing continues
(https://url.spec.whatwg.org/#percent-encoded-bytes).

Only decode when the next two characters are ASCII hex digits;
otherwise emit a literal `%` and continue. `%2g` now decodes to the
literal `%2g`, and the spec example `%25%s%1G` decodes to `%%s%1G`.

Fixes #3304.