### PR TITLE
coroutine: use symmetric transfer when returning to a waiting coroutine

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -69,6 +69,36 @@ execute_involving_handle_destruction_in_await_suspend(task* tsk) noexcept {
 #endif
 }
 
+// Defined in reactor.cc; declared here to avoid pulling in the heavy
+// reactor.hh from this widely-included header.
+void set_current_task(task* t);
+
+// Transfer control from a just-completed coroutine to the task waiting on it.
+//
+// `self` is the handle of the completing coroutine; its frame is destroyed here
+// (the frame is self-owned, so it must dispose of itself before transferring).
+// If the waiter is itself a coroutine in the current scheduling group and the
+// task quota is not depleted, resume it directly via symmetric transfer,
+// bypassing the reactor's task queue; the returned handle is then resumed by the
+// coroutine machinery as a tail call. Otherwise fall back to scheduling the
+// waiter through the reactor and return the no-op handle.
+inline std::coroutine_handle<> coroutine_return_to_waiter(task* waiter, std::coroutine_handle<> self) noexcept {
+    if (waiter) {
+        void* addr = waiter->to_coroutine_handle_address();
+        if (addr && waiter->group() == current_scheduling_group() && !need_preempt()) {
+            // The reactor's current-task pointer still refers to `self`, whose
+            // frame we are about to destroy; repoint it at the waiter so that
+            // e.g. stall backtraces taken while the waiter runs stay valid.
+            set_current_task(waiter);
+            self.destroy();
+            return std::coroutine_handle<>::from_address(addr);
+        }
+        schedule(waiter);
+    }
+    self.destroy();
+    return std::noop_coroutine();
+}
+
 class coroutine_allocators {
 public:
     static void* operator new(size_t size) {
@@ -90,6 +120,28 @@ class coroutine_traits_base {
 public:
     class promise_type final : public seastar::task, public coroutine_allocators {
         seastar::promise<T> _promise;
+        // Task waiting for this coroutine to complete, captured out of _promise
+        // before its state is made ready so that the regular ready path does not
+        // schedule it; final_suspend() then resumes it via symmetric transfer or
+        // schedules it explicitly. See final_awaiter.
+        task* _waiter = nullptr;
+
+        // Remove the waiting task from _promise without scheduling it, so that
+        // setting the promise's value below leaves the waiter to be resumed by
+        // final_suspend(). Call this on synchronous completion paths, just before
+        // the value or exception is set. It must not be used on paths that resolve
+        // the promise asynchronously (e.g. forward_to()), which need the regular
+        // scheduling machinery to remain in charge of the waiter.
+        void capture_waiter() noexcept { _waiter = _promise.take_waiting_task(); }
+
+        struct final_awaiter {
+            task* waiter;
+            bool await_ready() const noexcept { return false; }
+            std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                return coroutine_return_to_waiter(waiter, h);
+            }
+            void await_resume() noexcept {}
+        };
     public:
         promise_type() = default;
         promise_type(promise_type&&) = delete;
@@ -98,35 +150,49 @@ public:
 #if SEASTAR_API_LEVEL < 10
         template<typename U>
         void return_value(U&& value) {
+            capture_waiter();
             _promise.set_value(std::forward<U>(value));
         }
 
         [[deprecated("Forwarding coroutine returns are deprecated as too dangerous. Use 'co_return co_await ...' until explicit syntax is available.")]]
         void return_value(future<T>&& fut) noexcept {
+            // Asynchronous resolution: leave the waiter attached to _promise so
+            // that forward_to()'s completion resumes it through the reactor.
             fut.forward_to(std::move(_promise));
         }
 #else
         // this non-templated version only exists to support co_returning a braced-init-list
         void return_value(T&& value) noexcept {
+            capture_waiter();
             _promise.set_value(std::forward<T>(value));
         }
 
         template<typename U>
         requires std::is_convertible_v<U&&, T>
         void return_value(U&& value) noexcept {
+            capture_waiter();
             _promise.set_value(std::forward<U>(value));
         }
 #endif
 
         void return_value(coroutine::exception ce) noexcept {
+            capture_waiter();
             _promise.set_exception(std::move(ce.eptr));
         }
 
+        // Called by the exception/try_future awaiters, which resolve the promise
+        // and destroy the frame directly without reaching final_suspend(). It must
+        // therefore leave the waiter attached so the regular ready path schedules
+        // it; do not capture_waiter() here.
+        //
+        // As a result these paths do not use symmetric transfer; extending them to
+        // do so (in particular try_future) is left to a later change.
         void set_exception(std::exception_ptr&& eptr) noexcept {
             _promise.set_exception(std::move(eptr));
         }
 
         void unhandled_exception() noexcept {
+            capture_waiter();
             _promise.set_exception(std::current_exception());
         }
 
@@ -135,7 +201,7 @@ public:
         }
 
         std::suspend_never initial_suspend() noexcept { return { }; }
-        std::suspend_never final_suspend() noexcept { return { }; }
+        final_awaiter final_suspend() noexcept { return final_awaiter{_waiter}; }
 
         virtual void run_and_dispose() noexcept override {
             auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
@@ -143,6 +209,10 @@ public:
         }
 
         task* waiting_task() noexcept override { return _promise.waiting_task(); }
+
+        void* to_coroutine_handle_address() noexcept override {
+            return std::coroutine_handle<promise_type>::from_promise(*this).address();
+        }
 
         scheduling_group set_scheduling_group(scheduling_group sg) noexcept {
             return std::exchange(this->_sg, sg);
@@ -155,20 +225,42 @@ class coroutine_traits_base<> {
 public:
    class promise_type final : public seastar::task, public coroutine_allocators {
         seastar::promise<> _promise;
+        // See the equivalent members in coroutine_traits_base<T>::promise_type.
+        task* _waiter = nullptr;
+
+        void capture_waiter() noexcept { _waiter = _promise.take_waiting_task(); }
+
+        struct final_awaiter {
+            task* waiter;
+            bool await_ready() const noexcept { return false; }
+            std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                return coroutine_return_to_waiter(waiter, h);
+            }
+            void await_resume() noexcept {}
+        };
     public:
         promise_type() = default;
         promise_type(promise_type&&) = delete;
         promise_type(const promise_type&) = delete;
 
         void return_void() noexcept {
+            capture_waiter();
             _promise.set_value();
         }
 
+        // Called by the exception/try_future awaiters, which resolve the promise
+        // and destroy the frame directly without reaching final_suspend(). It must
+        // therefore leave the waiter attached so the regular ready path schedules
+        // it; do not capture_waiter() here.
+        //
+        // As a result these paths do not use symmetric transfer; extending them to
+        // do so (in particular try_future) is left to a later change.
         void set_exception(std::exception_ptr&& eptr) noexcept {
             _promise.set_exception(std::move(eptr));
         }
 
         void unhandled_exception() noexcept {
+            capture_waiter();
             _promise.set_exception(std::current_exception());
         }
 
@@ -177,7 +269,7 @@ public:
         }
 
         std::suspend_never initial_suspend() noexcept { return { }; }
-        std::suspend_never final_suspend() noexcept { return { }; }
+        final_awaiter final_suspend() noexcept { return final_awaiter{_waiter}; }
 
         virtual void run_and_dispose() noexcept override {
             auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
@@ -185,6 +277,10 @@ public:
         }
 
         task* waiting_task() noexcept override { return _promise.waiting_task(); }
+
+        void* to_coroutine_handle_address() noexcept override {
+            return std::coroutine_handle<promise_type>::from_promise(*this).address();
+        }
 
         scheduling_group set_scheduling_group(scheduling_group new_sg) noexcept {
             return task::set_scheduling_group(new_sg);

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -944,6 +944,15 @@ public:
 
     /// Returns the task which is waiting for this promise to resolve, or nullptr.
     task* waiting_task() const noexcept { return _task; }
+
+    /// Removes and returns the task which is waiting for this promise to resolve,
+    /// without scheduling it. The caller takes over responsibility for resuming
+    /// the returned task (e.g. via coroutine symmetric transfer) or scheduling it.
+    ///
+    /// The promise state (value or exception) must already have been set, since
+    /// making the promise ready via the regular path is what would otherwise
+    /// schedule the waiting task.
+    task* take_waiting_task() noexcept { return std::exchange(_task, nullptr); }
 };
 
 /// \brief A promise with type but no local data.
@@ -1015,6 +1024,7 @@ public:
 
     /// Returns the task which is waiting for this promise to resolve, or nullptr.
     using internal::promise_base::waiting_task;
+    using internal::promise_base::take_waiting_task;
 
 private:
 
@@ -1084,6 +1094,7 @@ public:
 
     /// Returns the task which is waiting for this promise to resolve, or nullptr.
     using internal::promise_base::waiting_task;
+    using internal::promise_base::take_waiting_task;
 
     /// \brief Gets the promise's associated future.
     ///

--- a/include/seastar/core/task.hh
+++ b/include/seastar/core/task.hh
@@ -54,6 +54,11 @@ public:
     virtual void run_and_dispose() noexcept = 0;
     /// Returns the next task which is waiting for this task to complete execution, or nullptr.
     virtual task* waiting_task() noexcept = 0;
+    /// If this task is a coroutine that can be resumed via symmetric transfer,
+    /// returns the address of its coroutine frame; otherwise returns nullptr.
+    /// Used to hand control directly from a completing coroutine to the coroutine
+    /// waiting on it, bypassing the reactor's task queue.
+    virtual void* to_coroutine_handle_address() noexcept { return nullptr; }
     void update_resume_point(std::source_location sl) { _resume_point = sl; }
     auto get_resume_point() const { return _resume_point; }
     scheduling_group group() const { return _sg; }

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -514,6 +514,48 @@ SEASTAR_TEST_CASE(test_coroutine_return_exception_ptr) {
     });
 }
 
+// Regression test for a lost-wakeup bug in coroutine symmetric transfer.
+//
+// The coroutine::exception, coroutine::return_exception_ptr and
+// coroutine::try_future awaiters resolve the coroutine's promise and then
+// destroy the frame directly, without going through final_suspend(). A waiter
+// that has already suspended on the coroutine must still be woken. The bug
+// captured the waiter for deferred handling by final_suspend() but, since these
+// paths never reach final_suspend(), the waiter was never rescheduled and any
+// code awaiting such a coroutine hung.
+//
+// Each case below forces the waiter to be genuinely suspended by yielding before
+// the result is injected; the pre-existing exception tests resolve synchronously
+// (no suspended waiter) and so did not exercise this path.
+SEASTAR_TEST_CASE(test_exception_awaiter_wakes_suspended_waiter) {
+    // Waiter is a coroutine suspended on the inner coroutine.
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<> {
+        counter_ref ref{counter};
+        co_await yield();
+        co_await coroutine::exception(std::make_exception_ptr(std::runtime_error("threw")));
+    });
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<> {
+        counter_ref ref{counter};
+        co_await yield();
+        co_await coroutine::return_exception_ptr(std::make_exception_ptr(std::runtime_error("threw")));
+    });
+    co_await check_coroutine_throws<std::runtime_error>([] (int& counter) -> future<int> {
+        counter_ref ref{counter};
+        co_await yield();
+        co_await coroutine::try_future(seastar::make_exception_future<int>(std::runtime_error("threw")));
+        co_return 0;
+    });
+
+    // Waiter is a thread blocked in future::get(), matching the file_io_test hang.
+    co_await seastar::async([] {
+        auto throwing = [] () -> future<> {
+            co_await yield();
+            co_await coroutine::return_exception_ptr(std::make_exception_ptr(std::runtime_error("threw")));
+        };
+        BOOST_REQUIRE_THROW(throwing().get(), std::runtime_error);
+    });
+}
+
 SEASTAR_TEST_CASE(test_maybe_yield) {
     int var = 0;
     bool done = false;


### PR DESCRIPTION
When a coroutine completes and the task waiting on it is itself a
coroutine, resume that waiter directly via symmetric transfer instead of
scheduling it on the reactor's task queue. This eliminates a task-queue
round-trip on the common "one coroutine awaits another" path, and, being
a guaranteed tail call, does not grow the stack across chains of
back-to-back completions.

The transfer is only taken when the waiter is a coroutine in the current
scheduling group and the task quota is not depleted (!need_preempt());
every other case - a non-coroutine continuation, a waiter in a different
scheduling group, a depleted quota, or no waiter at all - falls back to
the existing schedule() behavior, preserving scheduling-group accounting
and preemption bounds.

Mechanics:

 - task gains a virtual to_coroutine_handle_address() returning nullptr
   by default; only the future-coroutine promise overrides it, so
   non-coroutine waiters transparently take the scheduling fallback.

 - promise_base gains take_waiting_task(), which removes the waiter
   without scheduling it. The coroutine promise captures the waiter this
   way on each synchronous completion path before setting its value, so
   the regular ready path does not schedule it; final_suspend() then
   either transfers to it or schedules it. The deprecated asynchronous
   forward_to() return path deliberately keeps the waiter attached so the
   normal machinery resumes it.

 - final_suspend() now returns a suspending awaiter that self-destroys the
   (self-owned) frame and returns the waiter's handle for transfer, or
   noop_coroutine() otherwise. The reactor's current-task pointer is
   repointed to the waiter before the frame is destroyed so stall
   backtraces taken while the waiter runs stay valid.

Capturing the waiter for final_suspend() is only correct on paths that
actually reach final_suspend(). The coroutine::exception and
coroutine::try_future awaiters instead resolve the promise via
promise_type::set_exception() and then destroy the frame directly,
bypassing final_suspend(); set_exception() therefore leaves the waiter
attached so make_ready() schedules it as before. (Capturing it there
orphaned the waiter and hung file_io_test's thread-blocked get().) These
paths consequently do not use symmetric transfer yet; extending them,
particularly try_future, is left for a later change.

test_exception_awaiter_wakes_suspended_waiter covers this: it forces a
waiter (a coroutine, and a thread in future::get()) to be suspended
before each bypass awaiter injects its result, and hangs without the fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>