### PR TITLE
test: fix reversed buffer bound in add_exception_message()

### DIFF
--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -47,7 +47,7 @@ add_exception_message(const std::exception* ep, bool rec, char *out, char *end) 
         out = fmt::format_to_n(out, end - out, "{}{}: {}", pfx, seastar::pretty_type_name(typeid(*ep)), ep->what()).out;
     } else {
         auto tp = abi::__cxa_current_exception_type();
-        out = fmt::format_to_n(out, out - end, "{}{}", pfx, tp ? seastar::pretty_type_name(*tp) : "<unknown>").out;
+        out = fmt::format_to_n(out, end - out, "{}{}", pfx, tp ? seastar::pretty_type_name(*tp) : "<unknown>").out;
     }
 
     boost::execution_exception::location loc;

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -208,3 +208,38 @@ BOOST_AUTO_TEST_CASE(test_nested_throw_return_exception_future) {
     exception_message_check_helper(test_nested_exception_future_helper_instance);
 }
 
+// An object not derived from std::exception, so that reporting it has to go
+// through abi::__cxa_current_exception_type() rather than what().
+struct not_an_exception {};
+
+static bool do_throw_unknown = false;
+
+// Dummy test that on its own does nothing.
+SEASTAR_TEST_CASE(test_unknown_throw_helper) {
+    if (std::exchange(do_throw_unknown, false)) {
+        throw not_an_exception{};
+    }
+    return make_ready_future<>();
+}
+
+// Cannot be a SEASTAR_TEST_CASE, because of recursion of seastar::test::run.
+BOOST_AUTO_TEST_CASE(test_unknown_throw) {
+    do_throw_unknown = true;
+    auto def = defer([]() noexcept {
+        do_throw_unknown = false;
+    });
+
+    bool caught = false;
+    try {
+        using helper_type = std::remove_cvref_t<decltype(test_unknown_throw_helper_instance)>;
+        const_cast<helper_type&>(test_unknown_throw_helper_instance).run();
+    } catch (boost::execution_exception& e) {
+        caught = true;
+        // Should get a cpp exception failure
+        BOOST_REQUIRE_EQUAL(e.code(), boost::execution_exception::error_code::cpp_exception_error);
+        // Should name the thrown type, since it has no what() to report
+        BOOST_REQUIRE(e.what().find("not_an_exception") != std::string::npos);
+    }
+    BOOST_REQUIRE(caught);
+}
+


### PR DESCRIPTION
`add_exception_message()` in `src/testing/seastar_test.cc` formats a failing test's exception chain into a fixed 4096 byte buffer, passing the space left to `fmt::format_to_n()` as `end - out`. The branch that reports exceptions not derived from `std::exception` passes `out - end` instead:

```c++
    if (ep) {
        out = fmt::format_to_n(out, end - out, "{}{}: {}", pfx, ...).out;
    } else {
        auto tp = abi::__cxa_current_exception_type();
        out = fmt::format_to_n(out, out - end, "{}{}", pfx, ...).out;   // <--
    }
```

`out <= end` always holds, so `out - end` is non-positive and converts to a huge `size_t`. The call is then effectively unbounded: it writes the whole formatted string regardless of the room left, and the iterator it returns can end up past `end`, which makes the following `*out = 0` write out of bounds as well. The comment there ("always valid") holds only while the bound is honoured.

### Reachability

The branch runs when the exception that failed the test does not derive from `std::exception` - either thrown directly (the `catch (...)` in `seastar_test::run()`) or as the innermost link of a nested chain (the `catch (...)` around `std::rethrow_if_nested`). It is terminal: the recursion at the end is guarded by `if (ep)`, so the bad `out` is never passed to another frame.

Overflowing therefore needs the preceding, correctly bounded, frames to have very nearly filled the buffer. With `end = buf + 4095`, if a chain of `std::exception` frames leaves, say, 5 bytes free, the terminal frame writes `"; Caused by "` plus the type name - 12 bytes plus the name - in full, running past the end of the static buffer and then NUL-terminating beyond it. Short chains have room to spare and stay inside the buffer, which is why this has not been seen in practice.

It is confined to `libseastar_testing`, so it cannot affect production builds; the failure mode is memory corruption while reporting a test failure.

### Test

The test added with the original code in 7039ebc17 nests `std::out_of_range` around `std::invalid_argument`, so both frames take the correctly bounded branch and the buggy one had no coverage at all. This adds a case that throws a type which is not a `std::exception` and checks the reported message names it.

To be explicit: the new test covers the branch, not the overflow. Provoking the overflow needs a message sized to leave an exact few bytes free, which would be a brittle thing to commit; I left it out deliberately.

Verified with `tests/unit/test_fixture_test` in a dev (ASan/UBSan) build - full binary passes.