### PR TITLE
tls_gnutls: Enable verify_wrapper for both client and server mode

### DIFF
--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -530,10 +530,12 @@ public:
         // This would be nice, because we preferably want verification to
         // abort hand shake so peer immediately knows we bailed...
 #if GNUTLS_VERSION_NUMBER >= 0x030406
-        if (_type == type::CLIENT) {
-            gnutls_session_set_verify_function(*this, &verify_wrapper);
-        }
-#endif
+        // #3522 - we can set our verify for both client and server.
+        // It will never be called in the server case, unless the above
+        // call to gnutls_certificate_server_set_request was request or
+        // require. Which is what we want.
+        gnutls_session_set_verify_function(*this, &verify_wrapper);
+ #endif
         // if we are a client, check if we have a session ticket to unpack.
         if (_type == type::CLIENT && !_options.session_resume_data.empty()) {
             gtls_chk(gnutls_session_set_data(*this, _options.session_resume_data.data(), _options.session_resume_data.size()));
@@ -624,7 +626,10 @@ public:
                     return make_exception_future<>(verification_error("No certificate was found"));
 #if GNUTLS_VERSION_NUMBER >= 0x030406
                 case GNUTLS_E_CERTIFICATE_ERROR:
-                    verify(); // should throw. otherwise, fallthrough
+                    // callback should have thrown. otherwise, fallthrough
+                    if (_error) {
+                        return clear_output_and_return_exception(_error);
+                    }
                     [[fallthrough]];
 #endif
                 default:
@@ -643,20 +648,13 @@ public:
                     });
                 }
             }
-            if (_type == type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
-                verify();
-            }
+            // #3522 removed explicit call to verify here. Callback has already been
+            // called if required by being either client or requiring auth
             _connected = true;
             // make sure we reset output_pending
             return wait_for_output();
         } catch (...) {
-            auto ep = std::current_exception();
-            return wait_for_output().then_wrapped(
-                [this, ep = std::move(ep)](future<> f) {
-                  f.ignore_ready_future();
-                  _error = ep;
-                  return make_exception_future<>(ep);
-                });
+            return clear_output_and_return_exception(std::current_exception());
         }
     }
     future<> do_handshake() {
@@ -727,6 +725,15 @@ public:
            return make_exception_future(ep);
         });
     }
+    // See #3498. Throw helper that ensures we don't leak abandoned exception
+    // futures in _output_pending
+    future<> clear_output_and_return_exception(std::exception_ptr ep) {
+        return std::exchange(_output_pending, make_ready_future()).then_wrapped([this, ep](future<> f) {
+           f.ignore_ready_future();
+           _error = ep;
+           return make_exception_future(ep);
+        });
+    }
 
     static session * from_transport_ptr(gnutls_transport_ptr_t ptr) {
         return static_cast<session *>(ptr);
@@ -737,6 +744,9 @@ public:
             from_transport_ptr(gnutls_transport_get_ptr(gs))->verify();
             return 0;
         } catch (...) {
+            // set our error pointer already here. it saves us a throw in
+            // handshake
+            from_transport_ptr(gnutls_transport_get_ptr(gs))->_error = std::current_exception();
             return GNUTLS_E_CERTIFICATE_ERROR;
         }
     }

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -429,7 +429,10 @@ SEASTAR_TEST_CASE(test_failed_connect) {
     return connect_to_ssl_addr(b.build_certificate_credentials(), ipv4_addr()).handle_exception([](auto) {});
 }
 
-SEASTAR_TEST_CASE(test_non_tls) {
+// Verify that if we connect to a (non-tls) server,
+// do no IO, but have the connection dropped, we get
+// a ECONNRESET
+SEASTAR_TEST_CASE(test_abort_without_read_write) {
     ::listen_options opts;
     opts.reuse_address = true;
     auto addr = ::make_ipv4_address( {0x7f000001, 4712});
@@ -442,20 +445,105 @@ SEASTAR_TEST_CASE(test_non_tls) {
 
     auto f = connect_to_ssl_addr(b.build_certificate_credentials(), addr);
 
+    auto got_exception = make_shared<bool>(false);
 
     return c.then([f = std::move(f)](accept_result ar) mutable {
         ::connected_socket s = std::move(ar.connection);
-        std::cerr << "Established connection" << std::endl;
+        BOOST_TEST_MESSAGE("Established connection");
         auto sp = std::make_unique<::connected_socket>(std::move(s));
         timer<> t([s = std::ref(*sp)] {
-            std::cerr << "Killing server side" << std::endl;
+            BOOST_TEST_MESSAGE("Killing server side");
             s.get() = ::connected_socket();
         });
-        t.arm(timer<>::clock::now() + std::chrono::seconds(5));
+        t.arm(timer<>::clock::now() + std::chrono::seconds(2));
         return std::move(f).finally([t = std::move(t), sp = std::move(sp)] {});
-    }).handle_exception([server = std::move(server)](auto ep) {
-        std::cerr << "Got expected exception" << std::endl;
+    }).handle_exception([server = std::move(server), got_exception](auto ep) {
+        for (;;) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (seastar::nested_exception& ne) {
+                ep = ne.outer;
+                continue;
+            } catch (std::system_error& e) {
+                BOOST_TEST_MESSAGE("Got expected exception");
+                *got_exception = true;
+                return;
+            } catch (std::exception& e) {
+                try {
+                    std::rethrow_if_nested(e);
+                } catch (...) {
+                    ep = std::current_exception();
+                    continue;
+                }
+            }
+            break;
+        }
+    }).finally([got_exception] {
+        BOOST_CHECK(*got_exception);
     });
+}
+
+// Verify connecting to a non-tls server
+// fails.
+SEASTAR_THREAD_TEST_CASE(test_non_tls) {
+    ::listen_options opts;
+    opts.reuse_address = true;
+    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto server = server_socket(seastar::listen(addr, opts));
+    auto sa = server.accept();
+
+    tls::credentials_builder b;
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+
+    auto creds = b.build_certificate_credentials();
+    auto f = tls::connect(creds, addr);
+
+    auto ss = sa.get();
+    auto sis = ss.connection.input();
+    auto sos = ss.connection.output();
+    bool stop = false;
+    auto f2 = repeat_until_value([&] {
+        return sis.read().then([&](auto ignored) -> std::optional<int> {
+            return stop ? std::nullopt : std::optional<int>(1);
+        });
+    });
+    auto f3 = repeat_until_value([&] {
+        return sos.write("Goodbye mr Driscol, you've been bit by giant lizards").then([&] {
+            return sos.flush();
+        }).then([&]() -> std::optional<int> {
+            return stop ? std::nullopt : std::optional<int>(1);
+        });
+    });
+
+    // the connect as such should succeed, but the handshare following it
+    // should not.
+    auto c = f.get();
+    output_stream<char> out(c.output().detach(), 4096);
+
+    auto def = defer([&]() noexcept {
+        stop = true;
+        out.close().get();
+        server.abort_accept();
+        sis.close().get();
+        sos.close().get();
+        try {
+            f2.get();
+        } catch (...) {
+        }
+        try {
+            f3.get();
+        } catch (...) {
+        }
+    });
+
+    try {
+        out.write("apa").get();
+        out.flush().get();
+
+        BOOST_FAIL("Expected exception");
+    } catch (std::system_error& e) {
+        // ok
+    }
 }
 
 SEASTAR_TEST_CASE(test_abort_accept_before_handshake) {


### PR DESCRIPTION
Fixes #3522

Previously, we only set a verification wrapper callback for client
mode sockets. This because for server mode, the callback is never
called, unless certificate authentication is enabled. Nowdays,
we have support for this, so can make the design unilateral.
This also means we can drop explicit `verify()` calls in handshake,
and do one less extra rethrow in the error handling.

The test case test_non_tls was somewhat misnamed as it really
tested that a non-tls related reset will propagate through the
tls socket.

Renamed + added explicit exception check (and error code).
Added another test named test_non_tls that does exactly this, 
since this PR is about verifying the TLS connection.