### PR TITLE
http: reject requests with oversized URL or headers

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -134,6 +134,7 @@ class http_server {
     sstring _date = http_date();
     timer<> _date_format_timer { [this] {_date = http_date();} };
     size_t _content_length_limit = std::numeric_limits<size_t>::max();
+    size_t _request_size_limit = 32 * 1024;
     bool _content_streaming = false;
     std::optional<sstring> _server_header = sstring("Seastar httpd");
     bool _generate_date_header = true;
@@ -155,6 +156,15 @@ public:
     size_t get_content_length_limit() const;
 
     void set_content_length_limit(size_t limit);
+
+    /// Returns the combined size limit for the request line and headers.
+    size_t get_request_size_limit() const;
+
+    /// Sets the combined size limit for the request line and headers. Requests
+    /// exceeding it are rejected with 400 Bad Request before the handler runs,
+    /// bounding the memory a client can force the server to buffer. Defaults to
+    /// 32 KiB.
+    void set_request_size_limit(size_t limit);
 
     bool get_content_streaming() const;
 

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -97,6 +97,7 @@ struct reply {
         unprocessable_entity = 422, //!< unprocessable_entity
         upgrade_required = 426, //!< upgrade_required
         too_many_requests = 429, //!< too_many_requests
+        request_header_fields_too_large = 431, //!< request_header_fields_too_large
         login_timeout = 440, //!< login_timeout
         internal_server_error = 500, //!< internal_server_error
         not_implemented = 501, //!< not_implemented

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -201,6 +201,7 @@ void connection::generate_error_reply_and_close(std::unique_ptr<http::request> r
 
 future<> connection::read_one() {
     _parser.init();
+    _parser.set_size_limit(_server.get_request_size_limit());
     return _read_buf.consume(_parser).then([this] () mutable {
         if (_parser.eof()) {
             _done = true;
@@ -214,6 +215,13 @@ future<> connection::read_one() {
 
         if (_tls) {
             req->protocol_name = "https";
+        }
+        if (_parser.size_limit_exceeded()) {
+            if (req->_version.empty()) {
+                req->_version = "1.1";
+            }
+            generate_error_reply_and_close(std::move(req), http::reply::status_type::bad_request, "Request header or URL too large");
+            return make_ready_future<>();
         }
         if (_parser.failed()) {
             if (req->_version.empty()) {
@@ -370,6 +378,14 @@ size_t http_server::get_content_length_limit() const {
 
 void http_server::set_content_length_limit(size_t limit) {
     _content_length_limit = limit;
+}
+
+size_t http_server::get_request_size_limit() const {
+    return _request_size_limit;
+}
+
+void http_server::set_request_size_limit(size_t limit) {
+    _request_size_limit = limit;
 }
 
 bool http_server::get_content_streaming() const {

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -216,17 +216,17 @@ future<> connection::read_one() {
         if (_tls) {
             req->protocol_name = "https";
         }
-        if (_parser.size_limit_exceeded()) {
-            if (req->_version.empty()) {
-                req->_version = "1.1";
-            }
-            generate_error_reply_and_close(std::move(req), http::reply::status_type::bad_request, "Request header or URL too large");
-            return make_ready_future<>();
-        }
         if (_parser.failed()) {
             if (req->_version.empty()) {
                 // we might have failed to parse even the version
                 req->_version = "1.1";
+            }
+            if (_parser.size_limit_exceeded()) {
+                auto status = _parser.uri_too_large()
+                        ? http::reply::status_type::uri_too_long
+                        : http::reply::status_type::request_header_fields_too_large;
+                generate_error_reply_and_close(std::move(req), status, "Request line or headers too large");
+                return make_ready_future<>();
             }
             generate_error_reply_and_close(std::move(req), http::reply::status_type::bad_request, "Can't parse the request");
             return make_ready_future<>();

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -79,6 +79,7 @@ static const std::unordered_map<reply::status_type, std::string_view> status_str
     {reply::status_type::unprocessable_entity, "422 Unprocessable Entity"},
     {reply::status_type::upgrade_required, "426 Upgrade Required"},
     {reply::status_type::too_many_requests, "429 Too Many Requests"},
+    {reply::status_type::request_header_fields_too_large, "431 Request Header Fields Too Large"},
     {reply::status_type::login_timeout, "440 Login Timeout"},
     {reply::status_type::internal_server_error, "500 Internal Server Error"},
     {reply::status_type::not_implemented, "501 Not Implemented"},

--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/core/ragel.hh>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <seastar/http/request.hh>
@@ -131,19 +132,27 @@ public:
         error,
         eof,
         done,
+        too_large,
     };
     std::unique_ptr<http::request> _req;
     sstring _field_name;
     sstring _value;
     state _state;
+    size_t _size_limit = std::numeric_limits<size_t>::max();
+    size_t _parsed_size = 0;
 public:
     void init() {
         init_base();
         _req.reset(new http::request());
         _state = state::eof;
+        _parsed_size = 0;
         %% write init;
     }
+    void set_size_limit(size_t limit) {
+        _size_limit = limit;
+    }
     char* parse(char* p, char* pe, char* eof) {
+        char* start = p;
         sstring_builder::guard g(_builder, p, pe);
         [[maybe_unused]] auto str = [this, &g, &p] { g.mark_end(p); return get_str(); };
         bool done = false;
@@ -172,6 +181,15 @@ public:
         } else {
             _state = state::done;
         }
+        // Bound the request line and headers so a client can't force the server
+        // to buffer unbounded memory before the handler runs (issue #2698).
+        _parsed_size += (p ? p : pe) - start;
+        if (_state != state::error && _parsed_size > _size_limit) {
+            _state = state::too_large;
+            if (!p) {
+                p = pe;
+            }
+        }
         return p;
     }
     auto get_parsed_request() {
@@ -182,6 +200,9 @@ public:
     }
     bool failed() const {
         return _state == state::error;
+    }
+    bool size_limit_exceeded() const {
+        return _state == state::too_large;
     }
 };
 

--- a/src/http/request_parser.rl
+++ b/src/http/request_parser.rl
@@ -54,6 +54,12 @@ action store_version {
     _req->_version = str();
 }
 
+action mark_request_line_end {
+    // Absolute byte offset of the end of the request line, so an oversized
+    // request can be attributed to the URI (414) vs the header fields (431).
+    _request_line_size = _parsed_size + (p - start);
+}
+
 action store_field_name {
     _field_name = str();
 }
@@ -117,7 +123,7 @@ field_content = (field_vchar | sp_ht)*;
 
 field = tchar+ >mark %store_field_name;
 value = field_content >mark %trim_trailing_whitespace_and_store_value;
-start_line = ((operation sp uri sp http_version) -- crlf) crlf;
+start_line = ((operation sp uri sp http_version) -- crlf) crlf %mark_request_line_end;
 header_1st = (field ':' sp_ht* <: value crlf) %assign_field;
 header_cont = (sp_ht+ <: value crlf) %extend_field;
 header = header_1st header_cont*;
@@ -140,12 +146,14 @@ public:
     state _state;
     size_t _size_limit = std::numeric_limits<size_t>::max();
     size_t _parsed_size = 0;
+    size_t _request_line_size = 0;
 public:
     void init() {
         init_base();
         _req.reset(new http::request());
         _state = state::eof;
         _parsed_size = 0;
+        _request_line_size = 0;
         %% write init;
     }
     void set_size_limit(size_t limit) {
@@ -199,10 +207,21 @@ public:
         return _state == state::eof;
     }
     bool failed() const {
-        return _state == state::error;
+        // An oversized request is a parse failure too, so callers only need to
+        // check failed() to know whether parsing succeeded; size_limit_exceeded()
+        // then tells them why, to pick the right HTTP status.
+        return _state == state::error || _state == state::too_large;
     }
     bool size_limit_exceeded() const {
         return _state == state::too_large;
+    }
+    // Only meaningful when size_limit_exceeded(). True when the URI is what
+    // overflowed the limit -- either the request line never finished (still
+    // reading the URI) or the request line alone already exceeded the limit --
+    // as opposed to the header fields pushing the request over.
+    bool uri_too_large() const {
+        return _state == state::too_large &&
+                (_request_line_size == 0 || _request_line_size > _size_limit);
     }
 };
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -880,6 +880,47 @@ SEASTAR_TEST_CASE(content_length_limit) {
     });
 }
 
+SEASTAR_TEST_CASE(request_size_limit) {
+    return seastar::async([] {
+        loopback_connection_factory lcf(1);
+        http_server server("test");
+        server.set_request_size_limit(1024);
+        httpd::http_server_tester::listeners(server).emplace_back(lcf.get_server_socket());
+
+        future<> client = seastar::async([&lcf] {
+            auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
+            auto check_status = [&cln] (sstring header_value, http::reply::status_type expected) {
+                auto req = http::request::make("GET", "test", "/test");
+                if (!header_value.empty()) {
+                    req._headers["X-Big"] = std::move(header_value);
+                }
+                std::optional<http::reply::status_type> status;
+                cln.make_request(std::move(req), [&status] (const http::reply& rep, input_stream<char>&& in) {
+                    status = rep._status;
+                    return seastar::async([in = std::move(in)] () mutable {
+                        util::skip_entire_stream(in).get();
+                        in.close().get();
+                    });
+                }).get();
+                BOOST_REQUIRE(status.has_value());
+                BOOST_REQUIRE_EQUAL(status.value(), expected);
+            };
+
+            check_status("",                  http::reply::status_type::ok);
+            check_status(sstring(4096, 'x'),   http::reply::status_type::bad_request); // over limit
+
+            cln.close().get();
+        });
+
+        auto handler = new json_test_handler(json::stream_object("hello"));
+        server._routes.put(GET, "/test", handler);
+        server.do_accepts(0).get();
+
+        client.get();
+        server.stop().get();
+    });
+}
+
 SEASTAR_TEST_CASE(test_client_unexpected_reply_status) {
     return seastar::async([] {
         class handl : public httpd::handler_base {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -889,8 +889,8 @@ SEASTAR_TEST_CASE(request_size_limit) {
 
         future<> client = seastar::async([&lcf] {
             auto cln = http::client(std::make_unique<loopback_http_factory>(lcf));
-            auto check_status = [&cln] (sstring header_value, http::reply::status_type expected) {
-                auto req = http::request::make("GET", "test", "/test");
+            auto check_status = [&cln] (sstring path, sstring header_value, http::reply::status_type expected) {
+                auto req = http::request::make("GET", "test", std::move(path));
                 if (!header_value.empty()) {
                     req._headers["X-Big"] = std::move(header_value);
                 }
@@ -906,8 +906,10 @@ SEASTAR_TEST_CASE(request_size_limit) {
                 BOOST_REQUIRE_EQUAL(status.value(), expected);
             };
 
-            check_status("",                  http::reply::status_type::ok);
-            check_status(sstring(4096, 'x'),   http::reply::status_type::bad_request); // over limit
+            check_status("/test", "", http::reply::status_type::ok);
+            // Oversized headers are rejected with 431, an oversized URI with 414.
+            check_status("/test", sstring(4096, 'x'), http::reply::status_type::request_header_fields_too_large);
+            check_status("/" + sstring(4096, 'x'), "", http::reply::status_type::uri_too_long);
 
             cln.close().get();
         });

--- a/tests/unit/request_parser_test.cc
+++ b/tests/unit/request_parser_test.cc
@@ -72,3 +72,53 @@ SEASTAR_TEST_CASE(test_header_parsing) {
     }
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_request_size_limit) {
+    struct test_set {
+        sstring msg;
+        size_t limit;
+        bool too_large;
+
+        temporary_buffer<char> buf() {
+            return temporary_buffer<char>(msg.c_str(), msg.size());
+        }
+    };
+
+    sstring big_uri = "GET /" + sstring(1024, 'a') + " HTTP/1.1\r\nHost: test\r\n\r\n";
+    sstring big_header = "GET /test HTTP/1.1\r\nX-Big: " + sstring(1024, 'a') + "\r\n\r\n";
+
+    std::vector<test_set> tests = {
+        { "GET /test HTTP/1.1\r\nHost: test\r\n\r\n", 64, false },
+        { big_uri, 64, true },
+        { big_header, 64, true },
+        { big_uri, 4096, false },
+    };
+
+    http_request_parser parser;
+    for (auto& tset : tests) {
+        parser.init();
+        parser.set_size_limit(tset.limit);
+        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
+        BOOST_REQUIRE_EQUAL(parser.size_limit_exceeded(), tset.too_large);
+    }
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_request_size_limit_scattered) {
+    // The limit must hold when a single oversized header is split across
+    // buffers, since the parser accumulates it before the request completes.
+    sstring part1 = "GET /test HTTP/1.1\r\nX-Big: " + sstring(200, 'a');
+    sstring part2 = sstring(400, 'a') + "\r\n\r\n";
+    auto feed = [] (http_request_parser& parser, const sstring& s) {
+        return parser(temporary_buffer<char>(s.c_str(), s.size())).get();
+    };
+
+    http_request_parser parser;
+    parser.init();
+    parser.set_size_limit(512);
+    BOOST_REQUIRE(!feed(parser, part1).has_value());
+    BOOST_REQUIRE(!parser.size_limit_exceeded());
+    feed(parser, part2);
+    BOOST_REQUIRE(parser.size_limit_exceeded());
+    return make_ready_future<>();
+}

--- a/tests/unit/request_parser_test.cc
+++ b/tests/unit/request_parser_test.cc
@@ -78,6 +78,7 @@ SEASTAR_TEST_CASE(test_request_size_limit) {
         sstring msg;
         size_t limit;
         bool too_large;
+        bool uri_too_large;
 
         temporary_buffer<char> buf() {
             return temporary_buffer<char>(msg.c_str(), msg.size());
@@ -88,10 +89,10 @@ SEASTAR_TEST_CASE(test_request_size_limit) {
     sstring big_header = "GET /test HTTP/1.1\r\nX-Big: " + sstring(1024, 'a') + "\r\n\r\n";
 
     std::vector<test_set> tests = {
-        { "GET /test HTTP/1.1\r\nHost: test\r\n\r\n", 64, false },
-        { big_uri, 64, true },
-        { big_header, 64, true },
-        { big_uri, 4096, false },
+        { "GET /test HTTP/1.1\r\nHost: test\r\n\r\n", 64, false, false },
+        { big_uri, 64, true, true },     // the URI itself overflows -> 414
+        { big_header, 64, true, false }, // the header fields overflow -> 431
+        { big_uri, 4096, false, false },
     };
 
     http_request_parser parser;
@@ -100,6 +101,10 @@ SEASTAR_TEST_CASE(test_request_size_limit) {
         parser.set_size_limit(tset.limit);
         BOOST_REQUIRE(parser(tset.buf()).get().has_value());
         BOOST_REQUIRE_EQUAL(parser.size_limit_exceeded(), tset.too_large);
+        // An oversized request must also report as failed(), so a single check
+        // tells callers parsing did not succeed.
+        BOOST_REQUIRE_EQUAL(parser.failed(), tset.too_large);
+        BOOST_REQUIRE_EQUAL(parser.uri_too_large(), tset.uri_too_large);
     }
     return make_ready_future<>();
 }
@@ -120,5 +125,6 @@ SEASTAR_TEST_CASE(test_request_size_limit_scattered) {
     BOOST_REQUIRE(!parser.size_limit_exceeded());
     feed(parser, part2);
     BOOST_REQUIRE(parser.size_limit_exceeded());
+    BOOST_REQUIRE(parser.failed());
     return make_ready_future<>();
 }


### PR DESCRIPTION
Fixes #2698.

The HTTP request parser buffered the request line and all headers with no upper bound, so a client could force unbounded allocation — one huge header (contiguous) or many headers (non-contiguous) — and OOM the server before the handler runs. The handler cannot guard against this since it only sees a fully-parsed request.

Track the bytes consumed for the request line + headers in the parser and reject once a configurable limit is exceeded. The limit is a single combined bound on the request line and headers, defaulting to 32 KiB and settable via `http_server::set_request_size_limit()`, mirroring the existing `content_length_limit` plumbing. Adds parser-level (single-buffer + scattered) and end-to-end tests.

Update addressing review: an oversized request now also makes the parser `failed()` return true (callers check one condition; `size_limit_exceeded()` explains why). The response is 414 (URI Too Long) when the URI overflows and 431 (Request Header Fields Too Large) otherwise, distinguished by the recorded request-line length; adds the 431 `status_type`.