### PR TITLE
net/tls: send TLS alert when client certificate verification fails

### DIFF
--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -575,6 +575,31 @@ public:
         return s;
     }
 
+    // Calls verify() and, if verification fails, sends the appropriate TLS alert
+    // to the peer before propagating the exception. Returns nullopt when
+    // verification succeeded (caller should continue normally), or a future
+    // that sends the alert and resolves to the verification error.
+    std::optional<future<>> verify_and_send_alert() {
+        gnutls_alert_description_t cert_alert = GNUTLS_A_BAD_CERTIFICATE;
+        std::exception_ptr vex;
+        try {
+            verify(&cert_alert);
+        } catch (...) {
+            vex = std::current_exception();
+        }
+        if (!vex) {
+            return std::nullopt;
+        }
+        _error = vex;
+        return wait_for_output().then_wrapped([this, cert_alert, vex = std::move(vex)](future<> f) mutable {
+            f.ignore_ready_future();
+            return send_alert(GNUTLS_AL_FATAL, cert_alert).then_wrapped([vex = std::move(vex)](future<> f) mutable {
+                f.ignore_ready_future();
+                return make_exception_future<>(std::move(vex));
+            });
+        });
+    }
+
     future<> send_alert(gnutls_alert_level_t level, gnutls_alert_description_t desc) {
         return repeat([this, level, desc]() {
             auto res = gnutls_alert_send(*this, level, desc);
@@ -624,7 +649,13 @@ public:
                     return make_exception_future<>(verification_error("No certificate was found"));
 #if GNUTLS_VERSION_NUMBER >= 0x030406
                 case GNUTLS_E_CERTIFICATE_ERROR:
-                    verify(); // should throw. otherwise, fallthrough
+                    // Before propagating the error, send the appropriate TLS
+                    // alert to the peer so it gets a meaningful error rather
+                    // than an abrupt connection close.
+                    if (auto vf = verify_and_send_alert()) {
+                        return std::move(*vf);
+                    }
+                    // verify() didn't throw (cert verification disabled?), fall through
                     [[fallthrough]];
 #endif
                 default:
@@ -644,7 +675,12 @@ public:
                 }
             }
             if (_type == type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
-                verify();
+                // Certificate verification failed after successful TLS handshake.
+                // Send the appropriate alert to the peer so it gets a meaningful
+                // error rather than an abrupt connection close.
+                if (auto vf = verify_and_send_alert()) {
+                    return std::move(*vf);
+                }
             }
             _connected = true;
             // make sure we reset output_pending
@@ -742,7 +778,22 @@ public:
         return from_transport_ptr(ptr)->pull(dst, len);
     }
 
-    void verify() {
+    // Returns the TLS alert description appropriate for a certificate
+    // that failed verification with the given gnutls_certificate_verify_peers3 status.
+    static gnutls_alert_description_t cert_status_to_alert(unsigned int status) noexcept {
+        if (status & (GNUTLS_CERT_SIGNER_NOT_FOUND | GNUTLS_CERT_SIGNER_NOT_CA)) {
+            return GNUTLS_A_UNKNOWN_CA;
+        } else if (status & GNUTLS_CERT_REVOKED) {
+            return GNUTLS_A_CERTIFICATE_REVOKED;
+        } else if (status & GNUTLS_CERT_EXPIRED) {
+            return GNUTLS_A_CERTIFICATE_EXPIRED;
+        }
+        return GNUTLS_A_BAD_CERTIFICATE;
+    }
+
+    // out_alert, if non-null, is set to the appropriate TLS alert before
+    // verification_error is thrown, so the caller can send the alert to the peer.
+    void verify(gnutls_alert_description_t* out_alert = nullptr) {
         if (!_creds->_enable_certificate_verification) {
             return;
         }
@@ -769,6 +820,9 @@ public:
                 }
                 ss << "(Issuer=[" << dn->issuer << "], Subject=[" << dn->subject << "])";
                 stat_str = ss.str();
+            }
+            if (out_alert) {
+                *out_alert = cert_status_to_alert(status);
             }
             throw verification_error(stat_str);
         }

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -830,6 +830,166 @@ SEASTAR_TEST_CASE(test_simple_x509_client_server_client_auth_dn_callback_fails) 
     });
 }
 
+// Test that when a TLS server rejects a client certificate (bad CA), it sends a
+// proper TLS fatal alert to the client rather than silently dropping the
+// connection. This test reproduces issue #3516, where the server dropped the
+// connection without sending an alert, so the client would see EOF instead of
+// an exception. After the fix, the client receives a std::system_error wrapping
+// GNUTLS_E_FATAL_ALERT_RECEIVED.
+SEASTAR_THREAD_TEST_CASE(test_server_sends_alert_for_bad_client_cert) {
+    if (!using_gnutls()) {
+        return;
+    }
+
+    // Server: requires client auth but has NO trust file. Without trusted CAs
+    // loaded, GnuTLS does not include a certificate_authorities extension in the
+    // CertificateRequest message, so the client sends its certificate
+    // unconditionally and the TLS handshake completes. Then Seastar's
+    // post-handshake verify() call finds the cert untrusted (no trust anchors)
+    // and rejects it. This exercises the verify_and_send_alert() path added by
+    // the fix, which was previously missing for the server-side (post-handshake)
+    // cert verification code path.
+    auto server_creds = [] {
+        tls::credentials_builder b;
+        b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+        // Intentionally no set_x509_trust_file(): GnuTLS then accepts any cert
+        // during the handshake, and Seastar's post-handshake verify() rejects it.
+        b.set_client_auth(tls::client_auth::REQUIRE);
+        return b.build_server_credentials();
+    }();
+
+    // Client: presents other.crt and trusts catest.pem so it accepts the server's
+    // cert. The specific client cert used doesn't matter for triggering the bug;
+    // any cert will be rejected by the server since it has no trust anchors.
+    auto client_creds = [] {
+        tls::credentials_builder b;
+        b.set_x509_key_file(certfile("other.crt"), certfile("other.key"), tls::x509_crt_format::PEM).get();
+        b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+        return b.build_certificate_credentials();
+    }();
+
+    listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto server = tls::listen(server_creds, addr, opts);
+
+    auto sa = server.accept();
+    auto c = tls::connect(client_creds, addr).get();
+    auto s = sa.get();
+
+    auto server_in = s.connection.input();
+    auto client_in = c.input();
+
+    // Both reads must be started before any .get() call so the TLS handshake
+    // can proceed cooperatively on both sides. The server completes the
+    // handshake, then post-handshake verifies the client cert, finds it
+    // untrusted (no trusted CAs on the server), and rejects it.
+    auto server_read = server_in.read();
+    auto client_read = client_in.read();
+
+    // The server should reject the untrusted client certificate.
+    try {
+        server_read.get();
+        BOOST_FAIL("Server should have thrown tls::verification_error");
+    } catch (tls::verification_error&) {
+        // expected
+    }
+
+    // The client should receive a TLS fatal alert (GNUTLS_E_FATAL_ALERT_RECEIVED),
+    // reported as std::system_error with "alert" in the message. An EOF would
+    // return an empty buffer without throwing; any other system error would have
+    // a different message. Either outcome means the fix is not working.
+    try {
+        client_read.get();
+        BOOST_FAIL("Client should have received a TLS alert exception, not EOF or data");
+    } catch (std::system_error& e) {
+        BOOST_CHECK_MESSAGE(std::string(e.what()).find("alert") != std::string::npos,
+            std::string("Expected a TLS alert error, got: ") + e.what());
+    } catch (...) {
+        BOOST_FAIL("Expected std::system_error for TLS alert, got a different exception type");
+    }
+
+    try { client_in.close().get(); } catch (...) {}
+    try { server_in.close().get(); } catch (...) {}
+}
+
+// A more natural variant of the above: the server has a proper trust store
+// (catest.pem) and the client presents a certificate signed by the wrong CA
+// (other.crt, signed by caother.pem). GnuTLS detects the CA mismatch during
+// the handshake itself and rejects it with an alert rather than going through
+// Seastar's post-handshake verify path. Either way, the important property is
+// the same: the client receives a TLS alert rather than an abrupt EOF.
+SEASTAR_THREAD_TEST_CASE(test_server_sends_alert_for_wrong_ca_client_cert) {
+    if (!using_gnutls()) {
+        return;
+    }
+
+    // Server: requires client auth and trusts catest.pem.
+    auto server_creds = [] {
+        tls::credentials_builder b;
+        b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+        b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+        b.set_client_auth(tls::client_auth::REQUIRE);
+        return b.build_server_credentials();
+    }();
+
+    // Client: presents other.crt which is signed by caother.pem (NOT trusted
+    // by the server), but trusts catest.pem so it accepts the server's cert.
+    auto client_creds = [] {
+        tls::credentials_builder b;
+        b.set_x509_key_file(certfile("other.crt"), certfile("other.key"), tls::x509_crt_format::PEM).get();
+        b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+        return b.build_certificate_credentials();
+    }();
+
+    listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto server = tls::listen(server_creds, addr, opts);
+
+    auto sa = server.accept();
+    auto c = tls::connect(client_creds, addr).get();
+    auto s = sa.get();
+
+    auto server_in = s.connection.input();
+    auto client_in = c.input();
+
+    // Both reads must be in flight before any .get() so the handshake can
+    // proceed cooperatively on both sides.
+    auto server_read = server_in.read();
+    auto client_read = client_in.read();
+
+    // The server rejects the client certificate (wrong CA). The exact exception
+    // type depends on where in the handshake the rejection occurs.
+    try {
+        server_read.get();
+        BOOST_FAIL("Server should have thrown an exception");
+    } catch (std::exception&) {
+        // expected
+    }
+
+    // The client must receive a TLS alert (GNUTLS_E_FATAL_ALERT_RECEIVED),
+    // reported as std::system_error with "alert" in the message. An EOF would
+    // return an empty buffer without throwing; any other system error would have
+    // a different message. Either outcome means the fix is not working.
+    try {
+        client_read.get();
+        BOOST_FAIL("Client should have received a TLS alert exception, not EOF or data");
+    } catch (std::system_error& e) {
+        BOOST_CHECK_MESSAGE(std::string(e.what()).find("alert") != std::string::npos,
+            std::string("Expected a TLS alert error, got: ") + e.what());
+    } catch (...) {
+        BOOST_FAIL("Expected std::system_error for TLS alert, got a different exception type");
+    }
+
+    try { client_in.close().get(); } catch (...) {}
+    try { server_in.close().get(); } catch (...) {}
+}
+
 SEASTAR_TEST_CASE(test_many_large_message_x509_client_server) {
     // Make sure we load our own auth trust pem file, otherwise our certs
     // will not validate


### PR DESCRIPTION
When a TLS server rejects a client certificate, the peer was seeing an abrupt and unexplained connection close instead of a proper TLS alert.

gnutls_session_set_verify_function() was only installed for CLIENT sessions (where Seastar verifies the server's cert). For SERVER sessions, gnutls_handshake() succeeds even when the client presents a bad certificate. The certificate check was then done post-handshake by calling verify() directly, but if verify() throws, the exception propagated to the outer catch() block with no TLS alert sent.

Additionally, the GNUTLS_E_CERTIFICATE_ERROR path (reached for CLIENT sessions via verify_wrapper) also swallowed the exception without first sending an alert.

Fix:
- Add cert_status_to_alert() to map gnutls_certificate_verify_peers3 status flags to the semantically correct TLS alert description: GNUTLS_A_UNKNOWN_CA for an untrusted signer, GNUTLS_A_CERTIFICATE_REVOKED for revoked certs, GNUTLS_A_CERTIFICATE_EXPIRED for expired certs, and GNUTLS_A_BAD_CERTIFICATE for other failures.
- Extend verify() with an optional out_alert parameter that is set to the appropriate alert before a verification_error is thrown.
- Add verify_and_send_alert() helper that calls verify(), and when it fails, flushes pending output then calls send_alert() before propagating the exception. Returns nullopt on success so call sites can fall through normally.
- Use verify_and_send_alert() in both the GNUTLS_E_CERTIFICATE_ERROR switch case and the post-handshake verify() call.

This is similar to commit 0e48ba883 ("net/tls: on TLS handshake failure, send error to client", fixes #912) which added send_alert() for other handshake failures, but was not applied to certificate verification failures.