### PR TITLE
memory: don't override free_sized/free_aligned_sized under ASAN

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2800,10 +2800,20 @@ void free(void* ptr, size_t size) {
 
 }
 
-#if !(__GLIBC__ == 2 && __GLIBC_MINOR__ >= 43) && !(__GLIBC__ > 2)
+#if !(__GLIBC__ == 2 && __GLIBC_MINOR__ >= 43) && !(__GLIBC__ > 2) && !defined(SEASTAR_ASAN_ENABLED)
 
 // glibc 2.43 or later defines free_sized and free_aligned_sized, while we want to use
-// it even earlier
+// it even earlier.
+//
+// Do NOT define these under AddressSanitizer: ASAN interposes free_sized/
+// free_aligned_sized so it can track sized deallocations. A strong, exported
+// (visibility("default") + used) definition here would override ASAN's
+// interceptor and route the free straight to libc, bypassing ASAN's shadow and
+// quarantine bookkeeping. That silently corrupts ASAN's internal metadata and
+// leads to a delayed abort ("CHECK failed: AddrIsInMem ... (0x0, 0x0)") at an
+// unrelated allocation during quarantine recycling. Recent compilers (GCC 15+)
+// emit free_sized calls automatically (e.g. for std::string), so this is easily
+// hit. Under ASAN we must let the call fall through to ASAN's interceptor.
 
 extern "C"
 [[gnu::visibility("default")]]


### PR DESCRIPTION
In SEASTAR_DEFAULT_ALLOCATOR builds on glibc < 2.43 we define the C23 free_sized/free_aligned_sized functions so the program links on systems whose libc lacks them. These are strong, exported (visibility("default") + used) symbols that call raw libc free.

Under AddressSanitizer this is harmful: ASAN interposes free_sized/ free_aligned_sized to track sized deallocations, but our strong definitions win symbol resolution and route the free straight to libc, bypassing ASAN's shadow and quarantine bookkeeping. Recent compilers (GCC 15+) emit free_sized calls automatically (e.g. when destroying a std::string), so this is hit easily. The bypassed frees silently corrupt ASAN's internal metadata and surface later as a delayed abort at an unrelated allocation during quarantine recycling:

  AddressSanitizer: CHECK failed: asan_poisoning.cpp:88
    "((AddrIsInMem(addr + size - (1ULL << 3)))) != (0)" (0x0, 0x0)

Skip these definitions when SEASTAR_ASAN_ENABLED so the calls fall through to ASAN's own interceptors and stay tracked.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3264.
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3116.