### PR TITLE
core/memory: fix unaligned allocation in posix_memalign

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2415,6 +2415,7 @@ int posix_memalign(void** ptr, size_t align, size_t size) noexcept {
     if (try_trigger_error_injector()) {
         return ENOMEM;
     }
+    size = std::max(size, align);
     *ptr = allocate_aligned(align, size);
     if (!*ptr) {
         return ENOMEM;

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -752,3 +752,37 @@ SEASTAR_TEST_CASE(c23_free_sized) {
     free_aligned_sized(p2, 1024, 4096);
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_posix_memalign) {
+    auto verify = [](size_t alignment, size_t size) {
+        void *p = NULL;
+        int result = posix_memalign(&p, alignment, size);
+        BOOST_REQUIRE(result == 0);
+        BOOST_REQUIRE(p != nullptr);
+        BOOST_REQUIRE_MESSAGE(
+            (reinterpret_cast<uintptr_t>(p) % alignment) == 0,
+            fmt::format("failed with p {} alignment {} size {}",
+                        fmt::ptr(p), alignment, size));
+        free(p);
+    };
+
+    // posix_memalign does not place a restriction on the allocated size, unlike
+    // aligned_alloc which requires size to be a multiple of alignment. at the
+    // time this test was written verify(32,16) does not fail without the
+    // proceeding allocation.
+    //
+    // this case can be seen in both the glibc test suite:
+    //   https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/tst-posix_memalign.c;h=5039b6501710a550e71f1bc659b1b5c0baa03cf3;hb=HEAD#l109
+    //
+    // and apple's libmalloc test suite:
+    //   https://opensource.apple.com/source/libmalloc/libmalloc-283.60.1/tests/posix_memalign_test.c.auto.html
+    //
+    // at the time the test is written it will fail on release builds with
+    // seastar allocator and pass when using the default allocator in debug
+    // mode.
+
+    verify(16, 32);
+    verify(32, 16);
+
+    return make_ready_future<>();
+}


### PR DESCRIPTION
When posix_memalign is called with a size smaller than the requested alignment, the underlying Seastar allocator may return unaligned memory. This occurs because the allocator expects the size to be at least as large as the alignment.

This patch fixes the issue by forcing the requested size to be at least as large as the requested alignment before passing t to allocate_aligned(), matching the behavior of standard libc implementations.

A regression test is also added to alloc_test.cc.

Fixes #1940