### PR TITLE
http: Remove deprecated httpd::request and httpd::reply aliases

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -316,10 +316,6 @@ std::ostream& operator<<(std::ostream& os, reply::status_type st);
 
 } // namespace http
 
-namespace httpd {
-using reply [[deprecated("Use http::reply instead")]] = http::reply;
-}
-
 }
 
 template <> struct fmt::formatter<seastar::http::reply::status_type> : fmt::ostream_formatter {};

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -440,10 +440,6 @@ inline const sstring& deprecated_content(const request& req) noexcept { return r
 
 } // namespace httpd
 
-namespace httpd {
-using request [[deprecated("Use http::request instead")]] = http::request;
-}
-
 }
 
 template <>

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -70,7 +70,7 @@ public:
 // NOTE: Remove this once `query_parameters` is removed
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-std::unordered_map<sstring, sstring>& deprecated_query_parameters(request& r) noexcept {
+std::unordered_map<sstring, sstring>& deprecated_query_parameters(http::request& r) noexcept {
     return r.query_parameters;
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
These aliases were deprecated in commits bdd5d929891d ("http: Move httpd::request to http:: namespace", 2022-11-10) and 717ff4108d46 ("http: Move httpd::reply to http:: namespace", 2022-11-10) in favor of http::request and http::reply respectively as a part of http client implementation.