### PR TITLE
tls: throw GnuTLS errors with the tls::error_category() instance

### DIFF
--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -117,9 +117,11 @@ public:
 };
 
 
-static const gnutls_error_category& local_error_category() {
-    static const gnutls_error_category ec;
-    return ec;
+// Must return the same instance that tls::error_category() resolves to
+// (via the crypto provider, tls::gnutls::error_category()), so that errors
+// thrown here compare equal to the public category by identity.
+static const std::error_category& local_error_category() {
+    return tls::gnutls::error_category();
 }
 
 // Checks a gnutls return value.

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -458,6 +458,21 @@ SEASTAR_TEST_CASE(test_non_tls) {
     });
 }
 
+SEASTAR_THREAD_TEST_CASE(test_error_category_instance) {
+    // Errors thrown by the TLS layer must carry the exact category instance
+    // that tls::error_category() returns: std::error_category compares by
+    // object identity, so a second instance of the same category class never
+    // compares equal (issue #3562).
+    tls::credentials_builder b;
+    b.set_x509_key(tls::blob("garbage"), tls::blob("garbage"), tls::x509_crt_format::PEM);
+    try {
+        b.build_certificate_credentials();
+        BOOST_FAIL("expected an exception parsing garbage certificates");
+    } catch (const std::system_error& e) {
+        BOOST_REQUIRE(e.code().category() == tls::error_category());
+    }
+}
+
 SEASTAR_TEST_CASE(test_abort_accept_before_handshake) {
     auto certs = ::make_shared<tls::server_credentials>(::make_shared<tls::dh_params>());
     return certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).then([certs] {


### PR DESCRIPTION
Since 46b57ae0f ("net/tls: dispatch tls::error_category() through crypto_provider"), the GnuTLS backend throws its errors with a file-local static `gnutls_error_category` instance, while `tls::error_category()` resolves (via the crypto provider) to `tls::gnutls::error_category()`, which owns a second static instance of the same class. `std::error_category` compares by object identity, so

```cpp
e.code().category() == tls::error_category()
```

is false for every error thrown by the GnuTLS backend, silently breaking client code that identifies TLS errors this way (for example ScyllaDB's `is_broken_pipe_or_connection_reset` in `transport/generic_server.cc`). The OpenSSL backend is unaffected: its throw sites and accessor share a single static.

Fix by forwarding the file-local accessor to `tls::gnutls::error_category()`, and add a regression test that fails against the previous code (verified: 2 failures without the fix, green with it; full tls_test suite passes).

Fixes #3562
