### PR TITLE
perf: avoid `using namespace seastar` in header

### DIFF
--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -32,7 +32,14 @@
 #include <seastar/testing/linux_perf_event.hh>
 #include <seastar/util/noncopyable_function.hh>
 
-using namespace seastar;
+// Avoid `using namespace seastar;` here: it would inject
+// seastar::file_handle into global scope, conflicting with POSIX
+// `struct file_handle` (<bits/fcntl-linux.h>).  Pull in only the
+// seastar names this header actually mentions.
+using seastar::sstring;
+using seastar::future;
+using seastar::noncopyable_function;
+using seastar::is_future;
 
 namespace perf_tests {
 

--- a/tests/perf/container_perf.cc
+++ b/tests/perf/container_perf.cc
@@ -26,6 +26,8 @@
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/circular_buffer.hh>
 
+using namespace seastar;
+
 using trivial_elem = int;
 
 static constexpr size_t big_size = 10000;

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -28,6 +28,8 @@
 #include <seastar/util/later.hh>
 #include <vector>
 
+using namespace seastar;
+
 struct coroutine_test {
 };
 

--- a/tests/perf/fair_queue_perf.cc
+++ b/tests/perf/fair_queue_perf.cc
@@ -29,6 +29,8 @@
 #include <seastar/core/when_all.hh>
 #include <ranges>
 
+using namespace seastar;
+
 static constexpr fair_queue::class_id cid = 0;
 
 struct local_fq_and_class {

--- a/tests/perf/future_util_perf.cc
+++ b/tests/perf/future_util_perf.cc
@@ -30,6 +30,8 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/later.hh>
 
+using namespace seastar;
+
 struct parallel_for_each {
     std::vector<int> empty_range;
     std::vector<int> range;

--- a/tests/perf/metrics_perf.cc
+++ b/tests/perf/metrics_perf.cc
@@ -26,6 +26,8 @@
 
 #include <seastar/core/internal/estimated_histogram.hh>
 
+using namespace seastar;
+
 #include <ranges>
 #include <stdexcept>
 

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -26,6 +26,8 @@
 #include <ranges>
 #include <seastar/testing/perf_tests.hh>
 
+using namespace seastar;
+
 #include <cstdio>
 #include <fstream>
 #include <regex>

--- a/tests/perf/perf_tests_perf.cc
+++ b/tests/perf/perf_tests_perf.cc
@@ -23,6 +23,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/testing/perf_tests.hh>
 
+using namespace seastar;
+
 // Benchmarks that test raw overhead of almost empty perf tests
 // in all the basic variations.
 

--- a/tests/perf/rpc_perf.cc
+++ b/tests/perf/rpc_perf.cc
@@ -27,6 +27,8 @@
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/testing/random.hh>
 
+using namespace seastar;
+
 template<typename Compressor>
 struct compression {
     static constexpr size_t small_buffer_size = 128;

--- a/tests/perf/shared_token_bucket.cc
+++ b/tests/perf/shared_token_bucket.cc
@@ -29,6 +29,8 @@
 #include <seastar/util/later.hh>
 #include <seastar/util/shared_token_bucket.hh>
 
+using namespace seastar;
+
 // The test allows measuring if the shared_token_bucket<> allows the tokens
 // consumers to get tokens at the rate the bucket is configured with.
 //


### PR DESCRIPTION
This can bring seastar::file_handle name into the global namespace, where it clashes with the Linux file_handle symbol.