### PR TITLE
posix-stack: keep AP accept queues in listener state

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -20,6 +20,8 @@
  */
 
 #pragma once
+#include <deque>
+#include <memory>
 #include <unordered_set>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/internal/pollable_fd.hh>
@@ -166,6 +168,10 @@ struct proxy_data {
 };
 
 class posix_ap_server_socket_impl : public server_socket_impl {
+public:
+    struct acceptor_state;
+    using acceptor_state_ptr = std::shared_ptr<acceptor_state>;
+private:
     using protocol_and_socket_address = std::tuple<int, socket_address>;
     struct connection {
         pollable_fd fd;
@@ -175,14 +181,15 @@ class posix_ap_server_socket_impl : public server_socket_impl {
         connection(pollable_fd xfd, socket_address xaddr, conntrack::handle cth, std::optional<proxy_data> addr_data_opt) : fd(std::move(xfd)), addr(xaddr), connection_tracking_handle(std::move(cth)), proxy_protocol_header_opt(std::move(addr_data_opt)) {}
     };
     using port_map_t = std::unordered_set<protocol_and_socket_address>;
-    using sockets_map_t = std::unordered_map<protocol_and_socket_address, promise<accept_result>>;
-    using conn_map_t = std::unordered_multimap<protocol_and_socket_address, connection>;
     static thread_local port_map_t ports;
-    static thread_local sockets_map_t sockets;
-    static thread_local conn_map_t conn_q;
     int _protocol;
     socket_address _sa;
+    acceptor_state_ptr _state;
     std::pmr::polymorphic_allocator<char>* _allocator;
+    static acceptor_state_ptr register_acceptor_state(int protocol, socket_address sa, shard_id shard);
+    static acceptor_state_ptr find_acceptor_state(int protocol, socket_address sa, shard_id shard);
+    static void close_acceptor_state(const acceptor_state_ptr& state);
+    static void unregister_acceptor_state(int protocol, socket_address sa, shard_id shard, const acceptor_state_ptr& state);
 public:
     explicit posix_ap_server_socket_impl(int protocol, socket_address sa, std::pmr::polymorphic_allocator<char>* allocator = memory::malloc_allocator);
     ~posix_ap_server_socket_impl();
@@ -191,10 +198,17 @@ public:
     socket_address local_address() const override {
         return _sa;
     }
-    static void move_connected_socket(int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator);
+    static void move_connected_socket(acceptor_state_ptr state, int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator);
+#ifdef SEASTAR_TESTING_MAIN
+    acceptor_state_ptr testing_state() const {
+        return _state;
+    }
+#endif
+    static size_t testing_queued_connections(const acceptor_state_ptr& state);
 
     template <typename T>
     friend class std::hash;
+    friend class posix_server_socket_impl;
 };
 
 class posix_server_socket_impl : public server_socket_impl {

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -168,10 +168,9 @@ struct proxy_data {
 };
 
 class posix_ap_server_socket_impl : public server_socket_impl {
-public:
+private:
     struct acceptor_state;
     using acceptor_state_ptr = std::shared_ptr<acceptor_state>;
-private:
     using protocol_and_socket_address = std::tuple<int, socket_address>;
     struct connection {
         pollable_fd fd;
@@ -198,17 +197,24 @@ public:
     socket_address local_address() const override {
         return _sa;
     }
-    static void move_connected_socket(acceptor_state_ptr state, int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator);
 #ifdef SEASTAR_TESTING_MAIN
     acceptor_state_ptr testing_state() const {
         return _state;
     }
+    static void testing_move_connected_socket(acceptor_state_ptr state, int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator) {
+        move_connected_socket(std::move(state), protocol, sa, std::move(fd), addr, std::move(handle), std::move(addr_data_opt), allocator);
+    }
+    static size_t testing_queued_connections(const acceptor_state_ptr& state) {
+        return queued_connections(state);
+    }
 #endif
-    static size_t testing_queued_connections(const acceptor_state_ptr& state);
 
+private:
     template <typename T>
     friend class std::hash;
     friend class posix_server_socket_impl;
+    static void move_connected_socket(acceptor_state_ptr state, int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle handle, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator);
+    static size_t queued_connections(const acceptor_state_ptr& state);
 };
 
 class posix_server_socket_impl : public server_socket_impl {

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -174,7 +174,7 @@ struct protocol_acceptor_key_hash {
 };
 
 std::mutex acceptor_states_mutex;
-std::unordered_map<protocol_acceptor_key, std::weak_ptr<posix_ap_server_socket_impl::acceptor_state>, protocol_acceptor_key_hash> acceptor_states;
+std::unordered_map<protocol_acceptor_key, std::weak_ptr<void>, protocol_acceptor_key_hash> acceptor_states;
 
 }
 
@@ -803,7 +803,7 @@ posix_ap_server_socket_impl::find_acceptor_state(int protocol, socket_address sa
     if (i == acceptor_states.end()) {
         return {};
     }
-    auto state = i->second.lock();
+    auto state = std::static_pointer_cast<acceptor_state>(i->second.lock());
     if (!state || !state->accepting.load(std::memory_order_acquire)) {
         return {};
     }
@@ -922,7 +922,7 @@ posix_ap_server_socket_impl::move_connected_socket(acceptor_state_ptr state, int
 }
 
 size_t
-posix_ap_server_socket_impl::testing_queued_connections(const acceptor_state_ptr& state) {
+posix_ap_server_socket_impl::queued_connections(const acceptor_state_ptr& state) {
     return state->conn_q.size();
 }
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -24,8 +24,10 @@ module;
 #endif
 
 #include <chrono>
+#include <atomic>
 #include <cstring>
 #include <functional>
+#include <mutex>
 #include <random>
 #include <variant>
 #include <coroutine>
@@ -151,8 +153,30 @@ public:
 };
 
 thread_local posix_ap_server_socket_impl::port_map_t posix_ap_server_socket_impl::ports{};
-thread_local posix_ap_server_socket_impl::sockets_map_t posix_ap_server_socket_impl::sockets{};
-thread_local posix_ap_server_socket_impl::conn_map_t posix_ap_server_socket_impl::conn_q{};
+
+struct posix_ap_server_socket_impl::acceptor_state {
+    std::atomic<bool> accepting = true;
+    std::optional<promise<accept_result>> socket;
+    std::deque<connection> conn_q;
+};
+
+namespace {
+
+using protocol_acceptor_key = std::tuple<int, seastar::net::socket_address, seastar::shard_id>;
+
+struct protocol_acceptor_key_hash {
+    size_t operator()(const protocol_acceptor_key& key) const {
+        auto h1 = std::hash<int>()(std::get<0>(key));
+        auto h2 = std::hash<seastar::net::socket_address>()(std::get<1>(key));
+        auto h3 = std::hash<seastar::shard_id>()(std::get<2>(key));
+        return h1 ^ (h2 << 1) ^ (h3 << 2);
+    }
+};
+
+std::mutex acceptor_states_mutex;
+std::unordered_map<protocol_acceptor_key, std::weak_ptr<posix_ap_server_socket_impl::acceptor_state>, protocol_acceptor_key_hash> acceptor_states;
+
+}
 
 class posix_tcp_connected_socket_operations : public posix_connected_socket_operations {
 public:
@@ -741,9 +765,13 @@ posix_server_socket_impl::accept() {
                 _allocator);
             co_return accept_result{connected_socket(std::move(csi)), sa};
         } else {
+            auto state = posix_ap_server_socket_impl::find_acceptor_state(_protocol, _sa, cpu);
+            if (!state) {
+                continue;
+            }
             // FIXME: future is discarded
-            (void)smp::submit_to(cpu, [protocol = _protocol, ssa = _sa, fd = std::move(fd.get_file_desc()), sa, cth = std::move(cth), addr_data_opt = std::move(addr_data_opt), allocator = _allocator] () mutable {
-                posix_ap_server_socket_impl::move_connected_socket(protocol, ssa, pollable_fd(std::move(fd)), sa, std::move(cth), std::move(addr_data_opt), allocator);
+            (void)smp::submit_to(cpu, [state = std::move(state), protocol = _protocol, ssa = _sa, fd = std::move(fd.get_file_desc()), sa, cth = std::move(cth), addr_data_opt = std::move(addr_data_opt), allocator = _allocator] () mutable {
+                posix_ap_server_socket_impl::move_connected_socket(std::move(state), protocol, ssa, pollable_fd(std::move(fd)), sa, std::move(cth), std::move(addr_data_opt), allocator);
             });
         }
     };
@@ -758,25 +786,75 @@ socket_address posix_server_socket_impl::local_address() const {
     return _lfd.get_file_desc().get_address();
 }
 
+posix_ap_server_socket_impl::acceptor_state_ptr
+posix_ap_server_socket_impl::register_acceptor_state(int protocol, socket_address sa, shard_id shard) {
+    auto key = std::make_tuple(protocol, sa, shard);
+    auto state = std::make_shared<acceptor_state>();
+    std::lock_guard lock(acceptor_states_mutex);
+    acceptor_states[key] = state;
+    return state;
+}
+
+posix_ap_server_socket_impl::acceptor_state_ptr
+posix_ap_server_socket_impl::find_acceptor_state(int protocol, socket_address sa, shard_id shard) {
+    auto key = std::make_tuple(protocol, sa, shard);
+    std::lock_guard lock(acceptor_states_mutex);
+    auto i = acceptor_states.find(key);
+    if (i == acceptor_states.end()) {
+        return {};
+    }
+    auto state = i->second.lock();
+    if (!state || !state->accepting.load(std::memory_order_acquire)) {
+        return {};
+    }
+    return state;
+}
+
+void
+posix_ap_server_socket_impl::close_acceptor_state(const acceptor_state_ptr& state) {
+    state->accepting.store(false, std::memory_order_release);
+    state->conn_q.clear();
+    if (state->socket) {
+        state->socket->set_exception(std::system_error(ECONNABORTED, std::system_category()));
+        state->socket.reset();
+    }
+}
+
+void
+posix_ap_server_socket_impl::unregister_acceptor_state(int protocol, socket_address sa, shard_id shard, const acceptor_state_ptr& state) {
+    close_acceptor_state(state);
+    auto key = std::make_tuple(protocol, sa, shard);
+    std::lock_guard lock(acceptor_states_mutex);
+    auto i = acceptor_states.find(key);
+    if (i != acceptor_states.end() && !i->second.owner_before(state) && !state.owner_before(i->second)) {
+        acceptor_states.erase(i);
+    }
+}
+
 posix_ap_server_socket_impl::posix_ap_server_socket_impl(int protocol, socket_address sa, std::pmr::polymorphic_allocator<char>* allocator)
-        : _protocol(protocol), _sa(sa), _allocator(allocator)
+        : _protocol(protocol)
+        , _sa(sa)
+        , _allocator(allocator)
 {
     auto it = ports.emplace(std::make_tuple(_protocol, _sa));
     if (!it.second) {
         throw std::system_error(EADDRINUSE, std::system_category());
     }
+    _state = register_acceptor_state(_protocol, _sa, this_shard_id());
 }
 
 posix_ap_server_socket_impl::~posix_ap_server_socket_impl() {
+    unregister_acceptor_state(_protocol, _sa, this_shard_id(), _state);
     ports.erase(std::make_tuple(_protocol, _sa));
 }
 
 future<accept_result> posix_ap_server_socket_impl::accept() {
-    auto t_sa = std::make_tuple(_protocol, _sa);
-    auto conni = conn_q.find(t_sa);
-    if (conni != conn_q.end()) {
-        connection c = std::move(conni->second);
-        conn_q.erase(conni);
+    if (!_state->accepting.load(std::memory_order_acquire)) {
+        return make_exception_future<accept_result>(std::system_error(ECONNABORTED, std::system_category()));
+    }
+    if (!_state->conn_q.empty()) {
+        connection c = std::move(_state->conn_q.front());
+        _state->conn_q.pop_front();
         try {
             std::unique_ptr<connected_socket_impl> csi(
                     new posix_connected_socket_impl(_sa.family(), _protocol, std::move(c.fd), std::move(c.connection_tracking_handle), _allocator));
@@ -786,9 +864,9 @@ future<accept_result> posix_ap_server_socket_impl::accept() {
         }
     } else {
         try {
-            auto i = sockets.emplace(std::piecewise_construct, std::make_tuple(t_sa), std::make_tuple());
-            SEASTAR_ASSERT(i.second);
-            return i.first->second.get_future();
+            SEASTAR_ASSERT(!_state->socket);
+            _state->socket.emplace();
+            return _state->socket->get_future();
         } catch (...) {
             return make_exception_future<accept_result>(std::current_exception());
         }
@@ -797,13 +875,7 @@ future<accept_result> posix_ap_server_socket_impl::accept() {
 
 void
 posix_ap_server_socket_impl::abort_accept() {
-    auto t_sa = std::make_tuple(_protocol, _sa);
-    conn_q.erase(t_sa);
-    auto i = sockets.find(t_sa);
-    if (i != sockets.end()) {
-        i->second.set_exception(std::system_error(ECONNABORTED, std::system_category()));
-        sockets.erase(i);
-    }
+    close_acceptor_state(_state);
 }
 
 future<accept_result>
@@ -826,10 +898,11 @@ socket_address posix_reuseport_server_socket_impl::local_address() const {
 }
 
 void
-posix_ap_server_socket_impl::move_connected_socket(int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle cth, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator) {
-    auto t_sa = std::make_tuple(protocol, sa);
-    auto i = sockets.find(t_sa);
-    if (i != sockets.end()) {
+posix_ap_server_socket_impl::move_connected_socket(acceptor_state_ptr state, int protocol, socket_address sa, pollable_fd fd, socket_address addr, conntrack::handle cth, std::optional<proxy_data> addr_data_opt, std::pmr::polymorphic_allocator<char>* allocator) {
+    if (!state || !state->accepting.load(std::memory_order_acquire)) {
+        return;
+    }
+    if (state->socket) {
         try {
             auto csi = make_maybe_proxied_connected_socket_impl(
                 sa.family(),
@@ -838,14 +911,19 @@ posix_ap_server_socket_impl::move_connected_socket(int protocol, socket_address 
                 std::move(cth),
                 std::move(addr_data_opt),
                 allocator);
-            i->second.set_value(accept_result{connected_socket(std::move(csi)), std::move(addr)});
+            state->socket->set_value(accept_result{connected_socket(std::move(csi)), std::move(addr)});
         } catch (...) {
-            i->second.set_exception(std::current_exception());
+            state->socket->set_exception(std::current_exception());
         }
-        sockets.erase(i);
+        state->socket.reset();
     } else {
-        conn_q.emplace(std::piecewise_construct, std::make_tuple(t_sa), std::make_tuple(std::move(fd), std::move(addr), std::move(cth), std::move(addr_data_opt)));
+        state->conn_q.emplace_back(std::move(fd), std::move(addr), std::move(cth), std::move(addr_data_opt));
     }
+}
+
+size_t
+posix_ap_server_socket_impl::testing_queued_connections(const acceptor_state_ptr& state) {
+    return state->conn_q.size();
 }
 
 future<temporary_buffer<char>>

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -376,7 +376,7 @@ SEASTAR_TEST_CASE(posix_ap_late_handoff_after_abort_is_dropped) {
     ap.abort_accept();
 
     net::conntrack ct;
-    net::posix_ap_server_socket_impl::move_connected_socket(
+    net::posix_ap_server_socket_impl::testing_move_connected_socket(
             state,
             protocol,
             addr,

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -368,6 +368,41 @@ SEASTAR_THREAD_TEST_CASE(socket_bufsize) {
     BOOST_CHECK_LT(recv_default, 20'000'000);
 }
 
+SEASTAR_TEST_CASE(posix_ap_late_handoff_after_abort_is_dropped) {
+    auto addr = make_ipv4_address({19374});
+    constexpr int protocol = IPPROTO_TCP;
+    net::posix_ap_server_socket_impl ap(protocol, addr);
+    auto state = ap.testing_state();
+    ap.abort_accept();
+
+    net::conntrack ct;
+    net::posix_ap_server_socket_impl::move_connected_socket(
+            state,
+            protocol,
+            addr,
+            pollable_fd(file_desc::eventfd(0, 0)),
+            addr,
+            ct.get_handle(this_shard_id()),
+            std::nullopt,
+            memory::malloc_allocator);
+
+    BOOST_REQUIRE_EQUAL(net::posix_ap_server_socket_impl::testing_queued_connections(state), 0);
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(posix_ap_accept_after_abort_fails) {
+    auto addr = make_ipv4_address({19375});
+    constexpr int protocol = IPPROTO_TCP;
+    net::posix_ap_server_socket_impl ap(protocol, addr);
+    ap.abort_accept();
+
+    return ap.accept().then([] (accept_result) {
+        BOOST_FAIL("accept after abort completed successfully");
+    }).handle_exception_type([] (const std::system_error& e) {
+        BOOST_REQUIRE_EQUAL(e.code(), std::error_code(ECONNABORTED, std::system_category()));
+    });
+}
+
 static
 void
 test_load_balancing_algorithm_port(socket_address listen_addr, bool proxy_protocol) {


### PR DESCRIPTION
Fixes #738.

## Goal

Stop old AP listener work from keeping accepted connections alive after the listener is aborted or replaced. This avoids shutdown leaks from late cross-shard handoffs.

## What I changed

- Store accepted connections and waiting accept calls in per-listener state.
- Make cross-shard handoff use the listener state instead of a shared address-based queue.
- Make `abort_accept()` close the listener state, clear queued connections, and fail `accept()` with `ECONNABORTED`.
- Drop handoffs that arrive after the listener was closed or replaced.
- Add tests for late handoff after abort, listener restart on the same address, and `accept()` after abort.

## Tests

- `ninja -C build/dev CMakeFiles/seastar.dir/src/net/posix-stack.cc.o tests/unit/CMakeFiles/test_unit_socket.dir/socket_test.cc.o`

Local note: `ninja -C build/dev test_unit_socket` fails before running the socket tests in this environment because `boost/core/type_name.hpp` is missing and GnuTLS does not provide `gnutls_ciphersuite_get`.