### PR TITLE
coroutine: introduce try_expected_future

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -583,6 +583,47 @@ seastar::future<int> exception_propagating() {
 }
 ```
 
+### Propagating `std::expected` errors
+
+When errors are represented as values rather than exceptions, a function returns a
+`future<std::expected<T, E>>`: the future carries either a value, or an error `E`, or (should
+something go wrong at the future level) an exception. `coroutine::try_expected_future` is the
+`std::expected` counterpart of `coroutine::try_future`. It inspects the three possible outcomes
+of the awaited future and:
+
+- if the future resolved with a value, that value becomes the result of the `co_await`;
+- if the future resolved with an unexpected, the error is rebound to the coroutine's return type
+  (which must be a `future<std::expected<U, E>>` with a matching error type `E`) and returned to
+  the waiter directly, without resuming the coroutine;
+- if the future failed with an exception, the exception is forwarded to the waiter directly, just
+  like `coroutine::try_future`.
+
+In all cases the error is propagated without throwing, and the code following the `co_await` only
+runs on the success path. This is analogous to rust's
+[try operator](https://google.github.io/comprehensive-rust/error-handling/try.html) applied to
+`Result`.
+
+Example:
+
+```cpp
+enum class error { not_found, corrupted };
+
+seastar::future<std::expected<int, error>> read_value();
+
+seastar::future<std::expected<seastar::sstring, error>> read_value_as_string() {
+    // If read_value() resolves with an error, it is rebound to this coroutine's
+    // return type and returned directly. If it fails with an exception, the
+    // exception is propagated to the waiter. Otherwise, value holds the int.
+    auto value = co_await seastar::coroutine::try_expected_future(read_value());
+
+    // Only reached if read_value() resolved with a value.
+    co_return seastar::to_sstring(value);
+}
+```
+
+Just like `coroutine::try_future`, preemption checking can be disabled with
+`coroutine::try_expected_future_without_preemption_check`.
+
 ## Concurrency in coroutines
 
 The `co_await` operator allows for simple sequential execution. Multiple coroutines can execute in parallel, but each coroutine has only one outstanding computation at a time.

--- a/include/seastar/coroutine/try_expected_future.hh
+++ b/include/seastar/coroutine/try_expected_future.hh
@@ -1,0 +1,198 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+#pragma once
+
+#include <expected>
+#include <utility>
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/internal/current_task.hh>
+
+namespace seastar::internal {
+
+/// \brief Trait detecting whether \p T is a specialization of std::expected.
+template <typename T>
+struct is_std_expected : std::false_type {};
+
+template <typename V, typename E>
+struct is_std_expected<std::expected<V, E>> : std::true_type {};
+
+template <typename T>
+concept std_expected = is_std_expected<T>::value;
+
+template <bool CheckPreempt, std_expected T>
+class [[nodiscard]] try_expected_future_awaiter : public seastar::task {
+    // The wrapped result type, e.g. std::expected<value_type, error_type>.
+    using value_type = typename T::value_type;
+
+    seastar::future<T> _future;
+    void (*_resume_or_destroy)(try_expected_future_awaiter&){};
+    seastar::task* _coroutine_task{};
+    seastar::task* _waiting_task{};
+
+    // Resumes the coroutine (expected holds a value) or completes and destroys it
+    // (future failed, or expected holds an unexpected). On the value path the
+    // expected is put back into _future so that await_resume() can hand out the
+    // wrapped value.
+    template <typename U>
+    static void resume_or_destroy(try_expected_future_awaiter& self) {
+        auto promise_ptr = static_cast<U*>(self._coroutine_task);
+        auto hndl = std::coroutine_handle<U>::from_promise(*promise_ptr);
+
+        if (self._future.failed()) {
+            // Exceptional future: forward the exception to the waiter directly.
+            hndl.promise().set_exception(std::move(self._future).get_exception());
+            hndl.destroy();
+            return;
+        }
+
+        T expected = std::move(self._future).get();
+        if (!expected.has_value()) {
+            // The expected holds an unexpected: rebind it to the coroutine's
+            // return type and return with it, without resuming the coroutine.
+            hndl.promise().return_value(std::unexpected(std::move(expected).error()));
+            hndl.destroy();
+            return;
+        }
+
+        // The expected holds a value: put it back and resume the coroutine,
+        // await_resume() will hand out the wrapped value.
+        self._future = seastar::make_ready_future<T>(std::move(expected));
+        set_current_task(promise_ptr);
+        hndl.resume();
+    }
+
+public:
+    explicit try_expected_future_awaiter(seastar::future<T>&& f) noexcept : _future(std::move(f)) {}
+
+    try_expected_future_awaiter(const try_expected_future_awaiter&) = delete;
+    try_expected_future_awaiter(try_expected_future_awaiter&&) = delete;
+
+    bool await_ready() noexcept {
+        // A ready future has no non-destructive way to inspect its expected, so
+        // unwrap it and put it right back. Only skip suspending when it holds a
+        // value (the fast path); a failed future or an unexpected must suspend so
+        // that the coroutine can be completed and destroyed without being resumed.
+        if (!_future.available() || _future.failed() || (CheckPreempt && need_preempt())) {
+            return false;
+        }
+        T expected = std::move(_future).get();
+        bool has_value = expected.has_value();
+        _future = seastar::make_ready_future<T>(std::move(expected));
+        return has_value;
+    }
+
+    template<typename U>
+    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+        _resume_or_destroy = try_expected_future_awaiter::resume_or_destroy<U>;
+        _coroutine_task = &hndl.promise();
+        _waiting_task = hndl.promise().waiting_task();
+
+        if (_future.available()) {
+            execute_involving_handle_destruction_in_await_suspend(this);
+        } else {
+            _future.set_coroutine(*this);
+        }
+    }
+
+    value_type await_resume() {
+        // Only reached on the success path, where _future holds a value.
+        return std::move(_future).get().value();
+    }
+
+    virtual void run_and_dispose() noexcept final override {
+        _resume_or_destroy(*this);
+    }
+
+    virtual task* waiting_task() noexcept override {
+        return _waiting_task;
+    }
+};
+
+} // namespace seastar::internal
+
+namespace seastar::coroutine {
+
+/// \brief co_await:s a \ref future of a `std::expected` and returns the wrapped
+/// value if successful, terminating the coroutine otherwise, propagating the
+/// error directly to the waiter.
+///
+/// This is the `std::expected` counterpart of \ref coroutine::try_future. It
+/// distinguishes three outcomes of the awaited `future<std::expected<V, E>>`:
+///
+///  - If the future failed (holds an exception), the coroutine is not resumed;
+///    the exception is forwarded to the waiter directly and the coroutine is
+///    destroyed, exactly like \ref coroutine::try_future.
+///  - If the future resolved with an unexpected value, the coroutine is not
+///    resumed; the `std::unexpected` is rebound to the coroutine's return type
+///    (which must be a `future<std::expected<V2, E>>` with a matching error
+///    type) and returned to the waiter, and the coroutine is destroyed.
+///  - If the future resolved with a value, that value is the result of the
+///    `co_await`.
+///
+/// This lets a coroutine propagate errors up the `std::expected` chain without
+/// throwing, analogous to rust's
+/// [try operator](https://google.github.io/comprehensive-rust/error-handling/try.html).
+///
+/// For example:
+/// ```
+/// future<std::expected<int, error>> bar();
+///
+/// future<std::expected<result, error>> foo() {
+///     // If bar() resolves with an error (or a failed future), foo() returns
+///     // with that error (or exception) directly and this coroutine stops here.
+///     auto value = co_await coroutine::try_expected_future(bar());
+///     // Only reached if bar() resolved with a value.
+///     co_return compute_result(value);
+/// }
+/// ```
+///
+/// Note that by default, `try_expected_future` checks if the task quota is
+/// depleted, which means that it will yield if the future is ready and
+/// \ref seastar::need_preempt() returns true. Use
+/// \ref coroutine::try_expected_future_without_preemption_check to disable
+/// preemption checking.
+///
+/// \tparam T the `std::expected` specialization wrapped by the future.
+template<seastar::internal::std_expected T>
+class [[nodiscard]] try_expected_future : public seastar::internal::try_expected_future_awaiter<true, T> {
+public:
+    explicit try_expected_future(seastar::future<T>&& f) noexcept
+        : seastar::internal::try_expected_future_awaiter<true, T>(std::move(f))
+    {}
+};
+
+/// \brief co_await:s a \ref future of a `std::expected`, returns the wrapped
+/// value if successful, terminating the coroutine otherwise, propagating the
+/// error to the waiter.
+///
+/// Same as \ref coroutine::try_expected_future, but does not check for
+/// preemption.
+template<seastar::internal::std_expected T>
+class [[nodiscard]] try_expected_future_without_preemption_check : public seastar::internal::try_expected_future_awaiter<false, T> {
+public:
+    explicit try_expected_future_without_preemption_check(seastar::future<T>&& f) noexcept
+        : seastar::internal::try_expected_future_awaiter<false, T>(std::move(f))
+    {}
+};
+
+} // namespace seastar::coroutine

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -222,6 +222,7 @@ module;
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
+#include <seastar/coroutine/try_expected_future.hh>
 
 export module seastar;
 
@@ -595,6 +596,8 @@ using seastar::coroutine::as_future;
 using seastar::coroutine::return_exception_ptr;
 using seastar::coroutine::exception;
 using seastar::coroutine::parallel_for_each;
+using seastar::coroutine::try_expected_future;
+using seastar::coroutine::try_expected_future_without_preemption_check;
 
 }
 

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -39,6 +39,7 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/try_future.hh>
+#include <seastar/coroutine/try_expected_future.hh>
 #include <seastar/testing/random.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/defer.hh>
@@ -952,6 +953,115 @@ SEASTAR_TEST_CASE(test_try_future) {
     co_await run_try_future_test<false>(return_int, 128);
     co_await run_try_future_test<true>(return_ex_int, std::nullopt);
     co_await run_try_future_test<false>(return_ex_int, std::nullopt);
+}
+
+enum class try_error { boom, kaboom };
+
+// Underlying function returning a future<expected<int, try_error>> which may
+// resolve with a value, with an unexpected, or as an exceptional future. When
+// ready is false it suspends first, so the awaiter sees a not-yet-available
+// future (set_coroutine path); when true it resolves synchronously, exercising
+// the fast path where await_ready() unwraps a ready future.
+static future<std::expected<int, try_error>> try_expected_source(std::optional<try_error> err, bool throw_, bool ready) {
+    if (!ready) {
+        co_await sleep(1ms);
+    }
+    if (throw_) {
+        throw test_exception{};
+    }
+    if (err) {
+        co_return std::unexpected(*err);
+    }
+    co_return 128;
+}
+
+// Underlying function returning a future<expected<void, try_error>>.
+static future<std::expected<void, try_error>> try_expected_void_source(std::optional<try_error> err, bool throw_, bool ready) {
+    if (!ready) {
+        co_await sleep(1ms);
+    }
+    if (throw_) {
+        throw test_exception{};
+    }
+    if (err) {
+        co_return std::unexpected(*err);
+    }
+    co_return std::expected<void, try_error>{};
+}
+
+// Coroutine using try_expected_future. Note the return type wraps a different
+// value type (sstring) than the awaited future (int/void), to make sure the
+// unexpected is correctly rebound to the coroutine's return type.
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    int value;
+    if constexpr (CheckPreempt) {
+        value = co_await coroutine::try_expected_future(try_expected_source(err, throw_, ready));
+    } else {
+        value = co_await coroutine::try_expected_future_without_preemption_check(try_expected_source(err, throw_, ready));
+    }
+    // Only reached if the source resolved with a value.
+    run_past = true;
+    co_return seastar::to_sstring(value);
+}
+
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_void_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    if constexpr (CheckPreempt) {
+        co_await coroutine::try_expected_future(try_expected_void_source(err, throw_, ready));
+    } else {
+        co_await coroutine::try_expected_future_without_preemption_check(try_expected_void_source(err, throw_, ready));
+    }
+    run_past = true;
+    co_return sstring("done");
+}
+
+template <typename Consumer>
+static future<> run_try_expected_future_test(Consumer consumer, sstring expected_value, bool ready) {
+    // Success: the wrapped value is returned and the code past the co_await runs.
+    {
+        bool run_past = false;
+        auto res = co_await consumer(std::nullopt, false, ready, run_past);
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res.value(), expected_value);
+        BOOST_REQUIRE(run_past);
+    }
+
+    // Unexpected: the error is rebound to the coroutine's return type and the
+    // code past the co_await is skipped.
+    {
+        bool run_past = false;
+        auto res = co_await consumer(try_error::kaboom, false, ready, run_past);
+        BOOST_REQUIRE(!res.has_value());
+        BOOST_REQUIRE(res.error() == try_error::kaboom);
+        BOOST_REQUIRE(!run_past);
+    }
+
+    // Exceptional future: the exception is propagated to the waiter directly and
+    // the code past the co_await is skipped.
+    {
+        bool run_past = false;
+        bool caught = false;
+        try {
+            [[maybe_unused]] auto res = co_await consumer(std::nullopt, true, ready, run_past);
+        } catch (test_exception&) {
+            caught = true;
+        }
+        BOOST_REQUIRE(caught);
+        BOOST_REQUIRE(!run_past);
+    }
+}
+
+SEASTAR_TEST_CASE(test_try_expected_future) {
+    // Exercise both the ready (fast path, unwrap in await_ready) and not-ready
+    // (set_coroutine path) cases.
+    for (bool ready : {false, true}) {
+        co_await run_try_expected_future_test(try_expected_consumer<true>, sstring("128"), ready);
+        co_await run_try_expected_future_test(try_expected_consumer<false>, sstring("128"), ready);
+
+        co_await run_try_expected_future_test(try_expected_void_consumer<true>, sstring("done"), ready);
+        co_await run_try_expected_future_test(try_expected_void_consumer<false>, sstring("done"), ready);
+    }
 }
 
 #if SEASTAR_API_LEVEL < 10


### PR DESCRIPTION
Special awaiter which co_await:s a future<std::expected<V, E>> and returns the wrapped value if the future resolved with one, terminating the coroutine otherwise, propagating the error directly to its waiter.

This is the std::expected counterpart of coroutine::try_future, distinguishing three outcomes of the awaited future:

 - if the future failed (holds an exception), the exception is forwarded to the waiter directly and the coroutine is destroyed, exactly like coroutine::try_future;
 - if the future resolved with an unexpected, it is rebound to the coroutine's return type (a future<std::expected<V2, E>> with a matching error type) and returned to the waiter, without resuming the coroutine;
 - if the future resolved with a value, that value is the result of the co_await.

In all cases the error is propagated up the std::expected chain without being thrown, analogous to rust's try operator.

Like coroutine::try_future, a preemption-checking and a non-preemption-checking variant are provided. Since a ready future offers no non-destructive way to inspect its expected, await_ready() unwraps it and puts it right back via make_ready_future(), so a ready value can still take the fast path without suspending.

The new awaiter and both variants are exported from the seastar module, tested in coroutines_test, and documented in a new section of the coroutine exception handling chapter of doc/tutorial.md.