### PR TITLE
github: enable heap profiling on the dev job, fix alloc_test under it

### DIFF
--- a/.github/workflows/gen-matrix.py
+++ b/.github/workflows/gen-matrix.py
@@ -95,11 +95,16 @@ MATRIX_PATH = ("jobs", "regular_test", "strategy", "matrix")
 # Items only set enable-ccache when overriding the default (test.yaml treats
 # absent/empty as enabled).
 SPECIAL_ITEMS: list[dict[str, Any]] = [
+    # The dev job doubles as our heap profiling coverage: nothing else in
+    # the matrix defines SEASTAR_HEAPPROF, so the sampled-memory-profile
+    # code and the tests guarded by it are otherwise never compiled.
     {
         "compiler": "clang++-22",
         "standard": 23,
         "arch": "x86",
         "mode": "dev",
+        "options": "--heap-profiling",
+        "info": "heapprof, ",
     },
     {
         "compiler": "clang++-22",

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
           - {compiler: clang++-22, standard: 23, mode: sanitize, arch: arm}
           - {compiler: clang++-21, standard: 26, mode: sanitize, arch: x86}
           - {compiler: clang++-21, standard: 26, mode: debug, arch: arm}
-          - {compiler: clang++-22, standard: 23, arch: x86, mode: dev}
+          - {compiler: clang++-22, standard: 23, arch: x86, mode: dev, options: --heap-profiling, info: 'heapprof, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: release, enables: --enable-dpdk, options: --cook dpdk --dpdk-machine corei7-avx, info: 'dpdk, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: debug, enables: --enable-cxx-modules, enable-ccache: false, info: 'modules, '}
           - {compiler: clang++-22, standard: 23, arch: x86, mode: fuzz, test-args: -- -R 'Seastar.fuzz.'}

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -505,20 +505,20 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         auto stats1 = seastar::memory::sampled_memory_profile();
 
         // two back-to-back copies of the sample should have the same value
-        BOOST_CHECK_EQUAL(stats0, stats1);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats1.begin(), stats1.end());
 
         // check that we get the same value from the raw array iterface
         std::vector<seastar::memory::allocation_site> stats2(stats0.size());
         auto sz2 = seastar::memory::sampled_memory_profile(stats2.data(), stats2.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz2);
-        BOOST_CHECK_EQUAL(stats0, stats2);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats2.begin(), stats2.end());
 
         // check with +1 size, we expect to still only get size elements
         std::vector<seastar::memory::allocation_site> stats3(stats0.size() + 1);
         auto sz3 = seastar::memory::sampled_memory_profile(stats3.data(), stats3.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz3);
         stats3.resize(sz3);
-        BOOST_CHECK_EQUAL(stats0, stats3);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats3.begin(), stats3.end());
 
         return stats0;
     };

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -513,20 +513,20 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         auto stats1 = seastar::memory::sampled_memory_profile();
 
         // two back-to-back copies of the sample should have the same value
-        BOOST_CHECK_EQUAL(stats0, stats1);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats1.begin(), stats1.end());
 
         // check that we get the same value from the raw array iterface
         std::vector<seastar::memory::allocation_site> stats2(stats0.size());
         auto sz2 = seastar::memory::sampled_memory_profile(stats2.data(), stats2.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz2);
-        BOOST_CHECK_EQUAL(stats0, stats2);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats2.begin(), stats2.end());
 
         // check with +1 size, we expect to still only get size elements
         std::vector<seastar::memory::allocation_site> stats3(stats0.size() + 1);
         auto sz3 = seastar::memory::sampled_memory_profile(stats3.data(), stats3.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz3);
         stats3.resize(sz3);
-        BOOST_CHECK_EQUAL(stats0, stats3);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats3.begin(), stats3.end());
 
         return stats0;
     };


### PR DESCRIPTION
Nothing in the test matrix sets `Seastar_HEAP_PROFILING`, so the sampled memory profile code and every test behind `SEASTAR_HEAPPROF` are never compiled. Add `--heap-profiling` to the existing one-off `dev` job instead of a new matrix row, so this costs no extra CI time. The pairwise rows are untouched.

That immediately caught a latent breakage, fixed in the second commit: `alloc_test` compared `std::vector<allocation_site>` with `BOOST_CHECK_EQUAL`, which needs an `operator<<` for the vector. The only thing that ever supplied one is the generic printer in `sstring.hh`, behind `SEASTAR_DEPRECATED_OSTREAM_FORMATTERS` (default off since after those assertions were written in 06c1941). `BOOST_CHECK_EQUAL_COLLECTIONS` needs only the per-element `operator<<` the test already defines.

The failure was reproduced by this PR's own CI before the fix; `alloc_test` now builds and passes in a `--heap-profiling` dev build.