### PR TITLE
iostream: Deprecate consumption_result(optional<buffer>) constructor

### DIFF
--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -287,7 +287,8 @@ public:
     using consumption_variant = std::variant<continue_consuming, stop_consuming_type, skip_bytes>;
     using tmp_buf = typename stop_consuming_type::tmp_buf;
 
-    /*[[deprecated]]*/ consumption_result(std::optional<tmp_buf> opt_buf) {
+    [[deprecated("Use stop_consuming/continue_consuming/skip_bytes constructors")]]
+    consumption_result(std::optional<tmp_buf> opt_buf) {
         if (opt_buf) {
             _result = stop_consuming_type{std::move(opt_buf.value())};
         }


### PR DESCRIPTION
The user is supposed to construct it with explicit stop_consuming or continue_consuming types. This "shortcut" ("sugar"?) had been deprecated with a comment since it was introduced, but it's better to deprecate it explicitly.