### PR TITLE
http: reject path traversal in directory_handler

### DIFF
--- a/src/http/file_handler.cc
+++ b/src/http/file_handler.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <string_view>
 
 #include <seastar/http/file_handler.hh>
 #include <seastar/core/seastar.hh>
@@ -36,6 +37,28 @@ namespace seastar {
 
 namespace httpd {
 
+// Refuse a decoded path that could escape doc_root: any ".." segment, or a
+// leading '/' (get_decoded_param() strips the matcher's own '/', so one here
+// means a doubled slash like "//etc"). It also percent-decodes the value, so
+// encoded traversal like "%2e%2e%2f" is already "../" and is caught here too.
+static bool is_unsafe_path(std::string_view path) {
+    if (!path.empty() && path.front() == '/') {
+        return true;
+    }
+    for (size_t start = 0; start <= path.size();) {
+        size_t sep = path.find('/', start);
+        auto segment = path.substr(start, sep - start);
+        if (segment == "..") {
+            return true;
+        }
+        if (sep == std::string_view::npos) {
+            break;
+        }
+        start = sep + 1;
+    }
+    return false;
+}
+
 directory_handler::directory_handler(const sstring& doc_root,
         file_transformer* transformer)
         : file_interaction_handler(transformer), doc_root(doc_root) {
@@ -43,7 +66,12 @@ directory_handler::directory_handler(const sstring& doc_root,
 
 future<std::unique_ptr<http::reply>> directory_handler::handle(const sstring& path,
         std::unique_ptr<http::request> req, std::unique_ptr<http::reply> rep) {
-    sstring full_path = doc_root + req->param.get_decoded_param("path");
+    sstring decoded_path = req->param.get_decoded_param("path");
+    if (is_unsafe_path(decoded_path)) {
+        rep->set_status(http::reply::status_type::not_found);
+        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
+    }
+    sstring full_path = doc_root + decoded_path;
     auto h = this;
     return engine().file_type(full_path).then(
             [h, full_path, req = std::move(req), rep = std::move(rep)](auto val) mutable {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -6,6 +6,9 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/http/handlers.hh>
 #include <seastar/http/common.hh>
+#include <seastar/http/file_handler.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/util/memory-data-sink.hh>
 #include <seastar/http/matcher.hh>
 #include <seastar/http/matchrules.hh>
@@ -24,6 +27,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "loopback_socket.hh"
 #include "memory-data-sink.hh"
+#include "tmpdir.hh"
 #include <boost/algorithm/string.hpp>
 #include <boost/dll.hpp>
 #include <seastar/core/thread.hh>
@@ -310,6 +314,48 @@ SEASTAR_TEST_CASE(test_url_decode_edge_cases) {
         BOOST_REQUIRE_EQUAL(out, sstring(c.path));
     }
     return make_ready_future<>();
+}
+
+// A directory_handler must never serve a file outside its doc_root. Both raw
+// ("../") and percent-encoded ("%2e%2e%2f") traversal are rejected before the
+// filesystem is touched, so a "secret" sibling of doc_root stays unreachable
+// even though it exists on disk. See issue #3475.
+SEASTAR_THREAD_TEST_CASE(test_directory_handler_path_traversal) {
+    tmpdir tmp;
+    auto doc_root = tmp.path() / "public";
+    touch_directory(doc_root.native()).get();
+
+    auto write_file = [] (const std::filesystem::path& p, sstring content) {
+        auto f = open_file_dma(p.native(), open_flags::create | open_flags::wo).get();
+        auto os = make_file_output_stream(f).get();
+        os.write(std::move(content)).get();
+        os.flush().get();
+        os.close().get();
+    };
+    write_file(doc_root / "index.html", "public");
+    // A file sitting next to doc_root that traversal would try to reach.
+    write_file(tmp.path() / "secret", "secret");
+
+    // doc_root ends with '/': get_decoded_param() strips the path matcher's
+    // leading '/' from the param, so the handler concatenates doc_root + name.
+    directory_handler handler(doc_root.native() + "/");
+
+    auto handle = [&handler] (sstring param) {
+        auto req = std::make_unique<http::request>();
+        req->param.set("path", std::move(param));
+        auto rep = std::make_unique<http::reply>();
+        return handler.handle("", std::move(req), std::move(rep)).get();
+    };
+
+    // A legitimate request inside doc_root is served.
+    BOOST_REQUIRE_EQUAL((int)handle("/index.html")->_status,
+                        (int)http::reply::status_type::ok);
+
+    // Raw and percent-encoded traversal must not escape doc_root.
+    for (sstring param : {"/../secret", "/%2e%2e%2fsecret", "/subdir/../../secret"}) {
+        BOOST_REQUIRE_EQUAL((int)handle(param)->_status,
+                            (int)http::reply::status_type::not_found);
+    }
 }
 
 SEASTAR_TEST_CASE(test_routes) {


### PR DESCRIPTION
## Problem

`directory_handler::handle()` builds the served path as

```cpp
sstring full_path = doc_root + req->param.get_decoded_param("path");
```

and later calls `open_file_dma(full_path, open_flags::ro)` with no
canonicalization or rejection of traversal sequences. A client can therefore
escape the document root:

- **Raw:** `GET /file/../secret` &rarr; `doc_root + "../secret"`
- **Percent-encoded:** `GET /file/%2e%2e%2fsecret`. `get_decoded_param()`
  percent-decodes the value (`common.hh`), so `%2e%2e%2f` becomes a literal
  `../` &mdash; the encoded form is if anything worse than the raw one.

## Fix

Add a small static `is_unsafe_path()` helper and, in
`directory_handler::handle()`, reject the request with `not_found` **before**
touching the filesystem when the decoded path is absolute (starts with `/`) or
contains any `..` path segment. This follows the "reject rather than silently
mangle" approach from #3465.

- `file_handler` (single fixed file) is unaffected &mdash; only
  `directory_handler` is guarded.
- `..` is only rejected as a whole path segment, so ordinary names such as
  `..foo` or `foo..bar` are still served.

## Test

Adds `test_directory_handler_path_traversal` to `tests/unit/httpd_test.cc`.
It creates a `doc_root` containing `index.html` and a sibling `secret` file
just outside it, then drives `directory_handler` with:

- a legitimate in-root request (`/index.html`) &rarr; `ok`;
- raw traversal (`/../secret`, `/subdir/../../secret`) &rarr; `not_found`;
- percent-encoded traversal (`/%2e%2e%2fsecret`) &rarr; `not_found`.

Issue #3475 explicitly asks for both raw and encoded coverage.

Fixes #3475.
