### PR TITLE
reactor_backend: include <span>

### DIFF
--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -40,6 +40,7 @@
 #include <bitset>
 #include <thread>
 #include <stack>
+#include <span>
 #include <memory>
 #include <vector>
 #include <optional>


### PR DESCRIPTION
std::span is used in this header. Since a header should be self-contained and not rely on transitive includes, include <span> explicitly.