### PR TITLE
tests/io_queue: measure fair shares over a longer window

### DIFF
--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -766,7 +766,14 @@ SEASTAR_THREAD_TEST_CASE(test_gauge_integrator_test) {
 // the configured bandwidth+burst limit by up to one threshold unit.
 static constexpr size_t bw_slack = 128*1024;
 
-static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, internal::priority_class pc, size_t bandwidth_goal, unsigned parallelizm = 1, size_t req_size = 128*1024) {
+// The value returned is a cumulative average since the start of the run, so the
+// initial burst is folded into it: over a one second window the burst accounts
+// for ~9% of the bytes seen, and it shrinks as 1/window from there. A caller
+// that compares two of these against each other wants a window long enough that
+// the burst no longer dominates the comparison; min_window puts a floor on the
+// measured interval for those. The default preserves the historical behaviour of
+// returning on the first sample that meets the goal.
+static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, internal::priority_class pc, size_t bandwidth_goal, unsigned parallelizm = 1, std::chrono::seconds min_window = std::chrono::seconds(1), size_t req_size = 128*1024) {
     fmt::print("Run {} workload\n", pc.id());
     bool keep_going = true;
     uint64_t nr_requests = 0;
@@ -793,7 +800,7 @@ static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, internal:
         auto now = std::chrono::steady_clock::now();
         real_bandwidth = (nr_requests * req_size) / std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
         fmt::print("Measured for {} {} MB/s, goal {} MB/s\n", pc.id(), real_bandwidth >> 20, bandwidth_goal >> 20);
-        if (real_bandwidth >= bandwidth_goal || now >= stop) {
+        if ((real_bandwidth >= bandwidth_goal && now >= start + min_window) || now >= stop) {
             break;
         }
     }
@@ -967,8 +974,14 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
 
     background_drain drain(tio);
 
-    auto f0 = run_and_check_bandwidth(tio, pc0, bandwidth * 0.8 * 0.95, 4);
-    auto f1 = run_and_check_bandwidth(tio, pc1, bandwidth * 0.2 * 0.95, 4);
+    // Unlike the tests above, this one compares the two bandwidths against each
+    // other, within 1.25%. A one second window cannot support that: the burst is
+    // then ~9% of what is measured, so a couple of requests' worth of variation
+    // in how it lands between the two classes moves the ratio further than the
+    // check allows. Four seconds dilutes the burst term, and the quantisation of
+    // the measurement itself, by 4x.
+    auto f0 = run_and_check_bandwidth(tio, pc0, bandwidth * 0.8 * 0.95, 4, std::chrono::seconds(4));
+    auto f1 = run_and_check_bandwidth(tio, pc1, bandwidth * 0.2 * 0.95, 4, std::chrono::seconds(4));
     auto bw0 = f0.get();
     auto bw1 = f1.get();
 


### PR DESCRIPTION
`test_2_class_group_bandwidth_throttler_fair_shares` compares two bandwidths against each other
within 1.25%, but `run_and_check_bandwidth()` returns on the first sample that meets the goal, and
that is always the sample at t=1s. The value is a cumulative average since the start of the run, so
it folds in the initial burst, which at one second is ~9% of the bytes measured.

Per-second request counts over increasing windows, idle machine:

| window | pc0 | pc1 |
| --- | --- | --- |
| 1s | 704 | 176 |
| 2s | 672 | 168 |
| 4s | 656 | 164 |
| 8s | 648 | 162 |

Steady state is 640 and 160 requests/s (80 and 20 MiB/s); the burst contributes 64 and 16 requests,
i.e. 8 and 2 MiB, an exact 4:1 split. Both the burst term and the quantisation of the measurement
fall off as 1/window, and the observed spread of the ratio follows: 0.0057 at one second, 0.0008 at
eight.

At one second the entire comparison rests on two integer counts of 704 and 176, where one request of
difference in the smaller one moves the ratio by 22% of the interval being checked. The CI failure
value 3.93820214 is exactly `701/178`, against `703/176` and `704/176` locally - two requests either
way is the whole margin.

So: measure for at least 4s in this test, diluting both error terms by 4x. Other callers of
`run_and_check_bandwidth` keep the previous behaviour, so only this test gets slower - full
`io_queue_test` goes from 15.3s to 18.3s. 2s would have been enough for the observed failures (1.6x
margin); 4s is the smallest value with a comfortable one.

Supersedes the earlier version of this PR, which just disabled the test. Refs #3569.

### One thing worth flagging separately

This makes the test robust to the burst term, but not to reactor starvation, and starvation produces
a much larger effect that a longer window will not fix. Pinning the test to cores 0-1 and running
spinners on those same cores:

| load on the reactor's cores | result |
| --- | --- |
| 1 spinner/core | 25/25 pass, pc1 count still 176 |
| 2 spinners/core | 24/24 fail, ratios 2.96-3.05, pc1 count 217-222 |
| 3 spinners/core | 25/25 fail, ratios 2.02-2.58, pc1 count 272-333 |
| 5 spinners/core | 25/25 fail, ratios 2.48-3.16, pc1 count 211-252 |

The signature is consistent: pc0's count stays roughly flat while **pc1's grows**, so under
starvation the low-share class takes progressively more than its share. That is the shape I would
expect from the anti-starvation credit in `fair_queue::priority_class_group_data::push_from_idle()`:

```c++
pc._accumulated = std::max<signed_capacity_t>(_last_accumulated - cfg.forgiving_factor / pc._shares, pc._accumulated);
```

The backdate is `forgiving_factor / shares`, so the 100-share class gets a 4x larger credit than the
400-share class on every idle->queued transition, and a starved reactor means many more such
transitions. I have not chased this further and it may well be intended, but if it is not, it would
be a throttler issue rather than a test one. Happy to open a separate issue if that is useful.
