### PR TITLE
reactor: Replace indirect_compare struct with a lambda

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -307,7 +307,6 @@ private:
         // chars are used.
         static constexpr size_t shortname_size = 4;
         sstring _shortname;
-        struct indirect_compare;
         seastar::metrics::metric_groups _metrics;
         virtual bool run_tasks() override;
         void rename(sstring new_name, sstring new_shortname);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1113,11 +1113,6 @@ reactor::task_queue_group::account_runtime(reactor& r, sched_entity& tq, sched_c
     tq._runtime += runtime;
 }
 
-struct reactor::task_queue::indirect_compare {
-    bool operator()(const sched_entity* tq1, const sched_entity* tq2) const {
-        return tq1->_vruntime < tq2->_vruntime;
-    }
-};
 
 reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsigned id, reactor_backend_selector rbs, reactor_config cfg)
     : _smp(std::move(smp))
@@ -3183,7 +3178,9 @@ void reactor::task_queue_group::activate(sched_entity* tq) {
 
 void reactor::task_queue_group::insert_active_entity(sched_entity* tq) {
     tq->_active = true;
-    auto less = task_queue::indirect_compare();
+    auto less = [] (const sched_entity* a, const sched_entity* b) {
+        return a->_vruntime < b->_vruntime;
+    };
     if (_active.empty() || less(_active.back(), tq)) {
         // Common case: idle->working
         // Common case: CPU intensive task queue going to the back


### PR DESCRIPTION
The single-use struct only obfuscates a simple vruntime comparison. Replace it with an inline lambda at the point of use.