### PR TITLE
treewide: make variables in headers inline

### DIFF
--- a/include/seastar/core/cacheline.hh
+++ b/include/seastar/core/cacheline.hh
@@ -28,13 +28,13 @@ namespace seastar {
 // Platform-dependent cache line size for alignment and padding purposes.
 // RISC-V: workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116662
 #ifdef __riscv
-constexpr std::size_t cache_line_size = 64;
+inline constexpr std::size_t cache_line_size = 64;
 #else
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winterference-size"
 #endif
-constexpr std::size_t cache_line_size = std::hardware_destructive_interference_size;
+inline constexpr std::size_t cache_line_size = std::hardware_destructive_interference_size;
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/include/seastar/core/units.hh
+++ b/include/seastar/core/units.hh
@@ -26,9 +26,9 @@
 namespace seastar {
 
 
-constexpr size_t KB = 1 << 10;
-constexpr size_t MB = 1 << 20;
-constexpr size_t GB = 1 << 30;
+inline constexpr size_t KB = 1 << 10;
+inline constexpr size_t MB = 1 << 20;
+inline constexpr size_t GB = 1 << 30;
 
 constexpr size_t operator""_KiB(unsigned long long n) { return n << 10; }
 constexpr size_t operator""_MiB(unsigned long long n) { return n << 20; }


### PR DESCRIPTION
Make some variables in headers inline to avoid multiple definitions (one per translation unit). This shows up with module builds.