### PR TITLE
build: optionally consume fmt as a module rather than headers

### DIFF
--- a/.github/workflows/gen-matrix.py
+++ b/.github/workflows/gen-matrix.py
@@ -124,6 +124,25 @@ SPECIAL_ITEMS: list[dict[str, Any]] = [
         "enable-ccache": False,
         "info": "modules, ",
     },
+    # Seastar_IMPORT_FMT only changes how a *consumer* sees Seastar's headers:
+    # Seastar's own sources include fmt textually either way, so the library
+    # this job builds is the same one the regular release jobs build, and
+    # running the test suite over it again would tell us nothing. What is new
+    # is what gets compiled with `import fmt;`: demos/hello_import_fmt, which
+    # comes along with the demos in the default target, and the installed
+    # consumers test.yaml builds afterwards. Hence no tests, no apps, and no
+    # Test step. ccache is off for the same reason as the modules job: module
+    # interface units do not go through it well.
+    {
+        "compiler": "clang++-22",
+        "standard": 23,
+        "arch": "x86",
+        "mode": "release",
+        "enables": "--enable-import-fmt",
+        "options": "--without-tests --without-apps",
+        "enable-ccache": False,
+        "info": "fmt module, ",
+    },
     {
         "compiler": "clang++-22",
         "standard": 23,

--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -94,9 +94,15 @@ fi
 # The check is version-guarded rather
 # than blanket-applied so future pre-20 clang versions in the matrix
 # don't pay the build cost.
+#
+# --enable-import-fmt needs one too, for a different reason: it consumes fmt as
+# a C++20 module, which no libfmt-dev ships -- the module has to be built
+# alongside the library, which cooking_recipe.cmake arranges (with FMT_MODULE)
+# when that option is on.
 cook_args=()
 clang_ver="${COMPILER#clang++-}"
-if [[ "$COMPILER" == clang++-* && "$clang_ver" -ge 20 || "$STANDARD" -ge 26 ]] ; then
+if [[ "$COMPILER" == clang++-* && "$clang_ver" -ge 20 || "$STANDARD" -ge 26 ]] \
+   || [[ "$ENABLES" == *import-fmt* ]]; then
     cook_args=(--cook fmt)
 fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,6 +98,31 @@ jobs:
         if: ${{ contains(inputs.enables, 'cxx-modules') }}
         run: cmake --build build/${{ inputs.mode }} --target hello_cxx_module
 
+      # Seastar_IMPORT_FMT publishes its definitions and flags to installed
+      # consumers only -- deliberately, so that Seastar's own targets keep
+      # including fmt textually -- so nothing in the build tree above compiles
+      # the way an application does. Install it and build one, over each
+      # channel. See tests/consumer/CMakeLists.txt.
+      - name: Build installed consumers
+        if: ${{ contains(inputs.enables, 'import-fmt') }}
+        run: |
+          # No --prefix here: the paths inside seastar.pc and the installed
+          # CMake package are fixed at configure time, so install where
+          # configure.py said (/usr/local) or they point somewhere else.
+          cmake --install build/${{ inputs.mode }}
+          # Seastar's CMake package re-finds fmt on the consumer's behalf, and
+          # the fmt module comes from there, but a cooked fmt is installed
+          # under the build directory rather than system-wide.
+          PKG_CONFIG_PATH="$(dirname "$(find /usr/local -name seastar.pc)")" \
+            cmake -G Ninja -S tests/consumer -B build/consumer \
+              -DCMAKE_CXX_COMPILER=${{ inputs.compiler }} \
+              -DCMAKE_CXX_STANDARD=${{ inputs.standard }} \
+              -DCMAKE_PREFIX_PATH="$PWD/build/${{ inputs.mode }}/_cooking/installed"
+          cmake --build build/consumer
+
+      # The import-fmt job builds no tests: the library it produces is the same
+      # one the regular jobs build, since Seastar_IMPORT_FMT only changes what
+      # a consumer's translation units do. See gen-matrix.py.
       - name: Test
-        if: ${{ ! contains(inputs.enables, 'cxx-modules') }}
+        if: ${{ ! contains(inputs.enables, 'cxx-modules') && ! contains(inputs.enables, 'import-fmt') }}
         run: ./test.py --mode=${{ inputs.mode }} ${{ inputs.test-args }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,7 @@ jobs:
           - {compiler: clang++-22, standard: 23, arch: x86, mode: dev, options: --heap-profiling, info: 'heapprof, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: release, enables: --enable-dpdk, options: --cook dpdk --dpdk-machine corei7-avx, info: 'dpdk, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: debug, enables: --enable-cxx-modules, enable-ccache: false, info: 'modules, '}
+          - {compiler: clang++-22, standard: 23, arch: x86, mode: release, enables: --enable-import-fmt, options: --without-tests --without-apps, enable-ccache: false, info: 'fmt module, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: fuzz, test-args: -- -R 'Seastar.fuzz.'}
     with:
       compiler: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ cmake_dependent_option (Seastar_MODULE
   "Build a C++20 module instead of a traditional library" OFF
   "CMAKE_VERSION VERSION_GREATER_EQUAL 3.26;CMAKE_CXX_STANDARD GREATER_EQUAL 20" OFF)
 
+cmake_dependent_option (Seastar_IMPORT_FMT
+  "Make consumers pull in fmt via `import fmt;` instead of textual includes" OFF
+  "CMAKE_CXX_STANDARD GREATER_EQUAL 20" OFF)
+
 set (CMAKE_C_FLAGS_SANITIZE
   "-Os -g"
   CACHE
@@ -1046,6 +1050,29 @@ endif ()
 if (Seastar_LOGGER_COMPILE_TIME_FMT)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_LOGGER_COMPILE_TIME_FMT)
+endif ()
+
+if (Seastar_IMPORT_FMT)
+  # Tell *external* consumers (through pkg-config) to pull fmt in as a module
+  # via the funnel (include/seastar/core/internal/fmt.hh).
+  #
+  # This is deliberately NOT put on the seastar target's INTERFACE: that would
+  # also reach Seastar's own targets that link seastar (seastar_testing, the
+  # apps, the tests) and the seastar module's global module fragment, none of
+  # which have an fmt module available -- they must keep including fmt textually.
+  # The pkg-config channel is only seen by genuinely external consumers.
+  #
+  # fmt's macros are not exported by the module; supply FMT_VERSION -- the only
+  # version-dependent fmt macro our public headers use -- derived from the fmt
+  # that was found, since Seastar does not bundle fmt.
+  string (REPLACE "." ";" _fmt_version_components "${fmt_VERSION}")
+  list (GET _fmt_version_components 0 _fmt_version_major)
+  list (GET _fmt_version_components 1 _fmt_version_minor)
+  list (GET _fmt_version_components 2 _fmt_version_patch)
+  math (EXPR _fmt_version_int
+    "${_fmt_version_major} * 10000 + ${_fmt_version_minor} * 100 + ${_fmt_version_patch}")
+  set (Seastar_PC_IMPORT_FMT_CFLAGS
+    "-DSEASTAR_IMPORT_FMT -DFMT_VERSION=${_fmt_version_int}")
 endif ()
 
 target_compile_definitions (seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,9 @@ cmake_dependent_option (Seastar_MODULE
   "Build a C++20 module instead of a traditional library" OFF
   "CMAKE_VERSION VERSION_GREATER_EQUAL 3.26;CMAKE_CXX_STANDARD GREATER_EQUAL 20" OFF)
 
+option (Seastar_IMPORT_FMT
+  "Seastar and its consumers pull in fmt via `import fmt;` instead of textual includes" OFF)
+
 set (CMAKE_C_FLAGS_SANITIZE
   "-Os -g"
   CACHE
@@ -1047,6 +1050,37 @@ endif ()
 if (Seastar_LOGGER_COMPILE_TIME_FMT)
   target_compile_definitions (seastar
     PUBLIC SEASTAR_LOGGER_COMPILE_TIME_FMT)
+endif ()
+
+if (Seastar_IMPORT_FMT)
+  # Tell *external* consumers (through pkg-config) to pull fmt in as a module
+  # via the funnel (include/seastar/core/internal/fmt.hh).
+  #
+  # SEASTAR_IMPORT_FMT is deliberately NOT put on the seastar target's
+  # INTERFACE: that would also reach Seastar's own targets that link seastar
+  # (seastar_testing, the apps, the tests) and the seastar module's global module
+  # fragment, none of which have an fmt module available -- they must keep
+  # including fmt textually.  The pkg-config channel is only seen by genuinely
+  # external consumers.
+  #
+  # fmt's macros are not exported by the module, so SEASTAR_FMT_VERSION -- which
+  # the version-dependent parts of our public headers key off, and which the
+  # funnel otherwise derives from FMT_VERSION -- has to be supplied here,
+  # derived from the fmt that was found, since Seastar does not bundle fmt.
+  #
+  # Unlike SEASTAR_IMPORT_FMT, this one is safe on the seastar target's
+  # INTERFACE: it is Seastar's own macro, and its value is exactly what the
+  # funnel computes for the targets that do include fmt textually.
+  string (REPLACE "." ";" _fmt_version_components "${fmt_VERSION}")
+  list (GET _fmt_version_components 0 _fmt_version_major)
+  list (GET _fmt_version_components 1 _fmt_version_minor)
+  list (GET _fmt_version_components 2 _fmt_version_patch)
+  math (EXPR _fmt_version_int
+    "${_fmt_version_major} * 10000 + ${_fmt_version_minor} * 100 + ${_fmt_version_patch}")
+  target_compile_definitions (seastar
+    PUBLIC SEASTAR_FMT_VERSION=${_fmt_version_int})
+  set (Seastar_PC_IMPORT_FMT_CFLAGS
+    "-DSEASTAR_IMPORT_FMT -DSEASTAR_FMT_VERSION=${_fmt_version_int}")
 endif ()
 
 target_compile_definitions (seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,12 @@ cmake_dependent_option (Seastar_MODULE
 
 option (Seastar_IMPORT_FMT
   "Seastar and its consumers pull in fmt via `import fmt;` instead of textual includes" OFF)
+if (Seastar_IMPORT_FMT AND CMAKE_VERSION VERSION_LESS 3.28)
+  # 3.28 is where CMake learned to consume an imported C++ module file set,
+  # which is how fmt ships its module.
+  message (FATAL_ERROR
+    "Seastar_IMPORT_FMT requires CMake 3.28 or later, found ${CMAKE_VERSION}.")
+endif ()
 
 set (CMAKE_C_FLAGS_SANITIZE
   "-Os -g"
@@ -1053,15 +1059,16 @@ if (Seastar_LOGGER_COMPILE_TIME_FMT)
 endif ()
 
 if (Seastar_IMPORT_FMT)
-  # Tell *external* consumers (through pkg-config) to pull fmt in as a module
-  # via the funnel (include/seastar/core/internal/fmt.hh).
+  # Tell *external* consumers to pull fmt in as a module via the funnel
+  # (include/seastar/core/internal/fmt.hh), through both channels they may
+  # arrive by: pkg-config, and the installed CMake package.
   #
-  # SEASTAR_IMPORT_FMT is deliberately NOT put on the seastar target's
-  # INTERFACE: that would also reach Seastar's own targets that link seastar
-  # (seastar_testing, the apps, the tests) and the seastar module's global module
-  # fragment, none of which have an fmt module available -- they must keep
-  # including fmt textually.  The pkg-config channel is only seen by genuinely
-  # external consumers.
+  # SEASTAR_IMPORT_FMT is deliberately confined to the *install* interface:
+  # on the plain INTERFACE it would also reach Seastar's own targets that link
+  # seastar from the build tree (seastar_testing, the apps, the tests) and the
+  # seastar module's global module fragment, none of which have an fmt module
+  # available -- they must keep including fmt textually.  Only genuinely
+  # external consumers see either channel.
   #
   # fmt's macros are not exported by the module, so SEASTAR_FMT_VERSION -- which
   # the version-dependent parts of our public headers key off, and which the
@@ -1078,9 +1085,29 @@ if (Seastar_IMPORT_FMT)
   math (EXPR _fmt_version_int
     "${_fmt_version_major} * 10000 + ${_fmt_version_minor} * 100 + ${_fmt_version_patch}")
   target_compile_definitions (seastar
-    PUBLIC SEASTAR_FMT_VERSION=${_fmt_version_int})
+    PUBLIC
+      SEASTAR_FMT_VERSION=${_fmt_version_int}
+      $<INSTALL_INTERFACE:SEASTAR_IMPORT_FMT>)
+  # FMT_ATTACH_TO_GLOBAL_MODULE goes along for pkg-config consumers, who have
+  # no target properties to carry it: it belongs to the compilation of fmt's
+  # module interface unit, which such a consumer does with its own flags, and
+  # is inert everywhere else.  See cmake/SeastarDependencies.cmake for why the
+  # mode depends on it.
   set (Seastar_PC_IMPORT_FMT_CFLAGS
-    "-DSEASTAR_IMPORT_FMT -DSEASTAR_FMT_VERSION=${_fmt_version_int}")
+    "-DSEASTAR_IMPORT_FMT -DSEASTAR_FMT_VERSION=${_fmt_version_int} -DFMT_ATTACH_TO_GLOBAL_MODULE")
+
+  # An importing consumer also needs the module itself, not just the flag
+  # saying to import it, and that is the one thing Seastar cannot hand over:
+  # CMake resolves `import fmt;` only against the module-providing targets a
+  # target links *directly*, so putting fmt::fmt-module on Seastar's interface
+  # would not reach the consumer's own translation units.  Each such target has
+  # to name it itself, alongside Seastar:
+  #
+  #   target_link_libraries (app PRIVATE Seastar::seastar fmt::fmt-module)
+  #
+  # find_package (Seastar) defines fmt::fmt-module for them, with the
+  # properties an importing build needs (cmake/SeastarDependencies.cmake).
+  # demos/hello_import_fmt is the in-tree example.
 endif ()
 
 target_compile_definitions (seastar

--- a/cmake/SeastarConfig.cmake.in
+++ b/cmake/SeastarConfig.cmake.in
@@ -56,6 +56,7 @@ include (SeastarDependencies)
 set (Seastar_DPDK @Seastar_DPDK@)
 set (Seastar_IO_URING @Seastar_IO_URING@)
 set (Seastar_HWLOC @Seastar_HWLOC@)
+set (Seastar_IMPORT_FMT @Seastar_IMPORT_FMT@)
 seastar_find_dependencies ()
 
 if (NOT TARGET Seastar::seastar)

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -98,6 +98,43 @@ macro (seastar_find_dependencies)
       "(found ${fmt_VERSION}). Re-run configure.py with --cook fmt "
       "to build a newer fmt locally.")
   endif ()
+  if (Seastar_IMPORT_FMT)
+    # `import fmt;` needs the module itself, which is a target of its own --
+    # separate from the library Seastar links for its own textual includes --
+    # and which fmt only defines when built with FMT_MODULE (see
+    # cooking_recipe.cmake).  Say so here rather than let the build trip over
+    # an `import fmt;` with nothing to import.
+    if (NOT TARGET fmt::fmt-module)
+      message (FATAL_ERROR
+        "Seastar_IMPORT_FMT requires an fmt built with FMT_MODULE, which is what "
+        "provides the fmt::fmt-module target. The fmt found in ${fmt_DIR} does not "
+        "have it. Re-run configure.py with --cook fmt to build a suitable fmt "
+        "locally.")
+    endif ()
+    # fmt ships the module as source: whoever consumes it compiles the interface
+    # unit themselves, so both of the following have to be arranged here --
+    # where consumers of the installed package come through too -- and not in
+    # Seastar's own CMakeLists.txt.
+    #
+    # FMT_ATTACH_TO_GLOBAL_MODULE detaches fmt's declarations from module `fmt`,
+    # leaving them traditionally mangled and identical to what a textual
+    # <fmt/...> include produces. Seastar needs that: its own sources include
+    # fmt textually either way, and its ABI is not fmt-free -- logger's
+    # failed_to_log() takes an fmt::string_view, and the formatters for
+    # log_level, backtraces and exception_ptr are defined out of line in the
+    # library -- so an importing translation unit would otherwise reference
+    # module-attached names that libseastar does not define. fmt documents the
+    # macro for exactly this, mixing importing and including TUs in one program.
+    #
+    # And fmt exports the module as demanding no more than C++20, which CMake
+    # takes literally and compiles the interface unit with -std=c++20; any
+    # translation unit on a later standard then refuses the resulting BMI. Ask
+    # for the standard actually in use.
+    set_property (TARGET fmt::fmt-module APPEND PROPERTY
+      IMPORTED_CXX_MODULES_COMPILE_DEFINITIONS FMT_ATTACH_TO_GLOBAL_MODULE)
+    set_property (TARGET fmt::fmt-module APPEND PROPERTY
+      IMPORTED_CXX_MODULES_COMPILE_FEATURES cxx_std_${CMAKE_CXX_STANDARD})
+  endif ()
   seastar_find_dep (lz4 1.7.3 REQUIRED)
   seastar_find_dep (GnuTLS 3.7.4)
   seastar_find_dep (OpenSSL 3.0)

--- a/configure.py
+++ b/configure.py
@@ -186,6 +186,11 @@ add_tristate(
     help='build as C++20 module')
 add_tristate(
     arg_parser,
+    name='import-fmt',
+    dest='import_fmt',
+    help='pulling fmt in as a C++20 module (`import fmt;`) rather than textually')
+add_tristate(
+    arg_parser,
     name='hwloc',
     dest='hwloc',
     help='hwloc support')
@@ -310,6 +315,7 @@ def configure_mode(mode):
         tr(CFLAGS, 'CXX_FLAGS'),
         tr(LDFLAGS, 'LD_FLAGS'),
         tr(args.cxx_modules, 'MODULE'),
+        tr(args.import_fmt, 'IMPORT_FMT'),
         tr(args.dpdk, 'DPDK'),
         tr(args.dpdk_machine, 'DPDK_MACHINE'),
         tr(args.hwloc, 'HWLOC', value_when_none='yes'),

--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -314,13 +314,32 @@ cooking_ingredient (dpdk
     INSTALL_COMMAND
       ${Ninja_EXECUTABLE} -C <BINARY_DIR> install)
 
+# Seastar_IMPORT_FMT needs fmt's fmt-module target, which fmt only defines when
+# built with FMT_MODULE, and which it in turn only offers for a module-capable
+# C++ standard.  Cooking does not forward CMAKE_CXX_STANDARD to ingredients, so
+# hand it over explicitly; without it fmt sees no standard at all and quietly
+# builds headers only.
+set (fmt_module_cmake_args)
+if (Seastar_IMPORT_FMT)
+  set (fmt_module_cmake_args
+    -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+    -DFMT_MODULE=ON)
+endif ()
+
+# An unreleased fmt: 12.2.0 does not export basic_ostream_formatter,
+# ostream_formatter or streamed() from its module, so a consumer built with
+# Seastar_IMPORT_FMT cannot name them, and Seastar's public headers do
+# (fmt::ostream_formatter, in a dozen formatter specializations). Fixed
+# upstream in fmtlib/fmt#4861. Pinned by commit, hash and all; switch to the
+# named release once one carrying the fix is out.
 cooking_ingredient (fmt
   EXTERNAL_PROJECT_ARGS
-    URL https://github.com/fmtlib/fmt/releases/download/12.2.0/fmt-12.2.0.zip
-    URL_HASH SHA256=a2f4a8d51178f954e4c339007f77edd76ba0cb2e36f87a48e5a5403d9be5878f
+    URL https://github.com/fmtlib/fmt/archive/8dc5d3f69f15417d13c60a4a21f7298ed24db41c.tar.gz
+    URL_HASH SHA256=1681c5f1b5b9a4e354a62fb8dba3509f38cb49321c7eabac7ab5dd98160bfb37
   CMAKE_ARGS
     -DFMT_DOC=OFF
-    -DFMT_TEST=OFF)
+    -DFMT_TEST=OFF
+    ${fmt_module_cmake_args})
 
 cooking_ingredient (liburing
   EXTERNAL_PROJECT_ARGS

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -126,6 +126,32 @@ seastar_add_demo (tutorial_examples
 seastar_add_demo (http_client
   SOURCES http_client_demo.cc)
 
+if (Seastar_IMPORT_FMT)
+  # Compile coverage for the `import fmt;` side of
+  # <seastar/core/internal/fmt.hh>. Everything else in the build tree keeps
+  # including fmt textually -- see the Seastar_IMPORT_FMT block in the top-level
+  # CMakeLists.txt -- so this target opts in by hand, the same two pieces an
+  # external consumer puts together: the flag, and fmt's module target.
+  add_executable (hello_import_fmt)
+  target_sources (hello_import_fmt
+    PRIVATE
+      hello-import-fmt.cc)
+  target_compile_definitions (hello_import_fmt
+    PRIVATE
+      SEASTAR_IMPORT_FMT)
+  target_link_libraries (hello_import_fmt
+    PRIVATE
+      seastar
+      fmt::fmt-module)
+  # Seastar's cmake_minimum_required predates CMP0155, so C++ sources are not
+  # scanned for imports by default and `import fmt;` would have nothing to
+  # resolve against. Asked for per-target rather than project-wide: this is the
+  # only target in the tree that imports fmt.
+  set_target_properties (hello_import_fmt
+    PROPERTIES
+      CXX_SCAN_FOR_MODULES ON)
+endif ()
+
 if (Seastar_MODULE)
   add_executable (hello_cxx_module)
   target_sources (hello_cxx_module

--- a/demos/hello-import-fmt.cc
+++ b/demos/hello-import-fmt.cc
@@ -1,0 +1,65 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+// A stand-in for an application built the way Seastar_IMPORT_FMT advertises:
+// Seastar's headers, and hence fmt, pulled in as a module rather than
+// textually. Seastar's own sources always include fmt textually, so without a
+// consumer like this one the `import fmt;` side of
+// <seastar/core/internal/fmt.hh> is never compiled at all.
+//
+// Note the absence of any <fmt/...> include: it is the point of the exercise,
+// and mixing one in would be a redefinition error. Everything fmt-related here
+// arrives through the funnel. The headers below are the ones that put fmt in
+// their interface -- formatters of every kind Seastar writes, compile-time
+// format strings -- so that each of those uses is instantiated.
+
+#include <chrono>
+#include <vector>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/format.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/log.hh>
+
+using namespace seastar;
+
+static logger applog("hello-import-fmt");
+
+int main(int argc, char** argv) {
+    app_template app;
+    return app.run(argc, argv, [] () -> future<> {
+        // A formatter Seastar defines itself, over a Seastar type.
+        applog.info("listening on {}", socket_address(ipv4_addr("127.0.0.1", 1234)));
+        // seastar::format(), plus formatters written in terms of
+        // fmt::ostream_formatter.
+        applog.info("{}", format("address {}, family {}",
+                                 net::inet_address("::1"),
+                                 net::inet_address::family::INET6));
+        // fmt's own formatters for ranges, chrono and strings, as reached
+        // through the module.
+        applog.info("{} in {}", std::vector<int>{1, 2, 3}, std::chrono::seconds(1));
+        applog.info("{:>10}", sstring("right"));
+        return make_ready_future<>();
+    });
+}

--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/util/assert.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
@@ -222,7 +223,7 @@ public:
 
 }
 
-#if FMT_VERSION < 100000
+#if SEASTAR_FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
 struct fmt::formatter<seastar::abort_requested_exception> : fmt::formatter<string_view> {

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -31,7 +31,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/tuple_utils.hh>
 #include <seastar/util/std-compat.hh>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <vector>
 #include <boost/container/static_vector.hpp>
 

--- a/include/seastar/core/execution_stage.hh
+++ b/include/seastar/core/execution_stage.hh
@@ -30,7 +30,7 @@
 #include <seastar/util/reference_wrapper.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/tuple_utils.hh>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <vector>
 #include <boost/container/static_vector.hpp>
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -33,7 +33,7 @@
 #include <functional>
 #include <optional>
 #include <queue>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -31,7 +31,7 @@
 #include <cstdint>
 #include <optional>
 #include <queue>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace bi = boost::intrusive;
 

--- a/include/seastar/core/format.hh
+++ b/include/seastar/core/format.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar {
 

--- a/include/seastar/core/internal/fmt.hh
+++ b/include/seastar/core/internal/fmt.hh
@@ -24,9 +24,27 @@
 // Single point through which Seastar pulls in {fmt}.
 //
 // All Seastar code that needs {fmt} includes this header instead of the
-// individual <fmt/*.h> headers.  For now it is a plain textual include of
-// every fmt header Seastar uses; routing everything through here lets a
-// later change switch to `import fmt;` in one place.
+// individual <fmt/*.h> headers.  When SEASTAR_IMPORT_FMT is defined (see the
+// Seastar_IMPORT_FMT option in CMakeLists.txt) this imports fmt as a C++20
+// module; otherwise it is a plain textual include of every fmt header Seastar
+// uses.  Consumers must pick one per translation unit -- mixing `import fmt;`
+// with a textual <fmt/*.h> in the same TU is a redefinition error -- which is
+// exactly why every Seastar fmt include is funnelled through here.
+
+#ifdef SEASTAR_IMPORT_FMT
+
+// fmt's preprocessor macros are not part of the module, so the ones that
+// Seastar's public headers rely on must be provided out of band.  The only
+// such macro left is FMT_VERSION, supplied by the build and derived from the
+// fmt that was found (Seastar does not bundle fmt, so it cannot be hardcoded
+// here).
+#ifndef FMT_VERSION
+#error "SEASTAR_IMPORT_FMT requires the build to define FMT_VERSION (see Seastar_IMPORT_FMT)"
+#endif
+
+import fmt;
+
+#else
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -36,3 +54,5 @@
 #include <fmt/color.h>
 #include <fmt/compile.h>
 #include <fmt/core.h>
+
+#endif

--- a/include/seastar/core/internal/fmt.hh
+++ b/include/seastar/core/internal/fmt.hh
@@ -15,39 +15,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 /*
- * Copyright 2020 ScyllaDB
+ * Copyright (C) 2026 ScyllaDB
  */
 
 #pragma once
 
-#include <seastar/core/internal/fmt.hh>
-#include <exception>
+// Single point through which Seastar pulls in {fmt}.
+//
+// All Seastar code that needs {fmt} includes this header instead of the
+// individual <fmt/*.h> headers.  For now it is a plain textual include of
+// every fmt header Seastar uses; routing everything through here lets a
+// later change switch to `import fmt;` in one place.
 
-namespace seastar {
-
-class timed_out_error : public std::exception {
-public:
-    virtual const char* what() const noexcept {
-        return "timedout";
-    }
-};
-
-struct default_timeout_exception_factory {
-    static auto timeout() {
-        return timed_out_error();
-    }
-};
-
-} // namespace seastar
-
-#if FMT_VERSION < 100000
-// fmt v10 introduced formatter for std::exception
-template <>
-struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<string_view> {
-    auto format(const seastar::timed_out_error& e, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", e.what());
-    }
-};
-#endif
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
+#include <fmt/chrono.h>
+#include <fmt/color.h>
+#include <fmt/compile.h>
+#include <fmt/core.h>

--- a/include/seastar/core/internal/fmt.hh
+++ b/include/seastar/core/internal/fmt.hh
@@ -27,6 +27,11 @@
 // individual <fmt/*.h> headers.  For now it is a plain textual include of
 // every fmt header Seastar uses; routing everything through here lets a
 // later change switch to `import fmt;` in one place.
+//
+// It also defines SEASTAR_FMT_VERSION, which the version-dependent parts of
+// Seastar's public headers key off instead of fmt's own FMT_VERSION.  The
+// build may define it (as an integer, MMmmpp, like FMT_VERSION) for setups
+// where fmt does not supply it; otherwise it is taken from fmt.
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -36,3 +41,7 @@
 #include <fmt/color.h>
 #include <fmt/compile.h>
 #include <fmt/core.h>
+
+#ifndef SEASTAR_FMT_VERSION
+#define SEASTAR_FMT_VERSION FMT_VERSION
+#endif

--- a/include/seastar/core/internal/fmt.hh
+++ b/include/seastar/core/internal/fmt.hh
@@ -24,14 +24,31 @@
 // Single point through which Seastar pulls in {fmt}.
 //
 // All Seastar code that needs {fmt} includes this header instead of the
-// individual <fmt/*.h> headers.  For now it is a plain textual include of
-// every fmt header Seastar uses; routing everything through here lets a
-// later change switch to `import fmt;` in one place.
+// individual <fmt/*.h> headers.  When SEASTAR_IMPORT_FMT is defined (see the
+// Seastar_IMPORT_FMT option in CMakeLists.txt) this imports fmt as a C++20
+// module; otherwise it is a plain textual include of every fmt header Seastar
+// uses.  Consumers must pick one per translation unit -- mixing `import fmt;`
+// with a textual <fmt/*.h> in the same TU is a redefinition error -- which is
+// exactly why every Seastar fmt include is funnelled through here.
 //
 // It also defines SEASTAR_FMT_VERSION, which the version-dependent parts of
 // Seastar's public headers key off instead of fmt's own FMT_VERSION.  The
 // build may define it (as an integer, MMmmpp, like FMT_VERSION) for setups
-// where fmt does not supply it; otherwise it is taken from fmt.
+// where fmt does not supply it; otherwise it is taken from fmt.  Importing fmt
+// is such a setup: fmt's preprocessor macros are not part of the module, so
+// the version has to come from the build, derived from the fmt that Seastar
+// was configured against (Seastar does not bundle fmt, so it cannot be
+// hardcoded here).
+
+#ifdef SEASTAR_IMPORT_FMT
+
+#ifndef SEASTAR_FMT_VERSION
+#error "SEASTAR_IMPORT_FMT requires the build to define SEASTAR_FMT_VERSION (see Seastar_IMPORT_FMT)"
+#endif
+
+import fmt;
+
+#else
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -44,4 +61,6 @@
 
 #ifndef SEASTAR_FMT_VERSION
 #define SEASTAR_FMT_VERSION FMT_VERSION
+#endif
+
 #endif

--- a/include/seastar/core/internal/fmt.hh
+++ b/include/seastar/core/internal/fmt.hh
@@ -31,6 +31,14 @@
 // with a textual <fmt/*.h> in the same TU is a redefinition error -- which is
 // exactly why every Seastar fmt include is funnelled through here.
 //
+// The fmt module has to be one built with FMT_ATTACH_TO_GLOBAL_MODULE, so that
+// its declarations stay traditionally mangled and interchangeable with what a
+// textual include yields.  Seastar's own sources include fmt textually either
+// way, and its ABI mentions fmt types, so a translation unit importing a
+// module-attached fmt could not link against the library.  The build arranges
+// this (see cmake/SeastarDependencies.cmake); it is worth knowing about when
+// compiling fmt's module interface unit by hand.
+//
 // It also defines SEASTAR_FMT_VERSION, which the version-dependent parts of
 // Seastar's public headers key off instead of fmt's own FMT_VERSION.  The
 // build may define it (as an integer, MMmmpp, like FMT_VERSION) for setups

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -27,7 +27,7 @@
 #include <map>
 #include <type_traits>
 #include <variant>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/metrics_registration.hh>

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -27,7 +27,7 @@
 #include <map>
 #include <type_traits>
 #include <variant>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/metrics_types.hh>

--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <concepts>
 #include <functional>
 #include <limits>
@@ -335,7 +336,7 @@ public:
     uint64_t ui() const {
         auto d = std::get<double>(u);
         if (d >= 0 && d <= double(std::numeric_limits<long>::max())) {
-            return lround(d);
+            return std::lround(d);
         } else {
             // double value is out of range or NaN or Inf
             ulong_conversion_error(d);
@@ -346,7 +347,7 @@ public:
     int64_t i() const {
         auto d = std::get<double>(u);
         if (d >= double(std::numeric_limits<long>::min()) && d <= double(std::numeric_limits<long>::max())) {
-            return lround(d);
+            return std::lround(d);
         } else {
             // double value is out of range or NaN or Inf
             ulong_conversion_error(d);

--- a/include/seastar/core/print.hh
+++ b/include/seastar/core/print.hh
@@ -23,7 +23,7 @@
 
 #include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <iostream>
 #include <iomanip>
 #include <chrono>

--- a/include/seastar/core/shared_ptr.hh
+++ b/include/seastar/core/shared_ptr.hh
@@ -25,7 +25,7 @@
 #include <seastar/util/is_smart_ptr.hh>
 #include <seastar/util/indirect.hh>
 #include <boost/intrusive/parent_from_member.hpp>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 #include <concepts>
 #include <ostream>
 #include <type_traits>

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -36,10 +36,7 @@
 #include <ostream>
 #include <functional>
 #include <type_traits>
-#include <fmt/format.h>
-#if FMT_VERSION >= 110000
-#include <fmt/ranges.h>
-#endif
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/util/assert.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/temporary_buffer.hh>

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -36,10 +36,7 @@
 #include <ostream>
 #include <functional>
 #include <type_traits>
-#include <fmt/format.h>
-#if FMT_VERSION >= 110000
-#include <fmt/ranges.h>
-#endif
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/util/assert.hh>
 #include <seastar/core/temporary_buffer.hh>
 

--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -851,7 +851,7 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<Key, T, Hash
 
 #endif
 
-#if FMT_VERSION >= 110000
+#if SEASTAR_FMT_VERSION >= 110000
 
 template <typename char_type, typename Size, Size max_size, bool NulTerminate>
 struct fmt::range_format_kind<seastar::basic_sstring<char_type, Size, max_size, NulTerminate>, char_type> : std::integral_constant<fmt::range_format, fmt::range_format::disabled>

--- a/include/seastar/core/timed_out_error.hh
+++ b/include/seastar/core/timed_out_error.hh
@@ -42,7 +42,7 @@ struct default_timeout_exception_factory {
 
 } // namespace seastar
 
-#if FMT_VERSION < 100000
+#if SEASTAR_FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
 struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<string_view> {

--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -34,6 +34,7 @@
 #include <optional>
 #include <unordered_map>
 #include <string_view>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/http/mime_types.hh>
 #include <seastar/http/types.hh>

--- a/include/seastar/net/ethernet.hh
+++ b/include/seastar/net/ethernet.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <array>
 #include <algorithm>

--- a/include/seastar/net/inet_address.hh
+++ b/include/seastar/net/inet_address.hh
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include <seastar/core/future.hh>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/core/sstring.hh>
 
 namespace seastar {

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -27,7 +27,7 @@
 #include <cassert>
 #include <functional>
 #include <iosfwd>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/net/unix_address.hh>
 

--- a/include/seastar/net/socket_defs.hh
+++ b/include/seastar/net/socket_defs.hh
@@ -25,7 +25,7 @@
 #include <array>
 #include <functional>
 #include <iosfwd>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/net/unix_address.hh>
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -25,7 +25,7 @@
 #include <unordered_set>
 #include <map>
 #include <any>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/api-level.hh>

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -26,7 +26,7 @@
 #include <map>
 #include <any>
 #include <string_view>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -21,10 +21,7 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
-#if FMT_VERSION >= 100000
-#include <fmt/std.h>
-#endif
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/net/api.hh>
 #include <stdexcept>

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -21,10 +21,7 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
-#if FMT_VERSION >= 100000
-#include <fmt/std.h>
-#endif
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/net/api.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -466,7 +466,7 @@ struct tuple_element<I, seastar::rpc::tuple<T...>> : tuple_element<I, tuple<T...
 
 template <> struct fmt::formatter<seastar::rpc::connection_id> : fmt::ostream_formatter {};
 
-#if FMT_VERSION < 100000
+#if SEASTAR_FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <std::derived_from<seastar::rpc::error> T>
 struct fmt::formatter<T> : fmt::formatter<string_view> {
@@ -476,7 +476,7 @@ struct fmt::formatter<T> : fmt::formatter<string_view> {
 };
 #endif
 
-#if FMT_VERSION < 100000
+#if SEASTAR_FMT_VERSION < 100000
 template <typename T>
 struct fmt::formatter<seastar::rpc::optional<T>> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }

--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -24,7 +24,7 @@
 #include <atomic>
 #include <memory>
 
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -35,7 +35,7 @@
 #include <memory>
 #include <variant>
 #include <boost/container/static_vector.hpp>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar {
 

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -36,7 +36,7 @@
 #include <source_location>
 #include <variant>
 #include <boost/container/static_vector.hpp>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar {
 

--- a/include/seastar/util/bool_class.hh
+++ b/include/seastar/util/bool_class.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <ostream>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar {
 

--- a/include/seastar/util/lazy.hh
+++ b/include/seastar/util/lazy.hh
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <ostream>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 /// \addtogroup logging
 /// @{

--- a/include/seastar/util/log-level.hh
+++ b/include/seastar/util/log-level.hh
@@ -22,7 +22,7 @@
 
 
 #include <iosfwd>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 /// \addtogroup logging
 /// @{

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -95,7 +95,7 @@ public:
         /// implicitly construct format_info from a constant format string
         /// \param fmt - {fmt} style format string
         template <std::convertible_to<std::string_view> S>
-        FMT_CONSTEVAL inline format_info(const S& format,
+        consteval inline format_info(const S& format,
                            std::source_location loc = std::source_location::current()) noexcept
             : format(format)
             , loc(loc)
@@ -120,7 +120,7 @@ public:
             , loc(loc)
         {}
         /// implicitly construct format_info with no format string.
-        FMT_CONSTEVAL format_info() noexcept
+        consteval format_info() noexcept
             : format_info("")
         {}
         fmt::format_string<Args...> format;

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -35,9 +35,7 @@
 #include <atomic>
 #include <mutex>
 #include <type_traits>
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fmt/std.h>
+#include <seastar/core/internal/fmt.hh>
 
 /// \addtogroup logging
 /// @{

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -32,9 +32,7 @@
 #include <iosfwd>
 #include <atomic>
 #include <mutex>
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fmt/std.h>
+#include <seastar/core/internal/fmt.hh>
 
 /// \addtogroup logging
 /// @{

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -115,7 +115,7 @@ public:
         /// implicitly construct format_info from a constant format string
         /// \param fmt - {fmt} style format string
         template <std::convertible_to<std::string_view> S>
-        FMT_CONSTEVAL inline format_info(const S& format,
+        consteval inline format_info(const S& format,
                            std::source_location loc = std::source_location::current()) noexcept
             : format(format)
             , loc(loc)
@@ -140,7 +140,7 @@ public:
             , loc(loc)
         {}
         /// implicitly construct format_info with no format string.
-        FMT_CONSTEVAL format_info() noexcept
+        consteval format_info() noexcept
             : format_info("")
         {}
         fmt::format_string<Args...> format;

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -56,7 +56,7 @@ namespace internal {
 // std::string_view without the caller needing to know which is in play.
 template <typename FormatString>
 fmt::string_view format_string_view(const FormatString& format) noexcept {
-#if defined(SEASTAR_LOGGER_COMPILE_TIME_FMT) && FMT_VERSION >= 100000
+#if defined(SEASTAR_LOGGER_COMPILE_TIME_FMT) && SEASTAR_FMT_VERSION >= 100000
     return format.get();
 #else
     return fmt::string_view(format);
@@ -129,7 +129,7 @@ public:
             : format(s)
             , loc(loc)
         {}
-#if FMT_VERSION >= 100000
+#if SEASTAR_FMT_VERSION >= 100000
         using runtime_format_string_t = fmt::runtime_format_string<char>;
 #else
         using runtime_format_string_t = fmt::basic_runtime<char>;
@@ -604,7 +604,7 @@ std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 #endif
 
-#if FMT_VERSION < 120201
+#if SEASTAR_FMT_VERSION < 120201
 
 // Seastar has no business defining a {fmt} formatter for std::exception_ptr,
 // a type it does not own; that is for the standard library or {fmt} to do (see

--- a/include/seastar/util/optimized_optional.hh
+++ b/include/seastar/util/optimized_optional.hh
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <optional>
 #include <type_traits>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar {
 

--- a/include/seastar/util/process.hh
+++ b/include/seastar/util/process.hh
@@ -31,7 +31,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/sstring.hh>

--- a/include/seastar/util/program-options.hh
+++ b/include/seastar/util/program-options.hh
@@ -24,7 +24,7 @@
 #include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <boost/any.hpp>
 #include <boost/intrusive/list.hpp>

--- a/include/seastar/util/tmp_file.hh
+++ b/include/seastar/util/tmp_file.hh
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <filesystem>
+
 #include <seastar/core/future.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/thread.hh>

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -30,11 +30,15 @@ liburing_libs=$<$<BOOL:@Seastar_IO_URING@>:$<JOIN:@URING_LIBRARIES@, >>
 dpdk_libs=$<JOIN:@dpdk_LIBRARIES@, >
 # Us.
 seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
+# Extra flags for consumers that opt into `import fmt;` (Seastar_IMPORT_FMT).
+# Kept out of the seastar target's INTERFACE so Seastar's own targets are not
+# affected; only external (pkg-config) consumers see these.
+seastar_import_fmt_cflags=@Seastar_PC_IMPORT_FMT_CFLAGS@
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 
 Requires: liblz4 >= 1.7.3
 Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
-Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags}
+Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags} ${seastar_import_fmt_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${c_ares_libs} ${fmt_libs}
 Libs.private: ${dl_libs} ${rt_libs} ${lksctp_tools_libs} ${liburing_libs} ${stdatomic_libs} ${dpdk_libs}

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -31,11 +31,15 @@ lttng_ust_libs=$<$<BOOL:@Seastar_LTTNG@>:@LTTngUST_LIBRARY@>
 dpdk_libs=$<JOIN:@dpdk_LIBRARIES@, >
 # Us.
 seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
+# Extra flags for consumers that opt into `import fmt;` (Seastar_IMPORT_FMT).
+# Kept out of the seastar target's INTERFACE so Seastar's own targets are not
+# affected; only external (pkg-config) consumers see these.
+seastar_import_fmt_cflags=@Seastar_PC_IMPORT_FMT_CFLAGS@
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 
 Requires: liblz4 >= 1.7.3
 Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
 Conflicts:
-Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags}
+Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags} ${seastar_import_fmt_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${c_ares_libs} ${fmt_libs}
 Libs.private: ${dl_libs} ${rt_libs} ${lksctp_tools_libs} ${liburing_libs} ${lttng_ust_libs} ${stdatomic_libs} ${dpdk_libs}

--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -33,7 +33,10 @@ dpdk_libs=$<JOIN:@dpdk_LIBRARIES@, >
 seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
 # Extra flags for consumers that opt into `import fmt;` (Seastar_IMPORT_FMT).
 # Kept out of the seastar target's INTERFACE so Seastar's own targets are not
-# affected; only external (pkg-config) consumers see these.
+# affected; only external consumers see these. Compiling fmt's module interface
+# unit is left to the consumer's own build -- that much pkg-config cannot
+# express -- but no extra library comes with it: FMT_ATTACH_TO_GLOBAL_MODULE
+# leaves the module's symbols the ordinary ones, already in ${fmt_libs}.
 seastar_import_fmt_cflags=@Seastar_PC_IMPORT_FMT_CFLAGS@
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 

--- a/src/core/app-template.cc
+++ b/src/core/app-template.cc
@@ -24,7 +24,7 @@
 #include <cstdlib>
 #include <chrono>
 #include <iostream>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/program_options.hpp>
 #include <boost/make_shared.hpp>
 

--- a/src/core/crypto_gnutls.cc
+++ b/src/core/crypto_gnutls.cc
@@ -28,7 +28,7 @@
 #include <gnutls/gnutls.h>
 #include <cstring>
 #include <stdexcept>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar::internal::crypto {
 

--- a/src/core/crypto_gnutls.cc
+++ b/src/core/crypto_gnutls.cc
@@ -27,7 +27,7 @@
 #include <gnutls/gnutls.h>
 #include <cstring>
 #include <stdexcept>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar::internal::crypto {
 

--- a/src/core/crypto_openssl.cc
+++ b/src/core/crypto_openssl.cc
@@ -31,7 +31,7 @@
 #include <openssl/err.h>
 #include <cstring>
 #include <stdexcept>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 namespace seastar::internal::crypto {
 

--- a/src/core/disk_params.cc
+++ b/src/core/disk_params.cc
@@ -23,9 +23,7 @@
 
 #include <chrono>
 #include <unordered_set>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 #include <sys/stat.h>
 #include <yaml-cpp/yaml.h>
 

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -20,8 +20,7 @@
  */
 
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <malloc.h>
 #include <string.h>
 #include <fcntl.h>

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -25,8 +25,7 @@
 #include <cstdint>
 #include <mutex>
 #include <utility>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/intrusive/parent_from_member.hpp>
 #include <boost/container/small_vector.hpp>
 #include <sys/uio.h>

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -24,8 +24,7 @@
 #include <cstdint>
 #include <mutex>
 #include <utility>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/intrusive/parent_from_member.hpp>
 #include <boost/container/small_vector.hpp>
 #include <sys/uio.h>

--- a/src/core/linux-aio.cc
+++ b/src/core/linux-aio.cc
@@ -25,7 +25,7 @@
 #include <cerrno>
 #include <cstring>
 #include <stdexcept>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <valgrind/valgrind.h>

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -79,8 +79,7 @@
 
 #include <seastar/util/assert.hh>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <boost/container/static_vector.hpp>
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -79,8 +79,7 @@
 
 #include <seastar/util/assert.hh>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 
 #include <dlfcn.h>

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -28,7 +28,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_api.hh>

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -27,7 +27,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_api.hh>

--- a/src/core/posix.cc
+++ b/src/core/posix.cc
@@ -24,7 +24,7 @@
 #include <set>
 #include <vector>
 #include <functional>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/mman.h>

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -19,8 +19,7 @@
  * Copyright (C) 2016 ScyllaDB
  */
 
-#include <fmt/core.h>
-#include <fmt/compile.h>
+#include <seastar/core/internal/fmt.hh>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include "proto/metrics2.pb.h"

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -87,8 +87,7 @@
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #ifdef SEASTAR_SHUFFLE_TASK_QUEUE
 #include <random>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -76,8 +76,7 @@
 #define min min    /* prevent xfs.h from defining min() as a macro */
 #include <xfs/xfs.h>
 #undef min
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #ifdef SEASTAR_SHUFFLE_TASK_QUEUE
 #include <random>

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -37,7 +37,7 @@
 #include <sys/syscall.h>
 #include <sys/resource.h>
 #include <boost/container/small_vector.hpp>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/util/assert.hh>
 
 #ifdef SEASTAR_HAVE_URING

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -35,7 +35,7 @@
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/resource.hh>
 
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <sys/time.h>
 #include <bitset>
 #include <thread>

--- a/src/core/resource.cc
+++ b/src/core/resource.cc
@@ -32,7 +32,7 @@
 #include <limits>
 #include <filesystem>
 #include <unordered_map>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 #include <seastar/util/assert.hh>
 
 #include <seastar/core/resource.hh>

--- a/src/core/semaphore.cc
+++ b/src/core/semaphore.cc
@@ -20,7 +20,7 @@
  */
 
 
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/semaphore.hh>
 

--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/print.hh>

--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -21,7 +21,7 @@
 
 
 #include <sstream>
-#include <fmt/core.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/loop.hh>
 #include <seastar/json/json_elements.hh>

--- a/src/net/ethernet.cc
+++ b/src/net/ethernet.cc
@@ -21,7 +21,7 @@
 
 #include <seastar/core/print.hh>
 #include <seastar/net/ethernet.hh>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/algorithm/string.hpp>
 #include <string>
 

--- a/src/net/inet_address.cc
+++ b/src/net/inet_address.cc
@@ -24,7 +24,7 @@
 #include <ostream>
 #include <arpa/inet.h>
 #include <boost/functional/hash.hpp>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>

--- a/src/net/ip.cc
+++ b/src/net/ip.cc
@@ -21,7 +21,7 @@
  */
 
 #include <boost/asio/ip/address_v4.hpp>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/net/ip.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -42,8 +42,7 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/map.hpp>
 
-#include <fmt/core.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -36,8 +36,7 @@
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
 
-#include <fmt/core.h>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -21,8 +21,7 @@
  */
 
 #include <boost/algorithm/string/trim.hpp>
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 #include <openssl/bio.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -13,7 +13,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/numeric.hpp>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 template <> struct fmt::formatter<seastar::rpc::streaming_domain_type> : fmt::ostream_formatter {};
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -12,7 +12,7 @@
 #include <seastar/util/assert.hh>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
-#include <fmt/ostream.h>
+#include <seastar/core/internal/fmt.hh>
 
 template <> struct fmt::formatter<seastar::rpc::streaming_domain_type> : fmt::ostream_formatter {};
 

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -31,8 +31,7 @@
 #include <variant>
 #include <vector>
 #include <boost/container/static_vector.hpp>
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/internal/build_id.hh>

--- a/src/util/backtrace.cc
+++ b/src/util/backtrace.cc
@@ -27,8 +27,7 @@
 #include <variant>
 #include <vector>
 #include <boost/container/static_vector.hpp>
-#include <fmt/ostream.h>
-#include <fmt/ranges.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/internal/build_id.hh>

--- a/src/util/build_id.cc
+++ b/src/util/build_id.cc
@@ -30,7 +30,7 @@
 #define HAS_ELF
 
 #include <stddef.h>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/align.hh>
 #endif

--- a/src/util/build_id.cc
+++ b/src/util/build_id.cc
@@ -29,7 +29,7 @@
 #define HAS_ELF
 
 #include <stddef.h>
-#include <fmt/format.h>
+#include <seastar/core/internal/fmt.hh>
 
 #include <seastar/core/align.hh>
 #endif

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -30,11 +30,7 @@
 #include <chrono>
 #include <algorithm>
 
-#include <fmt/core.h>
-#include <fmt/chrono.h>
-#include <fmt/color.h>
-#include <fmt/ostream.h>
-#include <fmt/std.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -31,11 +31,7 @@
 #include <algorithm>
 #include <ranges>
 
-#include <fmt/core.h>
-#include <fmt/chrono.h>
-#include <fmt/color.h>
-#include <fmt/ostream.h>
-#include <fmt/std.h>
+#include <seastar/core/internal/fmt.hh>
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>

--- a/tests/consumer/CMakeLists.txt
+++ b/tests/consumer/CMakeLists.txt
@@ -1,0 +1,152 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Copyright (C) 2026 ScyllaDB
+#
+# A standalone project that builds one small application against an *installed*
+# Seastar, once through each channel Seastar is published on: the CMake package
+# (find_package (Seastar), Seastar::seastar) and pkg-config (seastar.pc). Both
+# carry compile definitions and flags that Seastar's own build tree does not
+# apply to its own targets, Seastar_IMPORT_FMT's among them, so nothing in the
+# main build exercises them.
+#
+# It is not part of Seastar's build. Install Seastar somewhere, then:
+#
+#   cmake -G Ninja -S tests/consumer -B /tmp/consumer \
+#         -DCMAKE_PREFIX_PATH=<install prefix> -DCMAKE_CXX_STANDARD=<same as Seastar>
+#   cmake --build /tmp/consumer
+#
+# Building is the test: a consumer that cannot find the headers, is handed the
+# wrong flags, or ends up with fmt names Seastar's library does not define
+# fails to compile or link here.
+#
+# Doubles as the worked example of what an application has to do for
+# Seastar_IMPORT_FMT, which is more than linking Seastar -- see the fmt module
+# handling below.
+
+cmake_minimum_required (VERSION 3.28)
+
+project (SeastarConsumer
+  LANGUAGES CXX)
+
+# Seastar's headers need at least C++20, and its installed package warns if the
+# standard differs from the one it was built with; pass -DCMAKE_CXX_STANDARD to
+# match.
+if (NOT CMAKE_CXX_STANDARD)
+  set (CMAKE_CXX_STANDARD 20)
+endif ()
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+# Seastar builds with GNU extensions on, and a translation unit that disagrees
+# about them refuses a module BMI. seastar.pc names a standard of its own,
+# which lands after this one and wins for that channel -- harmlessly, since it
+# then applies to every source in the target, module interface unit included,
+# which is what the BMI needs.
+set (CMAKE_CXX_EXTENSIONS ON)
+
+# `import fmt;` (Seastar_IMPORT_FMT) needs the module's interface unit compiled
+# into a BMI, and that is on the consumer: CMake resolves an import only
+# against the module-providing targets a target links *directly*, so Seastar
+# cannot pass fmt's along on its interface. Each channel below therefore has to
+# arrange it, and neither should when Seastar was built the ordinary way -- the
+# textual <fmt/*.h> that Seastar's headers then include would collide with an
+# import of the same library.
+#
+# Whether it applies is read off the definitions the channel hands over, which
+# is the same thing <seastar/core/internal/fmt.hh> keys off.
+function (consumer_uses_fmt_module out definitions)
+  if ("SEASTAR_IMPORT_FMT" IN_LIST definitions OR "-DSEASTAR_IMPORT_FMT" IN_LIST definitions)
+    set (${out} TRUE PARENT_SCOPE)
+  else ()
+    set (${out} FALSE PARENT_SCOPE)
+  endif ()
+endfunction ()
+
+#
+# Channel 1: the CMake package.
+#
+
+find_package (Seastar REQUIRED)
+
+add_executable (consumer_cmake consumer.cc)
+target_link_libraries (consumer_cmake
+  PRIVATE
+    Seastar::seastar)
+
+get_target_property (seastar_definitions Seastar::seastar INTERFACE_COMPILE_DEFINITIONS)
+consumer_uses_fmt_module (cmake_needs_fmt_module "${seastar_definitions}")
+if (cmake_needs_fmt_module)
+  # find_package (Seastar) has already found fmt and given fmt::fmt-module the
+  # properties an importing build needs, so linking it is all that is left.
+  if (NOT TARGET fmt::fmt-module)
+    message (FATAL_ERROR
+      "Seastar was installed with Seastar_IMPORT_FMT but find_package (Seastar) "
+      "did not define fmt::fmt-module.")
+  endif ()
+  target_link_libraries (consumer_cmake
+    PRIVATE
+      fmt::fmt-module)
+  set_target_properties (consumer_cmake
+    PROPERTIES
+      CXX_SCAN_FOR_MODULES ON)
+endif ()
+
+#
+# Channel 2: pkg-config.
+#
+
+find_package (PkgConfig REQUIRED)
+pkg_check_modules (SEASTAR REQUIRED seastar)
+
+# Wired up by hand from what pkg-config reported, rather than through
+# pkg_check_modules' IMPORTED_TARGET: seastar.pc names its libraries by
+# absolute path, which that target carries as link *options*, placing them
+# ahead of the object files. A static archive there contributes nothing, and
+# the fmt Seastar links is one.
+add_executable (consumer_pkgconfig consumer.cc)
+target_include_directories (consumer_pkgconfig
+  PRIVATE
+    ${SEASTAR_INCLUDE_DIRS})
+target_compile_options (consumer_pkgconfig
+  PRIVATE
+    ${SEASTAR_CFLAGS_OTHER})
+target_link_libraries (consumer_pkgconfig
+  PRIVATE
+    ${SEASTAR_LDFLAGS})
+
+consumer_uses_fmt_module (pkgconfig_needs_fmt_module "${SEASTAR_CFLAGS_OTHER}")
+if (pkgconfig_needs_fmt_module)
+  # No targets come over this channel, so the module interface unit is compiled
+  # as part of this executable, from the source fmt installs alongside its
+  # headers. The flags it needs -- FMT_ATTACH_TO_GLOBAL_MODULE in particular --
+  # are in seastar.pc's Cflags and so already apply to it.
+  find_file (FMT_MODULE_SOURCE fmt/src/fmt.cc
+    PATHS ${SEASTAR_INCLUDE_DIRS}
+    NO_DEFAULT_PATH)
+  if (NOT FMT_MODULE_SOURCE)
+    message (FATAL_ERROR
+      "Seastar was installed with Seastar_IMPORT_FMT but fmt's module source "
+      "(fmt/src/fmt.cc) is not among the include directories seastar.pc names: "
+      "${SEASTAR_INCLUDE_DIRS}. It is installed by an fmt built with FMT_MODULE.")
+  endif ()
+  cmake_path (GET FMT_MODULE_SOURCE PARENT_PATH fmt_module_dir)
+  target_sources (consumer_pkgconfig
+    PRIVATE
+      FILE_SET fmt_module
+      TYPE CXX_MODULES
+      BASE_DIRS ${fmt_module_dir}
+      FILES ${FMT_MODULE_SOURCE})
+endif ()

--- a/tests/consumer/consumer.cc
+++ b/tests/consumer/consumer.cc
@@ -1,0 +1,53 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+// The application half of the installed-package test; see CMakeLists.txt in
+// this directory for what is being tested and how to run it.
+//
+// It stays deliberately small. What is under test is the packaging -- headers
+// found, flags and definitions arriving, the fmt module resolving, the whole
+// thing linking -- not Seastar's behaviour, which the unit tests cover. It
+// does need to reach the parts of the ABI that mention fmt types, since those
+// are what an `import fmt;` build can get wrong at link time: a logger call
+// (logger::failed_to_log), a formatter defined out of line in the library
+// (log_level), and one written in terms of fmt::ostream_formatter
+// (socket_address).
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/format.hh>
+#include <seastar/core/future.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/log.hh>
+
+using namespace seastar;
+
+static logger applog("consumer");
+
+int main(int argc, char** argv) {
+    app_template app;
+    return app.run(argc, argv, [] () -> future<> {
+        applog.info("hello from {}, at level {}",
+                    socket_address(ipv4_addr("127.0.0.1", 1234)),
+                    log_level::info);
+        applog.info("{}", format("{:>8}", "and format()"));
+        return make_ready_future<>();
+    });
+}


### PR DESCRIPTION
While C++ modules allow consuming a library both as a module and as headers,
this is difficult and sometimes trips compiler bugs. It's better to transition to
modules wholesale.

With fmt, this is possible because not so many libraries depend on it.

Add an option to have Seastar consume fmt as a module. An application can
then switch to modular fmt and at the same time flip the option on.

To minimize churn, all of the interfacing with fmt is routed to an internal
header fmt.hh, which then chooses whether to textually include or import.