### PR TITLE
posix: improve conntrack shard balancing

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <utility>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/make_task.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
@@ -129,12 +130,14 @@ public:
     class handle {
         shard_id _host_cpu;
         shard_id _target_cpu;
+        bool _defer_local_close = false;
         foreign_ptr<lw_shared_ptr<load_balancer>> _lb;
     public:
         handle() : _lb(nullptr) {}
-        handle(shard_id cpu, lw_shared_ptr<load_balancer> lb)
+        handle(shard_id cpu, lw_shared_ptr<load_balancer> lb, bool defer_local_close)
             : _host_cpu(this_shard_id())
             , _target_cpu(cpu)
+            , _defer_local_close(defer_local_close)
             , _lb(make_foreign(std::move(lb))) {}
 
         handle(const handle&) = delete;
@@ -146,9 +149,18 @@ public:
                 return;
             }
             // FIXME: future is discarded
-            (void)smp::submit_to(_host_cpu, [cpu = _target_cpu, lb = std::move(_lb)] {
-                lb->closed_cpu(cpu);
-            });
+            if (_defer_local_close && _host_cpu == this_shard_id()) {
+                // smp::submit_to() executes same-shard calls inline. For connection
+                // distribution handles, defer local close reports too so local and remote
+                // close accounting have comparable, delayed visibility.
+                schedule(make_task([cpu = _target_cpu, lb = std::move(_lb)] () mutable {
+                    lb->closed_cpu(cpu);
+                }));
+            } else {
+                (void)smp::submit_to(_host_cpu, [cpu = _target_cpu, lb = std::move(_lb)] {
+                    lb->closed_cpu(cpu);
+                });
+            }
         }
         shard_id cpu() {
             return _target_cpu;
@@ -158,10 +170,10 @@ public:
 
     conntrack() : _lb(make_lw_shared<load_balancer>()) {}
     handle get_handle() {
-        return handle(_lb->next_cpu(), _lb);
+        return handle(_lb->next_cpu(), _lb, true);
     }
     handle get_handle(shard_id cpu) {
-        return handle(_lb->force_cpu(cpu), _lb);
+        return handle(_lb->force_cpu(cpu), _lb, false);
     }
 };
 

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -20,15 +20,16 @@
  */
 
 #pragma once
+#include <algorithm>
+#include <cmath>
 #include <unordered_set>
+#include <utility>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/program-options.hh>
-
-#include <unordered_set>
 
 namespace seastar {
 
@@ -60,6 +61,16 @@ using namespace seastar;
 class conntrack {
     class load_balancer {
         std::vector<unsigned> _cpu_load;
+        // The least-loaded shard is cached, not to calculate it for every new connection.
+        // The value is the { shard_id, TTL } pair. The TTL is the number of future
+        // new connections that may reuse the cached shard before recalculating it.
+        // Destroyed connections also consume the TTL, since they change shard load.
+        std::pair<shard_id, unsigned> _least_loaded_cpu = {0, 0};
+        // The value used to reset the TTL depends on the number of currently open
+        // connections on the selected shard. The _least_loaded_cpu_ttl determines
+        // the fraction of that shard's open connections.
+        static constexpr float _least_loaded_cpu_ttl = 0.02; // 2%
+
         shard_id find_min_cpu() const {
             // Prefer shard 0 for the 1st connection
             if (_cpu_load[0] == 0) {
@@ -81,17 +92,31 @@ class conntrack {
         load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}
         void closed_cpu(shard_id cpu) {
             _cpu_load[cpu]--;
+            if (_least_loaded_cpu.second > 0) {
+                _least_loaded_cpu.second--;
+            }
         }
         shard_id next_cpu() {
             // FIXME: The naive algorithm will just round robin the connections around the shards.
             // A more complex version can keep track of the amount of activity in each connection,
             // and use that information.
-            auto cpu = find_min_cpu();
-            ++_cpu_load[cpu];
-            return cpu;
+            // Use the cached value if still valid.
+            if (_least_loaded_cpu.second == 0) {
+                _least_loaded_cpu.first = find_min_cpu();
+                auto ttl = static_cast<unsigned>(std::round(
+                        _cpu_load[_least_loaded_cpu.first] * _least_loaded_cpu_ttl));
+                _least_loaded_cpu.second = std::min(ttl, 10u);
+            } else {
+                _least_loaded_cpu.second--;
+            }
+            ++_cpu_load[_least_loaded_cpu.first];
+            return _least_loaded_cpu.first;
         }
         shard_id force_cpu(shard_id cpu) {
             _cpu_load[cpu]++;
+            if (_least_loaded_cpu.second > 0) {
+                _least_loaded_cpu.second--;
+            }
             return cpu;
         }
     };

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -60,6 +60,23 @@ using namespace seastar;
 class conntrack {
     class load_balancer {
         std::vector<unsigned> _cpu_load;
+        shard_id find_min_cpu() const {
+            // Prefer shard 0 for the 1st connection
+            if (_cpu_load[0] == 0) {
+                return 0;
+            }
+            shard_id min_cpu = 0;
+            auto min_load = _cpu_load[0];
+            for (shard_id i = 1; i < _cpu_load.size(); ++i) {
+                auto load = _cpu_load[i];
+                // Choose the highest-numbered shard for ties to avoid shard 0
+                if (load <= min_load) {
+                    min_load = load;
+                    min_cpu = i;
+                }
+            }
+            return min_cpu;
+        }
     public:
         load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}
         void closed_cpu(shard_id cpu) {
@@ -69,9 +86,8 @@ class conntrack {
             // FIXME: The naive algorithm will just round robin the connections around the shards.
             // A more complex version can keep track of the amount of activity in each connection,
             // and use that information.
-            auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
-            auto cpu = shard_id(std::distance(_cpu_load.begin(), min_el));
-            _cpu_load[cpu]++;
+            auto cpu = find_min_cpu();
+            ++_cpu_load[cpu];
             return cpu;
         }
         shard_id force_cpu(shard_id cpu) {

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -73,8 +73,17 @@ class conntrack {
         static constexpr float _least_loaded_cpu_ttl = 0.02; // 2%
 
         shard_id find_min_cpu() const {
-            auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
-            return shard_id(std::distance(_cpu_load.begin(), min_el));
+            shard_id min_cpu = 0;
+            auto min_load = _cpu_load[0];
+            for (shard_id i = 1; i < _cpu_load.size(); ++i) {
+                auto load = _cpu_load[i];
+                // Choose the highest-numbered shard for ties to avoid shard 0
+                if (load <= min_load) {
+                    min_load = load;
+                    min_cpu = i;
+                }
+            }
+            return min_cpu;
         }
     public:
         load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -20,7 +20,10 @@
  */
 
 #pragma once
+#include <algorithm>
+#include <cmath>
 #include <unordered_set>
+#include <utility>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/make_task.hh>
 #include <seastar/core/internal/pollable_fd.hh>
@@ -28,8 +31,6 @@
 #include <seastar/core/polymorphic_temporary_buffer.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/program-options.hh>
-
-#include <unordered_set>
 
 namespace seastar {
 
@@ -61,22 +62,48 @@ using namespace seastar;
 class conntrack {
     class load_balancer {
         std::vector<unsigned> _cpu_load;
+        // The least-loaded shard is cached, not to calculate it for every new connection.
+        // The value is the { shard_id, TTL } pair. The TTL is the number of future
+        // new connections that may reuse the cached shard before recalculating it.
+        // Destroyed connections also consume the TTL, since they change shard load.
+        std::pair<shard_id, unsigned> _least_loaded_cpu = {0, 0};
+        // The value used to reset the TTL depends on the number of currently open
+        // connections on the selected shard. The _least_loaded_cpu_ttl determines
+        // the fraction of that shard's open connections.
+        static constexpr float _least_loaded_cpu_ttl = 0.02; // 2%
+
+        shard_id find_min_cpu() const {
+            auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
+            return shard_id(std::distance(_cpu_load.begin(), min_el));
+        }
     public:
         load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}
         void closed_cpu(shard_id cpu) {
             _cpu_load[cpu]--;
+            if (_least_loaded_cpu.second > 0) {
+                _least_loaded_cpu.second--;
+            }
         }
         shard_id next_cpu() {
             // FIXME: The naive algorithm will just round robin the connections around the shards.
             // A more complex version can keep track of the amount of activity in each connection,
             // and use that information.
-            auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
-            auto cpu = shard_id(std::distance(_cpu_load.begin(), min_el));
-            _cpu_load[cpu]++;
-            return cpu;
+            // Use the cached value if still valid.
+            if (_least_loaded_cpu.second == 0) {
+                _least_loaded_cpu.first = find_min_cpu();
+                auto ttl = static_cast<unsigned>(std::round(_cpu_load[_least_loaded_cpu.first] * _least_loaded_cpu_ttl));
+                _least_loaded_cpu.second = std::min(ttl, 10u);
+            } else {
+                _least_loaded_cpu.second--;
+            }
+            ++_cpu_load[_least_loaded_cpu.first];
+            return _least_loaded_cpu.first;
         }
         shard_id force_cpu(shard_id cpu) {
             _cpu_load[cpu]++;
+            if (_least_loaded_cpu.second > 0) {
+                _least_loaded_cpu.second--;
+            }
             return cpu;
         }
     };

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -22,6 +22,7 @@
 #pragma once
 #include <unordered_set>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/make_task.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/net/stack.hh>
 #include <seastar/core/polymorphic_temporary_buffer.hh>
@@ -88,12 +89,14 @@ public:
     class handle {
         shard_id _host_cpu;
         shard_id _target_cpu;
+        bool _defer_local_close = false;
         foreign_ptr<lw_shared_ptr<load_balancer>> _lb;
     public:
         handle() : _lb(nullptr) {}
-        handle(shard_id cpu, lw_shared_ptr<load_balancer> lb)
+        handle(shard_id cpu, lw_shared_ptr<load_balancer> lb, bool defer_local_close)
             : _host_cpu(this_shard_id())
             , _target_cpu(cpu)
+            , _defer_local_close(defer_local_close)
             , _lb(make_foreign(std::move(lb))) {}
 
         handle(const handle&) = delete;
@@ -105,9 +108,18 @@ public:
                 return;
             }
             // FIXME: future is discarded
-            (void)smp::submit_to(_host_cpu, [cpu = _target_cpu, lb = std::move(_lb)] {
-                lb->closed_cpu(cpu);
-            });
+            if (_defer_local_close && _host_cpu == this_shard_id()) {
+                // smp::submit_to() executes same-shard calls inline. For connection
+                // distribution handles, defer local close reports too so local and remote
+                // close accounting have comparable, delayed visibility.
+                schedule(make_task([cpu = _target_cpu, lb = std::move(_lb)] () mutable {
+                    lb->closed_cpu(cpu);
+                }));
+            } else {
+                (void)smp::submit_to(_host_cpu, [cpu = _target_cpu, lb = std::move(_lb)] {
+                    lb->closed_cpu(cpu);
+                });
+            }
         }
         shard_id cpu() {
             return _target_cpu;
@@ -117,10 +129,10 @@ public:
 
     conntrack() : _lb(make_lw_shared<load_balancer>()) {}
     handle get_handle() {
-        return handle(_lb->next_cpu(), _lb);
+        return handle(_lb->next_cpu(), _lb, true);
     }
     handle get_handle(shard_id cpu) {
-        return handle(_lb->force_cpu(cpu), _lb);
+        return handle(_lb->force_cpu(cpu), _lb, false);
     }
 };
 

--- a/tests/unit/connect_test.cc
+++ b/tests/unit/connect_test.cc
@@ -28,7 +28,9 @@ SEASTAR_TEST_CASE(test_unconnected_socket_shutsdown_established_connection) {
     std::default_random_engine& rnd = testing::local_random_engine;
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
-    return do_with(engine().net().listen(sa, listen_options()), [sa] (auto& listener) {
+    listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
+    return do_with(engine().net().listen(sa, lo), [sa] (auto& listener) {
         auto f = listener.accept();
         auto unconn = make_socket();
         auto connf = unconn.connect(sa);
@@ -54,7 +56,9 @@ SEASTAR_TEST_CASE(test_accept_after_abort) {
     std::default_random_engine& rnd = testing::local_random_engine;
     auto distr = std::uniform_int_distribution<uint16_t>(12000, 65000);
     auto sa = make_ipv4_address({"127.0.0.1", distr(rnd)});
-    return do_with(seastar::server_socket(engine().net().listen(sa, listen_options())), [] (auto& listener) {
+    listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
+    return do_with(seastar::server_socket(engine().net().listen(sa, lo)), [] (auto& listener) {
         using ftype = future<accept_result>;
         promise<ftype> p;
         future<ftype> done = p.get_future();

--- a/tests/unit/epoll_test.cc
+++ b/tests/unit/epoll_test.cc
@@ -42,6 +42,7 @@ SEASTAR_THREAD_TEST_CASE(epoll_busy_spin_on_socket_error_test) {
     auto start_busy_time = engine().total_busy_time();
 
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     server_socket ss = seastar::listen(ipv4_addr(0), lo);
 

--- a/tests/unit/ipv6_test.cc
+++ b/tests/unit/ipv6_test.cc
@@ -75,7 +75,9 @@ SEASTAR_TEST_CASE(tcp_packet_test) {
     }
 
     return async([] {
-        auto sc = server_socket(engine().net().listen(ipv6_addr{"::1"}, {}));
+        listen_options lo;
+        lo.set_fixed_cpu(this_shard_id());
+        auto sc = server_socket(engine().net().listen(ipv6_addr{"::1"}, lo));
         auto la = sc.local_address();
 
         BOOST_REQUIRE(la.addr().is_ipv6());

--- a/tests/unit/proxy_protocol_test.cc
+++ b/tests/unit/proxy_protocol_test.cc
@@ -186,6 +186,7 @@ static void test_proxy_header_negative(
     std::vector<char> header) {
 
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -220,6 +221,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_bad_signature) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_small_packet_incomplete_header) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -251,6 +253,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_small_packet_incomplete_header) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_small_packet_incomplete_addresses) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -295,6 +298,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_small_packet_incomplete_addresses) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_local_mode) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -333,6 +337,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_local_mode_wrong_family) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv4_addresses) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -363,6 +368,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv4_addresses) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_ipv6_addresses) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -417,6 +423,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_unsupported_protocol) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_length_too_short_ipv4) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -458,6 +465,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_length_too_short_ipv4) {
 
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_length_too_short_ipv6) {
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -497,6 +505,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_length_too_short_ipv6) {
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_with_tlvs) {
     // TLVs should be skipped/ignored by the implementation
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 
@@ -535,6 +544,7 @@ SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_with_tlvs) {
 SEASTAR_THREAD_TEST_CASE(proxy_protocol_v2_extreme_ports) {
     // Test with port 0 and port 65535
     listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
     lo.reuse_address = true;
     lo.proxy_protocol = true;
 

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -62,7 +62,7 @@ future<> handle_connection(connected_socket s) {
 
 future<> echo_server_loop() {
     return do_with(
-        server_socket(listen(make_ipv4_address({1234}), listen_options{.reuse_address = true})), [](auto& listener) {
+        server_socket(listen(make_ipv4_address({1234}), listen_options{.reuse_address = true, .lba = server_socket::load_balancing_algorithm::fixed, .fixed_cpu = this_shard_id()})), [](auto& listener) {
               // Connect asynchronously in background.
               (void)connect(make_ipv4_address({"127.0.0.1", 1234})).then([](connected_socket&& socket) {
                   socket.shutdown_output();
@@ -94,6 +94,7 @@ SEASTAR_TEST_CASE(socket_allocation_test) {
 SEASTAR_TEST_CASE(socket_skip_test) {
     return seastar::async([&] {
         listen_options lo;
+        lo.set_fixed_cpu(this_shard_id());
         lo.reuse_address = true;
         server_socket ss = seastar::listen(ipv4_addr("127.0.0.1", 1234), lo);
 
@@ -122,6 +123,7 @@ SEASTAR_TEST_CASE(test_file_desc_fdinfo) {
 SEASTAR_TEST_CASE(socket_on_close_test) {
     return seastar::async([&] {
         listen_options lo;
+        lo.set_fixed_cpu(this_shard_id());
         lo.reuse_address = true;
         server_socket ss = seastar::listen(ipv4_addr("127.0.0.1", 12345), lo);
 
@@ -185,6 +187,7 @@ SEASTAR_TEST_CASE(socket_on_close_test) {
 SEASTAR_TEST_CASE(socket_on_close_local_shutdown_test) {
     return seastar::async([&] {
         listen_options lo;
+        lo.set_fixed_cpu(this_shard_id());
         lo.reuse_address = true;
         server_socket ss = seastar::listen(ipv4_addr("127.0.0.1", 12345), lo);
 
@@ -266,7 +269,7 @@ SEASTAR_TEST_CASE(socket_connect_abort_test) {
 // Check that server_socket::accept() is abortable by server_socket::abort_accept()
 SEASTAR_THREAD_TEST_CASE(socket_accept_abort_test) {
     ipv4_addr addr("127.0.0.1", 3174);
-    server_socket ss = seastar::listen(addr, listen_options{ .reuse_address = true });
+    server_socket ss = seastar::listen(addr, listen_options{ .reuse_address = true, .lba = server_socket::load_balancing_algorithm::fixed, .fixed_cpu = this_shard_id() });
     bool too_late = false;
     auto f = async([&] {
         try {
@@ -557,7 +560,9 @@ SEASTAR_THREAD_TEST_CASE(load_balancing_algorithm_port_ipv6_proxy_test) {
 
 SEASTAR_THREAD_TEST_CASE(inet_local_remote_address_sanity) {
     auto addr = make_ipv4_address(11003);
-    auto ls = listen(addr);
+    listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
+    auto ls = listen(addr, lo);
     auto ar_f = ls.accept();
 
     std::optional<connected_socket> cs = connect(addr).get();

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -268,6 +268,7 @@ SEASTAR_TEST_CASE(test_alpn_client_server) {
     certs->set_alpn_protocols({"h2", "http/1.1"});
 
     ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address({0x7f000001, 4712});
     auto server = tls::listen(certs, addr, opts);
@@ -447,6 +448,7 @@ SEASTAR_TEST_CASE(test_failed_connect) {
 
 SEASTAR_TEST_CASE(test_non_tls) {
     ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address( {0x7f000001, 4712});
     auto server = server_socket(seastar::listen(addr, opts));
@@ -493,6 +495,7 @@ SEASTAR_TEST_CASE(test_abort_accept_before_handshake) {
     auto certs = ::make_shared<tls::server_credentials>(::make_shared<tls::dh_params>());
     return certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).then([certs] {
         ::listen_options opts;
+        opts.set_fixed_cpu(this_shard_id());
         opts.reuse_address = true;
         auto addr = ::make_ipv4_address( {0x7f000001, 4712});
         auto server = server_socket(tls::listen(certs, addr, opts));
@@ -513,6 +516,7 @@ SEASTAR_TEST_CASE(test_abort_accept_after_handshake) {
         certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
 
         ::listen_options opts;
+        opts.set_fixed_cpu(this_shard_id());
         opts.reuse_address = true;
         auto addr = ::make_ipv4_address( {0x7f000001, 4712});
         auto server = tls::listen(certs, addr, opts);
@@ -541,6 +545,7 @@ SEASTAR_TEST_CASE(test_abort_accept_after_handshake) {
 SEASTAR_TEST_CASE(test_abort_accept_on_server_before_handshake) {
     return async([] {
         ::listen_options opts;
+        opts.set_fixed_cpu(this_shard_id());
         opts.reuse_address = true;
         auto addr = ::make_ipv4_address( {0x7f000001, 4712});
         auto server = server_socket(seastar::listen(addr, opts));
@@ -614,6 +619,9 @@ public:
             });
         }
         return f.then([this, addr] {
+            // Note: echoserver runs as sharded<echoserver> with listen() invoked
+            // on all shards (see run_echo_test()), so keep the default
+            // connection-distribution load balancing.
             ::listen_options opts;
             opts.reuse_address = true;
 
@@ -1009,6 +1017,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
     }).get();
 
     ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address( {0x7f000001, 4712});
     auto server = tls::listen(certs, addr, opts);
@@ -1450,6 +1459,7 @@ SEASTAR_THREAD_TEST_CASE(test_dn_name_handling) {
 
     auto fetch_dn = [server_creds, addr] (sstring id, shared_ptr<tls::certificate_credentials> client_cred) {
         listen_options lo{};
+        lo.set_fixed_cpu(this_shard_id());
         lo.reuse_address = true;
         auto server_sock = tls::listen(server_creds, addr, lo);
 
@@ -1968,6 +1978,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_only_shard0_notify) {
     });
 
     ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address( {0x7f000001, 4712});
     auto server = tls::listen(certs, addr, opts);
@@ -2381,6 +2392,7 @@ static std::pair<connected_socket, connected_socket> tls_socketpair() {
     certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
 
     ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address( {0x7f000001, 4712});
     auto ss = tls::listen(certs, addr, opts);

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -72,7 +72,9 @@ private:
 };
 
 future<> ud_server_client::init_server() {
-    return do_with(seastar::listen(server_addr), [this](server_socket& lstn) mutable {
+    listen_options lo;
+    lo.set_fixed_cpu(this_shard_id());
+    return do_with(seastar::listen(server_addr, lo), [this](server_socket& lstn) mutable {
 
         lstn_sock = &lstn; // required when aborting (on some tests)
 


### PR DESCRIPTION
1. Pin single-shard test servers to the invoking shard via `listen_options::set_fixed_cpu()`. Before this PR these tests only pass because the balancer resolves the all-idle tie to shard 0, which the last patch here changes.
2. Defer local connection close accounting so local and remote close reports have comparable, delayed visibility. The observable result was shard 0 receiving the majority of new connections under short-lived connection churn.
3. Cache the least-loaded shard not to recalculate for every new connection, with the TTL at 2% of the shard's currently open connections, additionally capped at 10.
4. Avoid lower-numbered shard preference on connection count ties.

Fixes #3514.
Alternative to #3524.

Note: the `Seastar.unit.prometheus` CI failure is a pre-existing bug in the prometheus handler (scrape label filtering depends on the serving shard) that the changed tie-breaking exposes; it is being fixed separately (#3630 / #3649). This PR depends on either of them landing first.

## Measurements
Two binaries were measured: `master` = master at `50015067`, and `#3526` = this PR's four patches applied on top of that same commit, so the only difference between them is this PR. Both release mode, measured back-to-back on the same machine, 4 shards (`--smp 4 --cpuset 0-3`). **ideal** = total connections / 4, i.e. a perfectly equal per-shard share; the counts column shows the per-shard tally of the median-CoV wave.

**HTTP rows**: connection-per-request HTTP load (each request opens a fresh connection, closed after the response) - 5 waves x 400k requests (3 x 40k for the 10ms rows); *handler* = server-side handler delay, so it is ~ each connection's lifetime; *bg* = long-lived idle connections held open per shard throughout, verified exact before measurement. **TCP rows**: raw TCP connections (no HTTP) arriving at the given rate for 30 s, each closed by the server after 10 ms; counts are accepted connections per shard - same accept-and-distribute path as HTTP, swept by arrival rate.

| workload | tree | connection counts [s0,s1,s2,s3] | s0/ideal | max/ideal | CoV |
|---|---|---|---:|---:|---:|
| HTTP conn-per-request, 0ms handler, no bg conns | master | `[151380, 63193, 58765, 126662]` | 1.514 | 1.514 | 0.400 |
| HTTP conn-per-request, 0ms handler, no bg conns | #3526 | `[134417, 59351, 63090, 143142]` | 1.344 | 1.431 | 0.389 |
| HTTP conn-per-request, 0ms handler, 4 bg conns/shard | master | `[147076, 62127, 61032, 129765]` | 1.471 | 1.471 | 0.389 |
| HTTP conn-per-request, 0ms handler, 4 bg conns/shard | #3526 | `[133074, 60771, 64504, 141651]` | 1.331 | 1.417 | 0.375 |
| HTTP conn-per-request, 0ms handler, 40 bg conns/shard | master | `[145208, 63015, 61397, 130380]` | 1.452 | 1.452 | 0.382 |
| HTTP conn-per-request, 0ms handler, 40 bg conns/shard | #3526 | `[132612, 59590, 64337, 143461]` | 1.326 | 1.435 | 0.383 |
| HTTP conn-per-request, 5ms handler, no bg conns | master | `[101563, 99735, 99421, 99281]` | 1.016 | 1.016 | 0.009 |
| HTTP conn-per-request, 5ms handler, no bg conns | #3526 | `[100139, 99351, 99833, 100677]` | 1.001 | 1.007 | 0.005 |
| HTTP conn-per-request, 5ms handler, 4 bg conns/shard | master | `[101573, 99868, 99478, 99081]` | 1.016 | 1.016 | 0.009 |
| HTTP conn-per-request, 5ms handler, 4 bg conns/shard | #3526 | `[100173, 99326, 99808, 100693]` | 1.002 | 1.007 | 0.005 |
| HTTP conn-per-request, 5ms handler, 40 bg conns/shard | master | `[101620, 99782, 99410, 99188]` | 1.016 | 1.016 | 0.010 |
| HTTP conn-per-request, 5ms handler, 40 bg conns/shard | #3526 | `[97967, 99131, 100670, 102232]` | 0.980 | 1.022 | 0.016 |
| HTTP conn-per-request, 10ms handler, no bg conns | master | `[10160, 9989, 9946, 9905]` | 1.016 | 1.016 | 0.010 |
| HTTP conn-per-request, 10ms handler, no bg conns | #3526 | `[9997, 9958, 9992, 10053]` | 1.000 | 1.005 | 0.003 |
| HTTP conn-per-request, 10ms handler, 4 bg conns/shard | master | `[10148, 9994, 9944, 9914]` | 1.015 | 1.015 | 0.009 |
| HTTP conn-per-request, 10ms handler, 4 bg conns/shard | #3526 | `[9979, 9942, 9994, 10085]` | 0.998 | 1.008 | 0.005 |
| HTTP conn-per-request, 10ms handler, 40 bg conns/shard | master | `[10162, 9983, 9939, 9916]` | 1.016 | 1.016 | 0.010 |
| HTTP conn-per-request, 10ms handler, 40 bg conns/shard | #3526 | `[9776, 9927, 10106, 10191]` | 0.978 | 1.019 | 0.016 |
| raw TCP, 1000 conn/s, 10ms lifetime | master | `[7506, 7500, 7500, 7494]` | 1.001 | 1.001 | 0.001 |
| raw TCP, 1000 conn/s, 10ms lifetime | #3526 | `[7497, 7500, 7503, 7500]` | 1.000 | 1.000 | 0.000 |
| raw TCP, 2000 conn/s, 10ms lifetime | master | `[16553, 15114, 14647, 13686]` | 1.104 | 1.104 | 0.069 |
| raw TCP, 2000 conn/s, 10ms lifetime | #3526 | `[14121, 14143, 15103, 16633]` | 0.941 | 1.109 | 0.068 |
| raw TCP, 4000 conn/s, 10ms lifetime | master | `[31799, 30056, 29167, 28978]` | 1.060 | 1.060 | 0.037 |
| raw TCP, 4000 conn/s, 10ms lifetime | #3526 | `[28952, 29606, 30226, 31216]` | 0.965 | 1.041 | 0.028 |
| raw TCP, 8000 conn/s, 10ms lifetime | master | `[61782, 60280, 59057, 58881]` | 1.030 | 1.030 | 0.019 |
| raw TCP, 8000 conn/s, 10ms lifetime | #3526 | `[58739, 59996, 60195, 61070]` | 0.979 | 1.018 | 0.014 |

Under short-lived-connection churn, #3526 removes the systematic shard-0 concentration: s0/ideal drops from 1.45-1.51 to 1.33-1.34 in extreme churn and from 1.016 to ~1.00 at realistic lifetimes. The residual tie-break surplus lands on the highest-numbered shard instead (max/ideal <= 1.44 in extreme churn, <= 1.02 elsewhere; visible as the mirrored counts in the 2000 conn/s row).

