### PR TITLE
dns: move-construct optional input stream

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -1259,7 +1259,7 @@ dns_resolver::impl::do_recvfrom(ares_socket_t fd, void * dst, size_t len, int fl
                     return -1;
                 }
                 if (!tcp.in) {
-                    tcp.in = tcp.socket.input();
+                    tcp.in.emplace(tcp.socket.input());
                 }
                 auto f = tcp.in->read_up_to(len);
                 if (!f.available()) {


### PR DESCRIPTION
Split out of #3559 (one deprecation fix per PR).

Uses `emplace()` to move-construct the optional `input_stream` instead of the deprecated `input_stream` move-assignment, silencing that deprecation warning.

Commit is `dabe12f3a` from #3559, cherry-picked verbatim onto master.