### PR TITLE
tests/loopback: emulate SHUT_WR in shutdown_output()

### DIFF
--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -106,6 +106,14 @@ public:
         }
     }
 
+    // Emulate SHUT_WR: keep already-queued data and append an EOF marker after
+    // it, rather than discarding it the way abort() does.
+    future<> shutdown_output() noexcept {
+        shutdown();
+        // empty buffer = EOF, the same marker the data sink's close() uses
+        return _q.push_eventually(temporary_buffer<char>(0)).handle_exception([] (std::exception_ptr) {});
+    }
+
     future<> wait_input_shutdown() {
         SEASTAR_ASSERT(!_shutdown.has_value());
         _shutdown.emplace();
@@ -206,7 +214,7 @@ public:
     }
     void shutdown_output() override {
         (void)smp::submit_to(_tx->get_owner_shard(), [tx = _tx] {
-            (*tx)->abort();
+            return (*tx)->shutdown_output();
         });
     }
     void set_nodelay(bool nodelay) override {


### PR DESCRIPTION
Seastar.unit.websocket times out intermittently:
```
  Test #36: Seastar.unit.websocket ...***Timeout 300.10 sec
```
Logging the close handshake shows the server reading EPIPE where it expects the peer's CLOSE frame:
```
  read_one consume FAILED: std::system_error (error system:32, Broken pipe)
```
`shutdown_output()` called `abort()`, which discards queued data and fails the peer with `EPIPE`; it should only fail unflushed writes, like posix `SHUT_WR` which still delivers flushed bytes before the FIN. So the just-flushed CLOSE frame was dropped, the server never closed, its handler stayed blocked in `in.read()`, and `process()` hung.

Append an `EOF` marker after the queued data instead of discarding it.