### PR TITLE
util: print concise exception messages in logs

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -640,10 +640,14 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
         std::rethrow_exception(eptr);
     } catch(...) {
         // Print what() for std::exception; fall back to the type name otherwise.
+        // system_error additionally carries an error code that what() does not
+        // include, so keep that without the verbose type-name prefix.
         try {
             throw;
         } catch (const seastar::nested_exception& ne) {
             out << fmt::format("{} (while cleaning up after {})", ne.inner, ne.outer);
+        } catch (const std::system_error& e) {
+            out << e.what() << " (error " << e.code() << ")";
         } catch (const std::exception& e) {
             out << e.what();
         } catch (...) {
@@ -673,7 +677,7 @@ std::ostream& operator<<(std::ostream& out, const std::exception& e) {
 }
 
 std::ostream& operator<<(std::ostream& out, const std::system_error& e) {
-    return out << e.what();
+    return out << e.what() << " (error " << e.code() << ")";
 }
 
 }

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -639,30 +639,28 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
     try {
         std::rethrow_exception(eptr);
     } catch(...) {
-        auto tp = abi::__cxa_current_exception_type();
-        if (tp) {
-            out << seastar::pretty_type_name(*tp);
-        } else {
-            // This case shouldn't happen...
-            out << "<unknown exception>";
-        }
-        // Print more information on some familiar exception types
+        // Print what() for std::exception; fall back to the type name otherwise.
         try {
             throw;
         } catch (const seastar::nested_exception& ne) {
-            out << fmt::format(": {} (while cleaning up after {})", ne.inner, ne.outer);
-        } catch (const std::system_error& e) {
-            out << " (error " << e.code() << ", " << e.what() << ")";
+            out << fmt::format("{} (while cleaning up after {})", ne.inner, ne.outer);
         } catch (const std::exception& e) {
-            out << " (" << e.what() << ")";
+            out << e.what();
         } catch (...) {
-            // no extra info
+            auto tp = abi::__cxa_current_exception_type();
+            if (tp) {
+                out << seastar::pretty_type_name(*tp);
+            } else {
+                out << "<unknown exception>";
+            }
         }
 
         try {
             throw;
         } catch (const std::nested_exception& ne) {
-            out << ": " << ne.nested_ptr();
+            if (ne.nested_ptr()) {
+                out << ": " << ne.nested_ptr();
+            }
         } catch (...) {
             // do nothing
         }
@@ -671,11 +669,11 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
 }
 
 std::ostream& operator<<(std::ostream& out, const std::exception& e) {
-    return out << seastar::pretty_type_name(typeid(e)) << " (" << e.what() << ")";
+    return out << e.what();
 }
 
 std::ostream& operator<<(std::ostream& out, const std::system_error& e) {
-    return out << seastar::pretty_type_name(typeid(e)) << " (error " << e.code() << ", " << e.what() << ")";
+    return out << e.what();
 }
 
 }

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging3) {
         }
     }
 
-    std::string expected_string("std::_Nested_exception<unknown_obj>: my error: Operation not permitted: very important information");
+    std::string expected_string("std::_Nested_exception<unknown_obj>: my error: Operation not permitted (error generic:1): very important information");
 
     BOOST_REQUIRE_EQUAL(log_msg.str(), expected_string);
 }

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -87,17 +87,14 @@ void exception_generator(uint32_t test_instance, int nesting_level) {
 // thrown by the  exception generator function with a specific output.
 std::string exception_generator_str(uint32_t test_instance,int nesting_level) {
     std::ostringstream ret;
-    const std::string runtime_err_str = "std::runtime_error";
     const std::string unknown_obj_str = "unknown_obj";
     const std::string nested_exception_with_unknown_obj_str = "std::_Nested_exception<unknown_obj>";
-    const std::string nested_exception_with_runtime_err_str = "std::_Nested_exception<std::runtime_error>";
 
     for(; nesting_level > 0; nesting_level--) {
         if (test_instance & 1) {
             fmt::print(ret, "{}", nested_exception_with_unknown_obj_str);
         } else {
-            fmt::print(ret, "{} (Exception Level {})", nested_exception_with_runtime_err_str,
-                       nesting_level);
+            fmt::print(ret, "Exception Level {}", nesting_level);
         }
         ret << ": ";
         test_instance >>= 1;
@@ -107,7 +104,7 @@ std::string exception_generator_str(uint32_t test_instance,int nesting_level) {
     if (test_instance & 1) {
         fmt::print(ret, "{}", unknown_obj_str);
     } else {
-        fmt::print(ret, "{} (Exception Level {})", runtime_err_str, nesting_level);
+        fmt::print(ret, "Exception Level {}", nesting_level);
     }
     return ret.str();
 }
@@ -140,7 +137,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging2) {
         log_msg << std::current_exception();
     }
 
-    BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("std::nested_exception: <no exception>"));
+    BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("std::nested_exception"));
 }
 
 class very_important_exception : public std::exception {
@@ -171,7 +168,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging3) {
         }
     }
 
-    std::string expected_string("std::_Nested_exception<unknown_obj>: std::_Nested_exception<std::system_error> (error generic:1, my error: Operation not permitted): very_important_exception (very important information)");
+    std::string expected_string("std::_Nested_exception<unknown_obj>: my error: Operation not permitted: very important information");
 
     BOOST_REQUIRE_EQUAL(log_msg.str(), expected_string);
 }
@@ -222,7 +219,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+    auto regex_str = "throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }
@@ -240,7 +237,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "std::_Nested_exception<unknown_obj>.*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+    auto regex_str = "std::_Nested_exception<unknown_obj>.*outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }
@@ -264,7 +261,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
+    auto regex_str = "inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?"
             " \\(while cleaning up after unknown_obj\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
@@ -290,8 +287,8 @@ BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_loggin
     BOOST_TEST_MESSAGE(log_msg.str());
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
-            " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)\\)";
+    auto regex_str = "inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?"
+            " \\(while cleaning up after outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -451,7 +451,7 @@ SEASTAR_TEST_CASE(test_get_on_exceptional_promise) {
 
 static void check_finally_exception(std::exception_ptr ex) {
   BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
-        "seastar::nested_exception: test_exception (bar) (while cleaning up after test_exception (foo))");
+        "bar (while cleaning up after foo)");
   try {
       // convert to the concrete type nested_exception
       std::rethrow_exception(ex);

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -502,7 +502,7 @@ SEASTAR_TEST_CASE(test_rpc_remote_verb_error) {
         env.register_handler(1, []() { throw std::runtime_error("test_error"); }).get();
         auto f = env.proto().make_client<void ()>(1);
         BOOST_REQUIRE_EXCEPTION(f(c1).get(), rpc::remote_verb_error, [](const rpc::remote_verb_error& e) {
-            return std::string_view(e.what()) == "std::runtime_error (test_error)";
+            return std::string_view(e.what()) == "test_error";
         });
 
         // Verify that nested exceptions are properly reported with full context.
@@ -519,7 +519,7 @@ SEASTAR_TEST_CASE(test_rpc_remote_verb_error) {
         auto f2 = env.proto().make_client<void ()>(2);
         BOOST_REQUIRE_EXCEPTION(f2(c1).get(), rpc::remote_verb_error, [](const rpc::remote_verb_error& e) {
             auto msg = std::string_view(e.what());
-            return msg == "seastar::nested_exception: std::runtime_error (inner) (while cleaning up after std::runtime_error (outer))";
+            return msg == "inner (while cleaning up after outer)";
         });
 
         c1.stop().get();


### PR DESCRIPTION
When logging an `exception_ptr`, `operator<<` always prefixes the
demangled C++ type name and wraps the message in parentheses, e.g.

```
std::runtime_error (Failed to do X)
std::_Nested_exception<std::runtime_error> (msg1): std::runtime_error (msg2)
```

The type name is rarely useful and makes nested chains hard to read.

Print only `what()` for `std::exception` subclasses, keeping the
demangled type name only for unknown (non-`std::exception`) objects,
where it is the only information available. `seastar::nested_exception`
is formatted as `{inner} (while cleaning up after {outer})` without the
type prefix, and a null `std::nested_exception` no longer appends a
trailing `: <no exception>`.

The examples above become:

```
Failed to do X
msg1: msg2
```

Fixes #1029.