### PR TITLE
reactor: rearm high resolution timer

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1743,6 +1743,7 @@ public:
         bool did_work = false;
         did_work |= _preempt_io_context.service_preempting_io();
         did_work |= queue_pending_file_io();
+        _hrtimer_completion.maybe_rearm(*this);
         did_work |= ::io_uring_submit(&_uring);
         return did_work;
     }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1753,7 +1753,6 @@ public:
     }
     virtual void wait_and_process_events(const sigset_t* active_sigmask) override {
         _smp_wakeup_completion.maybe_rearm(*this);
-        _hrtimer_completion.maybe_rearm(*this);
         ::io_uring_submit(&_uring);
         bool did_work = false;
         did_work |= _preempt_io_context.service_preempting_io();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -522,6 +522,10 @@ seastar_add_test (epoll
 seastar_add_test (reactor_backend
   SOURCES reactor_backend_test.cc)
 
+seastar_add_test (reactor_backend_highres_timer
+  SOURCES reactor_backend_highres_timer_test.cc
+  RUN_ARGS --reactor-backend io_uring)
+
 seastar_add_test (sstring
   KIND BOOST
   SOURCES sstring_test.cc)

--- a/tests/unit/reactor_backend_highres_timer_test.cc
+++ b/tests/unit/reactor_backend_highres_timer_test.cc
@@ -1,0 +1,40 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/internal/poll.hh>
+#include <seastar/testing/test_case.hh>
+
+#include <chrono>
+#include <string>
+
+using namespace seastar;
+using namespace std::chrono_literals;
+
+// Like DPDK, this poller prevents the reactor from entering interrupt mode.
+// The high-resolution timer must therefore be serviced while polling.
+SEASTAR_TEST_CASE(highres_timer_with_active_poller_test) {
+    BOOST_REQUIRE_EQUAL(std::string(engine().get_backend_name()), "io_uring");
+
+    auto active_poller = reactor::poller::simple([] {
+        return false;
+    });
+
+    co_await sleep(100ms);
+}

--- a/tests/unit/reactor_backend_test.cc
+++ b/tests/unit/reactor_backend_test.cc
@@ -21,17 +21,11 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/reactor.hh>
-#include <seastar/core/sleep.hh>
 #include <seastar/core/posix.hh>
-#include <seastar/core/internal/poll.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/testing/test_case.hh>
 
-#include <chrono>
-
 using namespace seastar;
-using namespace std::chrono_literals;
 
 // After a co_await on a pollable_fd future resolves, await_resume() calls
 // future::get() which calls get_available_state_ref(), which sees
@@ -68,14 +62,4 @@ SEASTAR_TEST_CASE(pollable_fd_state_completion_reuse_test) {
 
     ::close(sv[1]);
     co_return;
-}
-
-// Like DPDK, this poller prevents the reactor from entering interrupt mode.
-// The high-resolution timer must therefore be serviced while polling.
-SEASTAR_TEST_CASE(highres_timer_with_active_poller_test) {
-    auto active_poller = reactor::poller::simple([] {
-        return false;
-    });
-
-    co_await sleep(100ms);
 }

--- a/tests/unit/reactor_backend_test.cc
+++ b/tests/unit/reactor_backend_test.cc
@@ -21,11 +21,17 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/internal/poll.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/testing/test_case.hh>
 
+#include <chrono>
+
 using namespace seastar;
+using namespace std::chrono_literals;
 
 // After a co_await on a pollable_fd future resolves, await_resume() calls
 // future::get() which calls get_available_state_ref(), which sees
@@ -62,4 +68,14 @@ SEASTAR_TEST_CASE(pollable_fd_state_completion_reuse_test) {
 
     ::close(sv[1]);
     co_return;
+}
+
+// Like DPDK, this poller prevents the reactor from entering interrupt mode.
+// The high-resolution timer must therefore be serviced while polling.
+SEASTAR_TEST_CASE(highres_timer_with_active_poller_test) {
+    auto active_poller = reactor::poller::simple([] {
+        return false;
+    });
+
+    co_await sleep(100ms);
 }


### PR DESCRIPTION
Fixes #1890 

Regression example: 

```c++
int main(int argc, char** argv) { 
   seastar::app_template app;
   app.run(argc, argv, [] {
        std::cout << "Sleeping... " << std::flush;
        using namespace std::chrono_literals;
        return seastar::sleep(1s).then([] {
            std::cout << "Done.\n";
        });
    });
}
```

When Seastar uses the io_uring reactor with DPDK, `seastar::sleep()` may never complete. DPDK keeps the reactor active, so it does not enter the blocking path where the high-resolution timer completion is normally armed.

As a result, the timerfd expiration is not observed and the application hangs after printing `Sleeping...`.

By rearming the high-resolution timer completion from `kernel_submit_work()` before submitting pending `io_uring` operations, we ensure that timer expirations are monitored during active processing as well as while the reactor is idle.