### PR TITLE
file: query DIO alignment via statx regardless of build headers

### DIFF
--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -27,6 +27,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 #include <sys/uio.h>
 
@@ -37,6 +38,11 @@ namespace internal {
 
 struct fs_info;
 class io_sink;
+
+// Query DIO memory alignment using statx (kernel 6.1+). Returns the memory
+// buffer alignment required for direct I/O on the file, or std::nullopt if
+// the kernel or the filesystem doesn't report STATX_DIOALIGN.
+std::optional<size_t> query_statx_mem_align(int fd);
 
 }
 

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1220,7 +1220,7 @@ xfs_concurrency_from_kernel_version() {
     return 0;
 }
 
-namespace {
+namespace internal {
 
 // Query DIO memory alignment using statx (kernel 6.1+)
 // Returns the optimal memory buffer alignment for this file descriptor,
@@ -1258,6 +1258,10 @@ query_statx_mem_align(int fd) {
     return std::nullopt;
 }
 
+} // namespace internal
+
+namespace {
+
 // Query device-level alignment properties (common to all filesystems)
 struct device_alignment_info {
     std::optional<unsigned> memory_alignment;      // from statx
@@ -1268,7 +1272,7 @@ device_alignment_info query_device_alignment_info(int fd, dev_t device_id) {
     device_alignment_info info;
 
     // Query statx for DIO memory alignment (kernel 6.1+)
-    info.memory_alignment = query_statx_mem_align(fd);
+    info.memory_alignment = internal::query_statx_mem_align(fd);
 
     // Check for physical_block_size override from io_properties.yaml
     // Note: I/O queues may not be registered for all devices (e.g., tmpfs, test environments)

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <bit>
 #include <coroutine>
+#include <cstddef>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -33,15 +34,8 @@
 
 #define __user /* empty */  // for xfs includes, below
 
-// Define STATX_DIOALIGN and related fields if not available from system headers (Linux < 6.1)
-#ifndef STATX_DIOALIGN
-#define STATX_DIOALIGN 0x00002000U
-// Check if struct statx has the stx_dio_mem_align field (added in Linux 6.1)
-// We need to extend the structure for older kernels/headers
-#define SEASTAR_STATX_NEEDS_DIO_FIELDS 1
-#endif
-
 #include <sys/syscall.h>
+#include <sys/stat.h> // statx etc
 #include <dirent.h>
 #include <linux/types.h> // for xfs, below
 #include <linux/fs.h> // BLKBSZGET
@@ -1230,23 +1224,37 @@ namespace {
 
 // Query DIO memory alignment using statx (kernel 6.1+)
 // Returns the optimal memory buffer alignment for this file descriptor,
-// or std::nullopt if statx doesn't support STATX_DIOALIGN
+// or std::nullopt if the running kernel doesn't report STATX_DIOALIGN, or
+// doesn't support statx syscall.
 std::optional<size_t>
 query_statx_mem_align(int fd) {
-#ifndef SEASTAR_STATX_NEEDS_DIO_FIELDS
-    // Only call statx if we have the required struct fields
-    struct statx stx;
-    if (syscall(__NR_statx, fd, "", AT_EMPTY_PATH, STATX_DIOALIGN, &stx) == 0) {
-        if (stx.stx_mask & STATX_DIOALIGN) {
+    // Layout-compatible stand-in for struct statx (linux/stat.h), so the query
+    // is compiled in even when the headers we build against predate
+    // STATX_DIOALIGN (Linux 6.1); kernels that don't support it simply don't
+    // set the bit in stx_mask. The kernel UAPI struct is fixed at 256 bytes;
+    // only the fields we use are named, the rest is padding.
+    struct statx_for_dio {
+        uint32_t stx_mask;              // what results were written
+        uint32_t stx_blksize;
+        uint64_t pad_before[18];        // fields between stx_blksize and stx_dio_mem_align
+        uint32_t stx_dio_mem_align;     // memory buffer alignment for direct I/O (Linux 6.1+)
+        uint32_t stx_dio_offset_align;
+        uint64_t pad_after[12];         // later additions and spare space
+    };
+    constexpr uint32_t statx_dioalign = 0x00002000U;  // STATX_DIOALIGN
+    static_assert(sizeof(statx_for_dio) == 256, "statx buffer must be 256 bytes");
+#ifdef STATX_DIOALIGN
+    // building against Linux 6.1+ headers: verify the layout against the real struct
+    static_assert(statx_dioalign == STATX_DIOALIGN);
+    static_assert(offsetof(statx_for_dio, stx_dio_mem_align) == offsetof(struct statx, stx_dio_mem_align));
+#endif
+    statx_for_dio stx;
+    if (syscall(__NR_statx, fd, "", AT_EMPTY_PATH, statx_dioalign, &stx) == 0) {
+        if (stx.stx_mask & statx_dioalign) {
             // Use kernel-reported memory alignment (stx_dio_mem_align)
-            // Field is available in Linux 6.1+ headers
             return stx.stx_dio_mem_align;
         }
     }
-#else
-    // Headers don't have the stx_dio_mem_align field, so we can't use it
-    // even if the kernel supports it. We'll rely on other fallbacks.
-#endif
     return std::nullopt;
 }
 

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -43,14 +43,18 @@
 #include <seastar/util/tmp_file.hh>
 #include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/internal/magic.hh>
 #include <seastar/util/internal/iovec_utils.hh>
 #include <seastar/util/later.hh>
+#include <seastar/core/internal/uname.hh>
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <iostream>
 #include <sys/statfs.h>
 #include <fcntl.h>
+
+#include "core/file-impl.hh"
 
 using namespace seastar;
 namespace fs = std::filesystem;
@@ -1305,5 +1309,29 @@ SEASTAR_TEST_CASE(test_rename) {
         BOOST_REQUIRE(file_exists(filename1).get());
         BOOST_REQUIRE(file_exists(filename2).get());
         BOOST_REQUIRE(!file_exists(filename3).get());
+    });
+}
+
+SEASTAR_TEST_CASE(test_query_statx_mem_align) {
+    return tmp_dir::do_with_thread([] (tmp_dir& t) {
+        if (!internal::kernel_uname().whitelisted({"6.1"})) {
+            // the running kernel predates STATX_DIOALIGN
+            return;
+        }
+        sstring filename = (t.get_path() / "testfile.tmp").native();
+        int fd = ::open(filename.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+        BOOST_REQUIRE_GE(fd, 0);
+        auto close_fd = defer([fd] () noexcept { ::close(fd); });
+        struct statfs sfs;
+        BOOST_REQUIRE_EQUAL(::fstatfs(fd, &sfs), 0);
+        auto fstype = static_cast<unsigned long>(sfs.f_type);
+        if (fstype != internal::fs_magic::xfs && fstype != internal::fs_magic::ext4) {
+            // STATX_DIOALIGN reporting also depends on the filesystem; only
+            // assert on filesystems that have supported it since 6.1
+            return;
+        }
+        auto align = internal::query_statx_mem_align(fd);
+        BOOST_REQUIRE(align.has_value());
+        BOOST_REQUIRE_GT(*align, 0u);
     });
 }


### PR DESCRIPTION
The statx-based DIO memory alignment query (`query_statx_mem_align`) is compiled out on every system, regardless of kernel header version, because the `STATX_DIOALIGN` feature check at the top of `file.cc` runs before any header that defines the macro has been included. See #3536 for the full analysis and history.

Instead of fixing the include order, this drops the compile-time gate entirely: issue the raw statx syscall unconditionally against a layout-compatible stand-in for `struct statx` (the kernel UAPI struct is fixed at 256 bytes), and rely on the runtime check — kernels without `STATX_DIOALIGN` support simply don't set the bit in `stx_mask` and we fall back as before. When building against 6.1+ headers, `static_assert`s verify the stand-in layout against the real `struct statx`.

This also means the feature no longer depends on the headers of the build environment at all, which matters for builds that target newer kernels than they build against (e.g. old-sysroot toolchains).

The second commit moves the function into `seastar::internal`, declares it in `file-impl.hh`, and adds a unit test asserting the query returns an engaged optional on kernels ≥ 6.1 for filesystems that report it (xfs, ext4) — guarding against a regression of the silent failure, which went unnoticed precisely because the fallback path works.

Verified on kernel 6.17: on XFS-on-NVMe the query now returns 4 (the device DMA alignment), where the `XFS_IOC_DIOINFO` fallback reports 512, so DMA buffer memory alignment drops to `max(4, sizeof(void*))` = 8 bytes.

Fixes #3536
