### PR TITLE
CMakeLists: link URING::uring as PRIVATE, keep include dir PUBLIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,8 +1147,11 @@ set_option_if_package_is_found (Seastar_IO_URING LibUring)
 if (Seastar_IO_URING)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_HAVE_URING)
-  target_link_libraries (seastar
-    PUBLIC URING::uring)
+  # Uring include directories are public as seastar includes them in its public headers.
+  # The library is private as seastar uses it internally.
+  target_link_libraries (seastar PRIVATE URING::uring)
+  target_include_directories (seastar
+    SYSTEM PUBLIC $<TARGET_PROPERTY:URING::uring,INTERFACE_INCLUDE_DIRECTORIES>)
 endif ()
 
 if (Seastar_LD_FLAGS)


### PR DESCRIPTION
PR scylladb/seastar#3490 linked URING::uring as PUBLIC so consumers find liburing.h, which is included in seastar's public headers.

However making the link PUBLIC also propagates -luring to consumers. This is not needed, since consumers do not call into liburing directly, which is only used internally by seastar.

Additionally this makes the inconsistent linkage flags on consumer side when linking with seastar using .pc file vs cmake, since the .pc file does not add -luring.