### PR TITLE
`thread`: track context switches in the `ucontext` variant too

### DIFF
--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -50,6 +50,16 @@ thread_local jmp_buf_link* g_current_context;
 
 namespace {
 thread_local std::atomic_flag g_context_switch_in_progress{};
+
+inline void begin_context_switch() noexcept {
+    g_context_switch_in_progress.test_and_set(std::memory_order_relaxed);
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+}
+
+inline void end_context_switch() noexcept {
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+    g_context_switch_in_progress.clear(std::memory_order_relaxed);
+}
 }
 
 #ifdef SEASTAR_ASAN_ENABLED
@@ -80,6 +90,7 @@ thread_local jmp_buf_link* g_previous_context;
 
 void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void* stack_bottom, size_t stack_size)
 {
+    begin_context_switch();
     auto prev = std::exchange(g_current_context, this);
     link = prev;
     g_previous_context = prev;
@@ -87,10 +98,12 @@ void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void* st
     swapcontext(&prev->context, initial_context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::switch_in()
 {
+    begin_context_switch();
     auto prev = std::exchange(g_current_context, this);
     link = prev;
     g_previous_context = prev;
@@ -98,10 +111,12 @@ void jmp_buf_link::switch_in()
     swapcontext(&prev->context, &context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::switch_out()
 {
+    begin_context_switch();
     g_current_context = link;
     g_previous_context = this;
     __sanitizer_start_switch_fiber(&fake_stack, g_current_context->stack_bottom,
@@ -109,6 +124,7 @@ void jmp_buf_link::switch_out()
     swapcontext(&context, &g_current_context->context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::initial_switch_in_completed()
@@ -116,10 +132,12 @@ void jmp_buf_link::initial_switch_in_completed()
     // This is a new thread and it doesn't have the fake stack yet. ASan will
     // create it lazily, for now just pass nullptr.
     __sanitizer_finish_switch_fiber(nullptr, &g_previous_context->stack_bottom, &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::final_switch_out()
 {
+    begin_context_switch();
     g_current_context = link;
     g_previous_context = this;
     // Since the thread is about to die we pass nullptr as fake_stack_save argument
@@ -129,18 +147,6 @@ void jmp_buf_link::final_switch_out()
 }
 
 #else
-
-namespace {
-inline void begin_context_switch() noexcept {
-    g_context_switch_in_progress.test_and_set(std::memory_order_relaxed);
-    std::atomic_signal_fence(std::memory_order_seq_cst);
-}
-
-inline void end_context_switch() noexcept {
-    std::atomic_signal_fence(std::memory_order_seq_cst);
-    g_context_switch_in_progress.clear(std::memory_order_relaxed);
-}
-}
 
 inline void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void*, size_t)
 {

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -51,6 +51,16 @@ thread_local jmp_buf_link* g_current_context;
 
 namespace {
 thread_local std::atomic_flag g_context_switch_in_progress{};
+
+inline void begin_context_switch() noexcept {
+    g_context_switch_in_progress.test_and_set(std::memory_order_relaxed);
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+}
+
+inline void end_context_switch() noexcept {
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+    g_context_switch_in_progress.clear(std::memory_order_relaxed);
+}
 }
 
 #ifdef SEASTAR_ASAN_ENABLED
@@ -81,6 +91,7 @@ thread_local jmp_buf_link* g_previous_context;
 
 void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void* stack_bottom, size_t stack_size)
 {
+    begin_context_switch();
     auto prev = std::exchange(g_current_context, this);
     link = prev;
     g_previous_context = prev;
@@ -88,10 +99,12 @@ void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void* st
     swapcontext(&prev->context, initial_context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::switch_in()
 {
+    begin_context_switch();
     auto prev = std::exchange(g_current_context, this);
     link = prev;
     g_previous_context = prev;
@@ -99,10 +112,12 @@ void jmp_buf_link::switch_in()
     swapcontext(&prev->context, &context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::switch_out()
 {
+    begin_context_switch();
     g_current_context = link;
     g_previous_context = this;
     __sanitizer_start_switch_fiber(&fake_stack, g_current_context->stack_bottom,
@@ -110,6 +125,7 @@ void jmp_buf_link::switch_out()
     swapcontext(&context, &g_current_context->context);
     __sanitizer_finish_switch_fiber(g_current_context->fake_stack, &g_previous_context->stack_bottom,
                                     &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::initial_switch_in_completed()
@@ -117,10 +133,12 @@ void jmp_buf_link::initial_switch_in_completed()
     // This is a new thread and it doesn't have the fake stack yet. ASan will
     // create it lazily, for now just pass nullptr.
     __sanitizer_finish_switch_fiber(nullptr, &g_previous_context->stack_bottom, &g_previous_context->stack_size);
+    end_context_switch();
 }
 
 void jmp_buf_link::final_switch_out()
 {
+    begin_context_switch();
     g_current_context = link;
     g_previous_context = this;
     // Since the thread is about to die we pass nullptr as fake_stack_save argument
@@ -130,18 +148,6 @@ void jmp_buf_link::final_switch_out()
 }
 
 #else
-
-namespace {
-inline void begin_context_switch() noexcept {
-    g_context_switch_in_progress.test_and_set(std::memory_order_relaxed);
-    std::atomic_signal_fence(std::memory_order_seq_cst);
-}
-
-inline void end_context_switch() noexcept {
-    std::atomic_signal_fence(std::memory_order_seq_cst);
-    g_context_switch_in_progress.clear(std::memory_order_relaxed);
-}
-}
 
 inline void jmp_buf_link::initial_switch_in(ucontext_t* initial_context, const void*, size_t)
 {


### PR DESCRIPTION
Commit 8ced1f1832c80365a5c6869ea6120d9f3d78995a sets `g_context_switch_in_progress` around the `setjmp`/`longjmp` based switches only. Sanitized builds take the `SEASTAR_ASAN_ENABLED` branch and switch stacks via `swapcontext()`, which has the same problem: glibc's aarch64 swapcontext carries an empty (nop-only) CFI program while its third instruction already clobbers the link register, so a backtrace taken from a signal handler that lands mid-switch walks garbage frames and can crash in libgcc's unwinder.

Move `{begin}/{end}_context_switch()` to shared scope and apply them to the ucontext-based switch functions, mirroring the `setjmp` variant: the flag set before a switch is cleared at the resume point control transfers to, or in `initial_switch_in_completed()` for a thread's first entry.