### PR TITLE
memory: reject aligned large allocations with overflowing page counts

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1553,21 +1553,31 @@ abort_on_underflow(size_t size) {
 }
 
 [[gnu::always_inline]]
-inline void* allocate_large(size_t size, bool should_sample) {
+inline optional<unsigned> size_to_page_count(size_t size) {
     abort_on_underflow(size);
-    unsigned size_in_pages = (size + page_size - 1) >> page_bits;
-    if ((size_t(size_in_pages) << page_bits) < size) {
-        return nullptr; // (size + page_size - 1) caused an overflow
+    auto size_in_pages = (size + page_size - 1) >> page_bits;
+    if (size_in_pages > std::numeric_limits<unsigned>::max()) {
+        return {};
     }
-    return get_cpu_mem().allocate_large(size_in_pages, should_sample);
+    return static_cast<unsigned>(size_in_pages);
+}
 
+[[gnu::always_inline]]
+inline void* allocate_large(size_t size, bool should_sample) {
+    auto size_in_pages = size_to_page_count(size);
+    if (!size_in_pages) {
+        return nullptr;
+    }
+    return get_cpu_mem().allocate_large(*size_in_pages, should_sample);
 }
 
 void* allocate_large_aligned(size_t align, size_t size, bool should_sample) {
-    abort_on_underflow(size);
-    unsigned size_in_pages = (size + page_size - 1) >> page_bits;
+    auto size_in_pages = size_to_page_count(size);
+    if (!size_in_pages) {
+        return nullptr;
+    }
     unsigned align_in_pages = std::max(align, page_size) >> page_bits;
-    return get_cpu_mem().allocate_large_aligned(align_in_pages, size_in_pages, should_sample);
+    return get_cpu_mem().allocate_large_aligned(align_in_pages, *size_in_pages, should_sample);
 }
 
 void free_large(void* ptr) {

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -31,10 +31,13 @@
 
 #include <memory>
 #include <new>
+#include <limits>
 #include <vector>
 #include <future>
 #include <iostream>
 
+#include <cerrno>
+#include <cstdint>
 #include <malloc.h>
 #include <stdlib.h>
 
@@ -333,6 +336,32 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
     stats = seastar::memory::stats();
     BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
     BOOST_CHECK_EQUAL(failed_allocs(), 1);
+
+    constexpr auto overflowing_page_count =
+        uint64_t(std::numeric_limits<unsigned>::max()) + 2;
+    if constexpr (std::numeric_limits<size_t>::max() / memory::page_size >= overflowing_page_count) {
+        auto truncating_aligned_size = size_t(overflowing_page_count) * memory::page_size;
+
+        // test that aligned allocations whose page count would overflow fail
+        stats = seastar::memory::stats();
+        BOOST_REQUIRE_EQUAL(aligned_alloc(memory::page_size, truncating_aligned_size), nullptr);
+        BOOST_CHECK_EQUAL(failed_allocs(), 1);
+
+        stats = seastar::memory::stats();
+        BOOST_REQUIRE_EQUAL(memalign(memory::page_size, truncating_aligned_size), nullptr);
+        BOOST_CHECK_EQUAL(failed_allocs(), 1);
+
+        stats = seastar::memory::stats();
+        void* p_aligned = nullptr;
+        BOOST_REQUIRE_EQUAL(posix_memalign(&p_aligned, memory::page_size, truncating_aligned_size), ENOMEM);
+        BOOST_REQUIRE_EQUAL(p_aligned, nullptr);
+        BOOST_CHECK_EQUAL(failed_allocs(), 1);
+
+        stats = seastar::memory::stats();
+        BOOST_REQUIRE_THROW(sink = operator new(
+                truncating_aligned_size, std::align_val_t(memory::page_size)), std::bad_alloc);
+        BOOST_CHECK_EQUAL(failed_allocs(), 1);
+    }
 
     // test that huge realloc on nullptr returns null
     stats = seastar::memory::stats();


### PR DESCRIPTION
## Problem

`allocate_large()` already checks that its rounded page count fits in the allocator's `unsigned` page-count type before passing it to `cpu_pages`. `allocate_large_aligned()` performed the same rounding directly into `unsigned`, so huge aligned requests whose page count exceeds `UINT_MAX` could wrap and be handled as a much smaller allocation.

## Fix

- Factor the checked byte-to-page conversion into `size_to_page_count()`.
- Use it from both `allocate_large()` and `allocate_large_aligned()`.
- Return through the existing allocation-failure path for aligned requests whose page count cannot be represented.
- Add regression coverage for public aligned allocation APIs: `aligned_alloc()`, `memalign()`, `posix_memalign()`, and aligned `operator new`.

Fixes #3467

## Testing

- `ninja -C build/dev test_unit_alloc`
- `ctest --test-dir build/dev -R '^Seastar\.unit\.alloc$' --output-on-failure`