### PR TITLE
unaligned: Remove deprecated unaligned_cast()

### DIFF
--- a/include/seastar/core/unaligned.hh
+++ b/include/seastar/core/unaligned.hh
@@ -62,17 +62,4 @@ struct unaligned {
     operator T() const noexcept { return raw; }
 } __attribute__((packed));
 
-
-template <typename T, typename F>
-[[deprecated("violates strict aliasing rules. See issue #165.")]]
-inline auto unaligned_cast(F* p) noexcept {
-    return reinterpret_cast<unaligned<std::remove_pointer_t<T>>*>(p);
-}
-
-template <typename T, typename F>
-[[deprecated("violates strict aliasing rules. See issue #165.")]]
-inline auto unaligned_cast(const F* p) noexcept {
-    return reinterpret_cast<const unaligned<std::remove_pointer_t<T>>*>(p);
-}
-
 }


### PR DESCRIPTION
deprecated in 2021 by commit 2606d5e3
(deprecate unaligned_cast<> from unaligned.hh)