### PR TITLE
memory: honor large allocation alignment

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -943,8 +943,7 @@ cpu_pages::allocate_large(unsigned n_pages, bool should_sample) {
 void*
 cpu_pages::allocate_large_aligned(unsigned align_pages, unsigned n_pages, bool should_sample) {
     check_large_allocation(n_pages * page_size);
-    // buddy allocation is always aligned
-    return allocate_large_and_trim(n_pages, should_sample);
+    return allocate_large_and_trim(std::max(align_pages, n_pages), should_sample);
 }
 
 disable_backtrace_temporarily::disable_backtrace_temporarily()
@@ -1782,6 +1781,10 @@ inline void free(void* obj, S size = {}) {
 }
 
 void free_aligned(void* obj, size_t align, size_t size) {
+    if (align > page_size) {
+        free(obj);
+        return;
+    }
     if (size <= sizeof(free_object)) {
         size = sizeof(free_object);
     }

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -114,6 +114,34 @@ SEASTAR_TEST_CASE(test_aligned_alloc) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_large_alignment_larger_than_size) {
+    static constexpr size_t large_align = memory::huge_page_size < 512 * memory::page_size
+            ? memory::huge_page_size
+            : 512 * memory::page_size;
+    static constexpr size_t size = memory::page_size;
+    static_assert(large_align > size);
+
+    std::vector<void*> allocations;
+    allocations.reserve(4);
+    for (unsigned i = 0; i != 4; ++i) {
+        void* p = nullptr;
+        BOOST_REQUIRE_EQUAL(posix_memalign(&p, large_align, size), 0);
+        BOOST_REQUIRE(p != nullptr);
+        BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(p) % large_align, 0);
+        allocations.push_back(p);
+    }
+    for (auto p : allocations) {
+        free(p);
+    }
+
+    auto p = ::operator new(size, std::align_val_t(large_align));
+    BOOST_REQUIRE(p != nullptr);
+    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(p) % large_align, 0);
+    ::operator delete(p, size, std::align_val_t(large_align));
+
+    return make_ready_future<>();
+}
+
 #ifdef __cpp_sized_deallocation
 SEASTAR_TEST_CASE(test_sized_delete) {
     for (size_t size = 0; size <= 65536; size++) {


### PR DESCRIPTION
## Problem

`cpu_pages::allocate_large_aligned()` accepted `align_pages`, but treated any buddy allocation as sufficiently aligned and delegated to `allocate_large_and_trim(n_pages)`. For requests where the requested alignment is larger than the requested size, such as `posix_memalign(&p, 2 MiB, 4 KiB)`, the allocator could return a span that is only allocator-page aligned.

Sized aligned deallocation had a related issue for this class of allocations: when `align > page_size` and `size <= max_small_allocation`, `free_aligned()` could pass the small size into sized free and take the small-pool path even though allocation used the large path.

## Fix

- For large aligned requests, allocate from a buddy span sized for `max(align_pages, n_pages)` so the returned span satisfies the requested alignment.
- Route sized aligned frees with `align > page_size` through the ordinary pointer-inspecting free path.
- Add regression coverage for `posix_memalign()` and aligned C++ new where alignment is larger than size.

Fixes #3471

## Testing

- `ninja -C build/dev test_unit_alloc`
- `ctest --test-dir build/dev -R '^Seastar\.unit\.alloc$' --output-on-failure`
- `build/dev/tests/unit/alloc_test --run_test=test_large_alignment_larger_than_size --logger=HRF,test_suite --color_output=false -- --smp 1`