### PR TITLE
build: drop the fmt-12-1-dev cooking ingredient

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -315,20 +315,6 @@ cooking_ingredient (fmt
     -DFMT_DOC=OFF
     -DFMT_TEST=OFF)
 
-# Post-12.1.0 master snapshot, picked for fmt PR #4761 which fixes the
-# fmt/std.h vs fmt/ranges.h optional ambiguity that surfaces when
-# libstdc++-16 makes std::optional model std::ranges::range (C++26
-# P3168R2). Use via `--cook fmt-12-1-dev` instead of `--cook fmt`.
-# Drop once a tagged fmt release carries the fix.
-# Tracked at https://github.com/scylladb/seastar/issues/3411
-cooking_ingredient (fmt-12-1-dev
-  EXTERNAL_PROJECT_ARGS
-    URL https://github.com/fmtlib/fmt/archive/9cb8c0f92b4c345fb974a75d71370c23047528aa.tar.gz
-    URL_MD5 d7b894c137f688cc9895f4b9bb1a1762
-  CMAKE_ARGS
-    -DFMT_DOC=OFF
-    -DFMT_TEST=OFF)
-
 cooking_ingredient (liburing
   EXTERNAL_PROJECT_ARGS
     URL https://github.com/axboe/liburing/archive/liburing-2.1.tar.gz


### PR DESCRIPTION
`fmt-12-1-dev` was added in ee4b9ebe7 as an opt-in ingredient pinned to a post-12.1.0 fmt master snapshot (`9cb8c0f92b4c`) so C++26 builds could pick up fmtlib/fmt#4761, the fix for the `fmt/std.h` vs `fmt/ranges.h` formatter ambiguity for `std::optional` (fmtlib/fmt#4760). At the time the default `fmt` ingredient was 11.2.0 and no tagged fmt release carried the fix.

Both conditions are now gone:

- d9cbd5a20 ("build: update supported C++ standards to C++23, C++26") bumped the default `fmt` ingredient to 12.2.0 precisely to get that fix, and 12.2.0 does contain `9cb8c0f92b4c`.
- Nothing in the tree passes `--cook fmt-12-1-dev` any more; the ingredient definition and its comment are the only remaining references.

The leftover comment is actively misleading, since it tells users to prefer `--cook fmt-12-1-dev` over `--cook fmt` - which now means an older, less-tested fmt than the default.

Fixes #3411