### PR TITLE
coroutine: propagate std::expected errors from try_future

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ option (Seastar_DEPRECATED_OSTREAM_FORMATTERS
   "Enable operator<< for formatting standard library containers, which will be deprecated in future"
   OFF)
 
+option (Seastar_TRY_FUTURE_EXPECTED
+  "Make coroutine::try_future propagate std::expected unexpected values by exiting the coroutine; when off this usage is deprecated and behaves like a plain result"
+  ON)
+
 set (Seastar_API_LEVEL
   "9"
   CACHE
@@ -1007,6 +1011,11 @@ endif ()
 if (Seastar_DEPRECATED_OSTREAM_FORMATTERS)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_DEPRECATED_OSTREAM_FORMATTERS)
+endif ()
+
+if (Seastar_TRY_FUTURE_EXPECTED)
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_TRY_FUTURE_EXPECTED)
 endif ()
 
 if (LinuxMembarrier_FOUND)

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -583,6 +583,53 @@ seastar::future<int> exception_propagating() {
 }
 ```
 
+### Propagating `std::expected` errors
+
+When errors are represented as values rather than exceptions, a function returns a
+`future<std::expected<T, E>>`: the future carries either a value, or an error `E`, or (should
+something go wrong at the future level) an exception. When awaited through `coroutine::try_future`,
+a `future<std::expected<T, E>>` extends the error propagation described above to unexpected values.
+It inspects the three possible outcomes of the awaited future and:
+
+- if the future resolved with a value, that value becomes the result of the `co_await`;
+- if the future resolved with an unexpected, the error is rebound to the coroutine's return type
+  (which must be a `future<std::expected<U, E>>` with a matching error type `E`) and returned to
+  the waiter directly, without resuming the coroutine;
+- if the future failed with an exception, the exception is forwarded to the waiter directly, just
+  like for a non-`std::expected` result.
+
+In all cases the error is propagated without throwing, and the code following the `co_await` only
+runs on the success path. This is analogous to rust's
+[try operator](https://google.github.io/comprehensive-rust/error-handling/try.html) applied to
+`Result`.
+
+Example:
+
+```cpp
+enum class error { not_found, corrupted };
+
+seastar::future<std::expected<int, error>> read_value();
+
+seastar::future<std::expected<seastar::sstring, error>> read_value_as_string() {
+    // If read_value() resolves with an error, it is rebound to this coroutine's
+    // return type and returned directly. If it fails with an exception, the
+    // exception is propagated to the waiter. Otherwise, value holds the int.
+    auto value = co_await seastar::coroutine::try_future(read_value());
+
+    // Only reached if read_value() resolved with a value.
+    co_return seastar::to_sstring(value);
+}
+```
+
+Just like for any other result, preemption checking can be disabled with
+`coroutine::try_future_without_preemption_check`.
+
+This `std::expected`-aware behavior is enabled by the `SEASTAR_TRY_FUTURE_EXPECTED` macro (the
+`Seastar_TRY_FUTURE_EXPECTED` CMake option), which is on by default. When it is disabled, awaiting a
+`future<std::expected<T, E>>` through `coroutine::try_future` is deprecated and behaves like any
+other result: only a failed future exits the coroutine, and an unexpected value is handed out as the
+whole `std::expected` result of the `co_await`.
+
 ## Concurrency in coroutines
 
 The `co_await` operator allows for simple sequential execution. Multiple coroutines can execute in parallel, but each coroutine has only one outstanding computation at a time.

--- a/include/seastar/coroutine/try_future.hh
+++ b/include/seastar/coroutine/try_future.hh
@@ -21,10 +21,35 @@
 
 #pragma once
 
+#include <expected>
+#include <utility>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/internal/current_task.hh>
 
 namespace seastar::internal {
+
+/// \brief Trait detecting whether \p T is a specialization of std::expected.
+template <typename T>
+struct is_std_expected : std::false_type {};
+
+template <typename V, typename E>
+struct is_std_expected<std::expected<V, E>> : std::true_type {};
+
+template <typename T>
+concept std_expected = is_std_expected<T>::value;
+
+// Whether try_future should propagate an unexpected value of a
+// future<std::expected<...>> result by exiting the coroutine (rebinding it to
+// the coroutine's return type), rather than handing it out as a plain value.
+// Controlled by the SEASTAR_TRY_FUTURE_EXPECTED opt-in, on by default.
+#ifdef SEASTAR_TRY_FUTURE_EXPECTED
+template <typename T>
+inline constexpr bool try_future_propagates_expected = std_expected<T>;
+#else
+template <typename T>
+inline constexpr bool try_future_propagates_expected = false;
+#endif
 
 template <typename T, typename U>
 void try_future_resume_or_destroy_coroutine(seastar::future<T>& fut, seastar::task& coroutine_task) {
@@ -32,12 +57,28 @@ void try_future_resume_or_destroy_coroutine(seastar::future<T>& fut, seastar::ta
     auto hndl = std::coroutine_handle<U>::from_promise(*promise_ptr);
 
     if (fut.failed()) {
+        // Exceptional future: forward the exception to the waiter directly.
         hndl.promise().set_exception(std::move(fut).get_exception());
         hndl.destroy();
-    } else {
-        set_current_task(promise_ptr);
-        hndl.resume();
+        return;
     }
+
+    if constexpr (try_future_propagates_expected<T>) {
+        T expected = std::move(fut).get();
+        if (!expected.has_value()) {
+            // The expected holds an unexpected: rebind it to the coroutine's
+            // return type and return with it, without resuming the coroutine.
+            hndl.promise().return_value(std::unexpected(std::move(expected).error()));
+            hndl.destroy();
+            return;
+        }
+        // The expected holds a value: put it back so that await_resume() can
+        // hand out the wrapped value, then resume the coroutine.
+        fut = seastar::make_ready_future<T>(std::move(expected));
+    }
+
+    set_current_task(promise_ptr);
+    hndl.resume();
 }
 
 template <bool CheckPreempt, typename T>
@@ -53,9 +94,23 @@ public:
     try_future_awaiter(const try_future_awaiter&) = delete;
     try_future_awaiter(try_future_awaiter&&) = delete;
 
-    bool await_ready() const noexcept {
+    bool await_ready() noexcept {
         // Will suspend+schedule for ready failed futures too.
-        return _future.available() && !_future.failed() && (!CheckPreempt || !need_preempt());
+        if (!_future.available() || _future.failed() || (CheckPreempt && need_preempt())) {
+            return false;
+        }
+        if constexpr (try_future_propagates_expected<T>) {
+            // A ready future has no non-destructive way to inspect its expected,
+            // so unwrap it and put it right back. Only take the fast path when it
+            // holds a value; an unexpected must suspend so that the coroutine can
+            // be completed and destroyed without being resumed.
+            T expected = std::move(_future).get();
+            bool has_value = expected.has_value();
+            _future = seastar::make_ready_future<T>(std::move(expected));
+            return has_value;
+        } else {
+            return true;
+        }
     }
 
     template<typename U>
@@ -71,8 +126,12 @@ public:
         }
     }
 
-    T await_resume() {
-        if constexpr (std::is_void_v<T>) {
+    // Returns the unwrapped value_type on the std::expected fast path (only
+    // reached when the expected holds a value), otherwise the whole result T.
+    auto await_resume() {
+        if constexpr (try_future_propagates_expected<T>) {
+            return std::move(_future).get().value();
+        } else if constexpr (std::is_void_v<T>) {
             _future.get();
         } else {
             return std::move(_future).get();
@@ -124,6 +183,43 @@ namespace seastar::coroutine {
 /// which means that it will yield if the future is ready and \ref seastar::need_preempt()
 /// returns true.  Use \ref coroutine::try_future_without_preemption_check
 /// to disable preemption checking.
+///
+/// ## `std::expected` results
+///
+/// When the awaited future wraps a `std::expected<V, E>`, `try_future` extends
+/// its error propagation to unexpected values, treating them like a rust-style
+/// [try operator](https://google.github.io/comprehensive-rust/error-handling/try.html)
+/// on top of the exception handling above. It distinguishes three outcomes:
+///
+///  - If the future failed (holds an exception), the coroutine is not resumed;
+///    the exception is forwarded to the waiter directly and the coroutine is
+///    destroyed, exactly as for a non-`std::expected` result.
+///  - If the future resolved with an unexpected value, the coroutine is not
+///    resumed; the `std::unexpected` is rebound to the coroutine's return type
+///    (which must be a `future<std::expected<V2, E>>` with a matching error
+///    type) and returned to the waiter, and the coroutine is destroyed.
+///  - If the future resolved with a value, that value is the result of the
+///    `co_await`.
+///
+/// For example:
+/// ```
+/// future<std::expected<int, error>> bar();
+///
+/// future<std::expected<result, error>> foo() {
+///     // If bar() resolves with an error (or a failed future), foo() returns
+///     // with that error (or exception) directly and this coroutine stops here.
+///     auto value = co_await coroutine::try_future(bar());
+///     // Only reached if bar() resolved with a value.
+///     co_return compute_result(value);
+/// }
+/// ```
+///
+/// This `std::expected`-aware behavior is enabled by the
+/// `SEASTAR_TRY_FUTURE_EXPECTED` macro, which is defined by default. When it is
+/// not defined, awaiting a `future<std::expected<V, E>>` is deprecated and
+/// behaves like any other result: only a failed future exits the coroutine, and
+/// an unexpected value is handed out as the (whole `std::expected`) result of
+/// the `co_await`.
 template<typename T>
 class [[nodiscard]] try_future : public seastar::internal::try_future_awaiter<true, T> {
 public:
@@ -143,5 +239,38 @@ public:
         : seastar::internal::try_future_awaiter<false, T>(std::move(f))
     {}
 };
+
+#ifndef SEASTAR_TRY_FUTURE_EXPECTED
+
+/// \brief Deprecated legacy specialization for `future<std::expected>`.
+///
+/// When `SEASTAR_TRY_FUTURE_EXPECTED` is not defined, awaiting a
+/// `future<std::expected<V, E>>` does not treat an unexpected value specially: it
+/// behaves like the generic \ref try_future, handing the whole `std::expected`
+/// out as the result of the `co_await`. Define `SEASTAR_TRY_FUTURE_EXPECTED`
+/// (the default) to have unexpected values exit the coroutine instead.
+template<seastar::internal::std_expected T>
+class [[nodiscard]] try_future<T> : public seastar::internal::try_future_awaiter<true, T> {
+public:
+    [[deprecated("try_future on a future<std::expected> will propagate unexpected values; "
+                 "define SEASTAR_TRY_FUTURE_EXPECTED to opt in to the new behavior")]]
+    explicit try_future(seastar::future<T>&& f) noexcept
+        : seastar::internal::try_future_awaiter<true, T>(std::move(f))
+    {}
+};
+
+/// \brief Deprecated legacy specialization for `future<std::expected>`, without
+/// preemption checking. See \ref try_future.
+template<seastar::internal::std_expected T>
+class [[nodiscard]] try_future_without_preemption_check<T> : public seastar::internal::try_future_awaiter<false, T> {
+public:
+    [[deprecated("try_future_without_preemption_check on a future<std::expected> will propagate "
+                 "unexpected values; define SEASTAR_TRY_FUTURE_EXPECTED to opt in to the new behavior")]]
+    explicit try_future_without_preemption_check(seastar::future<T>&& f) noexcept
+        : seastar::internal::try_future_awaiter<false, T>(std::move(f))
+    {}
+};
+
+#endif // SEASTAR_TRY_FUTURE_EXPECTED
 
 } // namespace seastar::coroutine

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -954,6 +954,174 @@ SEASTAR_TEST_CASE(test_try_future) {
     co_await run_try_future_test<false>(return_ex_int, std::nullopt);
 }
 
+enum class try_error { boom, kaboom };
+
+// Underlying function returning a future<expected<int, try_error>> which may
+// resolve with a value, with an unexpected, or as an exceptional future. When
+// ready is false it suspends first, so the awaiter sees a not-yet-available
+// future (set_coroutine path); when true it resolves synchronously, exercising
+// the fast path where await_ready() unwraps a ready future.
+static future<std::expected<int, try_error>> try_expected_source(std::optional<try_error> err, bool throw_, bool ready) {
+    if (!ready) {
+        co_await sleep(1ms);
+    }
+    if (throw_) {
+        throw test_exception{};
+    }
+    if (err) {
+        co_return std::unexpected(*err);
+    }
+    co_return 128;
+}
+
+// Underlying function returning a future<expected<void, try_error>>.
+static future<std::expected<void, try_error>> try_expected_void_source(std::optional<try_error> err, bool throw_, bool ready) {
+    if (!ready) {
+        co_await sleep(1ms);
+    }
+    if (throw_) {
+        throw test_exception{};
+    }
+    if (err) {
+        co_return std::unexpected(*err);
+    }
+    co_return std::expected<void, try_error>{};
+}
+
+#ifdef SEASTAR_TRY_FUTURE_EXPECTED
+
+// Coroutine using try_future on a future<std::expected>, with the std::expected
+// special-casing enabled (SEASTAR_TRY_FUTURE_EXPECTED). Note the return type
+// wraps a different value type (sstring) than the awaited future (int/void), to
+// make sure the unexpected is correctly rebound to the coroutine's return type.
+// The co_await unwraps the value; an unexpected exits the coroutine before the
+// code past the co_await runs.
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    int value;
+    if constexpr (CheckPreempt) {
+        value = co_await coroutine::try_future(try_expected_source(err, throw_, ready));
+    } else {
+        value = co_await coroutine::try_future_without_preemption_check(try_expected_source(err, throw_, ready));
+    }
+    // Only reached if the source resolved with a value.
+    run_past = true;
+    co_return seastar::to_sstring(value);
+}
+
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_void_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    if constexpr (CheckPreempt) {
+        co_await coroutine::try_future(try_expected_void_source(err, throw_, ready));
+    } else {
+        co_await coroutine::try_future_without_preemption_check(try_expected_void_source(err, throw_, ready));
+    }
+    run_past = true;
+    co_return sstring("done");
+}
+
+// With the special-casing enabled, an unexpected exits the coroutine without
+// resuming it, so the code past the co_await does not run.
+static constexpr bool run_past_on_unexpected = false;
+
+#else // !SEASTAR_TRY_FUTURE_EXPECTED
+
+// Coroutine using try_future on a future<std::expected> with the std::expected
+// special-casing disabled: try_future is deprecated for this usage and hands the
+// whole std::expected out as the result of the co_await (only a failed future
+// exits the coroutine), so an unexpected is forwarded manually here. The
+// deprecation warning is expected; suppress it for these call sites.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    std::expected<int, try_error> value;
+    if constexpr (CheckPreempt) {
+        value = co_await coroutine::try_future(try_expected_source(err, throw_, ready));
+    } else {
+        value = co_await coroutine::try_future_without_preemption_check(try_expected_source(err, throw_, ready));
+    }
+    // Reached for both a value and an unexpected (only a failed future skips this).
+    run_past = true;
+    if (!value.has_value()) {
+        co_return std::unexpected(value.error());
+    }
+    co_return seastar::to_sstring(*value);
+}
+
+template <bool CheckPreempt>
+static future<std::expected<sstring, try_error>> try_expected_void_consumer(std::optional<try_error> err, bool throw_, bool ready, bool& run_past) {
+    std::expected<void, try_error> value;
+    if constexpr (CheckPreempt) {
+        value = co_await coroutine::try_future(try_expected_void_source(err, throw_, ready));
+    } else {
+        value = co_await coroutine::try_future_without_preemption_check(try_expected_void_source(err, throw_, ready));
+    }
+    run_past = true;
+    if (!value.has_value()) {
+        co_return std::unexpected(value.error());
+    }
+    co_return sstring("done");
+}
+
+#pragma GCC diagnostic pop
+
+// Without the special-casing, an unexpected does not exit the coroutine; it is
+// resumed and runs the code past the co_await, forwarding the unexpected itself.
+static constexpr bool run_past_on_unexpected = true;
+
+#endif // SEASTAR_TRY_FUTURE_EXPECTED
+
+template <typename Consumer>
+static future<> run_try_expected_future_test(Consumer consumer, sstring expected_value, bool ready) {
+    // Success: the wrapped value is returned and the code past the co_await runs.
+    {
+        bool run_past = false;
+        auto res = co_await consumer(std::nullopt, false, ready, run_past);
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res.value(), expected_value);
+        BOOST_REQUIRE(run_past);
+    }
+
+    // Unexpected: the error ends up in the coroutine's returned expected either
+    // way. Whether the code past the co_await runs depends on whether the
+    // std::expected special-casing is enabled (see run_past_on_unexpected).
+    {
+        bool run_past = false;
+        auto res = co_await consumer(try_error::kaboom, false, ready, run_past);
+        BOOST_REQUIRE(!res.has_value());
+        BOOST_REQUIRE(res.error() == try_error::kaboom);
+        BOOST_REQUIRE_EQUAL(run_past, run_past_on_unexpected);
+    }
+
+    // Exceptional future: the exception is propagated to the waiter directly and
+    // the code past the co_await is skipped, regardless of the special-casing.
+    {
+        bool run_past = false;
+        bool caught = false;
+        try {
+            [[maybe_unused]] auto res = co_await consumer(std::nullopt, true, ready, run_past);
+        } catch (test_exception&) {
+            caught = true;
+        }
+        BOOST_REQUIRE(caught);
+        BOOST_REQUIRE(!run_past);
+    }
+}
+
+SEASTAR_TEST_CASE(test_try_expected_future) {
+    // Exercise both the ready (fast path, unwrap in await_ready) and not-ready
+    // (set_coroutine path) cases.
+    for (bool ready : {false, true}) {
+        co_await run_try_expected_future_test(try_expected_consumer<true>, sstring("128"), ready);
+        co_await run_try_expected_future_test(try_expected_consumer<false>, sstring("128"), ready);
+
+        co_await run_try_expected_future_test(try_expected_void_consumer<true>, sstring("done"), ready);
+        co_await run_try_expected_future_test(try_expected_void_consumer<false>, sstring("done"), ready);
+    }
+}
+
 #if SEASTAR_API_LEVEL < 10
 future<int> co_return_tup_int_rv() {
     co_return std::tuple(42);


### PR DESCRIPTION
Extend coroutine::try_future so that awaiting a future<std::expected<V, E>> also propagates unexpected values, not just exceptions. This is the std::expected counterpart of try_future's exception handling, analogous to rust's try operator: the error is propagated up the std::expected chain without being thrown.

For a future<std::expected<V, E>>, try_future distinguishes three outcomes of the awaited future:

 - if the future failed (holds an exception), the exception is forwarded to the waiter directly and the coroutine is destroyed, exactly like for a non-std::expected result;
 - if the future resolved with an unexpected, it is rebound to the coroutine's return type (a future<std::expected<V2, E>> with a matching error type) and returned to the waiter, without resuming the coroutine;
 - if the future resolved with a value, that value is the result of the co_await.

Rather than a separate awaiter, the std::expected-specific checks are folded into the existing try_future_awaiter behind an if constexpr, so both the preemption-checking and non-preemption-checking variants get the behavior for free. Since a ready future offers no non-destructive way to inspect its expected, await_ready() unwraps it and puts it right back via make_ready_future(), so a ready value can still take the fast path without suspending.

The behavior is guarded by the SEASTAR_TRY_FUTURE_EXPECTED macro (the Seastar_TRY_FUTURE_EXPECTED CMake option), on by default. When disabled, awaiting a future<std::expected> through try_future is deprecated and behaves like any other result: only a failed future exits the coroutine, and the whole std::expected is handed out as the co_await result.

try_future is now exported from the seastar module. The behavior is tested in coroutines_test in both configurations, and documented in the coroutine exception handling chapter of doc/tutorial.md.