### PR TITLE
tests: Fix NDEBUG build

### DIFF
--- a/tests/perf/perf_tests_perf.cc
+++ b/tests/perf/perf_tests_perf.cc
@@ -139,7 +139,7 @@ PERF_TEST(overhead_check, high_overhead_test) {
 
 // The following tests run in order check that pre-run hooks are executed properly.
 
-static int hook_1_count = 0, hook_2_count = 1;
+[[maybe_unused]] static int hook_1_count = 0, hook_2_count = 1;
 
 PERF_PRE_RUN_HOOK([](const std::string& g, const std::string& c) {
     ++hook_1_count;
@@ -154,4 +154,3 @@ PERF_TEST(hook_checker, hook_did_run_0) {
     assert(hook_1_count > 0);
     assert(hook_2_count > 0);
 }
-


### PR DESCRIPTION
When building with NDEBUG assert becomes nothing and clang-23 complains about unused globals.

```
/build/seastar/tests/perf/perf_tests_perf.cc:142:12: error: variable 'hook_1_count' set but not used [-Werror,-Wunused-but-set-global]
  142 | static int hook_1_count = 0, hook_2_count = 1;
      |            ^
/build/seastar/tests/perf/perf_tests_perf.cc:142:30: error: variable 'hook_2_count' set but not used [-Werror,-Wunused-but-set-global]
  142 | static int hook_1_count = 0, hook_2_count = 1;
```

Mark them as maybe_unused to resolve this issue.