### PR TITLE
cooking: validate recipe before cleanup

### DIFF
--- a/cooking.sh
+++ b/cooking.sh
@@ -229,6 +229,17 @@ if [ -z "${ingredients_dir}" ]; then
     ingredients_dir="${cooking_dir}/installed"
 fi
 
+#
+# Validate recipe.
+#
+
+if [ -n "${recipe}" ]; then
+    if [ ! -f "${recipe}" ]; then
+        echo "Cooking: The '${recipe}' recipe does not exist!" >&2
+        exit 1
+    fi
+fi
+
 mkdir -p "${build_dir}"
 
 cat <<'EOF' > "${build_dir}/Cooking.cmake"
@@ -867,17 +878,6 @@ if [ -d "${ingredients_dir}" -a -z "${nested}" ]; then
 fi
 
 mkdir -p "${ingredients_dir}"
-
-#
-# Validate recipe.
-#
-
-if [ -n "${recipe}" ]; then
-    if [ ! -f "${recipe}" ]; then
-        echo "Cooking: The '${recipe}' recipe does not exist!" >&2
-        exit 1
-    fi
-fi
 
 #
 # Prepare lists of included and excluded ingredients.


### PR DESCRIPTION
Validate the requested cooking recipe path before removing previous cooking output.

Currently a typo in `-r` can remove the existing ingredients directory, `ready.txt`, and `CMakeCache.txt`, then fail with "recipe does not exist". Moving validation earlier keeps invalid input from deleting reusable cooked dependencies or cache state.

Fixes #3477.

Tests:
- `bash -n cooking.sh`
- manual invalid-recipe run with sentinel files in the ingredients directory, `CMakeCache.txt`, and `_cooking/ready.txt`; confirmed all sentinel files remain after the expected error.