### PR TITLE
tls: give the ERROR_* globals fixed backend-neutral values

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -53,6 +53,14 @@ class socket_address;
  * agnostic, so in theory it could be replaced
  * with OpenSSL or similar.
  *
+ * Errors are reported as \c std::system_error exceptions carrying
+ * \ref error_category. The \c ERROR_* globals below are backend-neutral
+ * error values: backend errors with an exported constant are translated to
+ * it when the error is created, so comparisons against these constants
+ * behave the same under either backend.
+ *
+ * The \c ERROR_* globals and \ref error_category are backend-neutral,
+ * statically initialized, and valid at any time in every build mode.
  */
 namespace tls {
 
@@ -662,7 +670,13 @@ namespace tls {
     /**
      * Error handling.
      *
-     * The error_category instance used by exceptions thrown by TLS
+     * The error_category instance used by exceptions thrown by TLS.
+     *
+     * This category is backend-neutral: it is the same instance no matter
+     * which backend is active, and it is valid at any time in every build
+     * mode. Error values in this category are either one of the \c ERROR_*
+     * constants below, or a backend-specific value for errors that have no
+     * exported constant.
      */
     const std::error_category& error_category();
 
@@ -672,27 +686,36 @@ namespace tls {
     const char* backend_name();
 
     /**
-     * The more common error codes encountered in TLS.
-     * Not an exhaustive list. Add exports as needed.
+     * The more common error codes encountered in TLS. Not an exhaustive list.
+     * Add exports as needed.
+     *
+     * These constants are backend-neutral: each has a fixed value,
+     * independent of the active backend, distinct from any raw GnuTLS or
+     * OpenSSL error value, and outside the errno range. When a backend
+     * reports an error that has an exported constant, it is translated to that constant, so errors in
+     * \ref error_category compare equal to these constants under either
+     * backend. Errors with no exported constant keep their backend-specific
+     * value: stable for a given backend, but comparing against such values
+     * is inherently backend-dependent.
      */
-    extern int ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
-    extern int ERROR_UNKNOWN_CIPHER_TYPE;
-    extern int ERROR_INVALID_SESSION;
-    extern int ERROR_UNEXPECTED_HANDSHAKE_PACKET;
-    extern int ERROR_UNKNOWN_CIPHER_SUITE;
-    extern int ERROR_UNKNOWN_ALGORITHM;
-    extern int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
-    extern int ERROR_SAFE_RENEGOTIATION_FAILED;
-    extern int ERROR_UNSAFE_RENEGOTIATION_DENIED;
-    extern int ERROR_UNKNOWN_SRP_USERNAME;
-    extern int ERROR_PREMATURE_TERMINATION;
-    extern int ERROR_PUSH;
-    extern int ERROR_PULL;
-    extern int ERROR_UNEXPECTED_PACKET;
-    extern int ERROR_UNSUPPORTED_VERSION;
-    extern int ERROR_NO_CIPHER_SUITES;
-    extern int ERROR_DECRYPTION_FAILED;
-    extern int ERROR_MAC_VERIFY_FAILED;
+    extern const int ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    extern const int ERROR_UNKNOWN_CIPHER_TYPE;
+    extern const int ERROR_INVALID_SESSION;
+    extern const int ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    extern const int ERROR_UNKNOWN_CIPHER_SUITE;
+    extern const int ERROR_UNKNOWN_ALGORITHM;
+    extern const int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    extern const int ERROR_SAFE_RENEGOTIATION_FAILED;
+    extern const int ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    extern const int ERROR_UNKNOWN_SRP_USERNAME;
+    extern const int ERROR_PREMATURE_TERMINATION;
+    extern const int ERROR_PUSH;
+    extern const int ERROR_PULL;
+    extern const int ERROR_UNEXPECTED_PACKET;
+    extern const int ERROR_UNSUPPORTED_VERSION;
+    extern const int ERROR_NO_CIPHER_SUITES;
+    extern const int ERROR_DECRYPTION_FAILED;
+    extern const int ERROR_MAC_VERIFY_FAILED;
 }
 }
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -53,6 +53,14 @@ class socket_address;
  * agnostic, so in theory it could be replaced
  * with OpenSSL or similar.
  *
+ * Errors are reported as \c std::system_error exceptions carrying
+ * \ref error_category. The \c ERROR_* globals below are backend-neutral
+ * error values: backend errors with an exported constant are translated to
+ * it when the error is created, so comparisons against these constants
+ * behave the same under either backend.
+ *
+ * The \c ERROR_* globals and \ref error_category are backend-neutral,
+ * statically initialized, and valid at any time in every build mode.
  */
 namespace tls {
 
@@ -698,7 +706,13 @@ namespace tls {
     /**
      * Error handling.
      *
-     * The error_category instance used by exceptions thrown by TLS
+     * The error_category instance used by exceptions thrown by TLS.
+     *
+     * This category is backend-neutral: it is the same instance no matter
+     * which backend is active, and it is valid at any time in every build
+     * mode. Error values in this category are either one of the \c ERROR_*
+     * constants below, or a backend-specific value for errors that have no
+     * exported constant.
      */
     const std::error_category& error_category();
 
@@ -708,27 +722,36 @@ namespace tls {
     const char* backend_name();
 
     /**
-     * The more common error codes encountered in TLS.
-     * Not an exhaustive list. Add exports as needed.
+     * The more common error codes encountered in TLS. Not an exhaustive list.
+     * Add exports as needed.
+     *
+     * These constants are backend-neutral: each has a fixed value,
+     * independent of the active backend, distinct from any raw GnuTLS or
+     * OpenSSL error value, and outside the errno range. When a backend
+     * reports an error that has an exported constant, it is translated to that constant, so errors in
+     * \ref error_category compare equal to these constants under either
+     * backend. Errors with no exported constant keep their backend-specific
+     * value: stable for a given backend, but comparing against such values
+     * is inherently backend-dependent.
      */
-    extern int ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
-    extern int ERROR_UNKNOWN_CIPHER_TYPE;
-    extern int ERROR_INVALID_SESSION;
-    extern int ERROR_UNEXPECTED_HANDSHAKE_PACKET;
-    extern int ERROR_UNKNOWN_CIPHER_SUITE;
-    extern int ERROR_UNKNOWN_ALGORITHM;
-    extern int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
-    extern int ERROR_SAFE_RENEGOTIATION_FAILED;
-    extern int ERROR_UNSAFE_RENEGOTIATION_DENIED;
-    extern int ERROR_UNKNOWN_SRP_USERNAME;
-    extern int ERROR_PREMATURE_TERMINATION;
-    extern int ERROR_PUSH;
-    extern int ERROR_PULL;
-    extern int ERROR_UNEXPECTED_PACKET;
-    extern int ERROR_UNSUPPORTED_VERSION;
-    extern int ERROR_NO_CIPHER_SUITES;
-    extern int ERROR_DECRYPTION_FAILED;
-    extern int ERROR_MAC_VERIFY_FAILED;
+    extern const int ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    extern const int ERROR_UNKNOWN_CIPHER_TYPE;
+    extern const int ERROR_INVALID_SESSION;
+    extern const int ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    extern const int ERROR_UNKNOWN_CIPHER_SUITE;
+    extern const int ERROR_UNKNOWN_ALGORITHM;
+    extern const int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    extern const int ERROR_SAFE_RENEGOTIATION_FAILED;
+    extern const int ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    extern const int ERROR_UNKNOWN_SRP_USERNAME;
+    extern const int ERROR_PREMATURE_TERMINATION;
+    extern const int ERROR_PUSH;
+    extern const int ERROR_PULL;
+    extern const int ERROR_UNEXPECTED_PACKET;
+    extern const int ERROR_UNSUPPORTED_VERSION;
+    extern const int ERROR_NO_CIPHER_SUITES;
+    extern const int ERROR_DECRYPTION_FAILED;
+    extern const int ERROR_MAC_VERIFY_FAILED;
 }
 }
 

--- a/src/core/crypto.cc
+++ b/src/core/crypto.cc
@@ -32,7 +32,6 @@ crypto_provider& provider() {
 
 void set_provider(std::unique_ptr<crypto_provider> p) {
     the_provider = std::move(p);
-    provider().get_tls_backend().init_error_codes();
 }
 
 md5_hasher make_md5_hasher() {

--- a/src/core/crypto.hh
+++ b/src/core/crypto.hh
@@ -58,6 +58,11 @@ public:
         const tls::tls_options& options) = 0;
 
     /// \brief Return the backend-specific TLS error category.
+    ///
+    /// This is not the category TLS errors are reported in (that is the
+    /// backend-neutral \c tls::error_category()); it is only used to format
+    /// messages for raw backend error values that have no backend-neutral
+    /// translation.
     virtual const std::error_category& error_category() = 0;
 
     /// \brief Generate a session ticket encryption key.
@@ -71,9 +76,6 @@ public:
 
     /// \brief Create backend-specific DH parameters from raw data.
     virtual std::unique_ptr<tls::dh_params_impl> make_dh_params(const tls::blob&, tls::x509_crt_format) = 0;
-
-    /// \brief Initialize backend-specific TLS error code constants.
-    virtual void init_error_codes() = 0;
 
     /// \brief Return the name of this TLS backend (e.g. "gnutls", "openssl").
     virtual const char* name() const = 0;

--- a/src/core/crypto_gnutls.cc
+++ b/src/core/crypto_gnutls.cc
@@ -44,7 +44,6 @@ public:
     shared_ptr<tls::credentials_impl> make_credentials_impl() override;
     std::unique_ptr<tls::dh_params_impl> make_dh_params(tls::dh_params::level) override;
     std::unique_ptr<tls::dh_params_impl> make_dh_params(const tls::blob&, tls::x509_crt_format) override;
-    void init_error_codes() override;
     const char* name() const override { return "gnutls"; }
 };
 
@@ -152,10 +151,6 @@ std::unique_ptr<tls::dh_params_impl> gnutls_tls_backend::make_dh_params(tls::dh_
 
 std::unique_ptr<tls::dh_params_impl> gnutls_tls_backend::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return tls::gnutls::make_dh_params(b, fmt);
-}
-
-void gnutls_tls_backend::init_error_codes() {
-    tls::gnutls::init_error_codes();
 }
 
 tls_backend& gnutls_crypto_provider::get_tls_backend() {

--- a/src/core/crypto_openssl.cc
+++ b/src/core/crypto_openssl.cc
@@ -47,7 +47,6 @@ public:
     shared_ptr<tls::credentials_impl> make_credentials_impl() override;
     std::unique_ptr<tls::dh_params_impl> make_dh_params(tls::dh_params::level) override;
     std::unique_ptr<tls::dh_params_impl> make_dh_params(const tls::blob&, tls::x509_crt_format) override;
-    void init_error_codes() override;
     const char* name() const override { return "openssl"; }
 };
 
@@ -172,10 +171,6 @@ std::unique_ptr<tls::dh_params_impl> openssl_tls_backend::make_dh_params(tls::dh
 
 std::unique_ptr<tls::dh_params_impl> openssl_tls_backend::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return tls::openssl::make_dh_params(b, fmt);
-}
-
-void openssl_tls_backend::init_error_codes() {
-    tls::openssl::init_error_codes();
 }
 
 tls_backend& openssl_crypto_provider::get_tls_backend() {

--- a/src/http/retry_strategy.cc
+++ b/src/http/retry_strategy.cc
@@ -29,8 +29,11 @@ static bool is_retryable_exception(std::exception_ptr ex) {
         try {
             std::rethrow_exception(ex);
         } catch (const std::system_error& sys_err) {
-            auto code = sys_err.code().value();
-            if (code == EPIPE || code == ECONNABORTED || code == ECONNRESET || code == tls::ERROR_PREMATURE_TERMINATION) {
+            const auto& code = sys_err.code();
+            if (code.value() == EPIPE || code.value() == ECONNABORTED || code.value() == ECONNRESET) {
+                return true;
+            }
+            if (code.category() == tls::error_category() && code.value() == tls::ERROR_PREMATURE_TERMINATION) {
                 return true;
             }
             try {

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -701,10 +701,6 @@ future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_relo
     }, tolerance);
 }
 
-const std::error_category& tls::error_category() {
-    return internal::crypto::provider().get_tls_backend().error_category();
-}
-
 const char* tls::backend_name() {
     return internal::crypto::provider().get_tls_backend().name();
 }
@@ -825,23 +821,99 @@ future<> tls::force_rehandshake(connected_socket& socket) {
 
 } // namespace seastar
 
-// Error code globals — initialized at startup by the active backend's
-// init_error_codes() method, called from smp::configure().
-int seastar::tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = 0;
-int seastar::tls::ERROR_UNKNOWN_CIPHER_TYPE = 0;
-int seastar::tls::ERROR_INVALID_SESSION = 0;
-int seastar::tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = 0;
-int seastar::tls::ERROR_UNKNOWN_CIPHER_SUITE = 0;
-int seastar::tls::ERROR_UNKNOWN_ALGORITHM = 0;
-int seastar::tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = 0;
-int seastar::tls::ERROR_SAFE_RENEGOTIATION_FAILED = 0;
-int seastar::tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = 0;
-int seastar::tls::ERROR_UNKNOWN_SRP_USERNAME = 0;
-int seastar::tls::ERROR_PREMATURE_TERMINATION = 0;
-int seastar::tls::ERROR_PUSH = 0;
-int seastar::tls::ERROR_PULL = 0;
-int seastar::tls::ERROR_UNEXPECTED_PACKET = 0;
-int seastar::tls::ERROR_UNSUPPORTED_VERSION = 0;
-int seastar::tls::ERROR_NO_CIPHER_SUITES = 0;
-int seastar::tls::ERROR_DECRYPTION_FAILED = 0;
-int seastar::tls::ERROR_MAC_VERIFY_FAILED = 0;
+namespace seastar::tls {
+
+// Fixed, backend-neutral values for the exported ERROR_* constants. The
+// values themselves are arbitrary, but they must be distinguishable from
+// anything else that could plausibly appear in a value comparison against
+// them:
+//  - above the errno range (errnos are < 4096 on Linux), so value-only
+//    comparisons cannot confuse them with system errors;
+//  - positive, distinct from raw (negative) GnuTLS errors passed through
+//    untranslated;
+//  - below 2^23, where untranslated OpenSSL ERR_PACK() values start (the
+//    library bits sit at offset 23 in OpenSSL 3.x, 24 in 1.x).
+enum class errc : int {
+    unknown_compression_algorithm = 0x10001,
+    unknown_cipher_type,
+    invalid_session,
+    unexpected_handshake_packet,
+    unknown_cipher_suite,
+    unknown_algorithm,
+    unsupported_signature_algorithm,
+    safe_renegotiation_failed,
+    unsafe_renegotiation_denied,
+    unknown_srp_username,
+    premature_termination,
+    push,
+    pull,
+    unexpected_packet,
+    unsupported_version,
+    no_cipher_suites,
+    decryption_failed,
+    mac_verify_failed,
+};
+
+const int ERROR_UNKNOWN_COMPRESSION_ALGORITHM   = int(errc::unknown_compression_algorithm);
+const int ERROR_UNKNOWN_CIPHER_TYPE             = int(errc::unknown_cipher_type);
+const int ERROR_INVALID_SESSION                 = int(errc::invalid_session);
+const int ERROR_UNEXPECTED_HANDSHAKE_PACKET     = int(errc::unexpected_handshake_packet);
+const int ERROR_UNKNOWN_CIPHER_SUITE            = int(errc::unknown_cipher_suite);
+const int ERROR_UNKNOWN_ALGORITHM               = int(errc::unknown_algorithm);
+const int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = int(errc::unsupported_signature_algorithm);
+const int ERROR_SAFE_RENEGOTIATION_FAILED       = int(errc::safe_renegotiation_failed);
+const int ERROR_UNSAFE_RENEGOTIATION_DENIED     = int(errc::unsafe_renegotiation_denied);
+const int ERROR_UNKNOWN_SRP_USERNAME            = int(errc::unknown_srp_username);
+const int ERROR_PREMATURE_TERMINATION           = int(errc::premature_termination);
+const int ERROR_PUSH                            = int(errc::push);
+const int ERROR_PULL                            = int(errc::pull);
+const int ERROR_UNEXPECTED_PACKET               = int(errc::unexpected_packet);
+const int ERROR_UNSUPPORTED_VERSION             = int(errc::unsupported_version);
+const int ERROR_NO_CIPHER_SUITES                = int(errc::no_cipher_suites);
+const int ERROR_DECRYPTION_FAILED               = int(errc::decryption_failed);
+const int ERROR_MAC_VERIFY_FAILED               = int(errc::mac_verify_failed);
+
+namespace {
+
+class tls_error_category final : public std::error_category {
+public:
+    const char* name() const noexcept override {
+        return "tls";
+    }
+    std::string message(int error) const override {
+        switch (errc(error)) {
+        case errc::unknown_compression_algorithm: return "Unknown compression algorithm";
+        case errc::unknown_cipher_type:           return "Unknown cipher type";
+        case errc::invalid_session:               return "Invalid session";
+        case errc::unexpected_handshake_packet:   return "Unexpected handshake packet";
+        case errc::unknown_cipher_suite:          return "Unknown cipher suite";
+        case errc::unknown_algorithm:             return "Unknown algorithm";
+        case errc::unsupported_signature_algorithm: return "Unsupported signature algorithm";
+        case errc::safe_renegotiation_failed:     return "Safe renegotiation failed";
+        case errc::unsafe_renegotiation_denied:   return "Unsafe renegotiation denied";
+        case errc::unknown_srp_username:          return "Unknown SRP username";
+        case errc::premature_termination:         return "Premature termination of TLS connection";
+        case errc::push:                          return "Error in the push function";
+        case errc::pull:                          return "Error in the pull function";
+        case errc::unexpected_packet:             return "Unexpected packet";
+        case errc::unsupported_version:           return "Unsupported TLS protocol version";
+        case errc::no_cipher_suites:              return "No supported cipher suites";
+        case errc::decryption_failed:             return "Decryption failed";
+        case errc::mac_verify_failed:             return "MAC verification failed";
+        }
+        // Not one of the backend-neutral values above: a raw error value
+        // from the active backend, which knows how to describe it. Such a
+        // value can only have been observed after the backend produced it,
+        // so the provider is necessarily installed by now.
+        return internal::crypto::provider().get_tls_backend().error_category().message(error);
+    }
+};
+
+} // anonymous namespace
+
+const std::error_category& error_category() {
+    static const tls_error_category ec;
+    return ec;
+}
+
+} // namespace seastar::tls

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -701,10 +701,6 @@ future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_relo
     }, tolerance);
 }
 
-const std::error_category& tls::error_category() {
-    return internal::crypto::provider().get_tls_backend().error_category();
-}
-
 const char* tls::backend_name() {
     return internal::crypto::provider().get_tls_backend().name();
 }
@@ -805,23 +801,99 @@ future<> tls::force_rehandshake(connected_socket& socket) {
 
 } // namespace seastar
 
-// Error code globals — initialized at startup by the active backend's
-// init_error_codes() method, called from smp::configure().
-int seastar::tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = 0;
-int seastar::tls::ERROR_UNKNOWN_CIPHER_TYPE = 0;
-int seastar::tls::ERROR_INVALID_SESSION = 0;
-int seastar::tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = 0;
-int seastar::tls::ERROR_UNKNOWN_CIPHER_SUITE = 0;
-int seastar::tls::ERROR_UNKNOWN_ALGORITHM = 0;
-int seastar::tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = 0;
-int seastar::tls::ERROR_SAFE_RENEGOTIATION_FAILED = 0;
-int seastar::tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = 0;
-int seastar::tls::ERROR_UNKNOWN_SRP_USERNAME = 0;
-int seastar::tls::ERROR_PREMATURE_TERMINATION = 0;
-int seastar::tls::ERROR_PUSH = 0;
-int seastar::tls::ERROR_PULL = 0;
-int seastar::tls::ERROR_UNEXPECTED_PACKET = 0;
-int seastar::tls::ERROR_UNSUPPORTED_VERSION = 0;
-int seastar::tls::ERROR_NO_CIPHER_SUITES = 0;
-int seastar::tls::ERROR_DECRYPTION_FAILED = 0;
-int seastar::tls::ERROR_MAC_VERIFY_FAILED = 0;
+namespace seastar::tls {
+
+// Fixed, backend-neutral values for the exported ERROR_* constants. The
+// values themselves are arbitrary, but they must be distinguishable from
+// anything else that could plausibly appear in a value comparison against
+// them:
+//  - above the errno range (errnos are < 4096 on Linux), so value-only
+//    comparisons cannot confuse them with system errors;
+//  - positive, distinct from raw (negative) GnuTLS errors passed through
+//    untranslated;
+//  - below 2^23, where untranslated OpenSSL ERR_PACK() values start (the
+//    library bits sit at offset 23 in OpenSSL 3.x, 24 in 1.x).
+enum class errc : int {
+    unknown_compression_algorithm = 0x10001,
+    unknown_cipher_type,
+    invalid_session,
+    unexpected_handshake_packet,
+    unknown_cipher_suite,
+    unknown_algorithm,
+    unsupported_signature_algorithm,
+    safe_renegotiation_failed,
+    unsafe_renegotiation_denied,
+    unknown_srp_username,
+    premature_termination,
+    push,
+    pull,
+    unexpected_packet,
+    unsupported_version,
+    no_cipher_suites,
+    decryption_failed,
+    mac_verify_failed,
+};
+
+const int ERROR_UNKNOWN_COMPRESSION_ALGORITHM   = int(errc::unknown_compression_algorithm);
+const int ERROR_UNKNOWN_CIPHER_TYPE             = int(errc::unknown_cipher_type);
+const int ERROR_INVALID_SESSION                 = int(errc::invalid_session);
+const int ERROR_UNEXPECTED_HANDSHAKE_PACKET     = int(errc::unexpected_handshake_packet);
+const int ERROR_UNKNOWN_CIPHER_SUITE            = int(errc::unknown_cipher_suite);
+const int ERROR_UNKNOWN_ALGORITHM               = int(errc::unknown_algorithm);
+const int ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = int(errc::unsupported_signature_algorithm);
+const int ERROR_SAFE_RENEGOTIATION_FAILED       = int(errc::safe_renegotiation_failed);
+const int ERROR_UNSAFE_RENEGOTIATION_DENIED     = int(errc::unsafe_renegotiation_denied);
+const int ERROR_UNKNOWN_SRP_USERNAME            = int(errc::unknown_srp_username);
+const int ERROR_PREMATURE_TERMINATION           = int(errc::premature_termination);
+const int ERROR_PUSH                            = int(errc::push);
+const int ERROR_PULL                            = int(errc::pull);
+const int ERROR_UNEXPECTED_PACKET               = int(errc::unexpected_packet);
+const int ERROR_UNSUPPORTED_VERSION             = int(errc::unsupported_version);
+const int ERROR_NO_CIPHER_SUITES                = int(errc::no_cipher_suites);
+const int ERROR_DECRYPTION_FAILED               = int(errc::decryption_failed);
+const int ERROR_MAC_VERIFY_FAILED               = int(errc::mac_verify_failed);
+
+namespace {
+
+class tls_error_category final : public std::error_category {
+public:
+    const char* name() const noexcept override {
+        return "tls";
+    }
+    std::string message(int error) const override {
+        switch (errc(error)) {
+        case errc::unknown_compression_algorithm: return "Unknown compression algorithm";
+        case errc::unknown_cipher_type:           return "Unknown cipher type";
+        case errc::invalid_session:               return "Invalid session";
+        case errc::unexpected_handshake_packet:   return "Unexpected handshake packet";
+        case errc::unknown_cipher_suite:          return "Unknown cipher suite";
+        case errc::unknown_algorithm:             return "Unknown algorithm";
+        case errc::unsupported_signature_algorithm: return "Unsupported signature algorithm";
+        case errc::safe_renegotiation_failed:     return "Safe renegotiation failed";
+        case errc::unsafe_renegotiation_denied:   return "Unsafe renegotiation denied";
+        case errc::unknown_srp_username:          return "Unknown SRP username";
+        case errc::premature_termination:         return "Premature termination of TLS connection";
+        case errc::push:                          return "Error in the push function";
+        case errc::pull:                          return "Error in the pull function";
+        case errc::unexpected_packet:             return "Unexpected packet";
+        case errc::unsupported_version:           return "Unsupported TLS protocol version";
+        case errc::no_cipher_suites:              return "No supported cipher suites";
+        case errc::decryption_failed:             return "Decryption failed";
+        case errc::mac_verify_failed:             return "MAC verification failed";
+        }
+        // Not one of the backend-neutral values above: a raw error value
+        // from the active backend, which knows how to describe it. Such a
+        // value can only have been observed after the backend produced it,
+        // so the provider is necessarily installed by now.
+        return internal::crypto::provider().get_tls_backend().error_category().message(error);
+    }
+};
+
+} // anonymous namespace
+
+const std::error_category& error_category() {
+    static const tls_error_category ec;
+    return ec;
+}
+
+} // namespace seastar::tls

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -116,17 +116,45 @@ public:
     }
 };
 
+// Translate a GnuTLS error to its backend-neutral tls::ERROR_* value, if it
+// has one. Errors without an exported constant keep the raw (negative)
+// GnuTLS value.
+static int translate_error(int error) {
+    switch (error) {
+    case GNUTLS_E_UNKNOWN_COMPRESSION_ALGORITHM:   return tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    case GNUTLS_E_UNKNOWN_CIPHER_TYPE:             return tls::ERROR_UNKNOWN_CIPHER_TYPE;
+    case GNUTLS_E_INVALID_SESSION:                 return tls::ERROR_INVALID_SESSION;
+    case GNUTLS_E_UNEXPECTED_HANDSHAKE_PACKET:     return tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    case GNUTLS_E_UNKNOWN_CIPHER_SUITE:            return tls::ERROR_UNKNOWN_CIPHER_SUITE;
+    case GNUTLS_E_UNKNOWN_ALGORITHM:               return tls::ERROR_UNKNOWN_ALGORITHM;
+    case GNUTLS_E_UNSUPPORTED_SIGNATURE_ALGORITHM: return tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    case GNUTLS_E_SAFE_RENEGOTIATION_FAILED:       return tls::ERROR_SAFE_RENEGOTIATION_FAILED;
+    case GNUTLS_E_UNSAFE_RENEGOTIATION_DENIED:     return tls::ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    case GNUTLS_E_UNKNOWN_SRP_USERNAME:            return tls::ERROR_UNKNOWN_SRP_USERNAME;
+    case GNUTLS_E_PREMATURE_TERMINATION:           return tls::ERROR_PREMATURE_TERMINATION;
+    case GNUTLS_E_PUSH_ERROR:                      return tls::ERROR_PUSH;
+    case GNUTLS_E_PULL_ERROR:                      return tls::ERROR_PULL;
+    case GNUTLS_E_UNEXPECTED_PACKET:               return tls::ERROR_UNEXPECTED_PACKET;
+    case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:      return tls::ERROR_UNSUPPORTED_VERSION;
+    case GNUTLS_E_NO_CIPHER_SUITES:                return tls::ERROR_NO_CIPHER_SUITES;
+    case GNUTLS_E_DECRYPTION_FAILED:               return tls::ERROR_DECRYPTION_FAILED;
+    case GNUTLS_E_MAC_VERIFY_FAILED:               return tls::ERROR_MAC_VERIFY_FAILED;
+    default:                                       return error;
+    }
+}
 
-static const gnutls_error_category& local_error_category() {
-    static const gnutls_error_category ec;
-    return ec;
+// Build the std::error_code reported for a GnuTLS error: the backend-neutral
+// tls::error_category(), with the error translated to its tls::ERROR_* value
+// when one exists.
+static std::error_code make_gnutls_error_code(int error) {
+    return {translate_error(error), tls::error_category()};
 }
 
 // Checks a gnutls return value.
 // < 0 -> error.
 static void gtls_chk(int res) {
     if (res < 0) {
-        throw std::system_error(res, local_error_category());
+        throw std::system_error(make_gnutls_error_code(res));
     }
 }
 
@@ -687,7 +715,7 @@ public:
         }
         // Note: only applicable to server.
         if (_type == type::CLIENT) {
-            throw std::system_error(GNUTLS_E_INVALID_REQUEST, local_error_category(), "re-handshake only applicable for server socket");
+            throw std::system_error(make_gnutls_error_code(GNUTLS_E_INVALID_REQUEST), "re-handshake only applicable for server socket");
         }
         return do_handshake_sync(&session::do_force_rehandshake);
     }
@@ -760,7 +788,7 @@ public:
             return;
         }
         if (res < 0) {
-            throw std::system_error(res, local_error_category());
+            throw std::system_error(make_gnutls_error_code(res));
         }
         if (status & GNUTLS_CERT_INVALID) {
             auto stat_str = cert_status_to_string(gnutls_certificate_type_get(*this), status);
@@ -850,7 +878,7 @@ public:
                     _connected = false;
                     return make_ready_future<temporary_buffer<char>>();
                 default:
-                    _error = std::make_exception_ptr(std::system_error(n, local_error_category()));
+                    _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(n)));
                     return make_exception_future<temporary_buffer<char>>(_error);
                 }
             }
@@ -1027,12 +1055,12 @@ public:
 
     future<>
     handle_error(int res) {
-        _error = std::make_exception_ptr(std::system_error(res, local_error_category()));
+        _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(res)));
         return make_exception_future(_error);
     }
     future<>
     handle_output_error(int res) {
-        _error = std::make_exception_ptr(std::system_error(res, local_error_category()));
+        _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(res)));
         // #453
         // defensively wait for output before generating the error.
         // if we have both error code and an exception in output
@@ -1043,7 +1071,7 @@ public:
                 // output was ok/done, just generate error code exception
                 return make_exception_future(_error);
             } catch (...) {
-                std::throw_with_nested(std::system_error(res, local_error_category()));
+                std::throw_with_nested(std::system_error(make_gnutls_error_code(res)));
             }
         });
     }
@@ -1385,6 +1413,9 @@ shared_ptr<tls::session_impl> tls::gnutls::make_session(
     return seastar::make_shared<session>(t, std::move(creds), std::move(sock), options);
 }
 
+// Note: this is not the category errors are reported in (that is the
+// backend-neutral tls::error_category()); it only formats messages for raw
+// GnuTLS error values that have no backend-neutral translation.
 const std::error_category& tls::gnutls::error_category() {
     static const gnutls_error_category ec;
     return ec;
@@ -1408,27 +1439,6 @@ std::unique_ptr<tls::dh_params_impl> tls::gnutls::make_dh_params(tls::dh_params:
 
 std::unique_ptr<tls::dh_params_impl> tls::gnutls::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return std::make_unique<gnutls_provider_dh_params_impl>(b, fmt);
-}
-
-void tls::gnutls::init_error_codes() {
-    tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = GNUTLS_E_UNKNOWN_COMPRESSION_ALGORITHM;
-    tls::ERROR_UNKNOWN_CIPHER_TYPE = GNUTLS_E_UNKNOWN_CIPHER_TYPE;
-    tls::ERROR_INVALID_SESSION = GNUTLS_E_INVALID_SESSION;
-    tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = GNUTLS_E_UNEXPECTED_HANDSHAKE_PACKET;
-    tls::ERROR_UNKNOWN_CIPHER_SUITE = GNUTLS_E_UNKNOWN_CIPHER_SUITE;
-    tls::ERROR_UNKNOWN_ALGORITHM = GNUTLS_E_UNKNOWN_ALGORITHM;
-    tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = GNUTLS_E_UNSUPPORTED_SIGNATURE_ALGORITHM;
-    tls::ERROR_SAFE_RENEGOTIATION_FAILED = GNUTLS_E_SAFE_RENEGOTIATION_FAILED;
-    tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = GNUTLS_E_UNSAFE_RENEGOTIATION_DENIED;
-    tls::ERROR_UNKNOWN_SRP_USERNAME = GNUTLS_E_UNKNOWN_SRP_USERNAME;
-    tls::ERROR_PREMATURE_TERMINATION = GNUTLS_E_PREMATURE_TERMINATION;
-    tls::ERROR_PUSH = GNUTLS_E_PUSH_ERROR;
-    tls::ERROR_PULL = GNUTLS_E_PULL_ERROR;
-    tls::ERROR_UNEXPECTED_PACKET = GNUTLS_E_UNEXPECTED_PACKET;
-    tls::ERROR_UNSUPPORTED_VERSION = GNUTLS_E_UNSUPPORTED_VERSION_PACKET;
-    tls::ERROR_NO_CIPHER_SUITES = GNUTLS_E_NO_CIPHER_SUITES;
-    tls::ERROR_DECRYPTION_FAILED = GNUTLS_E_DECRYPTION_FAILED;
-    tls::ERROR_MAC_VERIFY_FAILED = GNUTLS_E_MAC_VERIFY_FAILED;
 }
 
 } // namespace seastar

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -116,19 +116,45 @@ public:
     }
 };
 
+// Translate a GnuTLS error to its backend-neutral tls::ERROR_* value, if it
+// has one. Errors without an exported constant keep the raw (negative)
+// GnuTLS value.
+static int translate_error(int error) {
+    switch (error) {
+    case GNUTLS_E_UNKNOWN_COMPRESSION_ALGORITHM:   return tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    case GNUTLS_E_UNKNOWN_CIPHER_TYPE:             return tls::ERROR_UNKNOWN_CIPHER_TYPE;
+    case GNUTLS_E_INVALID_SESSION:                 return tls::ERROR_INVALID_SESSION;
+    case GNUTLS_E_UNEXPECTED_HANDSHAKE_PACKET:     return tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    case GNUTLS_E_UNKNOWN_CIPHER_SUITE:            return tls::ERROR_UNKNOWN_CIPHER_SUITE;
+    case GNUTLS_E_UNKNOWN_ALGORITHM:               return tls::ERROR_UNKNOWN_ALGORITHM;
+    case GNUTLS_E_UNSUPPORTED_SIGNATURE_ALGORITHM: return tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    case GNUTLS_E_SAFE_RENEGOTIATION_FAILED:       return tls::ERROR_SAFE_RENEGOTIATION_FAILED;
+    case GNUTLS_E_UNSAFE_RENEGOTIATION_DENIED:     return tls::ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    case GNUTLS_E_UNKNOWN_SRP_USERNAME:            return tls::ERROR_UNKNOWN_SRP_USERNAME;
+    case GNUTLS_E_PREMATURE_TERMINATION:           return tls::ERROR_PREMATURE_TERMINATION;
+    case GNUTLS_E_PUSH_ERROR:                      return tls::ERROR_PUSH;
+    case GNUTLS_E_PULL_ERROR:                      return tls::ERROR_PULL;
+    case GNUTLS_E_UNEXPECTED_PACKET:               return tls::ERROR_UNEXPECTED_PACKET;
+    case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:      return tls::ERROR_UNSUPPORTED_VERSION;
+    case GNUTLS_E_NO_CIPHER_SUITES:                return tls::ERROR_NO_CIPHER_SUITES;
+    case GNUTLS_E_DECRYPTION_FAILED:               return tls::ERROR_DECRYPTION_FAILED;
+    case GNUTLS_E_MAC_VERIFY_FAILED:               return tls::ERROR_MAC_VERIFY_FAILED;
+    default:                                       return error;
+    }
+}
 
-// Must return the same instance that tls::error_category() resolves to
-// (via the crypto provider, tls::gnutls::error_category()), so that errors
-// thrown here compare equal to the public category by identity.
-static const std::error_category& local_error_category() {
-    return tls::gnutls::error_category();
+// Build the std::error_code reported for a GnuTLS error: the backend-neutral
+// tls::error_category(), with the error translated to its tls::ERROR_* value
+// when one exists.
+static std::error_code make_gnutls_error_code(int error) {
+    return {translate_error(error), tls::error_category()};
 }
 
 // Checks a gnutls return value.
 // < 0 -> error.
 static void gtls_chk(int res) {
     if (res < 0) {
-        throw std::system_error(res, local_error_category());
+        throw std::system_error(make_gnutls_error_code(res));
     }
 }
 
@@ -689,7 +715,7 @@ public:
         }
         // Note: only applicable to server.
         if (_type == type::CLIENT) {
-            throw std::system_error(GNUTLS_E_INVALID_REQUEST, local_error_category(), "re-handshake only applicable for server socket");
+            throw std::system_error(make_gnutls_error_code(GNUTLS_E_INVALID_REQUEST), "re-handshake only applicable for server socket");
         }
         return do_handshake_sync(&session::do_force_rehandshake);
     }
@@ -762,7 +788,7 @@ public:
             return;
         }
         if (res < 0) {
-            throw std::system_error(res, local_error_category());
+            throw std::system_error(make_gnutls_error_code(res));
         }
         if (status & GNUTLS_CERT_INVALID) {
             auto stat_str = cert_status_to_string(gnutls_certificate_type_get(*this), status);
@@ -852,7 +878,7 @@ public:
                     _connected = false;
                     return make_ready_future<temporary_buffer<char>>();
                 default:
-                    _error = std::make_exception_ptr(std::system_error(n, local_error_category()));
+                    _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(n)));
                     return make_exception_future<temporary_buffer<char>>(_error);
                 }
             }
@@ -1029,12 +1055,12 @@ public:
 
     future<>
     handle_error(int res) {
-        _error = std::make_exception_ptr(std::system_error(res, local_error_category()));
+        _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(res)));
         return make_exception_future(_error);
     }
     future<>
     handle_output_error(int res) {
-        _error = std::make_exception_ptr(std::system_error(res, local_error_category()));
+        _error = std::make_exception_ptr(std::system_error(make_gnutls_error_code(res)));
         // #453
         // defensively wait for output before generating the error.
         // if we have both error code and an exception in output
@@ -1045,7 +1071,7 @@ public:
                 // output was ok/done, just generate error code exception
                 return make_exception_future(_error);
             } catch (...) {
-                std::throw_with_nested(std::system_error(res, local_error_category()));
+                std::throw_with_nested(std::system_error(make_gnutls_error_code(res)));
             }
         });
     }
@@ -1387,6 +1413,9 @@ shared_ptr<tls::session_impl> tls::gnutls::make_session(
     return seastar::make_shared<session>(t, std::move(creds), std::move(sock), options);
 }
 
+// Note: this is not the category errors are reported in (that is the
+// backend-neutral tls::error_category()); it only formats messages for raw
+// GnuTLS error values that have no backend-neutral translation.
 const std::error_category& tls::gnutls::error_category() {
     static const gnutls_error_category ec;
     return ec;
@@ -1410,27 +1439,6 @@ std::unique_ptr<tls::dh_params_impl> tls::gnutls::make_dh_params(tls::dh_params:
 
 std::unique_ptr<tls::dh_params_impl> tls::gnutls::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return std::make_unique<gnutls_provider_dh_params_impl>(b, fmt);
-}
-
-void tls::gnutls::init_error_codes() {
-    tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = GNUTLS_E_UNKNOWN_COMPRESSION_ALGORITHM;
-    tls::ERROR_UNKNOWN_CIPHER_TYPE = GNUTLS_E_UNKNOWN_CIPHER_TYPE;
-    tls::ERROR_INVALID_SESSION = GNUTLS_E_INVALID_SESSION;
-    tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = GNUTLS_E_UNEXPECTED_HANDSHAKE_PACKET;
-    tls::ERROR_UNKNOWN_CIPHER_SUITE = GNUTLS_E_UNKNOWN_CIPHER_SUITE;
-    tls::ERROR_UNKNOWN_ALGORITHM = GNUTLS_E_UNKNOWN_ALGORITHM;
-    tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = GNUTLS_E_UNSUPPORTED_SIGNATURE_ALGORITHM;
-    tls::ERROR_SAFE_RENEGOTIATION_FAILED = GNUTLS_E_SAFE_RENEGOTIATION_FAILED;
-    tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = GNUTLS_E_UNSAFE_RENEGOTIATION_DENIED;
-    tls::ERROR_UNKNOWN_SRP_USERNAME = GNUTLS_E_UNKNOWN_SRP_USERNAME;
-    tls::ERROR_PREMATURE_TERMINATION = GNUTLS_E_PREMATURE_TERMINATION;
-    tls::ERROR_PUSH = GNUTLS_E_PUSH_ERROR;
-    tls::ERROR_PULL = GNUTLS_E_PULL_ERROR;
-    tls::ERROR_UNEXPECTED_PACKET = GNUTLS_E_UNEXPECTED_PACKET;
-    tls::ERROR_UNSUPPORTED_VERSION = GNUTLS_E_UNSUPPORTED_VERSION_PACKET;
-    tls::ERROR_NO_CIPHER_SUITES = GNUTLS_E_NO_CIPHER_SUITES;
-    tls::ERROR_DECRYPTION_FAILED = GNUTLS_E_DECRYPTION_FAILED;
-    tls::ERROR_MAC_VERIFY_FAILED = GNUTLS_E_MAC_VERIFY_FAILED;
 }
 
 } // namespace seastar

--- a/src/net/tls_gnutls.hh
+++ b/src/net/tls_gnutls.hh
@@ -50,6 +50,10 @@ shared_ptr<session_impl> make_session(
     const tls_options& options);
 
 /// Return the GnuTLS error category.
+///
+/// This is not the category TLS errors are reported in (that is the
+/// backend-neutral tls::error_category()); it only formats messages for raw
+/// GnuTLS error values that have no backend-neutral translation.
 const std::error_category& error_category();
 
 /// Generate a session ticket key using GnuTLS.
@@ -63,8 +67,5 @@ std::unique_ptr<dh_params_impl> make_dh_params(dh_params::level);
 
 /// Create GnuTLS DH parameters from raw data.
 std::unique_ptr<dh_params_impl> make_dh_params(const blob&, x509_crt_format);
-
-/// Initialize TLS error codes with GnuTLS values.
-void init_error_codes();
 
 } // namespace seastar::tls::gnutls

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -133,8 +133,35 @@ static const std::error_category& openssl_error_cat() {
     return ec;
 }
 
+// Translate an OpenSSL error to its backend-neutral tls::ERROR_* value, if
+// it has one. The function bits are masked out so matching is on library +
+// reason only. Errors without an exported constant keep the raw ERR_PACK()ed
+// value.
+static int translate_error(unsigned long error) {
+    switch (ERR_PACK(ERR_GET_LIB(error), 0, ERR_GET_REASON(error))) {
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM): return tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNKNOWN_CIPHER_TYPE):               return tls::ERROR_UNKNOWN_CIPHER_TYPE;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SESSION_ID):                return tls::ERROR_INVALID_SESSION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_RECORD):                 return tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_PROTOCOL):              return tls::ERROR_UNKNOWN_CIPHER_SUITE;
+    case ERR_PACK(ERR_LIB_RSA, 0, RSA_R_UNKNOWN_ALGORITHM_TYPE):            return tls::ERROR_UNKNOWN_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM):   return tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_RENEGOTIATION_MISMATCH):            return tls::ERROR_SAFE_RENEGOTIATION_FAILED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED): return tls::ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SRP_USERNAME):              return tls::ERROR_UNKNOWN_SRP_USERNAME;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_EOF_WHILE_READING):      return tls::ERROR_PREMATURE_TERMINATION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_READ_BIO_NOT_SET):                  return tls::ERROR_PULL;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_MESSAGE):                return tls::ERROR_UNEXPECTED_PACKET;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_SSL_VERSION):           return tls::ERROR_UNSUPPORTED_VERSION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_CIPHERS_AVAILABLE):              return tls::ERROR_NO_CIPHER_SUITES;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED):                 return tls::ERROR_DECRYPTION_FAILED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC): return tls::ERROR_MAC_VERIFY_FAILED;
+    default:                                                                return static_cast<int>(error);
+    }
+}
+
 std::error_code make_error_code(openssl_errc e) {
-    return std::error_code(static_cast<int>(e), openssl_error_cat());
+    return std::error_code(translate_error(static_cast<unsigned long>(e)), tls::error_category());
 }
 
 std::vector<openssl_errc> get_all_openssl_errors() {
@@ -150,7 +177,7 @@ std::system_error make_openssl_error(const std::string & msg, std::vector<openss
     if (error_codes.empty()) {
         return std::system_error{
             static_cast<int>(ERR_PACK(ERR_LIB_USER, 0, ERR_R_OPERATION_FAIL)),
-            openssl_error_cat(),
+            tls::error_category(),
             msg};
     }
     auto err_code = static_cast<unsigned long>(error_codes.front());
@@ -163,8 +190,8 @@ std::system_error make_openssl_error(const std::string & msg, std::vector<openss
             fmt::format("{}: {}", msg, error_codes));
     }
     return std::system_error(
-        static_cast<int>(err_code),
-        openssl_error_cat(),
+        translate_error(err_code),
+        tls::error_category(),
         fmt::format("{}: {}", msg, error_codes));
 }
 
@@ -2356,6 +2383,9 @@ shared_ptr<tls::session_impl> tls::openssl::make_session(
     return seastar::make_shared<tls::openssl_session>(type, std::move(creds), std::move(sock), options);
 }
 
+// Note: this is not the category errors are reported in (that is the
+// backend-neutral tls::error_category()); it only formats messages for raw
+// OpenSSL error values that have no backend-neutral translation.
 const std::error_category& tls::openssl::error_category() {
     return openssl_error_cat();
 }
@@ -2376,27 +2406,6 @@ std::unique_ptr<tls::dh_params_impl> tls::openssl::make_dh_params(tls::dh_params
 
 std::unique_ptr<tls::dh_params_impl> tls::openssl::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return std::make_unique<openssl_provider_dh_params_impl>(b, fmt);
-}
-
-void tls::openssl::init_error_codes() {
-    tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
-    tls::ERROR_UNKNOWN_CIPHER_TYPE = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNKNOWN_CIPHER_TYPE);
-    tls::ERROR_INVALID_SESSION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SESSION_ID);
-    tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_RECORD);
-    tls::ERROR_UNKNOWN_CIPHER_SUITE = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_PROTOCOL);
-    tls::ERROR_UNKNOWN_ALGORITHM = ERR_PACK(ERR_LIB_RSA, 0, RSA_R_UNKNOWN_ALGORITHM_TYPE);
-    tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM);
-    tls::ERROR_SAFE_RENEGOTIATION_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_RENEGOTIATION_MISMATCH);
-    tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED);
-    tls::ERROR_UNKNOWN_SRP_USERNAME = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SRP_USERNAME);
-    tls::ERROR_PREMATURE_TERMINATION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_EOF_WHILE_READING);
-    tls::ERROR_PUSH = int(ERR_SYSTEM_FLAG | EPIPE);
-    tls::ERROR_PULL = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_READ_BIO_NOT_SET);
-    tls::ERROR_UNEXPECTED_PACKET = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_MESSAGE);
-    tls::ERROR_UNSUPPORTED_VERSION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_SSL_VERSION);
-    tls::ERROR_NO_CIPHER_SUITES = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_CIPHERS_AVAILABLE);
-    tls::ERROR_DECRYPTION_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED);
-    tls::ERROR_MAC_VERIFY_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
 }
 
 } // namespace seastar

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -134,8 +134,35 @@ static const std::error_category& openssl_error_cat() {
     return ec;
 }
 
+// Translate an OpenSSL error to its backend-neutral tls::ERROR_* value, if
+// it has one. The function bits are masked out so matching is on library +
+// reason only. Errors without an exported constant keep the raw ERR_PACK()ed
+// value.
+static int translate_error(unsigned long error) {
+    switch (ERR_PACK(ERR_GET_LIB(error), 0, ERR_GET_REASON(error))) {
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM): return tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNKNOWN_CIPHER_TYPE):               return tls::ERROR_UNKNOWN_CIPHER_TYPE;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SESSION_ID):                return tls::ERROR_INVALID_SESSION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_RECORD):                 return tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_PROTOCOL):              return tls::ERROR_UNKNOWN_CIPHER_SUITE;
+    case ERR_PACK(ERR_LIB_RSA, 0, RSA_R_UNKNOWN_ALGORITHM_TYPE):            return tls::ERROR_UNKNOWN_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM):   return tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_RENEGOTIATION_MISMATCH):            return tls::ERROR_SAFE_RENEGOTIATION_FAILED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED): return tls::ERROR_UNSAFE_RENEGOTIATION_DENIED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SRP_USERNAME):              return tls::ERROR_UNKNOWN_SRP_USERNAME;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_EOF_WHILE_READING):      return tls::ERROR_PREMATURE_TERMINATION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_READ_BIO_NOT_SET):                  return tls::ERROR_PULL;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_MESSAGE):                return tls::ERROR_UNEXPECTED_PACKET;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_SSL_VERSION):           return tls::ERROR_UNSUPPORTED_VERSION;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_CIPHERS_AVAILABLE):              return tls::ERROR_NO_CIPHER_SUITES;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED):                 return tls::ERROR_DECRYPTION_FAILED;
+    case ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC): return tls::ERROR_MAC_VERIFY_FAILED;
+    default:                                                                return static_cast<int>(error);
+    }
+}
+
 std::error_code make_error_code(openssl_errc e) {
-    return std::error_code(static_cast<int>(e), openssl_error_cat());
+    return std::error_code(translate_error(static_cast<unsigned long>(e)), tls::error_category());
 }
 
 std::vector<openssl_errc> get_all_openssl_errors() {
@@ -151,7 +178,7 @@ std::system_error make_openssl_error(const std::string & msg, std::vector<openss
     if (error_codes.empty()) {
         return std::system_error{
             static_cast<int>(ERR_PACK(ERR_LIB_USER, 0, ERR_R_OPERATION_FAIL)),
-            openssl_error_cat(),
+            tls::error_category(),
             msg};
     }
     auto err_code = static_cast<unsigned long>(error_codes.front());
@@ -164,8 +191,8 @@ std::system_error make_openssl_error(const std::string & msg, std::vector<openss
             fmt::format("{}: {}", msg, error_codes));
     }
     return std::system_error(
-        static_cast<int>(err_code),
-        openssl_error_cat(),
+        translate_error(err_code),
+        tls::error_category(),
         fmt::format("{}: {}", msg, error_codes));
 }
 
@@ -2416,6 +2443,9 @@ shared_ptr<tls::session_impl> tls::openssl::make_session(
     return seastar::make_shared<tls::openssl_session>(type, std::move(creds), std::move(sock), options);
 }
 
+// Note: this is not the category errors are reported in (that is the
+// backend-neutral tls::error_category()); it only formats messages for raw
+// OpenSSL error values that have no backend-neutral translation.
 const std::error_category& tls::openssl::error_category() {
     return openssl_error_cat();
 }
@@ -2436,27 +2466,6 @@ std::unique_ptr<tls::dh_params_impl> tls::openssl::make_dh_params(tls::dh_params
 
 std::unique_ptr<tls::dh_params_impl> tls::openssl::make_dh_params(const tls::blob& b, tls::x509_crt_format fmt) {
     return std::make_unique<openssl_provider_dh_params_impl>(b, fmt);
-}
-
-void tls::openssl::init_error_codes() {
-    tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
-    tls::ERROR_UNKNOWN_CIPHER_TYPE = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNKNOWN_CIPHER_TYPE);
-    tls::ERROR_INVALID_SESSION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SESSION_ID);
-    tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_RECORD);
-    tls::ERROR_UNKNOWN_CIPHER_SUITE = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_PROTOCOL);
-    tls::ERROR_UNKNOWN_ALGORITHM = ERR_PACK(ERR_LIB_RSA, 0, RSA_R_UNKNOWN_ALGORITHM_TYPE);
-    tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM);
-    tls::ERROR_SAFE_RENEGOTIATION_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_RENEGOTIATION_MISMATCH);
-    tls::ERROR_UNSAFE_RENEGOTIATION_DENIED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED);
-    tls::ERROR_UNKNOWN_SRP_USERNAME = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_SRP_USERNAME);
-    tls::ERROR_PREMATURE_TERMINATION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_EOF_WHILE_READING);
-    tls::ERROR_PUSH = int(ERR_SYSTEM_FLAG | EPIPE);
-    tls::ERROR_PULL = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_READ_BIO_NOT_SET);
-    tls::ERROR_UNEXPECTED_PACKET = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNEXPECTED_MESSAGE);
-    tls::ERROR_UNSUPPORTED_VERSION = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_UNSUPPORTED_SSL_VERSION);
-    tls::ERROR_NO_CIPHER_SUITES = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_CIPHERS_AVAILABLE);
-    tls::ERROR_DECRYPTION_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED);
-    tls::ERROR_MAC_VERIFY_FAILED = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
 }
 
 } // namespace seastar

--- a/src/net/tls_openssl.hh
+++ b/src/net/tls_openssl.hh
@@ -50,6 +50,10 @@ shared_ptr<session_impl> make_session(
     const tls_options& options);
 
 /// Return the OpenSSL error category.
+///
+/// This is not the category TLS errors are reported in (that is the
+/// backend-neutral tls::error_category()); it only formats messages for raw
+/// OpenSSL error values that have no backend-neutral translation.
 const std::error_category& error_category();
 
 /// Generate a session ticket key using OpenSSL.
@@ -63,8 +67,5 @@ std::unique_ptr<dh_params_impl> make_dh_params(dh_params::level);
 
 /// Create OpenSSL DH parameters from raw data.
 std::unique_ptr<dh_params_impl> make_dh_params(const blob&, x509_crt_format);
-
-/// Initialize TLS error codes with OpenSSL values.
-void init_error_codes();
 
 } // namespace seastar::tls::openssl

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -20,6 +20,7 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
+#include <algorithm>
 #include <ranges>
 #include <iostream>
 
@@ -743,6 +744,220 @@ static future<> run_echo_test(sstring message,
             return server->stop().finally([server]{});
         });
     });
+}
+
+static const std::vector<int>& all_exported_tls_errors() {
+    static const std::vector<int> errors = {
+        tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM,
+        tls::ERROR_UNKNOWN_CIPHER_TYPE,
+        tls::ERROR_INVALID_SESSION,
+        tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET,
+        tls::ERROR_UNKNOWN_CIPHER_SUITE,
+        tls::ERROR_UNKNOWN_ALGORITHM,
+        tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM,
+        tls::ERROR_SAFE_RENEGOTIATION_FAILED,
+        tls::ERROR_UNSAFE_RENEGOTIATION_DENIED,
+        tls::ERROR_UNKNOWN_SRP_USERNAME,
+        tls::ERROR_PREMATURE_TERMINATION,
+        tls::ERROR_PUSH,
+        tls::ERROR_PULL,
+        tls::ERROR_UNEXPECTED_PACKET,
+        tls::ERROR_UNSUPPORTED_VERSION,
+        tls::ERROR_NO_CIPHER_SUITES,
+        tls::ERROR_DECRYPTION_FAILED,
+        tls::ERROR_MAC_VERIFY_FAILED,
+    };
+    return errors;
+}
+
+static bool is_exported_tls_error(int value) {
+    const auto& errors = all_exported_tls_errors();
+    return std::find(errors.begin(), errors.end(), value) != errors.end();
+}
+
+// The ERROR_* constants are constant-initialized, so reading them from any
+// dynamic initializer, before the reactor exists, must observe the final
+// values. This initializer runs before main().
+static const int error_push_seen_at_static_init = tls::ERROR_PUSH;
+
+SEASTAR_THREAD_TEST_CASE(test_backend_neutral_error_constants) {
+    // The exported ERROR_* constants are backend-neutral: fixed values,
+    // distinct from each other and from anything else that could appear in
+    // a value comparison against them (errnos are < 4096, GnuTLS errors are
+    // negative, untranslated OpenSSL errors have the library bits set at
+    // offset 23 or above).
+    std::unordered_set<int> values;
+    for (auto e : all_exported_tls_errors()) {
+        BOOST_REQUIRE_GT(e, 4096);      // above the errno range
+        BOOST_REQUIRE_LT(e, 1 << 23);   // below packed OpenSSL errors
+        values.insert(e);
+    }
+    BOOST_REQUIRE_EQUAL(values.size(), all_exported_tls_errors().size());
+
+    // valid from static initializers, in every build mode
+    BOOST_REQUIRE_EQUAL(error_push_seen_at_static_init, tls::ERROR_PUSH);
+
+    // the category is backend-neutral, a single instance, and describes the
+    // exported constants itself, with no backend involvement.
+    BOOST_REQUIRE(&tls::error_category() == &tls::error_category());
+    BOOST_REQUIRE_EQUAL(std::string_view(tls::error_category().name()), "tls");
+    for (auto e : all_exported_tls_errors()) {
+        BOOST_REQUIRE(!tls::error_category().message(e).empty());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_unmapped_error_passthrough) {
+    // Backend errors with no exported ERROR_* constant are reported in
+    // tls::error_category() with their raw, backend-specific value, and
+    // error_code::message() falls back to the backend's own description.
+    tls::credentials_builder b;
+    b.set_x509_key(tls::blob("garbage"), tls::blob("garbage"), tls::x509_crt_format::PEM);
+    try {
+        b.build_certificate_credentials();
+        BOOST_FAIL("expected an exception parsing garbage certificates");
+    } catch (const std::system_error& e) {
+        BOOST_REQUIRE(e.code().category() == tls::error_category());
+        // a certificate parse failure has no exported constant, so the raw
+        // backend value passes through
+        BOOST_REQUIRE_NE(e.code().value(), 0);
+        BOOST_REQUIRE(!is_exported_tls_error(e.code().value()));
+        // message() delegates to the active backend for raw values
+        BOOST_REQUIRE(!e.code().message().empty());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_premature_termination_error_code) {
+    // Abruptly closing the transport underneath a TLS session must fail the
+    // client. Under GnuTLS the error is a std::system_error carrying the
+    // backend-neutral ERROR_PREMATURE_TERMINATION in tls::error_category();
+    // OpenSSL reports an abrupt handshake EOF differently, so the exact
+    // error is only checked when GnuTLS is the active backend.
+    ::listen_options opts;
+    opts.reuse_address = true;
+    auto addr = ::make_ipv4_address({0x7f000001, 4714});
+    auto server = server_socket(seastar::listen(addr, opts));
+
+    tls::credentials_builder b;
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    auto creds = b.build_certificate_credentials();
+
+    auto sf = server.accept();
+    auto cs = tls::connect(creds, addr, tls::tls_options{.server_name = "test.scylladb.org"}).get();
+    streams strms(std::move(cs));
+    // kick off the handshake; the write cannot complete before it does.
+    auto wf = strms.out.write(message).then([&] { return strms.out.flush(); });
+
+    // raw (non-TLS) server side: wait for the client hello, then shut the
+    // connection down without any TLS response. The client is now blocked
+    // reading the server hello and sees a bare transport EOF instead.
+    auto ar = sf.get();
+    auto in = ar.connection.input();
+    in.read().get();
+    ar.connection.shutdown_output();
+
+    bool write_failed = false;
+    try {
+        wf.get();
+    } catch (const std::system_error& e) {
+        write_failed = true;
+        if (using_gnutls()) {
+            BOOST_REQUIRE(e.code().category() == tls::error_category());
+            BOOST_REQUIRE_EQUAL(e.code().value(), tls::ERROR_PREMATURE_TERMINATION);
+        }
+    } catch (...) {
+        // other exception types are acceptable for other backends
+        write_failed = true;
+        BOOST_REQUIRE(!using_gnutls());
+    }
+    BOOST_REQUIRE(write_failed);
+
+    in.close().handle_exception([](std::exception_ptr) {}).get();
+    strms.out.close().handle_exception([](std::exception_ptr) {}).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_corrupt_record_error_code) {
+    // A corrupted TLS record must fail record verification on the receiving
+    // side, reported in tls::error_category(). Under GnuTLS the code is one
+    // of the backend-neutral decryption/MAC constants; other backends are
+    // only required to fail.
+    tls::credentials_builder b;
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    // server socket whose receive path can corrupt one incoming buffer
+    class corrupting_socket_impl : public loopback_connected_socket_impl {
+    public:
+        bool _corrupt = false;
+
+        using loopback_connected_socket_impl::loopback_connected_socket_impl;
+
+        class corrupting_source_impl : public data_source_impl {
+            data_source _src;
+            corrupting_socket_impl& _impl;
+        public:
+            corrupting_source_impl(data_source src, corrupting_socket_impl& impl)
+                : _src(std::move(src)), _impl(impl)
+            {}
+            future<temporary_buffer<char>> get() override {
+                return _src.get().then([this](temporary_buffer<char> buf) {
+                    if (std::exchange(_impl._corrupt, false) && !buf.empty()) {
+                        buf.get_write()[buf.size() - 1] ^= 0x01;
+                    }
+                    return buf;
+                });
+            }
+            future<> close() override {
+                return _src.close();
+            }
+        };
+        data_source source() override {
+            return data_source(std::make_unique<corrupting_source_impl>(loopback_connected_socket_impl::source(), *this));
+        }
+    };
+
+    auto b1 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::SERVER_TX);
+    auto b2 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::CLIENT_TX);
+    auto ssi = std::make_unique<corrupting_socket_impl>(b1, b2);
+    auto csi = std::make_unique<loopback_connected_socket_impl>(b2, b1);
+    auto& ssir = *ssi;
+
+    auto ss = tls::wrap_server(serv, connected_socket(std::move(ssi))).get();
+    auto cs = tls::wrap_client(creds, connected_socket(std::move(csi))).get();
+
+    auto os = cs.output().detach();
+    auto is = ss.input();
+
+    // one round trip completes the handshake cleanly
+    auto f1 = os.put(temporary_buffer<char>(10));
+    auto f2 = is.read();
+    f1.get();
+    f2.get();
+
+    // corrupt the next record the server receives
+    ssir._corrupt = true;
+    os.put(temporary_buffer<char>(10)).get();
+
+    bool failed = false;
+    try {
+        is.read().get();
+    } catch (const std::system_error& e) {
+        failed = true;
+        if (using_gnutls()) {
+            BOOST_REQUIRE(e.code().category() == tls::error_category());
+            BOOST_REQUIRE(e.code().value() == tls::ERROR_DECRYPTION_FAILED
+                          || e.code().value() == tls::ERROR_MAC_VERIFY_FAILED);
+        }
+    } catch (...) {
+        failed = true;
+        BOOST_REQUIRE(!using_gnutls());
+    }
+    BOOST_REQUIRE(failed);
+
+    os.close().handle_exception([](std::exception_ptr) {}).get();
+    is.close().handle_exception([](std::exception_ptr) {}).get();
 }
 
 /*

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -20,6 +20,7 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
+#include <algorithm>
 #include <ranges>
 #include <iostream>
 
@@ -707,6 +708,220 @@ static future<> run_echo_test(sstring message,
             return server->stop().finally([server]{});
         });
     });
+}
+
+static const std::vector<int>& all_exported_tls_errors() {
+    static const std::vector<int> errors = {
+        tls::ERROR_UNKNOWN_COMPRESSION_ALGORITHM,
+        tls::ERROR_UNKNOWN_CIPHER_TYPE,
+        tls::ERROR_INVALID_SESSION,
+        tls::ERROR_UNEXPECTED_HANDSHAKE_PACKET,
+        tls::ERROR_UNKNOWN_CIPHER_SUITE,
+        tls::ERROR_UNKNOWN_ALGORITHM,
+        tls::ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM,
+        tls::ERROR_SAFE_RENEGOTIATION_FAILED,
+        tls::ERROR_UNSAFE_RENEGOTIATION_DENIED,
+        tls::ERROR_UNKNOWN_SRP_USERNAME,
+        tls::ERROR_PREMATURE_TERMINATION,
+        tls::ERROR_PUSH,
+        tls::ERROR_PULL,
+        tls::ERROR_UNEXPECTED_PACKET,
+        tls::ERROR_UNSUPPORTED_VERSION,
+        tls::ERROR_NO_CIPHER_SUITES,
+        tls::ERROR_DECRYPTION_FAILED,
+        tls::ERROR_MAC_VERIFY_FAILED,
+    };
+    return errors;
+}
+
+static bool is_exported_tls_error(int value) {
+    const auto& errors = all_exported_tls_errors();
+    return std::find(errors.begin(), errors.end(), value) != errors.end();
+}
+
+// The ERROR_* constants are constant-initialized, so reading them from any
+// dynamic initializer, before the reactor exists, must observe the final
+// values. This initializer runs before main().
+static const int error_push_seen_at_static_init = tls::ERROR_PUSH;
+
+SEASTAR_THREAD_TEST_CASE(test_backend_neutral_error_constants) {
+    // The exported ERROR_* constants are backend-neutral: fixed values,
+    // distinct from each other and from anything else that could appear in
+    // a value comparison against them (errnos are < 4096, GnuTLS errors are
+    // negative, untranslated OpenSSL errors have the library bits set at
+    // offset 23 or above).
+    std::unordered_set<int> values;
+    for (auto e : all_exported_tls_errors()) {
+        BOOST_REQUIRE_GT(e, 4096);      // above the errno range
+        BOOST_REQUIRE_LT(e, 1 << 23);   // below packed OpenSSL errors
+        values.insert(e);
+    }
+    BOOST_REQUIRE_EQUAL(values.size(), all_exported_tls_errors().size());
+
+    // valid from static initializers, in every build mode
+    BOOST_REQUIRE_EQUAL(error_push_seen_at_static_init, tls::ERROR_PUSH);
+
+    // the category is backend-neutral, a single instance, and describes the
+    // exported constants itself, with no backend involvement.
+    BOOST_REQUIRE(&tls::error_category() == &tls::error_category());
+    BOOST_REQUIRE_EQUAL(std::string_view(tls::error_category().name()), "tls");
+    for (auto e : all_exported_tls_errors()) {
+        BOOST_REQUIRE(!tls::error_category().message(e).empty());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_unmapped_error_passthrough) {
+    // Backend errors with no exported ERROR_* constant are reported in
+    // tls::error_category() with their raw, backend-specific value, and
+    // error_code::message() falls back to the backend's own description.
+    tls::credentials_builder b;
+    b.set_x509_key(tls::blob("garbage"), tls::blob("garbage"), tls::x509_crt_format::PEM);
+    try {
+        b.build_certificate_credentials();
+        BOOST_FAIL("expected an exception parsing garbage certificates");
+    } catch (const std::system_error& e) {
+        BOOST_REQUIRE(e.code().category() == tls::error_category());
+        // a certificate parse failure has no exported constant, so the raw
+        // backend value passes through
+        BOOST_REQUIRE_NE(e.code().value(), 0);
+        BOOST_REQUIRE(!is_exported_tls_error(e.code().value()));
+        // message() delegates to the active backend for raw values
+        BOOST_REQUIRE(!e.code().message().empty());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_premature_termination_error_code) {
+    // Abruptly closing the transport underneath a TLS session must fail the
+    // client. Under GnuTLS the error is a std::system_error carrying the
+    // backend-neutral ERROR_PREMATURE_TERMINATION in tls::error_category();
+    // OpenSSL reports an abrupt handshake EOF differently, so the exact
+    // error is only checked when GnuTLS is the active backend.
+    ::listen_options opts;
+    opts.reuse_address = true;
+    auto addr = ::make_ipv4_address({0x7f000001, 4714});
+    auto server = server_socket(seastar::listen(addr, opts));
+
+    tls::credentials_builder b;
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    auto creds = b.build_certificate_credentials();
+
+    auto sf = server.accept();
+    auto cs = tls::connect(creds, addr, tls::tls_options{.server_name = "test.scylladb.org"}).get();
+    streams strms(std::move(cs));
+    // kick off the handshake; the write cannot complete before it does.
+    auto wf = strms.out.write(message).then([&] { return strms.out.flush(); });
+
+    // raw (non-TLS) server side: wait for the client hello, then shut the
+    // connection down without any TLS response. The client is now blocked
+    // reading the server hello and sees a bare transport EOF instead.
+    auto ar = sf.get();
+    auto in = ar.connection.input();
+    in.read().get();
+    ar.connection.shutdown_output();
+
+    bool write_failed = false;
+    try {
+        wf.get();
+    } catch (const std::system_error& e) {
+        write_failed = true;
+        if (using_gnutls()) {
+            BOOST_REQUIRE(e.code().category() == tls::error_category());
+            BOOST_REQUIRE_EQUAL(e.code().value(), tls::ERROR_PREMATURE_TERMINATION);
+        }
+    } catch (...) {
+        // other exception types are acceptable for other backends
+        write_failed = true;
+        BOOST_REQUIRE(!using_gnutls());
+    }
+    BOOST_REQUIRE(write_failed);
+
+    in.close().handle_exception([](std::exception_ptr) {}).get();
+    strms.out.close().handle_exception([](std::exception_ptr) {}).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_corrupt_record_error_code) {
+    // A corrupted TLS record must fail record verification on the receiving
+    // side, reported in tls::error_category(). Under GnuTLS the code is one
+    // of the backend-neutral decryption/MAC constants; other backends are
+    // only required to fail.
+    tls::credentials_builder b;
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    // server socket whose receive path can corrupt one incoming buffer
+    class corrupting_socket_impl : public loopback_connected_socket_impl {
+    public:
+        bool _corrupt = false;
+
+        using loopback_connected_socket_impl::loopback_connected_socket_impl;
+
+        class corrupting_source_impl : public data_source_impl {
+            data_source _src;
+            corrupting_socket_impl& _impl;
+        public:
+            corrupting_source_impl(data_source src, corrupting_socket_impl& impl)
+                : _src(std::move(src)), _impl(impl)
+            {}
+            future<temporary_buffer<char>> get() override {
+                return _src.get().then([this](temporary_buffer<char> buf) {
+                    if (std::exchange(_impl._corrupt, false) && !buf.empty()) {
+                        buf.get_write()[buf.size() - 1] ^= 0x01;
+                    }
+                    return buf;
+                });
+            }
+            future<> close() override {
+                return _src.close();
+            }
+        };
+        data_source source() override {
+            return data_source(std::make_unique<corrupting_source_impl>(loopback_connected_socket_impl::source(), *this));
+        }
+    };
+
+    auto b1 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::SERVER_TX);
+    auto b2 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::CLIENT_TX);
+    auto ssi = std::make_unique<corrupting_socket_impl>(b1, b2);
+    auto csi = std::make_unique<loopback_connected_socket_impl>(b2, b1);
+    auto& ssir = *ssi;
+
+    auto ss = tls::wrap_server(serv, connected_socket(std::move(ssi))).get();
+    auto cs = tls::wrap_client(creds, connected_socket(std::move(csi))).get();
+
+    auto os = cs.output().detach();
+    auto is = ss.input();
+
+    // one round trip completes the handshake cleanly
+    auto f1 = os.put(temporary_buffer<char>(10));
+    auto f2 = is.read();
+    f1.get();
+    f2.get();
+
+    // corrupt the next record the server receives
+    ssir._corrupt = true;
+    os.put(temporary_buffer<char>(10)).get();
+
+    bool failed = false;
+    try {
+        is.read().get();
+    } catch (const std::system_error& e) {
+        failed = true;
+        if (using_gnutls()) {
+            BOOST_REQUIRE(e.code().category() == tls::error_category());
+            BOOST_REQUIRE(e.code().value() == tls::ERROR_DECRYPTION_FAILED
+                          || e.code().value() == tls::ERROR_MAC_VERIFY_FAILED);
+        }
+    } catch (...) {
+        failed = true;
+        BOOST_REQUIRE(!using_gnutls());
+    }
+    BOOST_REQUIRE(failed);
+
+    os.close().handle_exception([](std::exception_ptr) {}).get();
+    is.close().handle_exception([](std::exception_ptr) {}).get();
 }
 
 /*


### PR DESCRIPTION
The exported `tls::ERROR_*` globals hold raw backend error values (GnuTLS `E_` codes or OpenSSL `ERR_PACK()`ed codes, depending on the crypto provider selected at startup). They are zero-initialized and only filled in by the active backend's `init_error_codes()` at reactor startup, so any read before that (static initializers, unit tests that never start a reactor) silently yields 0, and their values differ between backends.

Instead, give each exported constant a fixed, backend-neutral value and translate backend errors to these values at the point the error is created:

- The values start at 0x10001, chosen to be distinguishable from anything else that can appear in a value comparison against them: above the errno range, positive (raw GnuTLS errors are negative) and below 2^23 (where untranslated OpenSSL `ERR_PACK()` values start).
- `tls::error_category()` becomes a single backend-neutral category ("tls"), statically initialized and valid at any time. Its `message()` describes the exported constants itself and delegates to the active backend for raw values.
- Backend errors with no exported constant keep their backend-specific value in the same category, so nothing loses fidelity.
- The `init_error_codes()` machinery is removed entirely.

This is an ABI break (the constants change value) but arguably not an API break: code comparing TLS error codes against the exported constants keeps working and now behaves identically under either backend, per the discussion with @avikivity in https://github.com/scylladb/seastar/pull/3400#discussion_r3294418704.

This also fixes #3562 by construction (all errors now carry the one neutral category instance); the minimal standalone fix proposed as #3563 is subsumed by this change.

Also makes the http retry_strategy check the error category before comparing against `ERROR_PREMATURE_TERMINATION`; with the chosen value range this is hardening rather than a bug fix.

Tests cover the constants (range, uniqueness, validity from static initializers, category identity and messages), end-to-end translation of mapped errors (premature termination on abrupt transport EOF; decryption/MAC failure on a corrupted record), raw pass-through of unmapped errors and the `message()` delegation for them. Full `tls_test` suite validated locally under the GnuTLS provider.

Independent of #3400 (either can merge first; the other takes a small rebase).

Fixes #3562
