### PR TITLE
build: add lttng-ust to seastar.pc Libs.private

### DIFF
--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -27,6 +27,7 @@ lksctp_tools_cflags=-I$<JOIN:@lksctp-tools_INCLUDE_DIRS@, -I>
 lksctp_tools_libs=$<JOIN:@lksctp-tools_LIBRARIES@, >
 liburing_cflags=$<$<BOOL:@Seastar_IO_URING@>:-I$<JOIN:$<TARGET_PROPERTY:URING::uring,INTERFACE_INCLUDE_DIRECTORIES>, -I>>
 liburing_libs=$<$<BOOL:@Seastar_IO_URING@>:$<JOIN:@URING_LIBRARIES@, >>
+lttng_ust_libs=$<$<BOOL:@Seastar_LTTNG@>:@LTTngUST_LIBRARY@>
 dpdk_libs=$<JOIN:@dpdk_LIBRARIES@, >
 # Us.
 seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:seastar,INTERFACE_COMPILE_DEFINITIONS>, -D>
@@ -37,4 +38,4 @@ Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL
 Conflicts:
 Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${c_ares_libs} ${fmt_libs}
-Libs.private: ${dl_libs} ${rt_libs} ${lksctp_tools_libs} ${liburing_libs} ${stdatomic_libs} ${dpdk_libs}
+Libs.private: ${dl_libs} ${rt_libs} ${lksctp_tools_libs} ${liburing_libs} ${lttng_ust_libs} ${stdatomic_libs} ${dpdk_libs}


### PR DESCRIPTION
Since commit f98cc0cfdd ("io: Add LTTng-UST tracepoints to IO subsystem"), Seastar is built with Seastar_LTTNG=ON by default and links LTTng::UST as a PRIVATE dependency. The io_trace.cc/reactor_trace.cc translation units reference lttng_ust_* symbols, so a static libseastar.a leaves them unresolved unless the final executable also links lttng-ust.

seastar.pc.in was not updated to match, so its Libs.private omits lttng-ust and consumers linking Seastar statically via pkg-config are under-linked. Add lttng-ust to Libs.private, guarded by Seastar_LTTNG and following the existing Seastar_IO_URING pattern, so it collapses to nothing when the feature is disabled.