### PR TITLE
io_queue: fix flaky test_tb_params

### DIFF
--- a/include/seastar/core/disk_params.hh
+++ b/include/seastar/core/disk_params.hh
@@ -52,9 +52,13 @@ private:
     const unsigned _max_queues;
     unsigned _num_io_groups = 0;
     std::unordered_map<unsigned, disk_params> _disks;
-    std::chrono::duration<double> _latency_goal;
-    std::chrono::milliseconds _stall_threshold;
-    double _flow_ratio_backpressure_threshold;
+    // Mirror the default values from io_queue::config. parse_config() overrides
+    // them from the reactor options, but a disk_config_params that was never
+    // fed through parse_config() (e.g. in unit tests) must still generate a
+    // sane config instead of reading these members uninitialized.
+    std::chrono::duration<double> _latency_goal{std::chrono::milliseconds(1)};
+    std::chrono::milliseconds _stall_threshold{std::chrono::milliseconds(100)};
+    double _flow_ratio_backpressure_threshold = 1.1;
 
 public:
     explicit disk_config_params(unsigned max_queues) noexcept

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <ratio>
 #include <seastar/core/thread.hh>
 #include <seastar/core/sleep.hh>
@@ -583,16 +584,19 @@ SEASTAR_THREAD_TEST_CASE(test_tb_params) {
         auto fg_rate = std::chrono::duration<double, io_throttler::rate_resolution>(std::chrono::seconds(1)).count();
         double iops_read = rate / cost_read_512 * fg_rate;
         double iops_write = rate / cost_write_512 * fg_rate;
-        double bandwidth_read = rate / cost_read_128k * 131072 * fg_rate;
-        double bandwidth_write = rate / cost_write_128k * 131072 * fg_rate;
+        double bandwidth_read = rate / (cost_read_128k - cost_read_512) * (bw_req_size - iops_req_size) * fg_rate;
+        double bandwidth_write = rate / (cost_write_128k - cost_write_512) * (bw_req_size - iops_req_size) * fg_rate;
         seastar_logger.info("IOPS read: {}, IOPS write: {}, Bandwidth read: {}, Bandwidth write: {}",
                             iops_read, iops_write, bandwidth_read, bandwidth_write);
 
-        float error_margin = 0.05f; // 5% error margin
-        BOOST_CHECK((d.read_req_rate - iops_read) / d.read_req_rate < error_margin);
-        BOOST_CHECK((d.write_req_rate - iops_write) / d.write_req_rate < error_margin);
-        BOOST_CHECK((d.read_bytes_rate - bandwidth_read) / d.read_bytes_rate < error_margin);
-        BOOST_CHECK((d.write_bytes_rate - bandwidth_write) / d.write_bytes_rate < error_margin);
+        auto within_margin = [&] (double computed, double configured) {
+            float error_margin = 0.05f; // 5% error margin
+            return std::abs(computed - configured) / configured < error_margin;
+        };
+        BOOST_CHECK(within_margin(iops_read, d.read_req_rate));
+        BOOST_CHECK(within_margin(iops_write, d.write_req_rate));
+        BOOST_CHECK(within_margin(bandwidth_read, d.read_bytes_rate));
+        BOOST_CHECK(within_margin(bandwidth_write, d.write_bytes_rate));
     }
 }
 


### PR DESCRIPTION
test_tb_params calculated bandwidth from the full cost of a 128 KiB request and compared it to the configured bandwidth. 

That cost also includes a fixed per-operation (IOPS) term, so the calculated value is ~35% lower. The test only passed elsewhere by accident: it builds a disk_config_params without calling parse_config(), leaving several members uninitialized; when those members were ~0 by chance, it capped the request cost via maximum_capacity() and masked the error.

On g++-16/C++23/release/arm the garbage members were non-0.

This PR adds 2 patches:
- disk_params: give _latency_goal, _stall_threshold, and _flow_ratio_backpressure_threshold default initializers (mirroring io_queue::config), so a disk_config_params that skips parse_config() produces a sane config instead of reading uninitialized memory. Whit this fix in, the test starts to fail all the time.
- test_tb_params: derive bandwidth from the marginal per-byte cost (cost_128k − cost_512, over bw_req_size − iops_req_size).

Fixes: https://github.com/scylladb/seastar/issues/3499