### PR TITLE
tests/unit: replace hardcoded TLS certificates with build-system certs

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -417,7 +417,10 @@ seastar_add_test (httpd
   SOURCES
     httpd_test.cc
     loopback_socket.hh
-    memory-data-sink.hh)
+    memory-data-sink.hh
+  DEPENDS testcrt mtls_certs
+  LIBRARIES Boost::filesystem
+  WORKING_DIRECTORY ${Seastar_BINARY_DIR})
 
 seastar_add_test (websocket
   SOURCES websocket_test.cc)
@@ -690,7 +693,7 @@ function(seastar_sign_cert name)
   cmake_parse_arguments(CERT
     ""
     "CA;SERIAL_NUM;COMMON_NAME"
-    ""
+    "SANS"
     ${ARGN})
   set(cert ${name}.crt)
   set(privkey ${name}.key)
@@ -718,6 +721,16 @@ function(seastar_sign_cert name)
     # sign the cert with the request
     set(ca_cert ${CERT_CA}.crt)
     set(ca_privkey ${CERT_CA}.key)
+    if(CERT_SANS)
+      string(JOIN ", " san_str ${CERT_SANS})
+      file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${name}.ext"
+        "[req_ext]\nsubjectAltName = ${san_str}\n")
+      set(extfile_args -extfile ${name}.ext -extensions req_ext)
+      set(extfile_dep "${CMAKE_CURRENT_BINARY_DIR}/${name}.ext")
+    else()
+      set(extfile_args "")
+      set(extfile_dep "")
+    endif()
     add_custom_command(OUTPUT ${cert}
       COMMAND ${OPENSSL} x509
         -req -days 1000 -sha256
@@ -726,7 +739,8 @@ function(seastar_sign_cert name)
         -CA ${ca_cert}
         -CAkey ${ca_privkey}
         -out ${cert}
-      DEPENDS ${req} ${ca_cert} ${ca_privkey}
+        ${extfile_args}
+      DEPENDS ${req} ${ca_cert} ${ca_privkey} ${extfile_dep}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   else(DEFINED CERT_CA)
     # create a cert if CA is not specified
@@ -767,9 +781,19 @@ function(seastar_gen_mtls_certs)
     CA ${cert_ca}
     SERIAL_NUM 3
     COMMON_NAME "client2.org")
+  # client cert with DNS and URI SANs (used by httpd_test for SAN propagation test)
+  seastar_sign_cert("mtls_client_san"
+    CA ${cert_ca}
+    SERIAL_NUM 4
+    COMMON_NAME "san-client.server.com"
+    SANS "DNS:san-client.server.com" "URI:spiffe://example.com/client")
 
   add_custom_target(mtls_certs
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/mtls_client1.crt" "${CMAKE_CURRENT_BINARY_DIR}/mtls_client2.crt" "${CMAKE_CURRENT_BINARY_DIR}/mtls_server.crt"
+    DEPENDS
+      "${CMAKE_CURRENT_BINARY_DIR}/mtls_client1.crt"
+      "${CMAKE_CURRENT_BINARY_DIR}/mtls_client2.crt"
+      "${CMAKE_CURRENT_BINARY_DIR}/mtls_server.crt"
+      "${CMAKE_CURRENT_BINARY_DIR}/mtls_client_san.crt"
   )
 endfunction()
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -25,6 +25,7 @@
 #include "loopback_socket.hh"
 #include "memory-data-sink.hh"
 #include <boost/algorithm/string.hpp>
+#include <boost/dll.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/http/json_path.hh>
@@ -43,6 +44,10 @@
 
 using namespace seastar;
 using namespace httpd;
+
+static std::string certfile(const std::string& file) {
+    return (boost::dll::program_location().parent_path() / file).string();
+}
 
 class handl : public httpd::handler_base {
 public:
@@ -2659,34 +2664,12 @@ SEASTAR_TEST_CASE(test_request_scheduling_group) {
         try {
             scheduling_group observed_handler_sg;
 
-            static const char test_cert[] =
-                "-----BEGIN CERTIFICATE-----\n"
-                "MIIBzDCCAXOgAwIBAgIULUjD6YNpUtkaibrj8Z5pMg/bQlEwCgYIKoZIzj0EAwIw\n"
-                "FDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDMxOTA4Mjg0NloYDzIxMjYwMjIz\n"
-                "MDgyODQ2WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjO\n"
-                "PQMBBwNCAATsDbUqgqgR3llGWbVnz3jcY16/ZUWZT4kaIneoRbjTlMgr/Z5cBM2H\n"
-                "ZaN7zY6yuLFPkf/yRNCki9Q565EqqIzRo4GgMIGdMB0GA1UdDgQWBBTDUmIk5BxS\n"
-                "nWiOWNucItd2PWCL3jBPBgNVHSMESDBGgBTDUmIk5BxSnWiOWNucItd2PWCL3qEY\n"
-                "pBYwFDESMBAGA1UEAwwJbG9jYWxob3N0ghQtSMPpg2lS2RqJuuPxnmkyD9tCUTAP\n"
-                "BgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9zdIcEfwAAATAKBggq\n"
-                "hkjOPQQDAgNHADBEAiBVsdCtlAEz0bqR73UViNXOKln5KCEon77KdjKHsDI1gAIg\n"
-                "da4opFU4dPGt3kKOe2UNTIxre0rdIuQmv4sidCTBfx4=\n"
-                "-----END CERTIFICATE-----\n";
-            static const char test_key[] =
-                "-----BEGIN PRIVATE KEY-----\n"
-                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgPJLOJNZ40LFhA4h4\n"
-                "DD+iARBzBUVEHY18F04UNcm/FNihRANCAATsDbUqgqgR3llGWbVnz3jcY16/ZUWZ\n"
-                "T4kaIneoRbjTlMgr/Z5cBM2HZaN7zY6yuLFPkf/yRNCki9Q565EqqIzR\n"
-                "-----END PRIVATE KEY-----\n";
-
-            auto server_creds = ::make_shared<tls::server_credentials>(::make_shared<tls::dh_params>());
-            server_creds->set_x509_key(
-                    tls::blob(test_cert, sizeof(test_cert) - 1),
-                    tls::blob(test_key, sizeof(test_key) - 1),
-                    tls::x509_crt_format::PEM);
+            tls::credentials_builder server_builder;
+            server_builder.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+            auto server_creds = server_builder.build_server_credentials();
 
             tls::credentials_builder client_builder;
-            client_builder.set_x509_trust(tls::blob(test_cert, sizeof(test_cert) - 1), tls::x509_crt_format::PEM);
+            client_builder.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
             auto client_creds = client_builder.build_certificate_credentials();
 
             auto addr = socket_address(ipv4_addr("127.0.0.1", 0));
@@ -2708,7 +2691,7 @@ SEASTAR_TEST_CASE(test_request_scheduling_group) {
             // interleave client and server TLS handshake progress.
             future<> client = seastar::async([&] {
                 auto c_socket = tls::connect(client_creds, actual_addr,
-                        tls::tls_options{.server_name = sstring("localhost")}).get();
+                        tls::tls_options{.server_name = sstring("test.scylladb.org")}).get();
                 auto input = c_socket.input();
                 auto output = c_socket.output();
                 auto close_in = deferred_close(input);
@@ -2744,77 +2727,21 @@ SEASTAR_TEST_CASE(test_request_scheduling_group) {
 // TLS connection, even when the client certificate carries no SAN extensions.
 SEASTAR_TEST_CASE(test_mtls_dn_propagation) {
     return seastar::async([] {
-        // Self-signed CA (CN=server.com) that signs both the server and client certificates below.
-        static const char mtls_ca_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBkTCCATagAwIBAgIUHAGWAd2vYMIUpcWjOX8J2d4DCX4wCgYIKoZIzj0EAwIw\n"
-            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
-            "OTE4MjZaMBUxEzARBgNVBAMMCnNlcnZlci5jb20wWTATBgcqhkjOPQIBBggqhkjO\n"
-            "PQMBBwNCAASbsF3KPrYN03EHUBgmaTx8F3g2WHySxf1WAJMNA9KwPlSTpDCISXFQ\n"
-            "7vvXdbMnHzZuSH1t+QcODxZIFtx1D3sUo2QwYjAdBgNVHQ4EFgQUN/Ct/ixGWTdj\n"
-            "cgk8KeW0JtVgGlQwHwYDVR0jBBgwFoAUN/Ct/ixGWTdjcgk8KeW0JtVgGlQwDwYD\n"
-            "VR0RBAgwBocEfwAAATAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYC\n"
-            "IQDwOqCG4WYzj80SYkTaeiMxebJx6c3LvWyq/k9pyNyOQgIhAKBzeJWNd1r4HEAd\n"
-            "WHxi6RD5GDWWr7OzXhNNfwg66KEa\n"
-            "-----END CERTIFICATE-----\n";
-        // Server certificate: CN=server.server.com, signed by the CA above.
-        static const char mtls_server_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBdTCCARugAwIBAgIUC8xHpJtk5p3k3fFNIeburBRUqEcwCgYIKoZIzj0EAwIw\n"
-            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
-            "OTE4MjZaMBwxGjAYBgNVBAMMEXNlcnZlci5zZXJ2ZXIuY29tMFkwEwYHKoZIzj0C\n"
-            "AQYIKoZIzj0DAQcDQgAEPZJywC1vMYfkDjWlUSQJ71Wbea0N8VHBtkhreqGg0Yx5\n"
-            "32ZKUB4Tyr1urH/Q3mw6rL4hfJ3+RREtkDGOhYeKHKNCMEAwHQYDVR0OBBYEFA7S\n"
-            "KzBfmLHVa4OhtlxdBAnoN2rWMB8GA1UdIwQYMBaAFDfwrf4sRlk3Y3IJPCnltCbV\n"
-            "YBpUMAoGCCqGSM49BAMCA0gAMEUCIQDSQPxyVY6wR8rlCeqGu/7Kw3a7Zy0dNvWZ\n"
-            "NBLC3K00AgIgde5xN8bBO/HORzfxATxHUNU52aQVYN4XRvXvZuB5D28=\n"
-            "-----END CERTIFICATE-----\n";
-        static const char mtls_server_key[] =
-            "-----BEGIN EC PRIVATE KEY-----\n"
-            "MHcCAQEEICzgEWTe2FDq9e9+K+9UgiN5wVsT/biFBON8n80GgrwpoAoGCCqGSM49\n"
-            "AwEHoUQDQgAEPZJywC1vMYfkDjWlUSQJ71Wbea0N8VHBtkhreqGg0Yx532ZKUB4T\n"
-            "yr1urH/Q3mw6rL4hfJ3+RREtkDGOhYeKHA==\n"
-            "-----END EC PRIVATE KEY-----\n";
-        // Client certificate: CN=client.server.com, signed by the CA above.
-        static const char mtls_client_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBdTCCARugAwIBAgIUC8xHpJtk5p3k3fFNIeburBRUqEgwCgYIKoZIzj0EAwIw\n"
-            "FTETMBEGA1UEAwwKc2VydmVyLmNvbTAeFw0yNjA3MDgxOTE4MjZaFw0zNjA3MDUx\n"
-            "OTE4MjZaMBwxGjAYBgNVBAMMEWNsaWVudC5zZXJ2ZXIuY29tMFkwEwYHKoZIzj0C\n"
-            "AQYIKoZIzj0DAQcDQgAEDrhgfDYXOTNmK5OJFcD6Frk1SMfyxM0K6gtxWK0kEex3\n"
-            "vYUAEuESkboyF07yOUwZAnUDzquAO8xTeTJY3POuYqNCMEAwHQYDVR0OBBYEFBZF\n"
-            "A9LwGwhBHhsIiRI1KYCVymKDMB8GA1UdIwQYMBaAFDfwrf4sRlk3Y3IJPCnltCbV\n"
-            "YBpUMAoGCCqGSM49BAMCA0gAMEUCIQDZ/I/CUmkSPmyQAgEU2d04pVp3Cu0tQZpX\n"
-            "PxVvseCJBQIgdpuFxONoYHHNxjq0NpvRx6VLUrjJKb1LjGhWmzzU3zE=\n"
-            "-----END CERTIFICATE-----\n";
-        static const char mtls_client_key[] =
-            "-----BEGIN EC PRIVATE KEY-----\n"
-            "MHcCAQEEIOPelbFn46IcU/d8uNhj6EE/14PDYfDWFKaPnhUCiwYcoAoGCCqGSM49\n"
-            "AwEHoUQDQgAEDrhgfDYXOTNmK5OJFcD6Frk1SMfyxM0K6gtxWK0kEex3vYUAEuES\n"
-            "kboyF07yOUwZAnUDzquAO8xTeTJY3POuYg==\n"
-            "-----END EC PRIVATE KEY-----\n";
+        // Uses build-system generated mtls_ca.crt / mtls_server.crt / mtls_client1.crt.
+        // mtls_ca: CA (CN=redpanda.com), mtls_server: CN=server.redpanda.com,
+        // mtls_client1: CN=client1.org (no SAN extensions).
 
         // Server requires a client certificate signed by the CA.
         tls::credentials_builder server_builder;
-        server_builder.set_x509_trust(
-                tls::blob(mtls_ca_cert, sizeof(mtls_ca_cert) - 1),
-                tls::x509_crt_format::PEM);
-        server_builder.set_x509_key(
-                tls::blob(mtls_server_cert, sizeof(mtls_server_cert) - 1),
-                tls::blob(mtls_server_key, sizeof(mtls_server_key) - 1),
-                tls::x509_crt_format::PEM);
+        server_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        server_builder.set_x509_key_file(certfile("mtls_server.crt"), certfile("mtls_server.key"), tls::x509_crt_format::PEM).get();
         server_builder.set_client_auth(tls::client_auth::REQUIRE);
         auto server_creds = server_builder.build_server_credentials();
 
         // Client presents its certificate to satisfy the server's REQUIRE policy.
         tls::credentials_builder client_builder;
-        client_builder.set_x509_trust(
-                tls::blob(mtls_ca_cert, sizeof(mtls_ca_cert) - 1),
-                tls::x509_crt_format::PEM);
-        client_builder.set_x509_key(
-                tls::blob(mtls_client_cert, sizeof(mtls_client_cert) - 1),
-                tls::blob(mtls_client_key, sizeof(mtls_client_key) - 1),
-                tls::x509_crt_format::PEM);
+        client_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        client_builder.set_x509_key_file(certfile("mtls_client1.crt"), certfile("mtls_client1.key"), tls::x509_crt_format::PEM).get();
         auto client_creds = client_builder.build_certificate_credentials();
 
         std::optional<session_dn> observed_dn;
@@ -2843,7 +2770,7 @@ SEASTAR_TEST_CASE(test_mtls_dn_propagation) {
         // interleave client and server TLS handshake progress.
         future<> client_fiber = seastar::async([&] {
             auto c_socket = tls::connect(client_creds, actual_addr,
-                    tls::tls_options{.server_name = sstring("server.server.com")}).get();
+                    tls::tls_options{.server_name = sstring("server.redpanda.com")}).get();
             auto input = c_socket.input();
             auto output = c_socket.output();
             auto close_in = deferred_close(input);
@@ -2859,10 +2786,10 @@ SEASTAR_TEST_CASE(test_mtls_dn_propagation) {
         client_fiber.get();
 
         // The handler must have received a populated tls_dn matching the
-        // client certificate (CN=client.server.com) issued by the CA (CN=server.com).
+        // client certificate (CN=client1.org) issued by the CA (CN=redpanda.com).
         BOOST_REQUIRE(observed_dn.has_value());
-        BOOST_REQUIRE_NE(observed_dn->subject.find("client.server.com"), sstring::npos);
-        BOOST_REQUIRE_NE(observed_dn->issuer.find("server.com"), sstring::npos);
+        BOOST_REQUIRE_NE(observed_dn->subject.find("client1.org"), sstring::npos);
+        BOOST_REQUIRE_NE(observed_dn->issuer.find("redpanda.com"), sstring::npos);
         // tls_san must be set (non-null) for any TLS connection, even when the
         // client certificate carries no SAN extensions.
         BOOST_REQUIRE(observed_san.has_value());
@@ -2877,79 +2804,18 @@ SEASTAR_TEST_CASE(test_mtls_dn_propagation) {
 // req.tls_san, so that handlers can use them for identity (e.g. SPIFFE URIs).
 SEASTAR_TEST_CASE(test_mtls_san_propagation) {
     return seastar::async([] {
-        // Self-signed CA, server cert, and client cert with DNS + URI SANs:
-        static const char san_ca_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBiTCCATCgAwIBAgIUNfVbgqgJmihN0bY8Tur8B70zzmcwCgYIKoZIzj0EAwIw\n"
-            "EjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNjA3MTExNjI1NDlaFw0zNjA3MDgxNjI1\n"
-            "NDlaMBIxEDAOBgNVBAMMB3Rlc3QtY2EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n"
-            "AAR4QEFdFDw+nwhd1LUpPmC9ZK9p74kJYh5H9Mk2puaVhtCIR1Ox5gx5IryScZCt\n"
-            "W7HJ7f3CTYnACUJs8usUFCjDo2QwYjAdBgNVHQ4EFgQUq+O8snr60kr3EhdYc/SP\n"
-            "xZ55lXwwHwYDVR0jBBgwFoAUq+O8snr60kr3EhdYc/SPxZ55lXwwDwYDVR0RBAgw\n"
-            "BocEfwAAATAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIE3qzWFI\n"
-            "xTE2fqwzTiA2V78X86duSrhU8JtBG4EJWVCUAiAQvKOdlsknMT8ixrR+/gMrONjQ\n"
-            "BbfIZq7UvH9rvIsaXg==\n"
-            "-----END CERTIFICATE-----\n";
-        static const char san_server_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBkTCCATagAwIBAgIUJ+OG5WKsjMCeak5qyMhQ0yqemlkwCgYIKoZIzj0EAwIw\n"
-            "EjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNjA3MTExNjI1NDlaFw0zNjA3MDgxNjI1\n"
-            "NDlaMBwxGjAYBgNVBAMMEXNlcnZlci5zZXJ2ZXIuY29tMFkwEwYHKoZIzj0CAQYI\n"
-            "KoZIzj0DAQcDQgAETcpMdHuAf7qZjMbW/yjtH0AjiJHpY2ZeOEXb2bMHohdJFm/x\n"
-            "8miPzvrB2bnRmlGen378xfd5Oz9F8JMqmzs3gqNgMF4wHAYDVR0RBBUwE4IRc2Vy\n"
-            "dmVyLnNlcnZlci5jb20wHQYDVR0OBBYEFPx3hhB+ycP8OwpuO16NLjMQaPItMB8G\n"
-            "A1UdIwQYMBaAFKvjvLJ6+tJK9xIXWHP0j8WeeZV8MAoGCCqGSM49BAMCA0kAMEYC\n"
-            "IQDGiFYnVUr9d4y3fQG/OeNcj77wdJY+S/QnA1gQP9kQlwIhAIjwr9z9j90sGJkT\n"
-            "Ddu7CCUTkG835Z1OL82FnlH93Fat\n"
-            "-----END CERTIFICATE-----\n";
-        static const char san_server_key[] =
-            "-----BEGIN EC PRIVATE KEY-----\n"
-            "MHcCAQEEIET2Je4ecbqCgzHPwf3Du8xK0R/pGomcbNvBXipYiYlkoAoGCCqGSM49\n"
-            "AwEHoUQDQgAETcpMdHuAf7qZjMbW/yjtH0AjiJHpY2ZeOEXb2bMHohdJFm/x8miP\n"
-            "zvrB2bnRmlGen378xfd5Oz9F8JMqmzs3gg==\n"
-            "-----END EC PRIVATE KEY-----\n";
-        // Client certificate with:
-        //   Subject: CN=san-client.server.com
-        //   SAN: DNS:san-client.server.com, URI:spiffe://example.com/client
-        static const char san_client_cert[] =
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIBtTCCAVygAwIBAgIUJ+OG5WKsjMCeak5qyMhQ0yqemlowCgYIKoZIzj0EAwIw\n"
-            "EjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNjA3MTExNjI1NDlaFw0zNjA3MDgxNjI1\n"
-            "NDlaMCAxHjAcBgNVBAMMFXNhbi1jbGllbnQuc2VydmVyLmNvbTBZMBMGByqGSM49\n"
-            "AgEGCCqGSM49AwEHA0IABMxX6lxFObOcqGG8pTcG8Q/Rp/gjtP5Dzc0JuujpPd5V\n"
-            "8s9o9pEhNvefKxtRsFARQNv1oU50XwM1DiG8SEwlFwqjgYEwfzA9BgNVHREENjA0\n"
-            "ghVzYW4tY2xpZW50LnNlcnZlci5jb22GG3NwaWZmZTovL2V4YW1wbGUuY29tL2Ns\n"
-            "aWVudDAdBgNVHQ4EFgQUf1AVQBs5CZbJNWHE9M6inq8vW+EwHwYDVR0jBBgwFoAU\n"
-            "q+O8snr60kr3EhdYc/SPxZ55lXwwCgYIKoZIzj0EAwIDRwAwRAIgES8m0DuidZ+4\n"
-            "4NOS+BVQ2CzGdPgzmWgsKWVkf+dRTbACICmAFsB8JWJM/UlvvV1OwMNggJD5qzZ7\n"
-            "uqbMXan0M9ai\n"
-            "-----END CERTIFICATE-----\n";
-        static const char san_client_key[] =
-            "-----BEGIN EC PRIVATE KEY-----\n"
-            "MHcCAQEEINoNMldawj3P5wAVOVB6AeObDXUFXrO8yPKoy0s7aM8NoAoGCCqGSM49\n"
-            "AwEHoUQDQgAEzFfqXEU5s5yoYbylNwbxD9Gn+CO0/kPNzQm66Ok93lXyz2j2kSE2\n"
-            "958rG1GwUBFA2/WhTnRfAzUOIbxITCUXCg==\n"
-            "-----END EC PRIVATE KEY-----\n";
+        // Uses build-system generated mtls_ca.crt / mtls_server.crt / mtls_client_san.crt.
+        // mtls_client_san carries: DNS:san-client.server.com, URI:spiffe://example.com/client.
 
         tls::credentials_builder server_builder;
-        server_builder.set_x509_trust(
-                tls::blob(san_ca_cert, sizeof(san_ca_cert) - 1),
-                tls::x509_crt_format::PEM);
-        server_builder.set_x509_key(
-                tls::blob(san_server_cert, sizeof(san_server_cert) - 1),
-                tls::blob(san_server_key, sizeof(san_server_key) - 1),
-                tls::x509_crt_format::PEM);
+        server_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        server_builder.set_x509_key_file(certfile("mtls_server.crt"), certfile("mtls_server.key"), tls::x509_crt_format::PEM).get();
         server_builder.set_client_auth(tls::client_auth::REQUIRE);
         auto server_creds = server_builder.build_server_credentials();
 
         tls::credentials_builder client_builder;
-        client_builder.set_x509_trust(
-                tls::blob(san_ca_cert, sizeof(san_ca_cert) - 1),
-                tls::x509_crt_format::PEM);
-        client_builder.set_x509_key(
-                tls::blob(san_client_cert, sizeof(san_client_cert) - 1),
-                tls::blob(san_client_key, sizeof(san_client_key) - 1),
-                tls::x509_crt_format::PEM);
+        client_builder.set_x509_trust_file(certfile("mtls_ca.crt"), tls::x509_crt_format::PEM).get();
+        client_builder.set_x509_key_file(certfile("mtls_client_san.crt"), certfile("mtls_client_san.key"), tls::x509_crt_format::PEM).get();
         auto client_creds = client_builder.build_certificate_credentials();
 
         std::optional<std::vector<tls::subject_alt_name>> observed_san;
@@ -2972,7 +2838,7 @@ SEASTAR_TEST_CASE(test_mtls_san_propagation) {
 
         future<> client_fiber = seastar::async([&] {
             auto c_socket = tls::connect(client_creds, actual_addr,
-                    tls::tls_options{.server_name = sstring("server.server.com")}).get();
+                    tls::tls_options{.server_name = sstring("server.redpanda.com")}).get();
             auto input = c_socket.input();
             auto output = c_socket.output();
             auto close_in = deferred_close(input);


### PR DESCRIPTION
Several httpd unit tests (test_request_scheduling_group, test_mtls_dn_propagation, test_mtls_san_propagation) embedded self-signed PEM certificates as string literals directly in the source. This is fragile: the certs expire, reviewers cannot easily inspect what they certify, and they diverge from the cert infrastructure already maintained by the build system for tls_test.cc.

Replace all hardcoded certs with file-based loading via a certfile() helper (same pattern used in tls_test.cc).  The scheduling group test reuses the existing test.crt/catest.pem pair.  The two mTLS tests reuse the existing mtls_ca/mtls_server/mtls_client1 certs.  For the SAN propagation test, which requires a client cert carrying both a DNS and a URI (SPIFFE) SAN, a new mtls_client_san cert is added to the build system.

To support per-cert SAN injection when signing with a CA, seastar_sign_cert gains an optional SANS list argument that writes an OpenSSL extension file at configure time and passes it to openssl x509 at build time.

The httpd test target is updated to depend on testcrt and mtls_certs and to link Boost::filesystem (needed by boost::dll::program_location).