### PR TITLE
dns: drain c-ares socket monitor readiness

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -751,7 +751,8 @@ dns_resolver::impl::poll_sockets() {
 #if ARES_VERSION >= 0x011300 && USE_CARES_EVENTFD
     // When using ARES_OPT_SOCK_STATE_CB with modern c-ares >= 1.34.0
     // we know exactly which sockets c-ares cares about through the callback
-    if (!_socket_monitors.empty()) {
+    bool processed = false;
+    for (;;) {
         // Most DNS queries use few sockets, so optimize for the common case by
         // stack-allocating a small buffer and only allocating on heap if needed
         constexpr int MAX_EVENTS = 16;
@@ -800,12 +801,12 @@ dns_resolver::impl::poll_sockets() {
 
         if (event_count > 0) {
             ares_process_fds(_channel, events, event_count, ARES_PROCESS_FLAG_NONE);
+            processed = true;
         } else {
-            // No sockets ready, just process timeouts
-            ares_process_fd(_channel, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
+            break;
         }
-    } else {
-        // No sockets monitored, just handle timeouts
+    }
+    if (!processed) {
         ares_process_fd(_channel, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
     }
 #elif USE_CARES_EVENTFD

--- a/tests/unit/dns_test.cc
+++ b/tests/unit/dns_test.cc
@@ -22,12 +22,14 @@
 #include <vector>
 #include <algorithm>
 
-#include <seastar/core/do_with.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/do_with.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/inet_address.hh>
 
@@ -35,6 +37,83 @@ using namespace seastar;
 using namespace seastar::net;
 
 static const sstring seastar_name = "seastar.io";
+
+static uint16_t read_be16(const char* p) {
+    return (uint16_t(uint8_t(p[0])) << 8) | uint8_t(p[1]);
+}
+
+static void write_be16(std::vector<char>& out, uint16_t v) {
+    out.push_back(char(v >> 8));
+    out.push_back(char(v));
+}
+
+static void write_be32(std::vector<char>& out, uint32_t v) {
+    out.push_back(char(v >> 24));
+    out.push_back(char(v >> 16));
+    out.push_back(char(v >> 8));
+    out.push_back(char(v));
+}
+
+static std::vector<char> make_tcp_dns_a_response(const temporary_buffer<char>& query) {
+    BOOST_REQUIRE_GE(query.size(), 12);
+    BOOST_REQUIRE_EQUAL(read_be16(query.get() + 4), 1);
+
+    size_t question_end = 12;
+    while (question_end < query.size() && query.get()[question_end] != 0) {
+        auto label_len = uint8_t(query.get()[question_end]);
+        BOOST_REQUIRE_LT(label_len, 64);
+        question_end += 1 + label_len;
+    }
+    BOOST_REQUIRE_LT(question_end, query.size());
+    question_end += 1 + sizeof(uint16_t) + sizeof(uint16_t);
+    BOOST_REQUIRE_LE(question_end, query.size());
+
+    std::vector<char> msg;
+    write_be16(msg, read_be16(query.get()));
+    write_be16(msg, 0x8180);
+    write_be16(msg, 1);
+    write_be16(msg, 1);
+    write_be16(msg, 0);
+    write_be16(msg, 0);
+    msg.insert(msg.end(), query.get() + 12, query.get() + question_end);
+
+    write_be16(msg, 0xc00c);
+    write_be16(msg, 1);
+    write_be16(msg, 1);
+    write_be32(msg, 60);
+    write_be16(msg, 4);
+    msg.push_back(char(127));
+    msg.push_back(char(0));
+    msg.push_back(char(0));
+    msg.push_back(char(42));
+
+    std::vector<char> tcp_response;
+    write_be16(tcp_response, msg.size());
+    tcp_response.insert(tcp_response.end(), msg.begin(), msg.end());
+    return tcp_response;
+}
+
+static future<> serve_split_tcp_dns_response(server_socket& listener) {
+    auto ar = co_await listener.accept();
+    auto socket = std::move(ar.connection);
+    auto in = socket.input();
+    auto out = socket.output();
+
+    auto len_buf = co_await in.read_exactly(2);
+    BOOST_REQUIRE_EQUAL(len_buf.size(), 2);
+    auto query_len = read_be16(len_buf.get());
+    auto query = co_await in.read_exactly(query_len);
+    BOOST_REQUIRE_EQUAL(query.size(), query_len);
+
+    auto response = make_tcp_dns_a_response(query);
+    co_await out.write(response.data(), 3);
+    co_await out.flush();
+    co_await sleep(std::chrono::milliseconds(10));
+    co_await out.write(response.data() + 3, response.size() - 3);
+    co_await out.flush();
+    co_await out.close();
+    co_await in.close();
+}
 
 static future<> test_resolve(dns_resolver::options opts) {
     auto d = dns_resolver(std::move(opts));
@@ -150,6 +229,51 @@ SEASTAR_TEST_CASE(test_connection_refused_tcp) {
     }).finally([d]{
         return d->close();
     });
+}
+
+SEASTAR_TEST_CASE(test_resolve_tcp_split_response) {
+    listen_options lo;
+    lo.reuse_address = true;
+    lo.set_fixed_cpu(this_shard_id());
+
+    auto listener = seastar::listen(make_ipv4_address({0x7f000001, 0}), lo);
+    auto server = serve_split_tcp_dns_response(listener);
+
+    dns_resolver::options opts;
+    opts.servers = std::vector<inet_address>({ inet_address("127.0.0.1") });
+    opts.use_tcp_query = true;
+    opts.tcp_port = listener.local_address().port();
+    opts.timeout = std::chrono::seconds(30);
+
+    auto d = ::make_lw_shared<dns_resolver>(engine().net(), opts);
+
+    auto cleanup = [&] () -> future<> {
+        co_await d->close();
+        listener.abort_accept();
+        co_await std::move(server);
+    };
+
+    std::exception_ptr ex;
+    try {
+        auto h = co_await with_timeout(timer<>::clock::now() + std::chrono::seconds(5),
+                d->get_host_by_name("split.seastar.test", inet_address::family::INET));
+        BOOST_REQUIRE_EQUAL(h.addr_entries.size(), 1);
+        BOOST_REQUIRE_EQUAL(h.addr_entries.front().addr, inet_address("127.0.0.42"));
+        BOOST_REQUIRE_EQUAL(h.addr_entries.front().ttl, std::chrono::seconds(60));
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    try {
+        co_await cleanup();
+    } catch (...) {
+        if (!ex) {
+            throw;
+        }
+    }
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
 }
 
 SEASTAR_TEST_CASE(test_resolve_tcp,


### PR DESCRIPTION
Fixes #3473.

## Problem

With c-ares >= 1.34, `ARES_OPT_SOCK_STATE_CB` puts the resolver on the socket-monitor path in `dns_resolver::impl::poll_sockets()`. That path processed ready monitored sockets with a single `ares_process_fds()` call per wakeup, unlike the legacy path which drains readiness in a loop.

For TCP DNS responses split across reads, c-ares can consume a partial buffer while still wanting readability. If Seastar still has `POLLIN` set after that synchronous read, returning from `poll_sockets()` leaves the remaining response data unread until the periodic DNS timeout tick.

## Solution

Drain the socket-monitor path the same way as the legacy path: rebuild the ready event list and call `ares_process_fds()` until no requested read or write readiness remains. Preserve the timeout-only `ares_process_fd()` call when no sockets were processed.

The regression test uses a loopback TCP DNS server that sends the TCP length plus one DNS response byte, waits briefly, then sends the rest of a valid A response. The old one-shot path times out waiting for the periodic DNS tick; the fixed path completes promptly.

## Testing

- `ninja -C build/dev test_unit_dns`
- `./build/dev/tests/unit/dns_test --run_test=test_resolve_tcp_split_response`
- `./build/dev/tests/unit/dns_test --run_test=test_connection_refused_tcp`
- `./build/dev/tests/unit/dns_test --run_test=test_resolve_numeric`
- `git diff --check origin/master...HEAD`