### PR TITLE
CMakeLists: link URING::uring as PUBLIC so consumers find liburing.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,7 +1143,7 @@ if (Seastar_IO_URING)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_HAVE_URING)
   target_link_libraries (seastar
-    PRIVATE URING::uring)
+    PUBLIC URING::uring)
 endif ()
 
 if (Seastar_LD_FLAGS)


### PR DESCRIPTION
Building Ceph against seastar fails to find liburing.h. Ceph builds liburing out of tree, so the header is off the default search path.

`reactor_config.hh` embeds `::io_uring` in a public struct under `SEASTAR_HAVE_URING`, so any consumer of the seastar headers needs `liburing.h` once that macro is set. `SEASTAR_HAVE_URING` is `PUBLIC`, but `URING::uring` was linked PRIVATE, so its include directory never reached consumers. Link it `PUBLIC` so the include directory propagates with the macro.