### PR TITLE
reactor: open accepted fd without O_NONBLOCK when using io_uring

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1857,7 +1857,7 @@ public:
         };
         return readable_or_writeable(listenfd).then([this, &listenfd] {
             auto desc = std::make_unique<accept_completion>(listenfd);
-            auto req = internal::io_request::make_accept(listenfd.fd.get(), desc->posix_sockaddr(), desc->socklen_ptr(), SOCK_NONBLOCK | SOCK_CLOEXEC);
+            auto req = internal::io_request::make_accept(listenfd.fd.get(), desc->posix_sockaddr(), desc->socklen_ptr(), SOCK_CLOEXEC);
             return submit_request(std::move(desc), std::move(req));
         });
     }
@@ -2484,7 +2484,7 @@ public:
             }
         };
         auto desc = std::make_unique<accept_completion>(listenfd);
-        auto req = internal::io_request::make_accept(listenfd.fd.get(), desc->posix_sockaddr(), desc->socklen_ptr(), SOCK_NONBLOCK | SOCK_CLOEXEC);
+        auto req = internal::io_request::make_accept(listenfd.fd.get(), desc->posix_sockaddr(), desc->socklen_ptr(), SOCK_CLOEXEC);
         return submit_request(std::move(desc), std::move(req));
     }
 


### PR DESCRIPTION
The io_uring backend opens fds without `O_NONBLOCK` (`do_blocking_io()`) so io_uring provides blocking semantics by arming the poll handler and retrying in the background. fe8035cb did this for `connect()`ed sockets but left `SOCK_NONBLOCK` on the accept op.

On an `O_NONBLOCK` socket the kernel sends in non-blocking mode -- `____sys_sendmsg()` ORs `MSG_DONTWAIT` into `msg_flags` for `O_NONBLOCK` files -- so a send punted to io-wq returns `-EAGAIN` instead of blocking, surfacing a spurious `-EAGAIN` to the application under load.

That `-EAGAIN` is expected, not a kernel quirk. Per send(2):

>    MSG_DONTWAIT ... if the operation would block, EAGAIN or EWOULDBLOCK is
>    returned. This provides similar behavior to setting the O_NONBLOCK flag

So an `O_NONBLOCK` socket already behaves like `MSG_DONTWAIT`. The fix is to not open the accepted fd non-blocking in the first place.

Drop `SOCK_NONBLOCK` from the io_uring accept op so accepted sockets match `connect()`ed ones.