### PR TITLE
http: refuse requests on connections with an expired client certificate

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <limits>
 #include <cctype>
@@ -63,6 +64,7 @@ class connection : public boost::intrusive::list_base_hook<> {
     http_server& _server;
     connected_socket _fd;
     std::optional<session_dn> _tls_dn;
+    std::optional<std::chrono::system_clock::time_point> _tls_expiry;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
     socket_address _client_addr;

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -62,6 +62,7 @@ public:
 class connection : public boost::intrusive::list_base_hook<> {
     http_server& _server;
     connected_socket _fd;
+    std::optional<session_dn> _tls_dn;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
     socket_address _client_addr;

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <limits>
 #include <cctype>
@@ -65,6 +66,7 @@ class connection : public boost::intrusive::list_base_hook<> {
     connected_socket _fd;
     std::optional<session_dn> _tls_dn;
     std::optional<std::vector<tls::subject_alt_name>> _tls_san;
+    std::optional<std::chrono::system_clock::time_point> _tls_expiry;
     input_stream<char> _read_buf;
     output_stream<char> _write_buf;
     socket_address _client_addr;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -30,14 +30,15 @@
 //
 #pragma once
 
-#include <seastar/core/iostream.hh>
 #include <seastar/core/sstring.hh>
 #include <string_view>
+#include <optional>
 #include <strings.h>
 #include <seastar/http/common.hh>
 #include <seastar/http/mime_types.hh>
 #include <seastar/http/types.hh>
 #include <seastar/net/socket_defs.hh>
+#include <seastar/net/api.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/string_utils.hh>
 #include <seastar/util/iostream.hh>
@@ -80,6 +81,8 @@ struct request {
     std::unordered_map<sstring, sstring> trailing_headers;
     std::unordered_map<sstring, sstring> chunk_extensions;
     sstring protocol_name = "http";
+    /// Distinguished name from the client's TLS certificate, if mTLS was used.
+    std::optional<session_dn> _tls_dn;
     http::body_writer_type body_writer; // for client
 
     using query_parameters_type = std::unordered_map<sstring, std::vector<sstring>, seastar::internal::string_view_hash, std::equal_to<>>;

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <optional>
 #include <unordered_set>
@@ -574,6 +575,17 @@ namespace tls {
      * system_error exception will be thrown.
      */
     future<std::optional<session_dn>> get_dn_information(connected_socket& socket);
+
+    /**
+     * Get the expiration time of the leaf certificate that the connected peer is using.
+     * This function forces the TLS handshake. If the handshake didn't happen before the
+     * call to 'get_certificate_expiry' it will be completed when the returned future will
+     * become ready.
+     * Returns the expiry time_point on success. If the peer didn't send a certificate,
+     * or the expiry field cannot be read, returns nullopt.
+     * If the socket is not connected a system_error exception will be thrown.
+     */
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry(connected_socket& socket);
 
     /**
      * Force a re-handshake (session key renegotiotion on TLS1.3).

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <optional>
 #include <unordered_set>
@@ -538,6 +539,17 @@ namespace tls {
      * system_error exception will be thrown.
      */
     future<std::optional<session_dn>> get_dn_information(connected_socket& socket);
+
+    /**
+     * Get the expiration time of the leaf certificate that the connected peer is using.
+     * This function forces the TLS handshake. If the handshake didn't happen before the
+     * call to 'get_certificate_expiry' it will be completed when the returned future will
+     * become ready.
+     * Returns the expiry time_point on success. If the peer didn't send a certificate,
+     * or the expiry field cannot be read, returns nullopt.
+     * If the socket is not connected a system_error exception will be thrown.
+     */
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry(connected_socket& socket);
 
     /**
      * Force a re-handshake (session key renegotiotion on TLS1.3).

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -215,6 +215,12 @@ future<> connection::read_one() {
         if (_tls) {
             req->protocol_name = "https";
             req->_tls_dn = _tls_dn;
+            if (_tls_expiry && std::chrono::system_clock::now() > *_tls_expiry) {
+                generate_error_reply_and_close(std::move(req),
+                    http::reply::status_type::unauthorized,
+                    "Client certificate has expired");
+                return make_ready_future<>();
+            }
         }
         if (_parser.failed()) {
             if (req->_version.empty()) {
@@ -312,10 +318,13 @@ future<> connection::process() {
 future<> connection::prepare() {
     if (_tls) {
         co_await tls::get_protocol_version(_fd);
-        // Retrieve the client certificate DN after the handshake completes.
-        // It is stored on the connection and copied into every request so
-        // that handlers can perform certificate-based authentication.
+        // Retrieve the client certificate DN and expiry after the handshake
+        // completes.  Both are stored on the connection: the DN is copied into
+        // every request so handlers can perform certificate-based
+        // authentication; the expiry is checked before each request to refuse
+        // service on long-lived connections whose certificate has since expired.
         _tls_dn = co_await tls::get_dn_information(_fd);
+        _tls_expiry = co_await tls::get_certificate_expiry(_fd);
     }
 }
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -214,6 +214,7 @@ future<> connection::read_one() {
 
         if (_tls) {
             req->protocol_name = "https";
+            req->_tls_dn = _tls_dn;
         }
         if (_parser.failed()) {
             if (req->_version.empty()) {
@@ -311,6 +312,10 @@ future<> connection::process() {
 future<> connection::prepare() {
     if (_tls) {
         co_await tls::get_protocol_version(_fd);
+        // Retrieve the client certificate DN after the handshake completes.
+        // It is stored on the connection and copied into every request so
+        // that handlers can perform certificate-based authentication.
+        _tls_dn = co_await tls::get_dn_information(_fd);
     }
 }
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -217,6 +217,12 @@ future<> connection::read_one() {
             req->protocol_name = "https";
             req->tls_dn = _tls_dn ? &*_tls_dn : nullptr;
             req->tls_san = _tls_san ? &*_tls_san : nullptr;
+            if (_tls_expiry && std::chrono::system_clock::now() > *_tls_expiry) {
+                generate_error_reply_and_close(std::move(req),
+                    http::reply::status_type::unauthorized,
+                    "Client certificate has expired");
+                return make_ready_future<>();
+            }
         }
         if (_parser.failed()) {
             if (req->_version.empty()) {
@@ -326,6 +332,7 @@ future<> connection::prepare() {
         // not an issue there.
         _tls_dn = co_await tls::get_dn_information(_fd);
         _tls_san = co_await tls::get_alt_name_information(_fd);
+        _tls_expiry = co_await tls::get_certificate_expiry(_fd);
     }
 }
 

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -787,6 +787,10 @@ future<std::optional<session_dn>> tls::get_dn_information(connected_socket& sock
     return get_tls_socket(socket)->get_distinguished_name();
 }
 
+future<std::optional<std::chrono::system_clock::time_point>> tls::get_certificate_expiry(connected_socket& socket) {
+    return get_tls_socket(socket)->get_certificate_expiry();
+}
+
 future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types) {
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
 }

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -767,6 +767,10 @@ future<std::optional<session_dn>> tls::get_dn_information(connected_socket& sock
     return get_tls_socket(socket)->get_distinguished_name();
 }
 
+future<std::optional<std::chrono::system_clock::time_point>> tls::get_certificate_expiry(connected_socket& socket) {
+    return get_tls_socket(socket)->get_certificate_expiry();
+}
+
 future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types) {
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
 }

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <any>
+#include <chrono>
 #include <memory>
 #include <span>
 #include <string_view>
@@ -178,6 +179,7 @@ public:
     virtual void close() = 0;
     virtual seastar::net::connected_socket_impl& socket() const = 0;
     virtual future<std::optional<session_dn>> get_distinguished_name() = 0;
+    virtual future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() = 0;
     virtual future<std::vector<subject_alt_name>> get_alt_name_information(
         std::unordered_set<subject_alt_name_type> types) = 0;
     virtual future<bool> is_resumed() = 0;
@@ -263,6 +265,9 @@ public:
     }
     future<std::optional<session_dn>> get_distinguished_name() {
         return _session->get_distinguished_name();
+    }
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() {
+        return _session->get_certificate_expiry();
     }
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) {
         return _session->get_alt_name_information(std::move(types));

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -1248,6 +1248,20 @@ public:
             return extract_dn_information();
         });
     }
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() override {
+        return state_checked_access([this] {
+            auto peer = get_peer_certificate();
+            if (!peer) {
+                return std::optional<std::chrono::system_clock::time_point>{};
+            }
+            time_t t = gnutls_x509_crt_get_expiration_time(peer.get());
+            if (t == (time_t)-1) {
+                return std::optional<std::chrono::system_clock::time_point>{};
+            }
+            return std::optional<std::chrono::system_clock::time_point>{
+                std::chrono::system_clock::from_time_t(t)};
+        });
+    }
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) override {
         return state_checked_access([this](std::unordered_set<subject_alt_name_type> types) {
             std::vector<subject_alt_name> res;

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -575,6 +575,31 @@ public:
         return s;
     }
 
+    // Calls verify() and, if verification fails, sends the appropriate TLS alert
+    // to the peer before propagating the exception. Returns nullopt when
+    // verification succeeded (caller should continue normally), or a future
+    // that sends the alert and resolves to the verification error.
+    std::optional<future<>> verify_and_send_alert() {
+        gnutls_alert_description_t cert_alert = GNUTLS_A_BAD_CERTIFICATE;
+        std::exception_ptr vex;
+        try {
+            verify(&cert_alert);
+        } catch (...) {
+            vex = std::current_exception();
+        }
+        if (!vex) {
+            return std::nullopt;
+        }
+        _error = vex;
+        return wait_for_output().then_wrapped([this, cert_alert, vex = std::move(vex)](future<> f) mutable {
+            f.ignore_ready_future();
+            return send_alert(GNUTLS_AL_FATAL, cert_alert).then_wrapped([vex = std::move(vex)](future<> f) mutable {
+                f.ignore_ready_future();
+                return make_exception_future<>(std::move(vex));
+            });
+        });
+    }
+
     future<> send_alert(gnutls_alert_level_t level, gnutls_alert_description_t desc) {
         return repeat([this, level, desc]() {
             auto res = gnutls_alert_send(*this, level, desc);
@@ -624,7 +649,13 @@ public:
                     return make_exception_future<>(verification_error("No certificate was found"));
 #if GNUTLS_VERSION_NUMBER >= 0x030406
                 case GNUTLS_E_CERTIFICATE_ERROR:
-                    verify(); // should throw. otherwise, fallthrough
+                    // Before propagating the error, send the appropriate TLS
+                    // alert to the peer so it gets a meaningful error rather
+                    // than an abrupt connection close.
+                    if (auto vf = verify_and_send_alert()) {
+                        return std::move(*vf);
+                    }
+                    // verify() didn't throw (cert verification disabled?), fall through
                     [[fallthrough]];
 #endif
                 default:
@@ -644,7 +675,12 @@ public:
                 }
             }
             if (_type == type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
-                verify();
+                // Certificate verification failed after successful TLS handshake.
+                // Send the appropriate alert to the peer so it gets a meaningful
+                // error rather than an abrupt connection close.
+                if (auto vf = verify_and_send_alert()) {
+                    return std::move(*vf);
+                }
             }
             _connected = true;
             // make sure we reset output_pending
@@ -742,7 +778,22 @@ public:
         return from_transport_ptr(ptr)->pull(dst, len);
     }
 
-    void verify() {
+    // Returns the TLS alert description appropriate for a certificate
+    // that failed verification with the given gnutls_certificate_verify_peers3 status.
+    static gnutls_alert_description_t cert_status_to_alert(unsigned int status) noexcept {
+        if (status & (GNUTLS_CERT_SIGNER_NOT_FOUND | GNUTLS_CERT_SIGNER_NOT_CA)) {
+            return GNUTLS_A_UNKNOWN_CA;
+        } else if (status & GNUTLS_CERT_REVOKED) {
+            return GNUTLS_A_CERTIFICATE_REVOKED;
+        } else if (status & GNUTLS_CERT_EXPIRED) {
+            return GNUTLS_A_CERTIFICATE_EXPIRED;
+        }
+        return GNUTLS_A_BAD_CERTIFICATE;
+    }
+
+    // out_alert, if non-null, is set to the appropriate TLS alert before
+    // verification_error is thrown, so the caller can send the alert to the peer.
+    void verify(gnutls_alert_description_t* out_alert = nullptr) {
         if (!_creds->_enable_certificate_verification) {
             return;
         }
@@ -769,6 +820,9 @@ public:
                 }
                 ss << "(Issuer=[" << dn->issuer << "], Subject=[" << dn->subject << "])";
                 stat_str = ss.str();
+            }
+            if (out_alert) {
+                *out_alert = cert_status_to_alert(status);
             }
             throw verification_error(stat_str);
         }

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -1202,6 +1202,20 @@ public:
             return extract_dn_information();
         });
     }
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() override {
+        return state_checked_access([this] {
+            auto peer = get_peer_certificate();
+            if (!peer) {
+                return std::optional<std::chrono::system_clock::time_point>{};
+            }
+            time_t t = gnutls_x509_crt_get_expiration_time(peer.get());
+            if (t == (time_t)-1) {
+                return std::optional<std::chrono::system_clock::time_point>{};
+            }
+            return std::optional<std::chrono::system_clock::time_point>{
+                std::chrono::system_clock::from_time_t(t)};
+        });
+    }
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) override {
         return state_checked_access([this](std::unordered_set<subject_alt_name_type> types) {
             std::vector<subject_alt_name> res;

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -40,6 +40,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <ctime>
 #include <functional>
 #include <span>
 #include <system_error>
@@ -1521,6 +1522,39 @@ public:
         }
         result_t dn = extract_dn_information(is_verification_error::no);
         return make_ready_future<result_t>(std::move(dn));
+    }
+
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() override {
+        using result_t = std::optional<std::chrono::system_clock::time_point>;
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(
+              std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!connected()) {
+            return handshake().then(
+              [this]() mutable { return get_certificate_expiry(); });
+        }
+        const auto peer_cert = get_peer_certificate();
+        if (!peer_cert) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        const ASN1_TIME* not_after = X509_get0_notAfter(peer_cert.get());
+        if (!not_after) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        struct tm tm = {};
+        if (ASN1_TIME_to_tm(not_after, &tm) != 1) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        time_t t = timegm(&tm);
+        if (t == (time_t)-1) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        return make_ready_future<result_t>(
+            std::chrono::system_clock::from_time_t(t));
     }
 
     future<std::vector<subject_alt_name>> get_alt_name_information(

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -40,6 +40,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <ctime>
 #include <functional>
 #include <ranges>
 #include <span>
@@ -1578,6 +1579,39 @@ public:
         }
         result_t dn = extract_dn_information(is_verification_error::no);
         return make_ready_future<result_t>(std::move(dn));
+    }
+
+    future<std::optional<std::chrono::system_clock::time_point>> get_certificate_expiry() override {
+        using result_t = std::optional<std::chrono::system_clock::time_point>;
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(
+              std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!connected()) {
+            return handshake().then(
+              [this]() mutable { return get_certificate_expiry(); });
+        }
+        const auto peer_cert = get_peer_certificate();
+        if (!peer_cert) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        const ASN1_TIME* not_after = X509_get0_notAfter(peer_cert.get());
+        if (!not_after) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        struct tm tm = {};
+        if (ASN1_TIME_to_tm(not_after, &tm) != 1) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        time_t t = timegm(&tm);
+        if (t == (time_t)-1) {
+            return make_ready_future<result_t>(std::nullopt);
+        }
+        return make_ready_future<result_t>(
+            std::chrono::system_clock::from_time_t(t));
     }
 
     future<std::vector<subject_alt_name>> get_alt_name_information(

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -2736,3 +2736,127 @@ SEASTAR_TEST_CASE(test_request_scheduling_group) {
         }
     });
 }
+
+// Verify that when mTLS is configured with client_auth::REQUIRE, the client
+// certificate's Distinguished Name (DN) is extracted during the TLS handshake
+// and propagated into every http::request via req._tls_dn, so that handlers
+// can perform certificate-based authentication.
+SEASTAR_TEST_CASE(test_mtls_dn_propagation) {
+    return seastar::async([] {
+        // Self-signed CA (CN=server.com) that signs both the server and client certificates below.
+        static const char mtls_ca_cert[] =
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBkTCCATagAwIBAgIUHAGWAd2vYMIUpcWjOX8J2d4DCX4wCgYIKoZIzj0EAwIw\n"
+            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
+            "OTE4MjZaMBUxEzARBgNVBAMMCnNlcnZlci5jb20wWTATBgcqhkjOPQIBBggqhkjO\n"
+            "PQMBBwNCAASbsF3KPrYN03EHUBgmaTx8F3g2WHySxf1WAJMNA9KwPlSTpDCISXFQ\n"
+            "7vvXdbMnHzZuSH1t+QcODxZIFtx1D3sUo2QwYjAdBgNVHQ4EFgQUN/Ct/ixGWTdj\n"
+            "cgk8KeW0JtVgGlQwHwYDVR0jBBgwFoAUN/Ct/ixGWTdjcgk8KeW0JtVgGlQwDwYD\n"
+            "VR0RBAgwBocEfwAAATAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYC\n"
+            "IQDwOqCG4WYzj80SYkTaeiMxebJx6c3LvWyq/k9pyNyOQgIhAKBzeJWNd1r4HEAd\n"
+            "WHxi6RD5GDWWr7OzXhNNfwg66KEa\n"
+            "-----END CERTIFICATE-----\n";
+        // Server certificate: CN=server.server.com, signed by the CA above.
+        static const char mtls_server_cert[] =
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBdTCCARugAwIBAgIUC8xHpJtk5p3k3fFNIeburBRUqEcwCgYIKoZIzj0EAwIw\n"
+            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
+            "OTE4MjZaMBwxGjAYBgNVBAMMEXNlcnZlci5zZXJ2ZXIuY29tMFkwEwYHKoZIzj0C\n"
+            "AQYIKoZIzj0DAQcDQgAEPZJywC1vMYfkDjWlUSQJ71Wbea0N8VHBtkhreqGg0Yx5\n"
+            "32ZKUB4Tyr1urH/Q3mw6rL4hfJ3+RREtkDGOhYeKHKNCMEAwHQYDVR0OBBYEFA7S\n"
+            "KzBfmLHVa4OhtlxdBAnoN2rWMB8GA1UdIwQYMBaAFDfwrf4sRlk3Y3IJPCnltCbV\n"
+            "YBpUMAoGCCqGSM49BAMCA0gAMEUCIQDSQPxyVY6wR8rlCeqGu/7Kw3a7Zy0dNvWZ\n"
+            "NBLC3K00AgIgde5xN8bBO/HORzfxATxHUNU52aQVYN4XRvXvZuB5D28=\n"
+            "-----END CERTIFICATE-----\n";
+        static const char mtls_server_key[] =
+            "-----BEGIN EC PRIVATE KEY-----\n"
+            "MHcCAQEEICzgEWTe2FDq9e9+K+9UgiN5wVsT/biFBON8n80GgrwpoAoGCCqGSM49\n"
+            "AwEHoUQDQgAEPZJywC1vMYfkDjWlUSQJ71Wbea0N8VHBtkhreqGg0Yx532ZKUB4T\n"
+            "yr1urH/Q3mw6rL4hfJ3+RREtkDGOhYeKHA==\n"
+            "-----END EC PRIVATE KEY-----\n";
+        // Client certificate: CN=client.server.com, signed by the CA above.
+        static const char mtls_client_cert[] =
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBdTCCARugAwIBAgIUC8xHpJtk5p3k3fFNIeburBRUqEgwCgYIKoZIzj0EAwIw\n"
+            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
+            "OTE4MjZaMBwxGjAYBgNVBAMMEWNsaWVudC5zZXJ2ZXIuY29tMFkwEwYHKoZIzj0C\n"
+            "AQYIKoZIzj0DAQcDQgAEDrhgfDYXOTNmK5OJFcD6Frk1SMfyxM0K6gtxWK0kEex3\n"
+            "vYUAEuESkboyF07yOUwZAnUDzquAO8xTeTJY3POuYqNCMEAwHQYDVR0OBBYEFBZF\n"
+            "A9LwGwhBHhsIiRI1KYCVymKDMB8GA1UdIwQYMBaAFDfwrf4sRlk3Y3IJPCnltCbV\n"
+            "YBpUMAoGCCqGSM49BAMCA0gAMEUCIQDZ/I/CUmkSPmyQAgEU2d04pVp3Cu0tQZpX\n"
+            "PxVvseCJBQIgdpuFxONoYHHNxjq0NpvRx6VLUrjJKb1LjGhWmzzU3zE=\n"
+            "-----END CERTIFICATE-----\n";
+        static const char mtls_client_key[] =
+            "-----BEGIN EC PRIVATE KEY-----\n"
+            "MHcCAQEEIOPelbFn46IcU/d8uNhj6EE/14PDYfDWFKaPnhUCiwYcoAoGCCqGSM49\n"
+            "AwEHoUQDQgAEDrhgfDYXOTNmK5OJFcD6Frk1SMfyxM0K6gtxWK0kEex3vYUAEuES\n"
+            "kboyF07yOUwZAnUDzquAO8xTeTJY3POuYg==\n"
+            "-----END EC PRIVATE KEY-----\n";
+
+        // Server requires a client certificate signed by the CA.
+        tls::credentials_builder server_builder;
+        server_builder.set_x509_trust(
+                tls::blob(mtls_ca_cert, sizeof(mtls_ca_cert) - 1),
+                tls::x509_crt_format::PEM);
+        server_builder.set_x509_key(
+                tls::blob(mtls_server_cert, sizeof(mtls_server_cert) - 1),
+                tls::blob(mtls_server_key, sizeof(mtls_server_key) - 1),
+                tls::x509_crt_format::PEM);
+        server_builder.set_client_auth(tls::client_auth::REQUIRE);
+        auto server_creds = server_builder.build_server_credentials();
+
+        // Client presents its certificate to satisfy the server's REQUIRE policy.
+        tls::credentials_builder client_builder;
+        client_builder.set_x509_trust(
+                tls::blob(mtls_ca_cert, sizeof(mtls_ca_cert) - 1),
+                tls::x509_crt_format::PEM);
+        client_builder.set_x509_key(
+                tls::blob(mtls_client_cert, sizeof(mtls_client_cert) - 1),
+                tls::blob(mtls_client_key, sizeof(mtls_client_key) - 1),
+                tls::x509_crt_format::PEM);
+        auto client_creds = client_builder.build_certificate_credentials();
+
+        std::optional<session_dn> observed_dn;
+
+        auto addr = socket_address(ipv4_addr("127.0.0.1", 0));
+        listen_options lo;
+        lo.reuse_address = true;
+        lo.set_fixed_cpu(this_shard_id());
+
+        http_server server("test");
+        server._routes.put(GET, "/test", new function_handler([&observed_dn](const_req req, http::reply&) {
+            observed_dn = req._tls_dn;
+            return sstring{};
+        }, "txt"));
+
+        server.listen(addr, lo, server_creds).get();
+        auto actual_addr = http_server_tester::listeners(server)[0].local_address();
+
+        // Run the client in a separate fiber so the reactor can
+        // interleave client and server TLS handshake progress.
+        future<> client_fiber = seastar::async([&] {
+            auto c_socket = tls::connect(client_creds, actual_addr,
+                    tls::tls_options{.server_name = sstring("server.server.com")}).get();
+            auto input = c_socket.input();
+            auto output = c_socket.output();
+            auto close_in = deferred_close(input);
+            auto close_out = deferred_close(output);
+
+            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\n\r\n")).get();
+            output.flush().get();
+            auto resp = input.read().get();
+            BOOST_REQUIRE_NE(resp.size(), 0u);
+            BOOST_REQUIRE_NE(std::string(resp.get(), resp.size()).find("200 OK"), std::string::npos);
+        });
+
+        client_fiber.get();
+
+        // The handler must have received a populated _tls_dn matching the
+        // client certificate (CN=client.server.com) issued by the CA (CN=server.com).
+        BOOST_REQUIRE(observed_dn.has_value());
+        BOOST_REQUIRE_NE(observed_dn->subject.find("client.server.com"), sstring::npos);
+        BOOST_REQUIRE_NE(observed_dn->issuer.find("server.com"), sstring::npos);
+
+        server.stop().get();
+    });
+}

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -35,6 +35,8 @@
 #include <seastar/http/json_path.hh>
 #include <seastar/http/response_parser.hh>
 #include <sstream>
+#include <cstdlib>
+#include <ctime>
 #include <seastar/core/shared_future.hh>
 #include <seastar/http/client.hh>
 #include <seastar/http/url.hh>
@@ -2913,6 +2915,221 @@ SEASTAR_TEST_CASE(test_mtls_san_propagation) {
         };
         BOOST_REQUIRE(has_san(tls::subject_alt_name_type::dnsname, "san-client.server.com"));
         BOOST_REQUIRE(has_san(tls::subject_alt_name_type::uri, "spiffe://example.com/client"));
+
+        server.stop().get();
+    });
+}
+
+// Format a time_point as an ASN.1 GeneralizedTime string (YYYYMMDDHHMMSSZ),
+// suitable for openssl's -not_before/-not_after options.
+static std::string to_asn1_time(std::chrono::system_clock::time_point tp) {
+    auto t = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm;
+    ::gmtime_r(&t, &tm);
+    char buf[sizeof("YYYYMMDDHHMMSSZ")];
+    std::strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &tm);
+    return std::string(buf);
+}
+
+// Verify that if a client certificate expires while a keep-alive mTLS
+// connection stays open, the server rejects further requests on that same
+// connection with 401 "Client certificate has expired" (src/http/httpd.cc,
+// connection::read_one()). This test is unavoidably timing-based: it signs
+// a very short-lived client certificate (issued with the existing mtls_ca
+// certificate authority) immediately before connecting, and sleeps until
+// just past its expiry before the second request.
+//
+// Note if a client certificate is *already* expired when the connection is
+// being established, the error handling is different from what we check here -
+// The lower-level TLS implementation will reject the handshake before the
+// connection is ever handed to the http server. That case is tested below in
+// a separate test - test_mtls_client_cert_already_expired().
+SEASTAR_TEST_CASE(test_mtls_client_cert_expiry) {
+    return seastar::async([] {
+        // How long the freshly-signed client certificate remains valid for,
+        // starting from just before the connection is established. Only
+        // needs to comfortably outlast certificate signing + the TLS
+        // handshake + one HTTP round trip.
+        constexpr auto validity = std::chrono::seconds(2);
+
+        tmpdir tmp;
+        auto client_key = (tmp.path() / "expiry_client.key").string();
+        auto client_csr = (tmp.path() / "expiry_client.csr").string();
+        auto client_crt = (tmp.path() / "expiry_client.crt").string();
+
+        auto run = [](sstring cmd) {
+            BOOST_REQUIRE_EQUAL(std::system(cmd.c_str()), 0);
+        };
+
+        // Key generation and the CSR aren't time-sensitive, so do them
+        // up front, before starting the validity-window clock.
+        run(seastar::format("openssl ecparam -name prime256v1 -genkey -noout -out {}", client_key));
+        run(seastar::format("openssl req -new -sha256 -key {} -subj /CN=expiry-client.org -out {}", client_key, client_csr));
+
+        // Uses build-system generated mtls_ca.crt/mtls_ca.key (the same CA
+        // that signs mtls_server.crt and mtls_client1.crt elsewhere in this
+        // file) as the issuer for the short-lived client certificate.
+        auto expiry = std::chrono::system_clock::now() + validity;
+        run(seastar::format("openssl x509 -req -sha256 -in {} -CA {} -CAkey {} -set_serial 1000 "
+                    "-not_before {} -not_after {} -out {}",
+                    client_csr, certfile("mtls_ca.crt"), certfile("mtls_ca.key"),
+                    to_asn1_time(std::chrono::system_clock::now() - std::chrono::hours(1)),
+                    to_asn1_time(expiry), client_crt));
+
+        tls::credentials_builder server_builder;
+        server_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        server_builder.set_x509_key_file(certfile("mtls_server.crt"), certfile("mtls_server.key"), tls::x509_crt_format::PEM).get();
+        server_builder.set_client_auth(tls::client_auth::REQUIRE);
+        auto server_creds = server_builder.build_server_credentials();
+
+        tls::credentials_builder client_builder;
+        client_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        client_builder.set_x509_key_file(client_crt, client_key, tls::x509_crt_format::PEM).get();
+        auto client_creds = client_builder.build_certificate_credentials();
+
+        auto addr = socket_address(ipv4_addr("127.0.0.1", 0));
+        listen_options lo;
+        lo.reuse_address = true;
+        lo.set_fixed_cpu(this_shard_id());
+
+        http_server server("test");
+        server._routes.put(GET, "/test", new function_handler([](const_req req) {
+            return "";
+        }, "txt"));
+
+        server.listen(addr, lo, server_creds).get();
+        auto actual_addr = http_server_tester::listeners(server)[0].local_address();
+
+        // Run the client in a separate fiber so the reactor can
+        // interleave client and server TLS handshake progress.
+        future<> client_fiber = seastar::async([&] {
+            auto c_socket = tls::connect(client_creds, actual_addr,
+                    tls::tls_options{.server_name = sstring("server.redpanda.com")}).get();
+            auto input = c_socket.input();
+            auto output = c_socket.output();
+            auto close_in = deferred_close(input);
+            auto close_out = deferred_close(output);
+
+            // First request: the certificate is still valid, so it succeeds.
+            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\n\r\n")).get();
+            output.flush().get();
+            auto resp1 = input.read().get();
+            BOOST_REQUIRE_NE(resp1.size(), 0u);
+            BOOST_REQUIRE_NE(std::string(resp1.get(), resp1.size()).find("200 OK"), std::string::npos);
+
+            // Sleep until we know the client certificate has expired:
+            auto remaining = expiry + std::chrono::milliseconds(10) - std::chrono::system_clock::now();
+            if (remaining > remaining.zero()) {
+                seastar::sleep(std::chrono::duration_cast<std::chrono::milliseconds>(remaining)).get();
+            }
+
+            // Second request, on the same connection: the client certificate
+            // expiry is now in the past, so the server rejects it.
+            output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\n\r\n")).get();
+            output.flush().get();
+            auto resp2 = input.read().get();
+            BOOST_REQUIRE_NE(resp2.size(), 0u);
+            std::string resp2_str(resp2.get(), resp2.size());
+            BOOST_REQUIRE_NE(resp2_str.find("401"), std::string::npos);
+            BOOST_REQUIRE_NE(resp2_str.find("Client certificate has expired"), std::string::npos);
+        });
+
+        client_fiber.get();
+
+        server.stop().get();
+    });
+}
+
+// Verify that a client certificate that is *already* expired when the
+// connection is being established is rejected during the TLS handshake's
+// own certificate verification (this is true for both GnuTLS and OpenSSL
+// backends), rather than ever reaching connection::prepare()'s post-handshake
+// expiry check. The two backends surface the rejection to the client a little
+// differently -- OpenSSL throws on connect()/the first read or write, GnuTLS
+// instead (at least, when this test was written) just closes the connection,
+// which shows up as a clean (zero-byte) read with no exception. So this test
+// accepts either kind of errors as evidence of rejection and also confirms it
+// via the server's tls_handshake_errors() counter.
+SEASTAR_TEST_CASE(test_mtls_client_cert_already_expired) {
+    return seastar::async([] {
+        tmpdir tmp;
+        auto client_key = (tmp.path() / "expired_client.key").string();
+        auto client_csr = (tmp.path() / "expired_client.csr").string();
+        auto client_crt = (tmp.path() / "expired_client.crt").string();
+
+        auto run = [](sstring cmd) {
+            BOOST_REQUIRE_EQUAL(std::system(cmd.c_str()), 0);
+        };
+
+        run(seastar::format("openssl ecparam -name prime256v1 -genkey -noout -out {}", client_key));
+        run(seastar::format("openssl req -new -sha256 -key {} -subj /CN=already-expired-client.org -out {}", client_key, client_csr));
+        // A validity window that is in the past regardless of when
+        // this test actually runs.
+        run(seastar::format("openssl x509 -req -sha256 -in {} -CA {} -CAkey {} -set_serial 1001 "
+                    "-not_before {} -not_after {} -out {}",
+                    client_csr, certfile("mtls_ca.crt"), certfile("mtls_ca.key"),
+                    "20200101000000Z", "20200102000000Z", client_crt));
+
+        tls::credentials_builder server_builder;
+        server_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        server_builder.set_x509_key_file(certfile("mtls_server.crt"), certfile("mtls_server.key"), tls::x509_crt_format::PEM).get();
+        server_builder.set_client_auth(tls::client_auth::REQUIRE);
+        auto server_creds = server_builder.build_server_credentials();
+
+        tls::credentials_builder client_builder;
+        client_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        client_builder.set_x509_key_file(client_crt, client_key, tls::x509_crt_format::PEM).get();
+        auto client_creds = client_builder.build_certificate_credentials();
+
+        auto addr = socket_address(ipv4_addr("127.0.0.1", 0));
+        listen_options lo;
+        lo.reuse_address = true;
+        lo.set_fixed_cpu(this_shard_id());
+
+        http_server server("test");
+        server._routes.put(GET, "/test", new function_handler([](const_req req) {
+            return "";
+        }, "txt"));
+
+        server.listen(addr, lo, server_creds).get();
+        auto actual_addr = http_server_tester::listeners(server)[0].local_address();
+
+        BOOST_REQUIRE_EQUAL(server.tls_handshake_errors(), 0u);
+
+        // As explained above, we can learn the handshake was rejected either
+        // an exception, or by the server abruptly closing the connection
+        // (which shows up like an EOF, i.e., a zero-byte read).
+        // A real HTTP response (in particular a "200 OK" or even "401 Client
+        // Certificate Expired") would mean the certificate was wrongly
+        // accepted or rejected at an unexpected layer.
+        future<> client_fiber = seastar::async([&] {
+            try {
+                auto c_socket = tls::connect(client_creds, actual_addr,
+                        tls::tls_options{.server_name = sstring("server.redpanda.com")}).get();
+                auto input = c_socket.input();
+                auto output = c_socket.output();
+                auto close_in = deferred_close(input);
+                auto close_out = deferred_close(output);
+
+                output.write(sstring("GET /test HTTP/1.1\r\nHost: test\r\n\r\n")).get();
+                output.flush().get();
+                auto resp = input.read().get();
+                // Expected: the server closed the connection during TLS
+                // handshake verification, so we got a zero-byte read.
+                BOOST_REQUIRE_EQUAL(resp.size(), 0u);
+            } catch (...) {
+                // Expected: the handshake failed once forced to complete.
+            }
+        });
+
+        client_fiber.get();
+
+        // Give the server a moment to process the failed connection.
+        seastar::sleep(std::chrono::milliseconds(100)).get();
+
+        // Confirm the rejection happened during TLS handshake verification,
+        // not merely e.g. a client giving up for an unrelated reason.
+        BOOST_REQUIRE_GE(server.tls_handshake_errors(), 1u);
 
         server.stop().get();
     });


### PR DESCRIPTION
    http: refuse requests on connections with an expired client certificate
    
    TLS certificate verification at handshake time already rejects expired
    certificates, but this only protects against expired certs at connection
    establishment. On long-lived connections a client certificate can expire
    while the connection is still open; subsequent requests on that connection
    were previously accepted without any expiry check.
    
    To close this gap, add tls::get_certificate_expiry(), which extracts the
    notAfter field from the peer's leaf certificate after the TLS handshake.
    Implemented for both GnuTLS (gnutls_x509_crt_get_expiration_time) and
    OpenSSL (X509_get0_notAfter + ASN1_TIME_to_tm).
    
    The HTTP server fetches the expiry in connection::prepare() alongside the
    DN, stores it on the connection, and checks it in read_one() before
    dispatching each request. If the current time is past the expiry, the
    request is refused with 401 Unauthorized and the connection is closed.