### PR TITLE
Fix metrics queue label

### DIFF
--- a/include/seastar/net/net.hh
+++ b/include/seastar/net/net.hh
@@ -227,14 +227,13 @@ class qp {
     circular_buffer<packet> _tx_packetq;
 
 protected:
-    const std::string _stats_plugin_name;
     const std::string _queue_name;
     metrics::metric_groups _metrics;
     qp_stats _stats;
 
 public:
     qp(bool register_copy_stats = false,
-       const std::string stats_plugin_name = std::string("network"),
+       std::string port_name = "",
        uint8_t qid = 0);
     virtual ~qp();
     virtual future<> send(packet p) = 0;

--- a/src/net/dpdk.cc
+++ b/src/net/dpdk.cc
@@ -348,7 +348,6 @@ class dpdk_device : public device {
     rss_key_type _rss_key;
     port_stats _stats;
     timer<> _stats_collector;
-    const std::string _stats_plugin_name;
     const std::string _stats_plugin_inst;
     seastar::metrics::metric_groups _metrics;
     bool _is_i40e_device = false;
@@ -407,7 +406,6 @@ public:
         , _home_cpu(this_shard_id())
         , _use_lro(use_lro)
         , _enable_fc(enable_fc)
-        , _stats_plugin_name("network")
         , _stats_plugin_inst(std::string("port") + std::to_string(_port_idx))
         , _xstats(port_idx)
     {
@@ -420,7 +418,7 @@ public:
 
         // Register port statistics pollers
         namespace sm = seastar::metrics;
-        _metrics.add_group(_stats_plugin_name, {
+        _metrics.add_group("network", {
             // Rx Good
             sm::make_counter("rx_multicast", _stats.rx.good.mcast,
                             sm::description("Counts a number of received multicast packets."), {sm::shard_label(_stats_plugin_inst)}),
@@ -1244,8 +1242,7 @@ build_mbuf_cluster:
     };
 
 public:
-    explicit dpdk_qp(dpdk_device* dev, uint16_t qid,
-                     const std::string stats_plugin_name);
+    explicit dpdk_qp(dpdk_device* dev, uint16_t qid, std::string port_name);
 
     virtual void rx_start() override;
     virtual future<> send(packet p) override {
@@ -1911,9 +1908,8 @@ void dpdk_device::check_port_link_status()
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 template <bool HugetlbfsMemBackend>
-dpdk_qp<HugetlbfsMemBackend>::dpdk_qp(dpdk_device* dev, uint16_t qid,
-                                      const std::string stats_plugin_name)
-     : qp(true, stats_plugin_name, qid), _dev(dev), _qid(qid),
+dpdk_qp<HugetlbfsMemBackend>::dpdk_qp(dpdk_device* dev, uint16_t qid, std::string port_name)
+     : qp(true, port_name, qid), _dev(dev), _qid(qid),
        _rx_gc_poller(reactor::poller::simple([&] { return rx_gc(); })),
        _tx_buf_factory(qid),
        _tx_gc_poller(reactor::poller::simple([&] { return _tx_buf_factory.gc(); }))
@@ -1949,18 +1945,23 @@ dpdk_qp<HugetlbfsMemBackend>::dpdk_qp(dpdk_device* dev, uint16_t qid,
 
     // Register error statistics: Rx total and checksum errors
     namespace sm = seastar::metrics;
-    _metrics.add_group(_stats_plugin_name, {
-        sm::make_counter(_queue_name + "_rx_csum_errors", _stats.rx.bad.csum,
-                        sm::description("Counts a number of packets received by this queue that have a bad CSUM value. "
-                                        "A non-zero value of this metric usually indicates a HW issue, e.g. a bad cable.")),
+    std::vector<sm::label_instance> labels = {sm::label("queue")(_queue_name)};
+    if (!port_name.empty()) {
+        labels.push_back(sm::label("port")(port_name));
+    }
+    _metrics.add_group("network", {
+        sm::make_counter("rx_csum_errors_total", _stats.rx.bad.csum,
+                        sm::description("Counts a number of packets received per queue that have a bad CSUM value. "
+                                        "A non-zero value of this metric usually indicates a HW issue, e.g. a bad cable."), labels),
 
-        sm::make_counter(_queue_name + "_rx_errors", _stats.rx.bad.total,
-                        sm::description("Counts a total number of errors in the ingress path for this queue: CSUM errors, etc.")),
+        sm::make_counter("rx_errors_total", _stats.rx.bad.total,
+                        sm::description("Counts a total number of errors in the ingress path per queue: CSUM errors, etc."), labels),
 
-        sm::make_counter(_queue_name + "_rx_no_memory_errors", _stats.rx.bad.no_mem,
-                        sm::description("Counts a number of ingress packets received by this HW queue but dropped by the SW due to low memory. "
-                                        "A non-zero value indicates that seastar doesn't have enough memory to handle the packet reception or the memory is too fragmented.")),
+        sm::make_counter("rx_no_memory_errors_total", _stats.rx.bad.no_mem,
+                        sm::description("Counts a number of ingress packets received per queue but dropped by the SW due to low memory. "
+                                        "A non-zero value indicates that seastar doesn't have enough memory to handle the packet reception or the memory is too fragmented."), labels),
     });
+
 }
 
 #pragma GCC diagnostic pop
@@ -2238,11 +2239,9 @@ std::unique_ptr<qp> dpdk_device::init_local_queue(const program_options::option_
 
     std::unique_ptr<qp> qp;
     if (net_opts->_hugepages) {
-        qp = std::make_unique<dpdk_qp<true>>(this, qid,
-                                 _stats_plugin_name + "-" + _stats_plugin_inst);
+        qp = std::make_unique<dpdk_qp<true>>(this, qid, _stats_plugin_inst);
     } else {
-        qp = std::make_unique<dpdk_qp<false>>(this, qid,
-                                 _stats_plugin_name + "-" + _stats_plugin_inst);
+        qp = std::make_unique<dpdk_qp<false>>(this, qid, _stats_plugin_inst);
     }
 
     // FIXME: future is discarded

--- a/src/net/net.cc
+++ b/src/net/net.cc
@@ -104,88 +104,90 @@ bool qp::poll_tx() {
     return false;
 }
 
-qp::qp(bool register_copy_stats,
-       const std::string stats_plugin_name, uint8_t qid)
+qp::qp(bool register_copy_stats, std::string port_name, uint8_t qid)
         : _tx_poller(std::make_unique<internal::poller>(reactor::poller::simple([this] { return poll_tx(); })))
-        , _stats_plugin_name(stats_plugin_name)
         , _queue_name(std::string("queue") + std::to_string(qid))
 {
     namespace sm = metrics;
+    std::vector<sm::label_instance> labels = {sm::label("queue")(_queue_name)};
+    if (!port_name.empty()) {
+        labels.push_back(sm::label("port")(port_name));
+    }
 
-    _metrics.add_group(_stats_plugin_name, {
+    _metrics.add_group("network", {
         //
         // Packets rate: DERIVE:0:u
         //
-        sm::make_counter(_queue_name + "_rx_packets", _stats.rx.good.packets,
-                        sm::description("This metric is a receive packet rate for this queue.")),
+        sm::make_counter("rx_packets_total", _stats.rx.good.packets,
+                        sm::description("Receive packet rate per queue."), labels),
 
-        sm::make_counter(_queue_name + "_tx_packets", _stats.tx.good.packets,
-                        sm::description("This metric is a transmit packet rate for this queue.")),
+        sm::make_counter("tx_packets_total", _stats.tx.good.packets,
+                        sm::description("Transmit packet rate per queue."), labels),
         //
         // Bytes rate: DERIVE:0:U
         //
-        sm::make_counter(_queue_name + "_rx_bytes", _stats.rx.good.bytes,
-                        sm::description("This metric is a receive throughput for this queue.")),
+        sm::make_counter("rx_bytes_total", _stats.rx.good.bytes,
+                        sm::description("Receive throughput per queue."), labels),
 
-        sm::make_counter(_queue_name + "_tx_bytes", _stats.tx.good.bytes,
-                        sm::description("This metric is a transmit throughput for this queue.")),
+        sm::make_counter("tx_bytes_total", _stats.tx.good.bytes,
+                        sm::description("Transmit throughput per queue."), labels),
         //
         // Queue length: GAUGE:0:U
         //
         // Tx
-        sm::make_gauge(_queue_name + "_tx_packet_queue", [this] { return _tx_packetq.size(); },
-                        sm::description("Holds a number of packets pending to be sent. "
-                                        "This metric will have high values if the network backend doesn't keep up with the upper layers or if upper layers send big bursts of packets.")),
+        sm::make_gauge("tx_packets_queue", [this] { return _tx_packetq.size(); },
+                        sm::description("Holds a number of packets pending to be sent per queue. "
+                                        "This metric will have high values if the network backend doesn't keep up with the upper layers or if upper layers send big bursts of packets."), labels),
 
         //
         // Linearization counter: DERIVE:0:U
         //
-        sm::make_counter(_queue_name + "_xmit_linearized", _stats.tx.linearized,
-                        sm::description("Counts a number of linearized Tx packets. High value indicates that we send too fragmented packets.")),
+        sm::make_counter("xmit_linearized_packets_total", _stats.tx.linearized,
+                        sm::description("Counts a number of linearized Tx packets per queue. High value indicates that we send too fragmented packets."), labels),
 
         //
         // Number of packets in last bunch: GAUGE:0:U
         //
         // Tx
-        sm::make_gauge(_queue_name + "_tx_packet_queue_last_bunch", _stats.tx.good.last_bunch,
-                        sm::description(seastar::format("Holds a number of packets sent in the bunch. "
-                                        "A high value in conjunction with a high value of a {} indicates an efficient Tx packets bulking.", _queue_name + "_tx_packet_queue"))),
+        sm::make_gauge("tx_packets_queue_last_bunch", _stats.tx.good.last_bunch,
+                        sm::description("Holds a number of packets sent in the bunch per queue. "
+                                        "A high value in conjunction with a high value of a tx_packets_queue indicates an efficient Tx packets bulking."), labels),
         // Rx
-        sm::make_gauge(_queue_name + "_rx_packet_queue_last_bunch", _stats.rx.good.last_bunch,
-                        sm::description("Holds a number of packets received in the last Rx bunch. High value indicates an efficient Rx packets bulking.")),
+        sm::make_gauge("rx_packets_queue_last_bunch", _stats.rx.good.last_bunch,
+                        sm::description("Holds a number of packets received in the last Rx bunch per queue. High value indicates an efficient Rx packets bulking."), labels),
 
         //
         // Fragments rate: DERIVE:0:U
         //
         // Tx
-        sm::make_counter(_queue_name + "_tx_frags", _stats.tx.good.nr_frags,
-                        sm::description(seastar::format("Counts a number of sent fragments. Divide this value by a {} to get an average number of fragments in a Tx packet.", _queue_name + "_tx_packets"))),
+        sm::make_counter("tx_frags_total", _stats.tx.good.nr_frags,
+                        sm::description("Counts a number of sent fragments per queue. Divide this value by tx_packets_total to get an average number of fragments in a Tx packet."), labels),
         // Rx
-        sm::make_counter(_queue_name + "_rx_frags", _stats.rx.good.nr_frags,
-                        sm::description(seastar::format("Counts a number of received fragments. Divide this value by a {} to get an average number of fragments in an Rx packet.", _queue_name + "_rx_packets"))),
+        sm::make_counter("rx_frags_total", _stats.rx.good.nr_frags,
+                        sm::description("Counts a number of received fragments per queue. Divide this value by rx_packets_total to get an average number of fragments in an Rx packet."), labels),
     });
 
     if (register_copy_stats) {
-        _metrics.add_group(_stats_plugin_name, {
+        _metrics.add_group("network", {
             //
             // Non-zero-copy data bytes rate: DERIVE:0:u
             //
             // Tx
-            sm::make_counter(_queue_name + "_tx_copy_bytes", _stats.tx.good.copy_bytes,
-                        sm::description(seastar::format("Counts a number of sent bytes that were handled in a non-zero-copy way. Divide this value by a {} to get a portion of data sent using a non-zero-copy flow.", _queue_name + "_tx_bytes"))),
+            sm::make_counter("tx_copy_bytes_total", _stats.tx.good.copy_bytes,
+                        sm::description("Counts a number of sent bytes that were handled in a non-zero-copy way per queue. Divide this value by tx_bytes_total to get a portion of data sent using a non-zero-copy flow."), labels),
             // Rx
-            sm::make_counter(_queue_name + "_rx_copy_bytes", _stats.rx.good.copy_bytes,
-                        sm::description(seastar::format("Counts a number of received bytes that were handled in a non-zero-copy way. Divide this value by an {} to get a portion of received data handled using a non-zero-copy flow.", _queue_name + "_rx_bytes"))),
+            sm::make_counter("rx_copy_bytes_total", _stats.rx.good.copy_bytes,
+                        sm::description("Counts a number of received bytes that were handled in a non-zero-copy way per queue. Divide this value by rx_bytes_total to get a portion of received data handled using a non-zero-copy flow."), labels),
 
             //
             // Non-zero-copy data fragments rate: DERIVE:0:u
             //
             // Tx
-            sm::make_counter(_queue_name + "_tx_copy_frags", _stats.tx.good.copy_frags,
-                        sm::description(seastar::format("Counts a number of sent fragments that were handled in a non-zero-copy way. Divide this value by a {} to get a portion of fragments sent using a non-zero-copy flow.", _queue_name + "_tx_frags"))),
+            sm::make_counter("tx_copy_frags_total", _stats.tx.good.copy_frags,
+                        sm::description("Counts a number of sent fragments that were handled in a non-zero-copy way per queue. Divide this value by tx_frags_total to get a portion of fragments sent using a non-zero-copy flow."), labels),
             // Rx
-            sm::make_counter(_queue_name + "_rx_copy_frags", _stats.rx.good.copy_frags,
-                        sm::description(seastar::format("Counts a number of received fragments that were handled in a non-zero-copy way. Divide this value by a {} to get a portion of received fragments handled using a non-zero-copy flow.", _queue_name + "_rx_frags"))),
+            sm::make_counter("rx_copy_frags_total", _stats.rx.good.copy_frags,
+                        sm::description("Counts a number of received fragments that were handled in a non-zero-copy way per queue. Divide this value by rx_frags_total to get a portion of received fragments handled using a non-zero-copy flow."), labels),
 
         });
     }


### PR DESCRIPTION
# net: move queue name from metric name to label

Queue-level network metrics currently embed the queue name in the metric
name itself (e.g. `queue0_rx_packets`, `queue1_tx_bytes`). This makes it
impossible to aggregate across queues using standard Prometheus queries
and generates an unbounded set of metric names that grows with the queue
count.

Move the queue name out of the metric name and into a `queue` label, so
metrics are now named like:

```
rx_packets{queue="queue0"}
tx_bytes{queue="queue1"}
```

instead of:

```
queue0_rx_packets
queue1_tx_bytes
```

This is the idiomatic Prometheus pattern for per-instance metrics and
enables straightforward `sum by (queue)` / `sum without (queue)` queries.

### Changes

**`src/net/net.cc`** — Base `qp` class (15 metrics):

- Declare `auto queue_l = sm::label("queue")(_queue_name)` once at the
  top of the constructor.
- Remove `_queue_name + "_"` prefix from all 11 main-group metric names
  and all 4 copy-stats metric names.
- Attach `(queue_l)` to each metric registration.
- Replace `seastar::format(...)` description strings that interpolated
  `_queue_name + "_<metric>"` with plain strings referencing the bare
  metric name (e.g. `tx_packets` instead of `queue0_tx_packets`).
- Update descriptions to use "per queue" phrasing for consistency.

**`src/net/dpdk.cc`** — `dpdk_qp` subclass (3 metrics):

- Same transformation for `rx_csum_errors`, `rx_errors`, and
  `rx_no_memory_errors`.

No header changes — `_queue_name` is still used to produce the label
value.

> [!WARNING]
> **Breaking change**: any existing dashboards or alerting rules that
> reference metric names like `queue0_rx_packets` will need to be updated
> to use `rx_packets{queue="queue0"}`.

Fixes #2075
