### PR TITLE
test/iostream: Fix test_move_after_batched_write deprecation usage

### DIFF
--- a/tests/unit/output_stream_test.cc
+++ b/tests/unit/output_stream_test.cc
@@ -260,13 +260,13 @@ SEASTAR_THREAD_TEST_CASE(test_flush_on_empty_buffer_does_not_push_empty_packet_d
 
 SEASTAR_THREAD_TEST_CASE(test_move_after_batched_write) {
     std::stringstream ss;
-    output_stream<char> out;
+    std::optional<output_stream<char>> out;
     {
         auto out2 = output_stream<char>(testing::memory_data_sink(ss), 8);
         out2.write(sstring("smth")).get();
-        out = std::move(out2);
+        out.emplace(std::move(out2));
     }
-    out.close().get();
+    out->close().get();
     BOOST_REQUIRE_EQUAL(ss.str(), "smth");
 }
 


### PR DESCRIPTION
The test uses two deprecated features of output_stream -- default constructor and move-assignment operator like

    output_stream<char> out; // uses deprecated default constructor
    out = std::move(out2);   // uses deprecated operator=(&&)

Since the goal of the test (and the fix that this test tests, see PR #3464) was to validate the moved-from state of out2 the test should use move constructor instead