### PR TITLE
core: io_queue: Fix low performance with io_scheduler and --overprovisioned (Fixes #3202)

### DIFF
--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -1305,6 +1305,19 @@ io_queue::clock_type::time_point io_queue::stream::next_pending_aio() const noex
          * works faster, than it really does.
          */
         auto over = out.capacity_deficiency(_pending.head);
+
+        auto* ent = fq.top();
+        if (ent != nullptr) {
+            auto cap = ent->capacity();
+            if (cap <= _pending.cap) {
+                if (over > _pending.cap - cap) {
+                    over -= (_pending.cap - cap);
+                } else {
+                    over = 0;
+                }
+            }
+        }
+
         auto ticks = out.capacity_duration(over);
         return std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::microseconds>(ticks);
     }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -1306,7 +1306,7 @@ io_queue::clock_type::time_point io_queue::stream::next_pending_aio() const noex
          */
         auto over = out.capacity_deficiency(_pending.head);
 
-        auto* ent = fq.top();
+        auto* ent = const_cast<fair_queue&>(fq).top();
         if (ent != nullptr) {
             auto cap = ent->capacity();
             if (cap <= _pending.cap) {


### PR DESCRIPTION
Fixes #3202

## Description
When using `--overprovisioned` (or `--idle-poll-time-us=1`), the token bucket wait duration in `next_pending_aio` was calculated based on replenishing the entire reservation chunk (`_pending.cap`), which is usually ~12.5M tokens. This caused the reactor to sleep for ~750µs between each I/O dispatch, throttling throughput down to ~2.7K IOPS.

This PR adjusts the `over` (token deficiency) calculation by checking the exact capacity needed for the next request (`fq.top()->capacity()`). If the required capacity is smaller than the pending reservation, we reduce the wait time accordingly. This allows the reactor to sleep for the precise time needed by the next request (e.g. ~7µs for a 4KB read), completely restoring the throughput.
