### PR TITLE
httpd: Remove deprecated connection constructor taking socket_address

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -78,9 +78,6 @@ class connection : public boost::intrusive::list_base_hook<> {
     bool _done = false;
     const bool _tls;
 public:
-    [[deprecated("use connection(http_server&, connected_socket&&, bool tls)")]]
-    connection(http_server& server, connected_socket&& fd, socket_address, bool tls)
-            : connection(server, std::move(fd), tls) {}
     connection(http_server& server, connected_socket&& fd, bool tls)
             : _server(server)
             , _fd(std::move(fd))


### PR DESCRIPTION
The constructor was deprecated in commit 3841bbdd19e8 ("httpd: add a ctor without addr parameter", 2022-09-02). The socket_address parameter was unused — the connection retrieves remote and local addresses directly from the connected_socket.