### PR TITLE
`core/reactor`: add `SIGFPE` handler

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4303,6 +4303,11 @@ static void sigill_action(siginfo_t *info, ucontext_t* uc) noexcept {
     reraise_signal(SIGILL);
 }
 
+static void sigfpe_action(siginfo_t *info, ucontext_t* uc) noexcept {
+    print_with_backtrace("Floating point exception");
+    reraise_signal(SIGFPE);
+}
+
 // We don't need to handle SIGSEGV when asan is enabled.
 #ifdef SEASTAR_ASAN_ENABLED
 template<>
@@ -4419,6 +4424,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     install_oneshot_signal_handler<SIGSEGV, sigsegv_action>();
     install_oneshot_signal_handler<SIGABRT, sigabrt_action>();
     install_oneshot_signal_handler<SIGILL, sigill_action>();
+    install_oneshot_signal_handler<SIGFPE, sigfpe_action>();
 
 #ifdef SEASTAR_HAVE_DPDK
     const auto* native_stack = dynamic_cast<const net::native_stack_options*>(reactor_opts.network_stack.get_selected_candidate_opts());


### PR DESCRIPTION
`SIGFPE` is a notable & potentially common enough error that it deserves a handler in `seastar` - divisions by zero (including % 0 operations), integer overflows, etc., are commonplace bugs for developers to run into.

Add one alongside the existing signal handlers to ensure we print a backtrace for aiding developers in debugging before crashing.