### PR TITLE
net/tls: Remove deprecated sstring-name overloads

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -478,43 +478,11 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * ATTN: The method is going to be deprecated
-     *
-     * \param name The expected server name for the remote end point
-     */
-    /// @{
-    [[deprecated("Use overload with tls_options parameter")]]
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name);
-    [[deprecated("Use overload with tls_options parameter")]]
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name);
-    /// @}
-
-    /**
-     * Creates a TLS client connection using the default network stack and the
-     * supplied credentials.
-     * Typically these should contain enough information
-     * to validate the remote certificate (i.e. trust info).
-     *
      * \param options Optional additional session configuration
      */
     /// @{
     future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, tls_options option = {});
     future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, tls_options options = {});
-    /// @}
-
-    /**
-     * Creates a socket through which a TLS client connection can be created,
-     * using the default network stack and the supplied credentials.
-     * Typically these should contain enough information
-     * to validate the remote certificate (i.e. trust info).
-     *
-     * ATTN: The method is going to be deprecated
-     *
-     * \param name The expected server name for the remote end point
-     */
-    /// @{
-    [[deprecated("Use overload with tls_options parameter")]]
-    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name);
     /// @}
 
     /**
@@ -532,13 +500,9 @@ namespace tls {
     /**
      * Wraps an existing connection in SSL/TLS.
      *
-     * ATTN: The method is going to be deprecated
-     *
      * \param name The expected server name for the remote end point
      */
     /// @{
-    [[deprecated("Use overload with tls_options parameter")]]
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name);
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -709,11 +709,6 @@ const char* tls::backend_name() {
     return internal::crypto::provider().get_tls_backend().name();
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
-    tls_options options{.server_name = std::move(name)};
-    return wrap_client(std::move(cred), std::move(s), std::move(options));
-}
-
 future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, tls_options options) {
     session_ref sess(internal::crypto::provider().get_tls_backend().make_session(
         session_type::CLIENT, std::move(cred), net::get_impl::get(std::move(s)), options));
@@ -729,16 +724,6 @@ future<connected_socket> tls::wrap_server(shared_ptr<server_credentials> cred, c
     return make_ready_future<connected_socket>(std::move(sock));
 }
 
-future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, sstring name) {
-    tls_options options{.server_name = std::move(name)};
-    return connect(std::move(cred), std::move(sa), std::move(options));
-}
-
-future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, socket_address local, sstring name) {
-    tls_options options{.server_name = std::move(name)};
-    return connect(std::move(cred), std::move(sa), std::move(local), std::move(options));
-}
-
 future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, tls_options options) {
     return engine().connect(sa).then([cred = std::move(cred), options = std::move(options)](connected_socket s) mutable {
         return wrap_client(std::move(cred), std::move(s), std::move(options));
@@ -749,11 +734,6 @@ future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, 
     return engine().connect(sa, local).then([cred = std::move(cred), options = std::move(options)](connected_socket s) mutable {
         return wrap_client(std::move(cred), std::move(s), std::move(options));
     });
-}
-
-socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
-    tls_options options{.server_name = std::move(name)};
-    return tls::socket(std::move(cred), std::move(options));
 }
 
 socket tls::socket(shared_ptr<certificate_credentials> cred, tls_options options) {


### PR DESCRIPTION
connect(), socket() and wrap_client() had overloads taking a raw sstring server name in addition to the newer overloads taking a tls_options struct. The former were deprecated in favor of the latter in commit e7e51612f66a ("tls: Move server name into tls_options", 2023-09-01), i.e. more than a year ago.

No caller in the tree used the deprecated overloads directly, so remove them along with their thin-wrapper implementations.