### PR TITLE
reactor: sort tasks in task queue to maximize instruction cache utilization

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -863,7 +863,7 @@ public:
         if (ptr) {
             assert(ptr->_u.st == future_state_base::state::future);
             new (ptr) future_state(std::move(state));
-            make_ready<urgent::yes>();
+            make_ready<urgent::no>();
         }
     }
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -290,13 +290,17 @@ private:
     };
 
     struct task_queue final : public sched_entity {
+        static constexpr unsigned type_hash_size = 61;
         explicit task_queue(task_queue_group* p, unsigned id, sstring name, sstring shortname, float shares);
         const uint8_t _id;
         uint64_t _tasks_processed = 0;
         struct queue_fragment : boost::intrusive::list_base_hook<> {
             constexpr static unsigned max_tasks = 13;
-            unsigned start = 0;
-            unsigned end = 0;
+            uint8_t start = 0;
+            uint8_t end = 0;
+            uint8_t type_hash_index = type_hash_size;
+            queue_fragment() = default;
+            explicit queue_fragment(uint8_t type_hash_index) : type_hash_index(type_hash_index) {}
             task* tasks[max_tasks];
             bool can_push_front() const;
             bool is_full() const { return end == max_tasks; }
@@ -307,6 +311,7 @@ private:
         };
         struct fragmented_queue {
             using fragments_type = boost::intrusive::list<queue_fragment, boost::intrusive::constant_time_size<false>>;
+            queue_fragment* type_hash[type_hash_size + 1] = {};
             unsigned nr_tasks = 0;
             fragments_type fragments;
             void push_front(task* tsk) noexcept;

--- a/tests/unit/lowres_clock_test.cc
+++ b/tests/unit/lowres_clock_test.cc
@@ -46,7 +46,7 @@ SEASTAR_TEST_CASE(steady_clock_sanity) {
             auto const elapsed = lowres_clock::now() - t1;
             auto const minimum_elapsed = 0.9 * sleep_duration;
 
-            BOOST_REQUIRE(elapsed >= minimum_elapsed);
+            BOOST_REQUIRE_GE(elapsed, minimum_elapsed);
 
             return make_ready_future<>();
         });
@@ -68,12 +68,12 @@ SEASTAR_TEST_CASE(steady_clock_sanity_preempt) {
     // Yield to the reactor to give it a chance to update the
     // low-resolution clock. Yield just schedules an empty task and
     // waits for it to be executed. There is nothing special about it.
-    co_await ::seastar::yield();
+    co_await ::seastar::check_for_io_immediately();
 
     auto const elapsed = lowres_clock::now() - t1;
     auto const minimum_elapsed = 0.9 * sleep_duration;
 
-    BOOST_REQUIRE(elapsed >= minimum_elapsed);
+    BOOST_REQUIRE_GE(elapsed, minimum_elapsed);
 }
 
 //

--- a/tests/unit/queue_test.cc
+++ b/tests/unit/queue_test.cc
@@ -68,7 +68,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_pop_eventually) {
         testlog.trace("pusher: full={} empty={} stop={}", q.full(), q.empty(), stop);
         return q.push_eventually(std::move(data)).then([&] {
             pushed++;
-            if (stop && !q.empty()) {
+            if (stop && pushed > 100) {
                 testlog.debug("pusher done");
                 pusher_done = true;
                 return stop_iteration::yes;


### PR DESCRIPTION
Increase the affinity of tasks with instruction locality by placing them close
by in the task queue. This increases the chance that the instruction cache
will hold the instructions for the tasks, and similarly for the branch predictor
training history.

Tasks are deemed similar if they share the virtual table pointer. The matching
is lossy, so unrelated tasks can be executed together with some probability.

Note: I was not able to show any gain from this when it was written.