### PR TITLE
net: validate each device's config independently

### DIFF
--- a/src/net/config.cc
+++ b/src/net/config.cc
@@ -20,7 +20,7 @@
  */
 
 
-#include <boost/algorithm/cxx11/all_of.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/none_of.hpp>
 #include <boost/next_prior.hpp>
 #include <yaml-cpp/yaml.h>
@@ -68,21 +68,21 @@ namespace net {
             }
         }
 
-        // check if all of ip,gw,nm are specified when dhcp is off
-        if (all_of(device_configs, [](std::pair<std::string, device_config> p) {
-                return !(!p.second.ip_cfg.dhcp
-                    && (!p.second.ip_cfg.ip.empty() && !p.second.ip_cfg.gateway.empty()
-                           && !p.second.ip_cfg.netmask.empty()));
+        // check each device: when dhcp is off, all of ip, gw, nm must be specified
+        if (any_of(device_configs, [](std::pair<std::string, device_config> p) {
+                return !p.second.ip_cfg.dhcp
+                    && (p.second.ip_cfg.ip.empty() || p.second.ip_cfg.gateway.empty()
+                           || p.second.ip_cfg.netmask.empty());
             })) {
             throw config_exception(
                 "when dhcp is off then all of ip, gateway, netmask has to be specified");
         }
 
-        // check if dhcp is not used when ip/gw/nm are specified
-        if (all_of(device_configs, [](std::pair<std::string, device_config> p) {
+        // check each device: dhcp cannot be used together with static ip/gw/nm
+        if (any_of(device_configs, [](std::pair<std::string, device_config> p) {
                 return p.second.ip_cfg.dhcp
-                    && !(p.second.ip_cfg.ip.empty() || p.second.ip_cfg.gateway.empty()
-                           || p.second.ip_cfg.netmask.empty());
+                    && (!p.second.ip_cfg.ip.empty() || !p.second.ip_cfg.gateway.empty()
+                           || !p.second.ip_cfg.netmask.empty());
             })) {
             throw config_exception("dhcp and ip cannot be used together");
         }

--- a/tests/unit/net_config_test.cc
+++ b/tests/unit/net_config_test.cc
@@ -125,3 +125,21 @@ BOOST_AUTO_TEST_CASE(test_ip_missing_if_thrown) {
           "eth1: {pci-address: 0000:06:00.1, dhcp: true} }";
     BOOST_REQUIRE_THROW(parse_config(ss), config_exception);
 }
+
+// eth0 is valid, but eth1 has dhcp off and is missing netmask: each device must be validated.
+BOOST_AUTO_TEST_CASE(test_mixed_dhcp_off_incomplete_if_thrown) {
+    std::stringstream ss;
+    ss << "{eth0: {pci-address: 0000:06:00.0, ip: 192.168.100.10, gateway: 192.168.100.1, netmask: "
+          "255.255.255.0 } , eth1: {pci-address: 0000:06:00.1, ip: 192.168.100.11, gateway: "
+          "192.168.100.1 } }";
+    BOOST_REQUIRE_THROW(parse_config(ss), config_exception);
+}
+
+// eth0 is valid, but eth1 uses dhcp together with a static ip: each device must be validated.
+BOOST_AUTO_TEST_CASE(test_mixed_dhcp_and_ip_if_thrown) {
+    std::stringstream ss;
+    ss << "{eth0: {pci-address: 0000:06:00.0, ip: 192.168.100.10, gateway: 192.168.100.1, netmask: "
+          "255.255.255.0 } , eth1: {pci-address: 0000:06:00.1, dhcp: true, ip: 192.168.100.11, "
+          "gateway: 192.168.100.1, netmask: 255.255.255.0 } }";
+    BOOST_REQUIRE_THROW(parse_config(ss), config_exception);
+}


### PR DESCRIPTION
The dhcp/ip/gateway/netmask consistency checks in `net::parse_config()` wrapped their per-device predicate in `boost::all_of` over the whole device map, so a check only fired when **every** device was misconfigured. A single broken device (e.g. dhcp off but missing netmask, or dhcp on together with a static ip) passed validation whenever any other device was valid.

Switch both checks to `any_of` with per-device violation predicates so each device is validated on its own. Added tests pairing a valid device with a broken one for each check.