### PR TITLE
core/reactor: don't read the thread-local shard count in smp::qs_deleter

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -319,6 +319,7 @@ class smp : public std::enable_shared_from_this<smp> {
     std::optional<std::barrier<>> _all_event_loops_done;
     std::unique_ptr<internal::memory_prefaulter> _prefaulter;
     struct qs_deleter {
+      unsigned shard_count;
       void operator()(smp_message_queue** qs) const;
     };
     std::unique_ptr<smp_message_queue*[], qs_deleter> _qs_owner;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4329,8 +4329,8 @@ void install_oneshot_signal_handler<SIGSEGV, sigsegv_action>() {
 #endif
 
 void smp::qs_deleter::operator()(smp_message_queue** qs) const {
-    for (unsigned i = 0; i < this_smp_shard_count(); i++) {
-        for (unsigned j = 0; j < this_smp_shard_count(); j++) {
+    for (unsigned i = 0; i < shard_count; i++) {
+        for (unsigned j = 0; j < shard_count; j++) {
             qs[i][j].~smp_message_queue();
         }
         ::operator delete[](qs[i], std::align_val_t(alignof(smp_message_queue))
@@ -4739,7 +4739,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
 
     seastar_logger.info("Reactor backend: {}", backend_selector);
 
-    _qs_owner = decltype(smp::_qs_owner){new smp_message_queue* [_shard_count], qs_deleter{}};
+    _qs_owner = decltype(smp::_qs_owner){new smp_message_queue* [_shard_count], qs_deleter{_shard_count}};
 
     auto allocate_qs_owner = [this] (unsigned i) {
         // smp_message_queue has members with hefty alignment requirements.


### PR DESCRIPTION
`smp::qs_deleter::operator()` sizes its destruction loops with `this_smp_shard_count()`, which dereferences the `thread_local _this_smp`.  The deleter runs from `~smp()`, but `_this_smp` is only set on reactor threads, so it is null when the smp is destroyed on another thread.  That happens when the reactor runs on a dedicated thread and the `app_template` is destroyed elsewhere, for example at exit on the main thread; the deleter then dereferences null and faults under ASan/UBSan.

The queue array is allocated from `_shard_count`, so store that count in the deleter and use it at teardown instead of querying the thread-local.