### PR TITLE
core/loop: include do_with.hh for max_concurrent_for_each()

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -31,6 +31,7 @@
 #include <boost/container/small_vector.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/task.hh>
+#include <seastar/core/do_with.hh>
 #include <seastar/util/assert.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/core/semaphore.hh>


### PR DESCRIPTION
max_concurrent_for_each() calls do_with() but loop.hh neither includes nor declares it, so a TU including only <seastar/core/loop.hh> fails to compile. Include <seastar/core/do_with.hh> to make the header self-contained.

Fixes #3476