### PR TITLE
reactor: Remove deprecated handle_signal() method

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -402,9 +402,6 @@ private:
     bool poll_once();
     bool pure_poll_once();
 public:
-    /// Register a user-defined signal handler
-    [[deprecated("Use seastar::handle_signal(signo, handler, once); instead")]]
-    void handle_signal(int signo, noncopyable_function<void ()>&& handler);
     void wakeup();
     /// @private
     bool stopped() const noexcept { return _stopped; }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -791,10 +791,6 @@ void reactor::signals::failed_to_handle(int signo) {
     seastar_logger.error("Failed to handle signal {} on thread {} ({}): engine not ready", signo, tid, tname);
 }
 
-void reactor::handle_signal(int signo, noncopyable_function<void ()>&& handler) {
-    _signals.handle_signal(signo, std::move(handler));
-}
-
 // Accumulates an in-memory backtrace and flush to stderr eventually.
 // Async-signal safe.
 class backtrace_buffer {


### PR DESCRIPTION
The method was deprecated in commit c3e826ad1197 ("signal: add seastar signal api", 2024-08-07) in favor of the free function seastar::handle_signal(signo, handler, once).