### PR TITLE
coroutine: Mark more methods with clang::coro_await_elidable_argument

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -244,6 +244,11 @@ public:
     void await_resume() { _future.get(); }
 };
 
+template<typename T>
+struct [[nodiscard]] SEASTAR_CORO_AWAIT_ELIDABLE without_preemption_check : public seastar::future<T> {
+    explicit without_preemption_check(seastar::future<T>&& f) noexcept : seastar::future<T>(std::move(f)) {}
+};
+
 } // seastar::internal
 
 
@@ -258,9 +263,10 @@ namespace coroutine {
 /// If constructed from a future, co_await-ing it will bypass
 /// checking if the task quota is depleted, which means that
 /// a ready future will be handled immediately.
-template<typename T> struct [[nodiscard]] without_preemption_check : public seastar::future<T> {
-    explicit without_preemption_check(seastar::future<T>&& f) noexcept : seastar::future<T>(std::move(f)) {}
-};
+template<typename T>
+inline auto without_preemption_check(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT seastar::future<T>&& f) noexcept {
+    return internal::without_preemption_check<T>(std::move(f));
+}
 
 /// Make a lambda coroutine safe for use in an outer coroutine with
 /// functions that accept continuations.
@@ -302,7 +308,7 @@ public:
 ///
 /// \param f a \c future<> wrapped with \c without_preemption_check
 template<typename T>
-auto operator co_await(coroutine::without_preemption_check<T> f) noexcept {
+auto operator co_await(internal::without_preemption_check<T> f) noexcept {
     return internal::awaiter<false, T>(std::move(f));
 }
 
@@ -317,4 +323,3 @@ class coroutine_traits<seastar::future<T>, Args...> : public seastar::internal::
 };
 
 } // std
-

--- a/include/seastar/coroutine/as_future.hh
+++ b/include/seastar/coroutine/as_future.hh
@@ -28,8 +28,10 @@ namespace seastar {
 
 namespace internal {
 
+// This makes calls to the factories below safe elide contexts, so their
+// annotated arguments can propagate to the wrapped coroutine.
 template <bool CheckPreempt, typename T>
-class [[nodiscard]] as_future_awaiter {
+class [[nodiscard]] SEASTAR_CORO_AWAIT_ELIDABLE as_future_awaiter {
     seastar::future<T> _future;
 
 public:
@@ -85,10 +87,9 @@ namespace coroutine {
 /// returns true.  Use \ref coroutine::as_future_without_preemption_check
 /// to disable preemption checking.
 template<typename T = void>
-class [[nodiscard]] as_future : public seastar::internal::as_future_awaiter<true, T> {
-public:
-    explicit as_future(seastar::future<T>&& f) noexcept : seastar::internal::as_future_awaiter<true, T>(std::move(f)) {}
-};
+inline auto as_future(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT seastar::future<T>&& f) noexcept {
+    return seastar::internal::as_future_awaiter<true, T>(std::move(f));
+}
 
 /// \brief co_await:s a \ref future, returning it as result, without
 /// checking if preemption is needed.
@@ -98,10 +99,9 @@ public:
 /// However, it bypasses checking if the task quota is depleted, which means that
 /// a ready `future` will be handled immediately.
 template<typename T = void>
-class [[nodiscard]] as_future_without_preemption_check : public seastar::internal::as_future_awaiter<false, T> {
-public:
-    explicit as_future_without_preemption_check(seastar::future<T>&& f) noexcept : seastar::internal::as_future_awaiter<false, T>(std::move(f)) {}
-};
+inline auto as_future_without_preemption_check(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT seastar::future<T>&& f) noexcept {
+    return seastar::internal::as_future_awaiter<false, T>(std::move(f));
+}
 
 } // namespace seastar::coroutine
 

--- a/include/seastar/coroutine/try_future.hh
+++ b/include/seastar/coroutine/try_future.hh
@@ -40,8 +40,10 @@ void try_future_resume_or_destroy_coroutine(seastar::future<T>& fut, seastar::ta
     }
 }
 
+// This makes calls to the factories below safe elide contexts, so their
+// annotated arguments can propagate HALO to the wrapped coroutine.
 template <bool CheckPreempt, typename T>
-class [[nodiscard]] try_future_awaiter : public seastar::task {
+class [[nodiscard]] SEASTAR_CORO_AWAIT_ELIDABLE try_future_awaiter : public seastar::task {
     seastar::future<T> _future;
     void (*_resume_or_destroy)(seastar::future<T>&, seastar::task&){};
     seastar::task* _coroutine_task{};
@@ -125,23 +127,17 @@ namespace seastar::coroutine {
 /// returns true.  Use \ref coroutine::try_future_without_preemption_check
 /// to disable preemption checking.
 template<typename T>
-class [[nodiscard]] try_future : public seastar::internal::try_future_awaiter<true, T> {
-public:
-    explicit try_future(seastar::future<T>&& f) noexcept
-        : seastar::internal::try_future_awaiter<true, T>(std::move(f))
-    {}
-};
+inline auto try_future(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT seastar::future<T>&& f) noexcept {
+    return seastar::internal::try_future_awaiter<true, T>(std::move(f));
+}
 
 /// \brief co_await:s a \ref future, returns the wrapped result if successful,
 /// terminates the coroutine otherwise, propagating the exception to the waiter.
 ///
 /// Same as \ref coroutine::try_future, but does not check for preemption.
 template<typename T>
-class [[nodiscard]] try_future_without_preemption_check : public seastar::internal::try_future_awaiter<false, T> {
-public:
-    explicit try_future_without_preemption_check(seastar::future<T>&& f) noexcept
-        : seastar::internal::try_future_awaiter<false, T>(std::move(f))
-    {}
-};
+inline auto try_future_without_preemption_check(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT seastar::future<T>&& f) noexcept {
+    return seastar::internal::try_future_awaiter<false, T>(std::move(f));
+}
 
 } // namespace seastar::coroutine

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -54,6 +54,10 @@ static future<int> wrapped_ready_chain_top(int x) {
     co_return ready.get() + co_await coroutine::try_future(make_ready_future<int>(1));
 }
 
+static future<int> try_future_ready_chain_top(int x) {
+    co_return co_await coroutine::try_future(ready_chain_middle(x));
+}
+
 static future<int> when_all_ready_chain_top(int x) {
     auto [f] = co_await when_all(ready_chain_middle(x));
     co_return f.get();
@@ -88,6 +92,12 @@ PERF_TEST_C(coroutine_test, nested_ready_chain)
 PERF_TEST_C(coroutine_test, wrapped_ready_chain)
 {
     auto value = co_await wrapped_ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
+}
+
+PERF_TEST_C(coroutine_test, try_future_ready_chain)
+{
+    auto value = co_await try_future_ready_chain_top(0);
     perf_tests::do_not_optimize(value);
 }
 

--- a/tests/perf/coroutine_perf.cc
+++ b/tests/perf/coroutine_perf.cc
@@ -49,6 +49,10 @@ static future<int> ready_chain_top(int x) {
     co_return co_await ready_chain_middle(x);
 }
 
+static future<int> without_preemption_check_ready_chain_top(int x) {
+    co_return co_await coroutine::without_preemption_check(ready_chain_middle(x));
+}
+
 static future<int> wrapped_ready_chain_top(int x) {
     auto ready = co_await coroutine::as_future(ready_chain_middle(x));
     co_return ready.get() + co_await coroutine::try_future(make_ready_future<int>(1));
@@ -76,6 +80,12 @@ PERF_TEST_C(coroutine_test, empty)
 PERF_TEST_C(coroutine_test, without_preemption_check)
 {
     co_await coroutine::without_preemption_check(make_ready_future<>());
+}
+
+PERF_TEST_C(coroutine_test, without_preemption_check_ready_chain)
+{
+    auto value = co_await without_preemption_check_ready_chain_top(0);
+    perf_tests::do_not_optimize(value);
 }
 
 PERF_TEST_C(coroutine_test, ready)


### PR DESCRIPTION
In our previous patch series (https://github.com/scylladb/seastar/pull/3555)
which introduced HALO (heap-allocation-elision-optimization) originally we left
some coroutine wrappers untouched that could also benefit from
`clang::coro_await_elidable_argument`. 


This was because:

> Note that try_future would also be good candidate to mark but
> currently the argument doesn't work on constructor arguments so it's not
> applicable there.

It's easy to work around these issues by simply using factory functions instead
of using the type+constructor way.

This is technically an API break in case anybody is having weird usecases like:

```
coroutine::as_future<int> wrapper(foo());
co_await wrapper;
```

but this isn't really how anybody would use this so I don't think it's worth an
API version bump. I can't see any such uses in either Redpanda or ScyllaDb

The normal function style call-site stays in exactly the same
form.

Resulting perf improvements. 

```
Test                                                   inst(d)            allocs(d)        
-------------------------------------------------------------------------------------------
coroutine_test.without_preemption_check_ready_chain    -95.02 (-21.8%)       -1.00 (-50.0%)
coroutine_test.wrapped_ready_chain                     -93.02 (-19.0%)       -1.00 (-50.0%)
coroutine_test.try_future_ready_chain                  -93.02 (-21.0%)       -1.00 (-50.0%)
```