### PR TITLE
dns: opt out of c-ares RFC 6724 address sorting

### DIFF
--- a/include/seastar/net/dns.hh
+++ b/include/seastar/net/dns.hh
@@ -98,6 +98,11 @@ struct srv_record {
  * stack of choice, though for "normal" non-test
  * querying, you are probably better of with the
  * global calls further down.
+ *
+ * \note Addresses come back in DNS-response order, not sorted per RFC 6724.
+ * c-ares's sort probes each address through a connected socket; this stack
+ * can't, so it is disabled. A caller that needs a routable address should dial
+ * the returned addresses in turn until one connects.
  */
 class dns_resolver {
 public:

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -547,8 +547,15 @@ dns_resolver::impl::get_host_by_name(sstring name, opt_family family)  {
 // in Gcc 11 (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96003).
 #pragma GCC diagnostic ignored "-Wnonnull"
 
+    // c-ares would sort multi-address results per RFC 6724, but that needs a
+    // getsockname callback we cannot provide; opt out. See scylladb/seastar#3456.
+    int ai_flags = ARES_AI_CANONNAME;
+#ifdef ARES_AI_NOSORT
+    ai_flags |= ARES_AI_NOSORT;
+#endif
+
     ares_addrinfo_hints hints = {
-        .ai_flags = ARES_AI_CANONNAME,
+        .ai_flags = ai_flags,
         .ai_family = af,
         .ai_socktype = 0,
         .ai_protocol = 0,


### PR DESCRIPTION
Multi-address lookups come back in DNS-response order, sometimes with a non-routable IPv6 address first, and each one needlessly creates and destroys a datagram socket.

c-ares sorts getaddrinfo() results per RFC 6724 by probing each address: it opens a UDP socket, connects, and reads back the source with getsockname. Our socket hooks cannot run that probe. do_socket ignores the address family, an IPv6 probe connect throws, and we install no getsockname callback, so c-ares gives up on the sort after creating and closing the socket. Set ARES_AI_NOSORT so it skips the sort rather than failing it.

Implementing the probe does not work in our model. A getsockname callback cannot be limited to sort probes: c-ares also calls it on every connecting query socket to read the local binding. Seastar's connect() is async, so the connected_socket and its local_address() do not exist until the connection completes, and returning an error or a wildcard with port 0 makes c-ares treat the socket as dead and drop the query. Calling the sort directly is not an option either: c-ares does not export ares_sortaddrinfo(), and ares_set_sortlist() applies only to the deprecated gethostbyname() path. So NOSORT is the only knob c-ares gives us.

A caller that needs routable ordering can do that at the connect layer instead: resolve the full address list and dial each address in turn until one connects, as redpanda does in redpanda-data/redpanda#30796. That only partially matches c-ares's sort, but a robust client needs it regardless, since ordering alone never guarantees the first address is reachable.

Closes scylladb/seastar#3456