### PR TITLE
net/tls: fix concurrent put() on the socket in the OpenSSL backend

### DIFF
--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -52,6 +52,7 @@
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/net/stack.hh>
@@ -846,11 +847,17 @@ public:
         return _type == session_type::CLIENT ? "Client": "Server";
     }
 
-    // This function waits for the _output_pending future to resolve
-    // If an error occurs, it is saved off into _error and returned
+    // Waits for the put() currently tracked by _output_pending to drain. On
+    // failure the error is recorded in _error and re-raised; _output_pending is
+    // left failed so it acts as a circuit breaker (see its declaration).
+    //
+    // Awaits via get_future() rather than moving _output_pending out, so the
+    // in-flight put() stays observable through available()/failed() while it
+    // drains -- which is what bio_write_ex() relies on to avoid issuing a
+    // second, concurrent put().
     future<> wait_for_output() {
         tls_log.trace("{} wait_for_output", *this);
-        return std::exchange(_output_pending, make_ready_future())
+        return _output_pending.get_future()
           .handle_exception([this](auto ep) {
               tls_log.debug("{} wait_for_output error: {}", *this, ep);
               _error = ep;
@@ -937,7 +944,6 @@ public:
         auto i = bufs.begin();
         auto e = bufs.end();
         return with_semaphore(_out_sem, 1, [this, i, e] {
-            SEASTAR_ASSERT(_output_pending.available());
             return do_for_each(i, e, [this](temporary_buffer<char>& b) {
                 return do_put_one(b.get(), b.size());
             });
@@ -948,7 +954,6 @@ public:
         auto ptr = buf.get();
         auto size = buf.size();
         return with_semaphore(_out_sem, 1, [this, ptr, size] {
-            SEASTAR_ASSERT(_output_pending.available());
             return do_put_one(ptr, size);
         }).finally([b = std::move(buf)] {});
     }
@@ -959,9 +964,12 @@ public:
     // any unprocessed part of the packet is returned.
     future<> do_put_one(const char* ptr, size_t size) {
         tls_log.trace("{} do_put", *this);
-        SEASTAR_ASSERT(_output_pending.available());
 
-        // This do_until runs until either a renegotiation occurs or the packet is empty
+        // A key-update put() from the read path (under _in_sem) may be in flight
+        // here; _out_sem does not exclude it. No up-front drain is needed:
+        // bio_write_ex() declines while a put() is in flight, so the first
+        // SSL_write_ex reports WANT_WRITE and handle_do_put_ssl_err() drains and
+        // retries, like every later loop iteration.
         while (!eof() && size > 0) {
             size_t bytes_written = 0;
             auto [write_rc, ssl_err, error_codes] = ssl_call(
@@ -2044,11 +2052,42 @@ private:
     data_sink _out;
     std::exception_ptr _error;
 
+    // Reads and writes run concurrently (full duplex), serialized by two
+    // disjoint semaphores: _in_sem guards the read path (get()/SSL_read_ex),
+    // _out_sem the write path (put()/SSL_write_ex, plus flush, rehandshake and
+    // shutdown). Operations spanning both take them in the order _in_sem then
+    // _out_sem, so there is no deadlock.
+    //
+    // Because the semaphores are disjoint, a read and a write can both write to
+    // the socket at once: the write path always does, and the read path does too
+    // when SSL_read_ex emits a TLS key-update/renegotiation message. Neither
+    // semaphore serializes those socket writes; _output_pending does.
     semaphore _in_sem;
     semaphore _out_sem;
     tls_options _options;
 
-    future<> _output_pending;
+    // The put() currently in flight on _out, or a resolved future when _out is
+    // idle. _out is a data_sink, which permits only one put() at a time
+    // (posix_data_sink_impl asserts !_p); both the read and write paths can reach
+    // _out.put(), so that invariant is enforced here, not by the semaphores above.
+    //
+    // bio_write_ex(), the only caller of _out.put(), is a synchronous OpenSSL
+    // callback that cannot await, so it serializes cooperatively: while a put() is
+    // in flight (_output_pending unresolved) it declines via BIO_set_retry_write()
+    // and OpenSSL retries after wait_for_output() drains it; otherwise it issues
+    // the put() and reassigns _output_pending to it. This is race-free because the
+    // reactor is single-threaded and bio_write_ex() does not await -- but only
+    // while available()/failed() reflect the real put() state. That is why this is
+    // a shared_future: get_future() hands out an awaitable without consuming
+    // _output_pending, so available()/failed() keep reflecting the in-flight put()
+    // and several fibers can await the same put(). A plain future would have to be
+    // moved out to be awaited, falsifying available() and letting the guard issue
+    // a second, concurrent put().
+    //
+    // On output failure _output_pending is left failed as a circuit breaker:
+    // bio_write_ex() issues no further puts and re-raises. The failure is terminal
+    // (the socket is gone), so _output_pending is never reset.
+    shared_future<> _output_pending;
     buf_type _input;
     // ALPN protocols in OPENSSL format
     // This is a sequence of length-prefixed strings, where the first byte is the length
@@ -2180,18 +2219,22 @@ int bio_create(BIO*) {
     return 1;
 }
 
-/// Handles writes to the BIO
+/// Handles writes to the BIO -- the only place that calls _out.put().
 ///
-/// This function will attempt to call _out.put() and store the future in
-/// _output_pending.  If _output_pending has not yet resolved, return '0'
-/// and set the retry write flag.
+/// Enforces one put() in flight at a time (see the _output_pending
+/// declaration). OpenSSL calls this synchronously and we cannot await here, so
+/// if a put() is still in flight we decline with BIO_set_retry_write() and let
+/// the caller drain it via wait_for_output() once OpenSSL reports WANT_WRITE.
 int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
     auto session = unwrap_bio_ptr(b);
     tls_log.trace("{} bio_write_ex: dlen {}", *session, dlen);
     BIO_clear_retry_flags(b);
 
+    // A put() is still in flight: decline and ask OpenSSL to retry. This is
+    // honest only because wait_for_output() does not mark _output_pending ready
+    // before the put() drains.
     if (!session->_output_pending.available()) {
-        tls_log.trace("{} bio_write_ex: nothing pending in output", *session);
+        tls_log.trace("{} bio_write_ex: put still in flight", *session);
         BIO_set_retry_write(b);
         return 0;
     }
@@ -2199,17 +2242,19 @@ int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
     try {
         size_t n;
 
+        // Skip issuing if a previous put() failed; the failure is re-raised just
+        // below and the session tears down.
         if (!session->_output_pending.failed()) {
             auto buf = temporary_buffer<char>(dlen);
             std::memcpy(buf.get_write(), data, dlen);
             n = buf.size();
             session->_output_pending = session->_out.put(std::move(buf));
-            tls_log.trace("{} bio_write_ex: Appended {} bytes to output pending", *session, n);
+            tls_log.trace("{} bio_write_ex: issued put of {} bytes", *session, n);
         }
 
         if (session->_output_pending.failed()) {
             tls_log.debug("{} bio_write_ex: output pending has error", *session);
-            std::rethrow_exception(session->_output_pending.get_exception());
+            std::rethrow_exception(session->_output_pending.get_future().get_exception());
         }
 
         if (written != nullptr) {

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -2135,6 +2135,194 @@ SEASTAR_THREAD_TEST_CASE(test_send_recv_alloc_limits) {
     }
 }
 
+// Reproduces a crash specific to the OpenSSL TLS backend:
+//
+//   SEASTAR_ASSERT(!_p);   // posix_data_sink_impl::put(), posix-stack.cc
+//
+// The read and write paths use disjoint semaphores (_in_sem vs _out_sem) and
+// both can write to the underlying socket. The read path produces output while
+// processing an incoming TLS key-update/renegotiation: OpenSSL flushes the
+// pending key-update response from inside SSL_read_ex, as a put() on the
+// underlying data_sink. If an application write is in flight on that sink at the
+// same time, the read issues a second, concurrent put(), which
+// posix_data_sink_impl forbids (one put() at a time), tripping the assert.
+//
+// GnuTLS surfaces the rehandshake to the caller and re-runs it while holding
+// both semaphores, so it never issues that concurrent put(); the scenario is
+// OpenSSL-specific and the test is skipped for GnuTLS.
+//
+// The test installs an instrumented data_sink under the client that flags any
+// put() issued while another is in flight (what the posix assert detects) and
+// can hold a put() to open a deterministic window. It drives two server
+// key-updates: OpenSSL only flushes the response to the first while reading the
+// second, and that flush is the read-path put() held in flight while a
+// concurrent client write tries to issue the colliding put().
+SEASTAR_THREAD_TEST_CASE(test_concurrent_put_with_key_update) {
+    if (using_gnutls()) {
+        return;
+    }
+
+    tls::credentials_builder b;
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+    // Force TLS 1.3 so force_rehandshake() becomes a key-update, which is what
+    // makes the OpenSSL read path produce output.
+    b.set_minimum_tls_version(tls::tls_version::tlsv1_3);
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    // State shared between the test and the instrumented client sink.
+    struct gate_state {
+        unsigned outstanding = 0;   // put()s currently in flight on the sink
+        bool overlap = false;       // a put() started while another was in flight
+        bool arm = false;           // when set, the next put() is held
+        promise<> entered;          // resolved once a put() has been held
+        promise<> release;          // resolved by the test to release the held put()
+    };
+    // Held by lw_shared_ptr so it outlives the test body: openssl_session::close()
+    // tears the connection down via a detached reactor task (run_in_background,
+    // kept alive by shared_from_this()), so a sink put()'s finally can run after
+    // this fiber has returned and freed its stack. A reference to a stack gate
+    // would then be a use-after-return.
+    auto gate = make_lw_shared<gate_state>();
+
+    // A connected socket whose sink detects overlapping put()s (mirroring the
+    // posix_data_sink_impl contract) and can hold the first put() on demand.
+    class instrumented_socket_impl : public loopback_connected_socket_impl {
+    public:
+        lw_shared_ptr<gate_state> _gate;
+        instrumented_socket_impl(lw_shared_ptr<gate_state> g, lw_shared_ptr<loopback_buffer> tx, lw_shared_ptr<loopback_buffer> rx)
+            : loopback_connected_socket_impl(std::move(tx), std::move(rx))
+            , _gate(std::move(g))
+        {}
+        class sink_impl : public data_sink_impl {
+            data_sink _next;
+            lw_shared_ptr<gate_state> _gate;
+            future<> forward(std::vector<temporary_buffer<char>> bufs) {
+                if (_gate->outstanding != 0) {
+                    // Equivalent to SEASTAR_ASSERT(!_p) firing in
+                    // posix_data_sink_impl: a put() was issued while a previous
+                    // one had not yet completed.
+                    _gate->overlap = true;
+                }
+                ++_gate->outstanding;
+                future<> hold = make_ready_future<>();
+                if (_gate->arm) {
+                    _gate->arm = false;            // one-shot
+                    _gate->entered.set_value();    // announce the held put()
+                    hold = _gate->release.get_future();
+                }
+                return hold.then([this, bufs = std::move(bufs)] () mutable {
+                    return _next.put(std::move(bufs));
+                }).finally([gate = _gate] {
+                    --gate->outstanding;
+                });
+            }
+        public:
+            sink_impl(data_sink next, lw_shared_ptr<gate_state> g) : _next(std::move(next)), _gate(std::move(g)) {}
+            future<> flush() override { return _next.flush(); }
+            future<> close() override { return _next.close(); }
+            bool can_batch_flushes() const noexcept override { return false; }
+#if SEASTAR_API_LEVEL >= 9
+            future<> put(std::span<temporary_buffer<char>> bufs) override {
+                return forward(std::vector<temporary_buffer<char>>(
+                    std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end())));
+            }
+#else
+            using data_sink_impl::put;
+            future<> put(net::packet p) override {
+                return forward(p.release());
+            }
+#endif
+        };
+        data_sink sink() override {
+            return data_sink(std::make_unique<sink_impl>(loopback_connected_socket_impl::sink(), _gate));
+        }
+    };
+
+    auto b1 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::SERVER_TX);
+    auto b2 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::CLIENT_TX);
+    auto ssi = std::make_unique<loopback_connected_socket_impl>(b1, b2);
+    auto csi = std::make_unique<instrumented_socket_impl>(gate, b2, b1);
+
+    auto server = tls::wrap_server(serv, connected_socket(std::move(ssi))).get();
+    auto client = tls::wrap_client(creds, connected_socket(std::move(csi))).get();
+
+    auto cin = client.input();
+    auto cout = output_stream<char>(client.output().detach(), 1024);
+    auto sin = server.input();
+    auto sout = output_stream<char>(server.output().detach(), 1024);
+
+    auto exchange = [&](output_stream<char>& out, input_stream<char>& in, const char* msg) {
+        out.write(msg).get();
+        auto fin = in.read();
+        out.flush().get();
+        return fin.get();
+    };
+
+    // Complete the handshake and exchange data both ways so both sides are fully
+    // connected and the client's output is idle before we arm the trap.
+    exchange(cout, sin, "hello");
+    exchange(sout, cin, "hello");
+
+    // OpenSSL only flushes the key-update response while processing a subsequent
+    // incoming key-update (or on the next write). So the read path produces
+    // output only on the second key-update. Drive the first one here: the client
+    // reads it and schedules a response, but emits nothing yet.
+    tls::force_rehandshake(server).get();
+    exchange(sout, cin, "a");  // carries the 1st key-update; client schedules a response
+
+    // Queue the second key-update (plus a byte to flush it). The loopback
+    // delivers the key-update record and the data byte as separate buffers, so
+    // the client's read of the key-update returns WANT_READ after flushing the
+    // pending response -- meaning that flush lands as a read-path put().
+    tls::force_rehandshake(server).get();
+    sout.write("b").get();
+    sout.flush().get();
+
+    // Arm the trap: the next put() on the client socket (the flushed key-update
+    // response, emitted from the read path) will be held in flight.
+    gate->arm = true;
+
+    // Read on the client. While processing the second key-update it flushes the
+    // pending response as a put() -- which the gate holds -- then suspends in
+    // wait_for_output() awaiting it (holding _in_sem, not _out_sem).
+    auto fR = cin.read();
+    gate->entered.get_future().get();
+
+    // Now write on the client. With the read's put held in flight, the buggy code
+    // lets this write issue a second, concurrent put() on the same sink. The
+    // fixed code makes the write wait for the in-flight put().
+    auto fW = cout.write("world").then([&cout] { return cout.flush(); });
+
+    // Give the write path time to reach the point where it would issue the
+    // colliding put(). The read's put stays held, so the window stays open.
+    seastar::sleep(std::chrono::milliseconds(200)).get();
+
+    bool overlap = gate->overlap;
+
+    // Release the held put; both directions drain from here.
+    gate->release.set_value();
+
+    auto ignore = [](auto f) { try { f.get(); } catch (...) {} };
+    ignore(std::move(fW));
+    ignore(std::move(fR));
+    ignore(cout.close());
+    ignore(cin.close());
+    ignore(sout.close());
+    ignore(sin.close());
+    client.shutdown_input();
+    client.shutdown_output();
+    server.shutdown_input();
+    server.shutdown_output();
+
+    BOOST_CHECK_MESSAGE(!overlap,
+        "TLS layer issued two concurrent put()s on the underlying data_sink "
+        "(this is what trips SEASTAR_ASSERT(!_p) in posix_data_sink_impl)");
+}
+
 static std::pair<connected_socket, connected_socket> tls_socketpair() {
     auto certs = ::make_shared<tls::server_credentials>(::make_shared<tls::dh_params>());
     certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();


### PR DESCRIPTION
A data_sink permits only one put() in flight at a time (posix_data_sink_impl asserts !_p). The OpenSSL backend could violate this and crash:

    seastar::net::posix_data_sink_impl::put(): Assertion `!_p' failed.

The read and write paths use disjoint semaphores (_in_sem, _out_sem) and both can write to the underlying socket: a write encrypts application data, and a read emits a TLS key-update/renegotiation response from inside SSL_read_ex. When a read emitted output while a write's put() was in flight, a second, concurrent put() was issued on the same data_sink, tripping the assert.

bio_write_ex(), the only caller of _out.put(), already declines to issue a put() while one is in flight (BIO_set_retry_write), so OpenSSL retries after the in-flight put() drains. The guard was reading falsified state: wait_for_output() obtained an awaitable with

    std::exchange(_output_pending, make_ready_future())

which marked _output_pending available while the put() was still draining, so the guard saw an idle sink and issued the concurrent put(). This is not a missing lock; the reactor is single-threaded and the guard is already atomic.

Make _output_pending a shared_future so wait_for_output() can hand out an awaitable via get_future() without consuming it. available()/failed() then stay truthful while the put() drains, and both the read and write paths can await the same put().

Drop the SEASTAR_ASSERT(_output_pending.available()) preconditions in the two do_put() overloads and do_put_one(). They asserted that no put() is in flight when a write begins, which is false: _in_sem and _out_sem are disjoint, so a read-path put() can be in flight. The decline/retry path handles that correctly. The destructor's assert is kept; it still holds once close() has drained output.

Add test_concurrent_put_with_key_update, which installs an instrumented data_sink that flags overlapping put()s and drives two server key-updates to open the window deterministically. It is skipped for GnuTLS, which re-runs the handshake holding both semaphores and so never issues the concurrent put(). The full tls_test suite passes under both the OpenSSL and GnuTLS backends.