### PR TITLE
treewide: deprecate formatters for standard types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ option (Seastar_SSTRING
 
 option (Seastar_DEPRECATED_OSTREAM_FORMATTERS
   "Enable operator<< for formatting standard library containers, which will be deprecated in future"
-  ON)
+  OFF)
 
 set (Seastar_API_LEVEL
   "9"

--- a/apps/memcached/memcache.cc
+++ b/apps/memcached/memcache.cc
@@ -1353,7 +1353,7 @@ public:
         _chan.shutdown_input();
         _chan.shutdown_output();
         return _task->handle_exception([](std::exception_ptr e) {
-            std::cerr << "exception in udp_server " << e << '\n';
+            std::cerr << fmt::format("exception in udp_server {}\n", seastar::formattable(e));
         });
     }
 };
@@ -1418,7 +1418,7 @@ public:
     future<> stop() {
         _listener->abort_accept();
         return _task->handle_exception([](std::exception_ptr e) {
-            std::cerr << "exception in tcp_server " << e << '\n';
+            std::cerr << fmt::format("exception in tcp_server {}\n", seastar::formattable(e));
         });
     }
 };

--- a/demos/tls_echo_server.hh
+++ b/demos/tls_echo_server.hh
@@ -102,7 +102,7 @@ public:
                         });
                     }).handle_exception([this](auto ep) {
                         if (!_stopped) {
-                            std::cerr << "Error: " << ep << std::endl;
+                            std::cerr << fmt::format("Error: {}\n", seastar::formattable(ep));
                         }
                     }).then([this] {
                         return make_ready_future<stop_iteration>(_stopped ? stop_iteration::yes : stop_iteration::no);

--- a/demos/tls_echo_server_demo.cc
+++ b/demos/tls_echo_server_demo.cc
@@ -63,7 +63,7 @@ int main(int ac, char** av) {
             try {
                 server.invoke_on_all(&echoserver::listen, socket_address(ia), sstring(crt), sstring(key), tls::client_auth::NONE).get();
             } catch (...) {
-                std::cerr << "Error: " << std::current_exception() << std::endl;
+                std::cerr << fmt::format("Error: {}\n", seastar::formattable(std::current_exception()));
                 return 1;
             }
             std::cout << "TLS echo server running at " << addr << ":" << port << std::endl;

--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -125,7 +125,7 @@ int main(int ac, char** av) {
                     });
                 });
             }).handle_exception([](auto ep) {
-                std::cerr << "Error: " << ep << std::endl;
+                std::cerr << fmt::format("Error: {}\n", seastar::formattable(ep));
             });
         }).finally([] {
             engine().exit(0);

--- a/demos/udp_server_demo.cc
+++ b/demos/udp_server_demo.cc
@@ -66,7 +66,7 @@ public:
         }
         if (_task) {
             co_await _task->handle_exception([](std::exception_ptr e) {
-                std::cerr << "exception in udp_server: " << e << "\n";
+                std::cerr << fmt::format("exception in udp_server: {}\n", seastar::formattable(e));
             });
         }
     }

--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -161,9 +161,7 @@ public:
     }
 
     json_exception(std::exception_ptr e) {
-        std::ostringstream exception_description;
-        exception_description << e;
-        set(exception_description.str(), http::reply::status_type::internal_server_error);
+        set(fmt::format("{}", seastar::formattable(e)), http::reply::status_type::internal_server_error);
     }
 private:
     void set(const std::string& msg, http::reply::status_type code) {

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -581,8 +581,15 @@ std::ostream& operator<<(std::ostream&, const std::exception&);
 std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 
+// Seastar has no business defining a {fmt} formatter for std::exception_ptr,
+// a type it does not own; that is for the standard library or {fmt} to do (see
+// https://github.com/fmtlib/fmt/issues/4808). Until then we provide one, but
+// deprecate it in favour of seastar::formattable(), which wraps the pointer in
+// a Seastar-owned type. The deprecation is on parse() (which {fmt} odr-uses)
+// rather than on the specialization, so that it is diagnosed at the call site.
 template <>
 struct fmt::formatter<std::exception_ptr> {
+    [[deprecated("Use seastar::formattable(eptr) instead of formatting a std::exception_ptr directly")]]
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const std::exception_ptr& eptr, fmt::format_context& ctx) const -> decltype(ctx.out()) {
         return fmt::format_to(ctx.out(), "{}", seastar::formattable(eptr));

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -574,12 +574,17 @@ struct fmt::formatter<seastar::internal::formattable_exception_ptr> {
     auto format(const seastar::internal::formattable_exception_ptr&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
+#ifdef SEASTAR_DEPRECATED_OSTREAM_FORMATTERS
 // Pretty-printer for exceptions to be logged, e.g., std::current_exception().
 namespace std {
+[[deprecated("Use {fmt} instead, or disable Seastar_DEPRECATED_OSTREAM_FORMATTERS and implement your own operator<<")]]
 std::ostream& operator<<(std::ostream&, const std::exception_ptr&);
+[[deprecated("Use {fmt} instead, or disable Seastar_DEPRECATED_OSTREAM_FORMATTERS and implement your own operator<<")]]
 std::ostream& operator<<(std::ostream&, const std::exception&);
+[[deprecated("Use {fmt} instead, or disable Seastar_DEPRECATED_OSTREAM_FORMATTERS and implement your own operator<<")]]
 std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
+#endif
 
 // Seastar has no business defining a {fmt} formatter for std::exception_ptr,
 // a type it does not own; that is for the standard library or {fmt} to do (see

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -37,6 +37,7 @@
 #include <type_traits>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 /// \addtogroup logging
 /// @{
@@ -552,7 +553,5 @@ std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 
 template <> struct fmt::formatter<std::exception_ptr> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<std::exception> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<std::system_error> : fmt::ostream_formatter {};
 
 /// @}

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -543,7 +543,36 @@ public:
 };
 
 /// \endcond
+namespace internal {
+
+/// Wrapper returned by \ref seastar::formattable() that carries a
+/// \c std::exception_ptr to be formatted by {fmt}.
+struct formattable_exception_ptr {
+    std::exception_ptr eptr;
+};
+
+}
+
+/// Wrap a \c std::exception_ptr so that it can be formatted with {fmt}, e.g.
+/// \c fmt::format("{}", seastar::formattable(eptr)).
+///
+/// The exception is printed as its pretty type name, followed by any extra
+/// detail available for well-known exception types (the \c what() message,
+/// and the error code for \c std::system_error), recursing into nested
+/// exceptions. An empty \c exception_ptr is printed as \c "<no exception>".
+///
+/// \param eptr the exception to format; copied (cheap, refcounted).
+inline internal::formattable_exception_ptr formattable(std::exception_ptr eptr) {
+    return internal::formattable_exception_ptr{std::move(eptr)};
+}
+
 } // end seastar namespace
+
+template <>
+struct fmt::formatter<seastar::internal::formattable_exception_ptr> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const seastar::internal::formattable_exception_ptr&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 // Pretty-printer for exceptions to be logged, e.g., std::current_exception().
 namespace std {
@@ -552,6 +581,12 @@ std::ostream& operator<<(std::ostream&, const std::exception&);
 std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 
-template <> struct fmt::formatter<std::exception_ptr> : fmt::ostream_formatter {};
+template <>
+struct fmt::formatter<std::exception_ptr> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const std::exception_ptr& eptr, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "{}", seastar::formattable(eptr));
+    }
+};
 
 /// @}

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -241,7 +241,7 @@ app_template::run_deprecated(int ac, char ** av, std::function<void ()>&& func) 
     try {
         _smp->configure(_opts.smp_opts, _opts.reactor_opts);
     } catch (...) {
-        std::cerr << "Could not initialize seastar: " << std::current_exception() << std::endl;
+        std::cerr << fmt::format("Could not initialize seastar: {}\n", seastar::formattable(std::current_exception()));
         return 1;
     }
     _configuration = {std::move(configuration)};

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -491,6 +491,7 @@ using seastar::handle_signal;
 
 // Exception types
 using seastar::nested_exception;
+using seastar::formattable;
 using seastar::timed_out_error;
 using seastar::cancelled_error;
 using seastar::broken_promise;

--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -165,7 +165,7 @@ scoped_no_abort_on_internal_error::~scoped_no_abort_on_internal_error() {
 }
 
 void detail::warn_teardown_exception(const sstring& name, std::exception_ptr e) {
-    std::cerr << "Warning! Exception in fixture " << name << "::teardown. " << e << std::endl;
+    std::cerr << fmt::format("Warning! Exception in fixture {}::teardown. {}\n", name, seastar::formattable(e));
 }
 
 }

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -34,6 +34,7 @@
 #include <fmt/chrono.h>
 #include <fmt/color.h>
 #include <fmt/ostream.h>
+#include <fmt/std.h>
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
@@ -630,31 +631,34 @@ logging_settings extract_settings(const options& opts) {
 
 }
 
-namespace std {
-std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
+auto fmt::formatter<seastar::internal::formattable_exception_ptr>::format(
+        const seastar::internal::formattable_exception_ptr& fe, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    const auto& eptr = fe.eptr;
     if (!eptr) {
-        out << "<no exception>";
-        return out;
+        return fmt::format_to(out, "<no exception>");
     }
     try {
         std::rethrow_exception(eptr);
     } catch(...) {
         auto tp = abi::__cxa_current_exception_type();
         if (tp) {
-            out << seastar::pretty_type_name(*tp);
+            out = fmt::format_to(out, "{}", seastar::pretty_type_name(*tp));
         } else {
             // This case shouldn't happen...
-            out << "<unknown exception>";
+            out = fmt::format_to(out, "<unknown exception>");
         }
         // Print more information on some familiar exception types
         try {
             throw;
         } catch (const seastar::nested_exception& ne) {
-            out << fmt::format(": {} (while cleaning up after {})", ne.inner, ne.outer);
+            out = fmt::format_to(out, ": {} (while cleaning up after {})",
+                    seastar::formattable(ne.inner), seastar::formattable(ne.outer));
         } catch (const std::system_error& e) {
-            out << " (error " << e.code() << ", " << e.what() << ")";
+            out = fmt::format_to(out, " (error {}, {})", e.code(), e.what());
         } catch (const std::exception& e) {
-            out << " (" << e.what() << ")";
+            out = fmt::format_to(out, " ({})", e.what());
         } catch (...) {
             // no extra info
         }
@@ -662,7 +666,7 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
         try {
             throw;
         } catch (const std::nested_exception& ne) {
-            out << ": " << ne.nested_ptr();
+            out = fmt::format_to(out, ": {}", seastar::formattable(ne.nested_ptr()));
         } catch (...) {
             // do nothing
         }
@@ -670,12 +674,18 @@ std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
     return out;
 }
 
+namespace std {
+
+std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
+    return out << fmt::format("{}", seastar::formattable(eptr));
+}
+
 std::ostream& operator<<(std::ostream& out, const std::exception& e) {
-    return out << seastar::pretty_type_name(typeid(e)) << " (" << e.what() << ")";
+    return out << fmt::format("{}", e);
 }
 
 std::ostream& operator<<(std::ostream& out, const std::system_error& e) {
-    return out << seastar::pretty_type_name(typeid(e)) << " (error " << e.code() << ", " << e.what() << ")";
+    return out << fmt::format("{}", e);
 }
 
 }

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -674,6 +674,7 @@ auto fmt::formatter<seastar::internal::formattable_exception_ptr>::format(
     return out;
 }
 
+#ifdef SEASTAR_DEPRECATED_OSTREAM_FORMATTERS
 namespace std {
 
 std::ostream& operator<<(std::ostream& out, const std::exception_ptr& eptr) {
@@ -689,3 +690,4 @@ std::ostream& operator<<(std::ostream& out, const std::system_error& e) {
 }
 
 }
+#endif

--- a/tests/unit/alien_test.cc
+++ b/tests/unit/alien_test.cc
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
             }
             return seastar::now();
         }).handle_exception([](auto ep) {
-            std::cerr << "Error: " << ep << std::endl;
+            std::cerr << fmt::format("Error: {}\n", seastar::formattable(ep));
         }).finally([] {
             seastar::engine().exit(0);
         });

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -1015,12 +1015,12 @@ future<std::vector<int> &> co_return_reference() {
 SEASTAR_TEST_CASE(test_co_return_conversions) {
     std::ignore = co_await i2e();
     std::ignore = co_await e2i();
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(0), (std::vector<std::string>{}));
+    BOOST_REQUIRE(co_await co_return_vector(0) == (std::vector<std::string>{}));
     // gcc 13.3 will ICE if we inline the expected values here
     std::vector<std::string> foo_x2{"foo", "foo"};
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(2), foo_x2);
+    BOOST_REQUIRE(co_await co_return_vector(2) == foo_x2);
     std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-    BOOST_REQUIRE_EQUAL(co_await co_return_vector(3), foo_x3);
+    BOOST_REQUIRE(co_await co_return_vector(3) == foo_x3);
     BOOST_REQUIRE_EQUAL(&co_await co_return_reference(), &static_vector);
 }
 

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging1) {
             try {
                 exception_generator(inst, level);
             } catch(...) {
-                log_msg << std::current_exception();
+                log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
             }
             BOOST_REQUIRE_EQUAL(log_msg.str(), exception_generator_str(inst, level));
         }
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging2) {
     try {
         throw std::nested_exception();
     } catch(...) {
-        log_msg << std::current_exception();
+        log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
     }
 
     BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("std::nested_exception: <no exception>"));
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging3) {
             try {
                 std::throw_with_nested(unknown_obj("This is an unknown object"));
             } catch (...) {
-                log_msg << std::current_exception();
+                log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
             }
         }
     }
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(unknown_object_thrown_test) {
     try {
         throw unknown_obj("This is an unknown object");
     } catch(...) {
-        log_msg << std::current_exception();
+        log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
     }
 
     BOOST_REQUIRE_EQUAL(log_msg.str(), std::string("unknown_obj"));
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {
     try {
         throw_with_backtrace<std::runtime_error>("throw_with_backtrace_exception_logging");
     } catch(...) {
-        log_msg << std::current_exception();
+        log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
         try {
             std::throw_with_nested(unknown_obj("This is an unknown object"));
         } catch (...) {
-            log_msg << std::current_exception();
+            log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
         }
     }
 
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
             try {
                 throw seastar::nested_exception(std::move(inner), std::move(outer));
             } catch (...) {
-                log_msg << std::current_exception();
+                log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
             }
         }
     }
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_loggin
             try {
                 throw seastar::nested_exception(std::move(inner), std::move(outer));
             } catch (...) {
-                log_msg << std::current_exception();
+                log_msg << fmt::format("{}", seastar::formattable(std::current_exception()));
             }
         }
     }

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         promise<std::vector<std::string>> p;
         auto f = p.get_future();
         p.set_value({});
-        BOOST_REQUIRE_EQUAL(f.get(), (std::vector<std::string>{}));
+        BOOST_REQUIRE(f.get() == (std::vector<std::string>{}));
     }
     // brace-init-list: initializer_list<string> ctor
     {
@@ -228,7 +228,7 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         auto f = p.get_future();
         p.set_value({"foo", "foo"});
         std::vector<std::string> foo_x2{"foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x2);
+        BOOST_REQUIRE(f.get() == foo_x2);
     }
     // brace-init-list: (count, value) ctor
     {
@@ -236,7 +236,7 @@ SEASTAR_TEST_CASE(test_set_value_conversions) {
         auto f = p.get_future();
         p.set_value({3, "foo"});
         std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+        BOOST_REQUIRE(f.get() == foo_x3);
     }
     // reference preserved
     {
@@ -316,7 +316,7 @@ SEASTAR_TEST_CASE(test_make_ready_future_conversions) {
     {
         auto f = make_ready_future<std::vector<std::string>>(3, "foo");
         std::vector<std::string> foo_x3{"foo", "foo", "foo"};
-        BOOST_REQUIRE_EQUAL(f.get(), foo_x3);
+        BOOST_REQUIRE(f.get() == foo_x3);
     }
     // reference preserved
     {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1417,7 +1417,7 @@ SEASTAR_TEST_CASE(test_unregister_handler) {
         } catch (rpc::unknown_verb_error&) {
             // expected
         } catch (...) {
-            std::cerr << "call failed in an unexpected way: " << std::current_exception() << std::endl;
+            std::cerr << fmt::format("call failed in an unexpected way: {}\n", seastar::formattable(std::current_exception()));
             BOOST_REQUIRE(false);
         }
         BOOST_REQUIRE(!f_handler_called.available());
@@ -1438,7 +1438,7 @@ SEASTAR_TEST_CASE(test_unregister_handler) {
         } catch (rpc::unknown_verb_error&) {
             // expected
         } catch (...) {
-            std::cerr << "call failed in an unexpected way: " << std::current_exception() << std::endl;
+            std::cerr << fmt::format("call failed in an unexpected way: {}\n", seastar::formattable(std::current_exception()));
             BOOST_REQUIRE(false);
         }
 


### PR DESCRIPTION
Seastar defines formatters (both fmt and operator<<(std::ostream&) for some
standard types: std::exception_ptr, std::exception, and std::system_error. Deprecate
the lot and guard it with Seastar_DEPRECATED_OSTREAM_FORMATTERS.

fmt does not provide a formatter for std::exception_ptr [1], so to bridge the gap, define
a formatter via seastar::formattable(std::exception_ptr).

The new formattable helper is in our namespace, so we can export it to module users.

Finally, default Seastar_DEPRECATED_OSTREAM_FORMATTERS to OFF to nudge users off
the deprecated symbols.

[1] https://github.com/fmtlib/fmt/issues/4808