### PR TITLE
http: mark connection::close() and client::close() noexcept

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -150,7 +150,7 @@ public:
      * Connection must be closed regardless of whether there was an exception making the
      * request or not
      */
-    future<> close();
+    future<> close() noexcept;
 
 private:
     future<reply_ptr> do_make_request(const request& rq);
@@ -365,7 +365,7 @@ public:
      *
      * Client must be closed before destruction unconditionally
      */
-    future<> close();
+    future<> close() noexcept;
 
     /**
      * \brief Returns the total number of connections

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -188,7 +188,7 @@ void connection::shutdown() noexcept {
     _fd.shutdown_input();
 }
 
-future<> connection::close() {
+future<> connection::close() noexcept {
     // #2661. At least output stream close can fail with exception, because
     // the stream will do a flush. If connection never managed to send data, we
     // will throw again here. Need to suppress these exceptions.
@@ -456,7 +456,7 @@ future<> client::do_make_request(connection& con, const request& req, reply_hand
     }).finally([sub = std::move(sub)] {});
 }
 
-future<> client::close() {
+future<> client::close() noexcept {
     if (_pool.empty()) {
         return _new_connections->close();
     }


### PR DESCRIPTION
For use with with_closeable() and similar, these functions must be noexcept. Due to a bug in exporting
SEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT, this wasn't enforced, but to fix the bug we must first make these functions eligible.