### PR TITLE
rpc: optimize usage of unordered_map

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -805,8 +805,9 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
     }
     if (cancel) {
         cancel->cancel_wait = [this, id] {
-            _outstanding[id]->cancel();
-            _outstanding.erase(id);
+            auto it = _outstanding.find(id);
+            it->second->cancel();
+            _outstanding.erase(it);
         };
         h->pcancel = cancel;
         cancel->wait_back_pointer = &h->pcancel;
@@ -815,8 +816,9 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
 }
 void client::wait_timed_out(id_type id) {
     _stats.timeout++;
-    _outstanding[id]->timeout();
-    _outstanding.erase(id);
+    auto it = _outstanding.find(id);
+    it->second->timeout();
+    _outstanding.erase(it);
 }
 
 future<> client::stop() noexcept {
@@ -1329,10 +1331,10 @@ server::server(protocol_base* proto, server_socket ss, resource_limits limits, s
         : _proto(*proto), _ss(std::move(ss)), _limits(limits), _resources_available(limits.max_memory), _options(opts)
 {
     if (_options.streaming_domain) {
-        if (_servers.find(*_options.streaming_domain) != _servers.end()) {
+        auto [_, inserted] = _servers.try_emplace(*_options.streaming_domain, this);
+        if (!inserted) {
             throw std::runtime_error(format("An RPC server with the streaming domain {} is already exist", *_options.streaming_domain));
         }
-        _servers[*_options.streaming_domain] = this;
     }
     accept();
 }


### PR DESCRIPTION
Avoid using operator[] for lookups, as it creates the entry if it is not found. Note that if we did create the entry, it would be null, and we would have crashed, so this is a safe transformation.

Reuse the looked-up iterator for erasing, avoiding a second lookup.

Use try_emplace() instead of a check-and-insert sequence, combining the two lookups.

Note: I don't expect significant performance improvements, but every small reduction in instruction count helps.