### PR TITLE
http: fix response line for unknown status codes

### DIFF
--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -91,27 +91,27 @@ static const std::unordered_map<reply::status_type, std::string_view> status_str
     {reply::status_type::network_read_timeout, "598 Network Read Timeout"},
     {reply::status_type::network_connect_timeout, "599 Network Connect Timeout"}};
 
-template<typename Func>
-static auto with_string_view(reply::status_type status, Func&& func) -> std::invoke_result_t<Func, std::string_view> {
-  if (auto found = status_strings.find(status); found != status_strings.end()) [[likely]] {
-     return func(found->second);
-  }
-  auto dummy_buf = std::to_string(int(status));
-  return func(dummy_buf);
+static std::optional<std::string_view> find(reply::status_type status) {
+    if (auto found = status_strings.find(status); found != status_strings.end()) [[likely]] {
+        return found->second;
+    }
+    return std::nullopt;
 }
 
 } // namespace status_strings
 
 std::ostream& operator<<(std::ostream& os, reply::status_type st) {
-    return status_strings::with_string_view(st, [&](std::string_view txt) -> std::ostream& {
-        return os << txt;
-    });
+    if (auto status = status_strings::find(st); status) [[likely]] {
+        return os << *status;
+    }
+    return os << static_cast<int>(st);
 }
 
 sstring reply::response_line() const {
-    return status_strings::with_string_view(_status, [this](std::string_view txt) {
-        return seastar::format("HTTP/{} {}\r\n", _version, txt);
-    });
+    if (auto status = status_strings::find(_status); status) [[likely]] {
+        return seastar::format("HTTP/{} {}\r\n", _version, *status);
+    }
+    return seastar::format("HTTP/{} {} \r\n", _version, static_cast<int>(_status));
 }
 
 void reply::write_body(std::optional<std::string_view> content_type, body_writer_type&& body_writer) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2463,6 +2463,26 @@ SEASTAR_THREAD_TEST_CASE(test_write_reply_content) {
     BOOST_REQUIRE(s.ends_with("hello"));
 }
 
+SEASTAR_THREAD_TEST_CASE(test_write_reply_unknown_status) {
+    http::reply reply;
+    reply.set_version("1.1");
+    reply.set_status(static_cast<http::reply::status_type>(299));
+    reply.write_body("txt", sstring("hello"));
+
+    std::stringstream ss;
+    auto os = output_stream<char>(data_sink(std::make_unique<testing::memory_data_sink_impl>(ss)));
+    auto close_os = deferred_close(os);
+
+    reply.write_reply(os).get();
+    os.flush().get();
+
+    auto s = ss.str();
+    BOOST_REQUIRE(s.starts_with("HTTP/1.1 299 \r\n"));
+    BOOST_REQUIRE_NE(s.find("Content-Type: text/plain\r\n"), std::string::npos);
+    BOOST_REQUIRE_NE(s.find("Content-Length: 5\r\n"), std::string::npos);
+    BOOST_REQUIRE(s.ends_with("hello"));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_write_reply_body_writer) {
     // Tests write_reply() for the body_writer (chunked) path:
     // - response line is correctly formatted


### PR DESCRIPTION
Fixes #3468

## Problem

`http::reply::response_line()` builds the HTTP start line from known status strings that include both the numeric code and reason phrase, for example `200 OK`.

For custom or unmapped status values, the generic status formatter falls back to only the numeric code, for example `299` or `451`. When `response_line()` used that same generic formatting path, unknown statuses serialized as:

```http
HTTP/1.1 299\r\n
```

HTTP status lines still require the separator after the three-digit status code when the reason phrase is empty. Seastar's own response parser expects the same shape in `src/http/response_parser.rl`:

```ragel
http_version space status_code space ... crlf
```

So replies using custom or missing standard status codes could be malformed on the wire and rejected by Seastar's HTTP client parser.

## Solution

- Add a status table lookup helper so `response_line()` can distinguish known status strings from numeric fallback values.
- Keep known statuses unchanged, for example `HTTP/1.1 200 OK\r\n`.
- Format unknown statuses directly in `response_line()` with an empty reason phrase separator, for example `HTTP/1.1 299 \r\n`.
- Keep `operator<<` behavior unchanged for status values by moving its numeric fallback directly into the stream operator and removing the now-unnecessary `with_string_view()` callback helper.
- Add a `write_reply()` regression test using status `299`, which is intentionally not present in the known-status table, so the fallback path remains covered even if another standard code is added later.

## Testing

- `git diff --check HEAD~1..HEAD`
- `ninja -C build/dev test_unit_httpd_run`