### PR TITLE
future: Enable HALO

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -883,7 +883,10 @@ protected:
     void move_it(promise_base&& x) noexcept;
     promise_base(promise_base&& x) noexcept;
 
-    void clear() noexcept;
+    inline void clear() noexcept;
+
+    // clear_on_broken() handles the clear() slow path when the promise is unresolved.
+    void clear_on_broken() noexcept;
 
     // We never need to destruct this polymorphicly, so we can make it
     // protected instead of virtual
@@ -895,7 +898,16 @@ protected:
     promise_base& operator=(promise_base&& x) noexcept;
 
     template<urgent Urgent>
-    void make_ready() noexcept;
+    void make_ready() noexcept {
+        if (_task) {
+            assert_task_shard();
+            if constexpr (Urgent == urgent::yes) {
+                ::seastar::schedule_urgent(std::exchange(_task, nullptr));
+            } else {
+                ::seastar::schedule(std::exchange(_task, nullptr));
+            }
+        }
+    }
 
     template<typename T>
     void set_exception_impl(T&& val) noexcept {
@@ -1348,6 +1360,16 @@ protected:
 
     friend class promise_base;
 };
+
+inline void promise_base::clear() noexcept {
+    if (__builtin_expect(bool(_task) || (_future && !_state->available()), false)) {
+        clear_on_broken();
+        return;
+    }
+    if (_future) {
+        _future->detach_promise();
+    }
+}
 
 template <typename Func, typename... T>
 struct future_result  {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1444,7 +1444,7 @@ task* continuation_base_with_promise<Promise, T>::waiting_task() noexcept {
 ///           contains a success/failure indication (and in the case of a
 ///           failure, an exception).
 template <typename T>
-class [[nodiscard]] future : private internal::future_base {
+class [[nodiscard]] SEASTAR_CORO_AWAIT_ELIDABLE future : private internal::future_base {
     using future_state = seastar::future_state<internal::future_stored_type_t<T>>;
     future_state _state;
     static constexpr bool copy_noexcept = future_state::copy_noexcept;

--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -246,7 +246,7 @@ when_all_impl(Futs&&... futs) noexcept {
 /// \return an \c std::tuple<> of all futures returned; when ready,
 ///         all contained futures will be ready as well.
 template <typename... FutOrFuncs>
-inline auto when_all(FutOrFuncs&&... fut_or_funcs) noexcept {
+inline auto when_all(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT FutOrFuncs&&... fut_or_funcs) noexcept {
     return internal::when_all_impl(futurize_invoke_if_func(std::forward<FutOrFuncs>(fut_or_funcs))...);
 }
 
@@ -488,7 +488,7 @@ inline auto when_all_succeed_impl(Futures&&... futures) noexcept {
 /// \param fut_or_funcs futures or functions that return futures
 /// \return future containing values of futures returned by funcs
 template <typename... FutOrFuncs>
-inline auto when_all_succeed(FutOrFuncs&&... fut_or_funcs) noexcept {
+inline auto when_all_succeed(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT FutOrFuncs&&... fut_or_funcs) noexcept {
     return internal::when_all_succeed_impl(futurize_invoke_if_func(std::forward<FutOrFuncs>(fut_or_funcs))...);
 }
 

--- a/include/seastar/util/std-compat.hh
+++ b/include/seastar/util/std-compat.hh
@@ -71,3 +71,28 @@ using source_location
 #define SEASTAR_COROUTINE_LOC_STORE(promise) \
     (promise).update_resume_point(sl)
 #endif
+
+// Coroutine LLVM HALO support.
+#if defined(__clang__) && __clang_major__ >= 23 && defined(__has_cpp_attribute)
+  #if __has_cpp_attribute(clang::coro_await_elidable)
+    #define SEASTAR_CORO_AWAIT_ELIDABLE [[clang::coro_await_elidable]]
+  #else
+    #define SEASTAR_CORO_AWAIT_ELIDABLE
+  #endif
+
+  #if __has_cpp_attribute(clang::coro_only_destroy_when_complete)
+    #define SEASTAR_CORO_ONLY_DESTROY_WHEN_COMPLETE [[clang::coro_only_destroy_when_complete]]
+  #else
+    #define SEASTAR_CORO_ONLY_DESTROY_WHEN_COMPLETE
+  #endif
+
+  #if __has_cpp_attribute(clang::coro_await_elidable_argument)
+    #define SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT [[clang::coro_await_elidable_argument]]
+  #else
+    #define SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT
+  #endif
+#else
+  #define SEASTAR_CORO_AWAIT_ELIDABLE
+  #define SEASTAR_CORO_ONLY_DESTROY_WHEN_COMPLETE
+  #define SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT
+#endif

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -80,17 +80,14 @@ promise_base::promise_base(promise_base&& x) noexcept {
     move_it(std::move(x));
 }
 
-void promise_base::clear() noexcept {
-    if (__builtin_expect(bool(_task), false)) {
-        SEASTAR_ASSERT(_state && !_state->available());
-        set_to_broken_promise(*_state);
+void promise_base::clear_on_broken() noexcept {
+    SEASTAR_ASSERT(_state && !_state->available());
+    set_to_broken_promise(*_state);
+    if (_task) {
         ::seastar::schedule(std::exchange(_task, nullptr));
     }
     if (_future) {
         SEASTAR_ASSERT(_state);
-        if (!_state->available()) {
-            set_to_broken_promise(*_state);
-        }
         _future->detach_promise();
     }
 }
@@ -115,20 +112,6 @@ void promise_base::assert_task_shard() const noexcept {
 
 #endif
 
-template <promise_base::urgent Urgent>
-void promise_base::make_ready() noexcept {
-    if (_task) {
-        assert_task_shard();
-        if (Urgent == urgent::yes) {
-            ::seastar::schedule_urgent(std::exchange(_task, nullptr));
-        } else {
-            ::seastar::schedule(std::exchange(_task, nullptr));
-        }
-    }
-}
-
-template void promise_base::make_ready<promise_base::urgent::no>() noexcept;
-template void promise_base::make_ready<promise_base::urgent::yes>() noexcept;
 }
 
 template

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -22,16 +22,36 @@
 #include <seastar/testing/perf_tests.hh>
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/try_future.hh>
 #include <seastar/coroutine/generator.hh>
 #include <seastar/core/circular_buffer_fixed_capacity.hh>
 #include <seastar/util/later.hh>
+#include <string>
 #include <vector>
 
 using namespace seastar;
 
 struct coroutine_test {
 };
+
+static future<int> ready_chain_leaf(int x) {
+    co_return x + 1;
+}
+
+static future<int> ready_chain_middle(int x) {
+    co_return co_await ready_chain_leaf(x);
+}
+
+static future<int> ready_chain_top(int x) {
+    co_return co_await ready_chain_middle(x);
+}
+
+static future<int> wrapped_ready_chain_top(int x) {
+    auto ready = co_await coroutine::as_future(ready_chain_middle(x));
+    co_return ready.get() + co_await coroutine::try_future(make_ready_future<int>(1));
+}
 
 PERF_TEST_C(coroutine_test, empty)
 {
@@ -48,10 +68,250 @@ PERF_TEST_C(coroutine_test, ready)
     co_await make_ready_future<>();
 }
 
+PERF_TEST_C(coroutine_test, nested_ready_chain)
+{
+    auto value = co_await ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
+}
+
+PERF_TEST_C(coroutine_test, wrapped_ready_chain)
+{
+    auto value = co_await wrapped_ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
+}
+
 PERF_TEST_C(coroutine_test, maybe_yield)
 {
     co_await coroutine::maybe_yield();
 }
+
+namespace {
+
+static constexpr size_t CORO_BENCH_ITERS = 10000;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static bool always_false_global = false;
+
+bool always_false() {
+    perf_tests::do_not_optimize(always_false_global);
+    return always_false_global;
+}
+
+template<typename F>
+future<size_t> co_await_in_loop(F f) {
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < CORO_BENCH_ITERS; i++) {
+        co_await f();
+    }
+    perf_tests::stop_measuring_time();
+    co_return CORO_BENCH_ITERS;
+}
+
+template<typename F>
+future<size_t> collect_futures(F f) {
+    std::vector<future<>> futs;
+    futs.reserve(CORO_BENCH_ITERS);
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < CORO_BENCH_ITERS; i++) {
+        futs.emplace_back(f());
+    }
+    perf_tests::stop_measuring_time();
+
+    for (auto& fut : futs) {
+        co_await std::move(fut);
+    }
+    co_return CORO_BENCH_ITERS;
+}
+
+[[gnu::noinline]] future<> bench_ss_now() { return now(); }
+
+[[gnu::noinline]] future<> bench_empty_cont() { return maybe_yield(); }
+
+[[gnu::noinline]] static auto bench_ready_future_int() {
+    return make_ready_future<int>(1);
+}
+
+future<int> always_ready_coro() {
+    int x = 0;
+    if (always_false()) {
+        x = co_await coroutine::without_preemption_check(
+          bench_ready_future_int());
+    }
+    co_return x;
+}
+
+inline future<> always_ready() {
+    if (always_false()) [[unlikely]] {
+        return yield();
+    }
+    return now();
+}
+
+template<typename T>
+inline future<T> always_ready_val(T&& t) {
+    if (always_false()) [[unlikely]] {
+        return yield().then([=]() mutable { return std::move(t); });
+    }
+    return make_ready_future<T>(std::forward<T>(t));
+}
+
+future<> never_awaits() {
+    if (always_false()) {
+        co_await make_ready_future<>();
+    }
+}
+
+volatile int some_int;
+
+void do_work() { some_int = 1; }
+
+template<typename T>
+auto do_work_val(T& t) {
+    return always_ready_val(std::move(t));
+}
+
+inline future<> co_await_ready() {
+    co_await always_ready();
+    do_work();
+}
+
+template<size_t depth>
+inline future<> co_await_ready_nested() {
+    static_assert(depth > 0);
+
+    if constexpr (depth == 1) {
+        co_await always_ready();
+    } else {
+        co_await co_await_ready_nested<depth - 1>();
+    }
+    do_work();
+}
+
+struct small_object {
+    char x;
+};
+
+future<> nested_after_yield() {
+    using T = small_object;
+    T t{};
+    return yield().then([t = t]() mutable {
+        return do_work_val(t)
+          .then([](T t) { return do_work_val(t); })
+          .then([](T t) { return do_work_val(t); })
+          .then([](T t) { return do_work_val(t); })
+          .then([](T t) { return do_work_val(t); })
+          .then([](T) { return always_ready(); });
+    });
+}
+
+future<> chained_after_yield() {
+    using T = small_object;
+    T t{};
+    return yield()
+      .then([t = t]() mutable { return do_work_val(t); })
+      .then([](T t) { return do_work_val(t); })
+      .then([](T t) { return do_work_val(t); })
+      .then([](T t) { return do_work_val(t); })
+      .then([](T t) { return do_work_val(t); })
+      .then([](T) { return always_ready(); })
+      .finally([] {})
+      .finally([] {});
+}
+
+future<> coro_after_yield() {
+    small_object t{};
+    co_await yield();
+
+    t = co_await do_work_val(t);
+    t = co_await do_work_val(t);
+    t = co_await do_work_val(t);
+    t = co_await do_work_val(t);
+    t = co_await do_work_val(t);
+}
+
+future<> chain_then5() {
+    using T = std::string;
+    T t{};
+    return do_work_val(t)
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T) { return always_ready(); });
+}
+
+inline future<> nested_then5() {
+    return always_ready().then([] {
+        return always_ready().then([] {
+            return always_ready().then([] {
+                return always_ready().then(
+                  [] { return always_ready().then([] { do_work(); }); });
+            });
+        });
+    });
+}
+
+// Per-field coroutine: small, completes synchronously, body visible to the
+// caller.  With std::suspend_never at final_suspend the compiler can prove
+// bounded lifetime and stack-allocate (standard frame elision).  A custom
+// final awaiter that suspends blocks that proof.
+[[gnu::noinline]] future<int> per_field_process(int v) {
+    perf_tests::do_not_optimize(v);
+    co_return v + 1;
+}
+
+// Processes N fields in a loop, co_awaiting a directly-visible coroutine
+// per field.
+template<size_t NFields>
+future<size_t> co_await_per_field_direct() {
+    perf_tests::start_measuring_time();
+    for (size_t record = 0; record < CORO_BENCH_ITERS; ++record) {
+        int acc = 0;
+        for (size_t i = 0; i < NFields; ++i) {
+            acc = co_await per_field_process(acc);
+        }
+        perf_tests::do_not_optimize(acc);
+    }
+    perf_tests::stop_measuring_time();
+    co_return CORO_BENCH_ITERS;
+}
+
+} // anonymous namespace
+
+PERF_TEST_F(coroutine_test, cont_empty) { return co_await_in_loop(bench_empty_cont); }
+
+PERF_TEST_F(coroutine_test, cont_ss_now) { return co_await_in_loop(bench_ss_now); }
+
+PERF_TEST_F(coroutine_test, cont_ss_now_collect) { return collect_futures(bench_ss_now); }
+
+PERF_TEST_F(coroutine_test, cont_nested_then5) { return co_await_in_loop(nested_then5); }
+
+PERF_TEST_F(coroutine_test, cont_chain_then5) { return co_await_in_loop(chain_then5); }
+
+PERF_TEST_F(coroutine_test, cont_nested_after_yield) { return co_await_in_loop(nested_after_yield); }
+
+PERF_TEST_F(coroutine_test, cont_chained_after_yield) { return co_await_in_loop(chained_after_yield); }
+
+PERF_TEST_F(coroutine_test, coro_ready) { return co_await_in_loop(co_await_ready); }
+
+PERF_TEST_F(coroutine_test, coro_ready_collect) { return collect_futures(co_await_ready); }
+
+PERF_TEST_F(coroutine_test, coro_after_yield) { return co_await_in_loop(coro_after_yield); }
+
+PERF_TEST_F(coroutine_test, coro_ready_nested3) { return co_await_in_loop(co_await_ready_nested<3>); }
+
+PERF_TEST_F(coroutine_test, coro_ready_nested5) { return co_await_in_loop(co_await_ready_nested<5>); }
+
+PERF_TEST_F(coroutine_test, coro_empty) { return co_await_in_loop(always_ready_coro); }
+
+PERF_TEST_F(coroutine_test, coro_never_awaits_collect) { return collect_futures(never_awaits); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_1) { return co_await_per_field_direct<1>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_10) { return co_await_per_field_direct<10>(); }
+
+PERF_TEST_F(coroutine_test, coro_per_field_40) { return co_await_per_field_direct<40>(); }
 
 // Benchmark unbuffered generator: one suspension per element
 PERF_TEST_C(coroutine_test, unbuffered_generator)

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -22,6 +22,7 @@
 #include <seastar/testing/perf_tests.hh>
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/try_future.hh>
@@ -53,6 +54,16 @@ static future<int> wrapped_ready_chain_top(int x) {
     co_return ready.get() + co_await coroutine::try_future(make_ready_future<int>(1));
 }
 
+static future<int> when_all_ready_chain_top(int x) {
+    auto [f] = co_await when_all(ready_chain_middle(x));
+    co_return f.get();
+}
+
+static future<int> when_all_succeed_ready_chain_top(int x) {
+    auto [value] = co_await when_all_succeed(ready_chain_middle(x));
+    co_return value;
+}
+
 PERF_TEST_C(coroutine_test, empty)
 {
     co_return;
@@ -77,6 +88,18 @@ PERF_TEST_C(coroutine_test, nested_ready_chain)
 PERF_TEST_C(coroutine_test, wrapped_ready_chain)
 {
     auto value = co_await wrapped_ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
+}
+
+PERF_TEST_C(coroutine_test, when_all_ready_chain)
+{
+    auto value = co_await when_all_ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
+}
+
+PERF_TEST_C(coroutine_test, when_all_succeed_ready_chain)
+{
+    auto value = co_await when_all_succeed_ready_chain_top(0);
     perf_tests::do_not_optimize(value);
 }
 


### PR DESCRIPTION
Now that https://github.com/llvm/llvm-project/issues/188230 is fixed we can enable the LLVM HALO attributes in seastar.

This patch series consists of the following patches:

 - Extend the coroutine / continuation microbenches in seastar with a set of microbenches we had been using in Redpanda
 - Introduce macros for the llvm HALO related attributes
 - Mark `future` with `clang::coro_await_elidable`
 - Make some `future` related methods better inlinable
 - Mark `when_all` arguments with `clang::coro_await_elidable_argument`

The main benefit of HALO is that it allows eliding nested coroutine frame allocations which are fairly common in coroutine rich code.

Microbenchmark deltas from the HALO commit:

```
Test                                       inst(d)            allocs(d)
---------------------------------------------------------------------------------
coroutine_test.buffered_generator            +0.17  (+0.0%)       +0.00  (+0.0%)
coroutine_test.cont_chain_then5               0.00  (-0.0%)        0.00  (-1.6%)
coroutine_test.cont_chained_after_yield      +0.01  (+0.0%)       +0.00  (+0.0%)
coroutine_test.cont_empty                     0.00  (-0.0%)        0.00 (-17.2%)
coroutine_test.cont_nested_after_yield       -0.01  (-0.0%)        0.00  (-0.0%)
coroutine_test.cont_nested_then5             +0.00  (+0.0%)        0.00  (-3.7%)
coroutine_test.cont_ss_now                    0.00  (-0.0%)        0.00  (-9.0%)
coroutine_test.cont_ss_now_collect            0.00  (-0.0%)       +0.00  (+0.0%)
coroutine_test.coro_after_yield               0.00  (-0.0%)        0.00  (-0.0%)
coroutine_test.coro_empty                     0.00  (-0.0%)        0.00  (-0.0%)
coroutine_test.coro_never_awaits_collect     +0.00  (+0.0%)       +0.00  (+0.0%)
coroutine_test.coro_per_field_1               0.00  (-0.0%)        0.00  (-0.3%)
coroutine_test.coro_per_field_10             +0.21  (+0.0%)        0.00  (-4.9%)
coroutine_test.coro_per_field_40             +0.04  (+0.0%)       +0.00  (+0.1%)
coroutine_test.coro_ready                    +0.00  (+0.0%)        0.00  (-0.0%)
coroutine_test.coro_ready_collect            -0.03  (-0.0%)       +0.00  (+0.0%)
coroutine_test.coro_ready_nested3          -172.00 (-31.7%)       -2.00 (-66.7%)
coroutine_test.coro_ready_nested5          -346.01 (-39.1%)       -4.00 (-80.0%)
coroutine_test.empty                         +0.00  (+0.0%)       +0.00  (+0.0%)
coroutine_test.maybe_yield                    0.00  (-0.0%)        0.00  (-0.0%)
coroutine_test.nested_ready_chain          -180.09 (-30.1%)       -2.00 (-66.7%)
coroutine_test.ready                         +0.00  (+0.0%)       +0.00  (+0.0%)
coroutine_test.unbuffered_generator          -0.18  (-0.0%)        0.00  (-0.0%)
coroutine_test.without_preemption_check      +0.00  (+0.0%)       +0.00  (+0.0%)
coroutine_test.wrapped_ready_chain          -85.04 (-13.0%)       -1.00 (-33.3%)
```

All benches have been tested with clang-23 RC and `-mllvm -coro-elide-branch-ratio=0` (to avoid heuristics not triggering elision).

CI obviously isn't using clang-23 yet so if you rather prefer holding off merging this till then we can put this on hold also.