### PR TITLE
treewide: wrap exception_ptr before formatting

### DIFF
--- a/apps/httpd/main.cc
+++ b/apps/httpd/main.cc
@@ -116,7 +116,7 @@ int main(int ac, char** av) {
                 prometheus_started = true;
 
                 prometheus_server.listen(socket_address{prom_addr, pport}).handle_exception([prom_addr, pport] (auto ep) {
-                    std::cerr << seastar::format("Could not start Prometheus API server on {}:{}: {}\n", prom_addr, pport, ep);
+                    std::cerr << seastar::format("Could not start Prometheus API server on {}:{}: {}\n", prom_addr, pport, seastar::formattable(ep));
                     return make_exception_future<>(ep);
                 }).get();
 

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -990,7 +990,7 @@ int main(int ac, char** av) {
                     try {
                         iotune_tests.stop().get();
                     } catch (...) {
-                        fmt::print("Error occurred during iotune context shutdown: {}", std::current_exception());
+                        fmt::print("Error occurred during iotune context shutdown: {}", seastar::formattable(std::current_exception()));
                         abort();
                     }
                 });
@@ -1108,7 +1108,7 @@ int main(int ac, char** av) {
                     write_configuration_file(configuration["options-file"].as<sstring>(), format, configuration["properties-file"].as<sstring>());
                 }
             } catch (...) {
-                iotune_logger.error("Exception when writing {}: {}.\nPlease add the above values manually to your seastar command line.", file, std::current_exception());
+                iotune_logger.error("Exception when writing {}: {}.\nPlease add the above values manually to your seastar command line.", file, seastar::formattable(std::current_exception()));
                 return 1;
             }
             return 0;

--- a/apps/rpc_tester/rpc_tester.cc
+++ b/apps/rpc_tester/rpc_tester.cc
@@ -444,7 +444,7 @@ public:
                 return call_echo(x).then([x] {
                         fmt::print("{}.{} got response\n", this_shard_id(), x);
                 }).handle_exception([x] (auto ex) {
-                        fmt::print("{}.{} got error {}\n", this_shard_id(), x, ex);
+                        fmt::print("{}.{} got error {}\n", this_shard_id(), x, seastar::formattable(ex));
                 });
             };
         } else {

--- a/demos/http_client_demo.cc
+++ b/demos/http_client_demo.cc
@@ -99,7 +99,7 @@ int main(int ac, char** av) {
 
             cln->close().get();
         }).handle_exception([](auto ep) {
-            fmt::print("Error: {}", ep);
+            fmt::print("Error: {}", seastar::formattable(ep));
         });
     });
 }

--- a/demos/tutorial_examples.cc
+++ b/demos/tutorial_examples.cc
@@ -99,7 +99,7 @@ seastar::future<> service_loop_3() {
                 // connection to be handled before accepting the next one.
                 (void)handle_connection_3(std::move(res.connection), std::move(res.remote_address)).handle_exception(
                         [] (std::exception_ptr ep) {
-                    fmt::print(stderr, "Could not handle connection: {}\n", ep);
+                    fmt::print(stderr, "Could not handle connection: {}\n", seastar::formattable(ep));
                 });
             });
         });

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -623,7 +623,7 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t 
             // details, including nested exceptions (seastar::nested_exception,
             // std::nested_exception) which would otherwise lose their inner context
             // if we only called what().
-            const auto msg = fmt::format("{}", std::current_exception());
+            const auto msg = fmt::format("{}", seastar::formattable(std::current_exception()));
             const uint32_t len = msg.size();
             data = snd_buf(response_frame_headroom + 2 * sizeof(uint32_t) + len);
             auto os = make_serializer_stream(data);
@@ -650,7 +650,7 @@ inline future<> reply(no_wait_type, future<no_wait_type>&& r, uint64_t verb, int
     try {
         r.get();
     } catch (...) {
-        client->get_logger()(client->info(), msgid, ::seastar::format("exception \"{}\" in no_wait handler of the verb {} ignored", formattable(std::current_exception()), verb));
+        client->get_logger()(client->info(), msgid, ::seastar::format("exception \"{}\" in no_wait handler of the verb {} ignored", seastar::formattable(std::current_exception()), verb));
     }
     return make_ready_future<>();
 }
@@ -690,7 +690,7 @@ auto recv_helper(uint64_t verb, signature<Ret (InArgs...)> sig, Func&& func, Wan
             // FIXME: future is discarded
             (void)try_with_gate(client->get_server().reply_gate(), [verb, client, timeout, msg_id, err = std::move(err)] {
                 return reply<Serializer>(wait_style(), futurize<Ret>::make_exception_future(std::runtime_error(err.c_str())), verb, msg_id, client, timeout, std::nullopt).handle_exception([verb, client, msg_id] (std::exception_ptr eptr) {
-                    client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing an oversized message: {} for verb {}", eptr, verb));
+                    client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing an oversized message: {} for verb {}", seastar::formattable(eptr), verb));
                 });
             }).handle_exception_type([] (gate_closed_exception&) {/* ignore */});
             return make_ready_future();
@@ -704,11 +704,11 @@ auto recv_helper(uint64_t verb, signature<Ret (InArgs...)> sig, Func&& func, Wan
                         auto start = rpc_clock_type::now();
                         return apply(func, client->info(), timeout, WantClientInfo(), WantTimePoint(), signature(), std::move(args)).then_wrapped([verb, client, timeout, msg_id, permit = std::move(permit), start] (futurize_t<Ret> ret) mutable {
                             return reply<Serializer>(wait_style(), std::move(ret), verb, msg_id, client, timeout, rpc_clock_type::now() - start).handle_exception([verb, permit = std::move(permit), client, msg_id] (std::exception_ptr eptr) {
-                                client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing a message: {}, verb {}", eptr, verb));
+                                client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing a message: {}, verb {}", seastar::formattable(eptr), verb));
                             });
                         });
                     } catch (...) {
-                        client->get_logger()(client->info(), msg_id, seastar::format("caught exception while processing a message: {}, verb {}", std::current_exception(), verb));
+                        client->get_logger()(client->info(), msg_id, seastar::format("caught exception while processing a message: {}, verb {}", seastar::formattable(std::current_exception()), verb));
                         return make_ready_future();
                     }
                 }).handle_exception_type([g = std::move(g)] (gate_closed_exception&) {/* ignore */});

--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -512,7 +512,7 @@ future<data_sink> make_file_data_sink(file f, file_output_stream_options options
                     std::rethrow_exception(std::move(ex));
                 } catch (...) {
                     std::throw_with_nested(std::runtime_error(fmt::format("While handling failed construction of data_sink, caught exception: {}",
-                                fut.get_exception())));
+                                seastar::formattable(fut.get_exception()))));
                 }
             }
             return make_exception_future<data_sink>(std::move(ex));
@@ -656,4 +656,3 @@ template struct internal::stream_copy_consumer<char>;
 template future<> copy<char>(input_stream<char>&, output_stream<char>&);
 
 }
-

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -203,7 +203,7 @@ namespace internal {
 
 void report_failed_future(const std::exception_ptr& eptr) noexcept {
     ++engine()._abandoned_failed_futures;
-    seastar_logger.warn("Exceptional future ignored: {}, backtrace: {}", eptr, current_backtrace());
+    seastar_logger.warn("Exceptional future ignored: {}, backtrace: {}", seastar::formattable(eptr), current_backtrace());
 }
 
 void report_failed_future(const future_state_base& state) noexcept {

--- a/src/core/on_internal_error.cc
+++ b/src/core/on_internal_error.cc
@@ -61,7 +61,7 @@ void seastar::on_internal_error(logger& logger, std::string_view msg) {
 }
 
 void seastar::on_internal_error(logger& logger, std::exception_ptr ex) {
-    log_error_and_backtrace(logger, ex);
+    log_error_and_backtrace(logger, seastar::formattable(ex));
     if (abort_on_internal_error.load()) {
         abort();
     } else {

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -884,7 +884,7 @@ void write_value_as_string(buf_t& s, const mi::metric_value& value) noexcept {
     } catch (...) {
         auto ex = std::current_exception();
         // print this error as it's ignored later on by `connection::start_response`
-        seastar_logger.error("prometheus: write_value_as_string: {}: {}", s.str(), ex);
+        seastar_logger.error("prometheus: write_value_as_string: {}: {}", s.str(), seastar::formattable(ex));
         std::rethrow_exception(std::move(ex));
     }
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -940,7 +940,7 @@ static decltype(auto) install_signal_handler_stack() {
             throw_system_error_on(r == -1);
         } catch (...) {
             mem.release(); // We failed to restore previous stack, must leak it.
-            seastar_logger.error("Failed to restore signal stack: {}", std::current_exception());
+            seastar_logger.error("Failed to restore signal stack: {}", seastar::formattable(std::current_exception()));
         }
     });
 }
@@ -1519,7 +1519,7 @@ std::unique_ptr<cpu_stall_detector> make_cpu_stall_detector(cpu_stall_detector_c
                     "try setting /proc/sys/kernel/perf_event_paranoid to 1 or less to "
                     "enable kernel backtraces: falling back to posix timer.");
         } else {
-            seastar_logger.warn("Creation of perf_event based stall detector failed: falling back to posix timer: {}", std::current_exception());
+            seastar_logger.warn("Creation of perf_event based stall detector failed: falling back to posix timer: {}", seastar::formattable(std::current_exception()));
         }
         return std::make_unique<cpu_stall_detector_posix_timer>(cfg);
     }
@@ -3233,12 +3233,12 @@ void reactor::run_in_background(future<> f) {
         // _backgroud_gate closed in reactor::close()
         (void)with_gate(_background_gate, [f = std::move(f)] () mutable {
             return f.handle_exception([] (std::exception_ptr ex) {
-                seastar_logger.warn("Ignored background task failure: {}", std::move(ex));
+                seastar_logger.warn("Ignored background task failure: {}", seastar::formattable(std::move(ex)));
             });
         });
     } catch (...) {
         // Swallow gate_closed_exception in particular
-        seastar_logger.error("run_in_background: {}", std::current_exception());
+        seastar_logger.error("run_in_background: {}", seastar::formattable(std::current_exception()));
     }
 }
 
@@ -4888,7 +4888,7 @@ bool smp::pure_poll_queues() {
 __thread reactor* local_engine;
 
 void report_exception(std::string_view message, std::exception_ptr eptr) noexcept {
-    seastar_logger.error("{}: {}", message, eptr);
+    seastar_logger.error("{}: {}", message, seastar::formattable(eptr));
 }
 
 future<> check_direct_io_support(std::string_view path) noexcept {
@@ -5526,7 +5526,7 @@ run_in_background(future<> f) {
 }
 
 void log_timer_callback_exception(std::exception_ptr ex) noexcept {
-    seastar_logger.error("Timer callback failed: {}", ex);
+    seastar_logger.error("Timer callback failed: {}", seastar::formattable(ex));
 }
 
 void set_current_task(task* t) {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -362,7 +362,7 @@ future<> aio_storage_context::retry_loop() {
             } catch (...) {
                 // If submit failed, just log the error and break out of the inner loop.
                 // The coroutine will wait for the next condition variable signal to retry (or return if stopping).
-                seastar_logger.warn("aio_storage_context::retry_loop failed: {}", std::current_exception());
+                seastar_logger.warn("aio_storage_context::retry_loop failed: {}", seastar::formattable(std::current_exception()));
                 break;
             }
             auto iocbs = _aio_retries.data();
@@ -371,7 +371,7 @@ future<> aio_storage_context::retry_loop() {
                 try {
                     nr_consumed = handle_aio_error(iocbs[0], result.error);
                 } catch (...) {
-                    seastar_logger.error("aio retry failed: {}. Aborting.", std::current_exception());
+                    seastar_logger.error("aio retry failed: {}. Aborting.", seastar::formattable(std::current_exception()));
                     abort();
                 }
             } else {
@@ -953,7 +953,7 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
       try {
         maybe_switch_steady_clock_timers(timeout, _steady_clock_timer_reactor_thread, _steady_clock_timer_timer_thread);
       } catch (...) {
-        seastar_logger.error("Switching steady_clock timers back failed: {}. Aborting...", std::current_exception());
+        seastar_logger.error("Switching steady_clock timers back failed: {}. Aborting...", seastar::formattable(std::current_exception()));
         abort();
       }
     });

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -296,17 +296,17 @@ future<> connection::process() {
         try {
             std::get<0>(joined).get();
         } catch (...) {
-            hlogger.debug("Read exception encountered: {}", std::current_exception());
+            hlogger.debug("Read exception encountered: {}", seastar::formattable(std::current_exception()));
         }
         try {
             std::get<1>(joined).get();
         } catch (...) {
-            hlogger.debug("Response exception encountered: {}", std::current_exception());
+            hlogger.debug("Response exception encountered: {}", seastar::formattable(std::current_exception()));
         }
         return make_ready_future<>();
     }).finally([this]{
         return _read_buf.close().handle_exception([](std::exception_ptr e) {
-            hlogger.debug("Close exception encountered: {}", e);
+            hlogger.debug("Close exception encountered: {}", seastar::formattable(e));
         });
     });
 }
@@ -477,7 +477,7 @@ future<> http_server::accept_loop(int which, bool tls) {
                 hlogger.error("accept failed: {}", e);
             }
         } catch (...) {
-            hlogger.error("accept failed: {}", std::current_exception());
+            hlogger.error("accept failed: {}", seastar::formattable(std::current_exception()));
         }
     }
 }
@@ -522,7 +522,7 @@ future<> http_server::do_process_connection(connected_socket conn_fd, socket_add
         co_await conn->prepare();
     } catch (...) {
         ++_tls_handshake_errors;
-        hlogger.debug("connection preparation failed: {}", std::current_exception());
+        hlogger.debug("connection preparation failed: {}", seastar::formattable(std::current_exception()));
         co_return;
     }
     if (_request_scheduling_group) {
@@ -531,7 +531,7 @@ future<> http_server::do_process_connection(connected_socket conn_fd, socket_add
     try {
         co_await conn->process();
     } catch (...) {
-        hlogger.error("request error: {}", std::current_exception());
+        hlogger.error("request error: {}", seastar::formattable(std::current_exception()));
     }
 }
 

--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -1203,7 +1203,7 @@ dns_resolver::impl::do_connect(ares_socket_t fd, const sockaddr * addr, socklen_
                         e.tcp.socket = f.get();
                         dns_log.trace("Connection complete: {}", fd);
                     } catch (...) {
-                        dns_log.debug("Connect {} failed: {}", fd, std::current_exception());
+                        dns_log.debug("Connect {} failed: {}", fd, seastar::formattable(std::current_exception()));
                     }
                     e.avail = POLLOUT|POLLIN;
                     me->poll_sockets();
@@ -1273,7 +1273,7 @@ dns_resolver::impl::do_recvfrom(ares_socket_t fd, void * dst, size_t len, int fl
                             dns_log.trace("Read {} -> {} bytes", fd, buf.size());
                             e.tcp.indata = std::move(buf);
                         } catch (...) {
-                            dns_log.debug("Read {} failed: {}", fd, std::current_exception());
+                            dns_log.debug("Read {} failed: {}", fd, seastar::formattable(std::current_exception()));
                         }
                         e.avail |= POLLIN; // always reset state
                         me->poll_sockets();
@@ -1343,7 +1343,7 @@ dns_resolver::impl::do_recvfrom(ares_socket_t fd, void * dst, size_t len, int fl
                             e.udp.in = std::move(d);
                             e.avail |= POLLIN;
                         } catch (...) {
-                            dns_log.debug("Read {} failed: {}", fd, std::current_exception());
+                            dns_log.debug("Read {} failed: {}", fd, seastar::formattable(std::current_exception()));
                         }
                         me->poll_sockets();
                         me->release(fd);
@@ -1386,7 +1386,7 @@ ssize_t dns_resolver::impl::do_send_tcp(sock_entry& e, send_packet_t p, size_t b
                 f.get();
                 dns_log.trace("Send {}. {} bytes sent.", fd, bytes);
             } catch (...) {
-                dns_log.debug("Send {} failed: {}", fd, std::current_exception());
+                dns_log.debug("Send {} failed: {}", fd, seastar::formattable(std::current_exception()));
             }
             e.avail |= POLLOUT;
             me->poll_sockets();

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -258,7 +258,7 @@ static void shutdown_socket_fd(pollable_fd& fd, int how) noexcept {
         // EBADF (invalid file descriptor) -- irretrievable
         fd.shutdown(how);
     } catch (...) {
-        on_internal_error(seastar_logger, seastar::format("socket shutdown({}, {}) failed: {}", fd.get_file_desc().fdinfo(), how, std::current_exception()));
+        on_internal_error(seastar_logger, seastar::format("socket shutdown({}, {}) failed: {}", fd.get_file_desc().fdinfo(), how, seastar::formattable(std::current_exception())));
     }
 }
 

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -859,7 +859,7 @@ public:
         tls_log.trace("{} wait_for_output", *this);
         return _output_pending.get_future()
           .handle_exception([this](auto ep) {
-              tls_log.debug("{} wait_for_output error: {}", *this, ep);
+              tls_log.debug("{} wait_for_output error: {}", *this, seastar::formattable(ep));
               _error = ep;
               return make_exception_future(ep);
           });
@@ -1152,7 +1152,7 @@ public:
               _input = std::move(buf);
           })
           .handle_exception([this](auto ep) {
-              tls_log.debug("{} wait_for_input: exception: {}", *this, ep);
+              tls_log.debug("{} wait_for_input: exception: {}", *this, seastar::formattable(ep));
               _error = ep;
               return make_exception_future(ep);
           });

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -390,7 +390,7 @@ void logger::failed_to_log(std::exception_ptr ex,
             if (fmt.size() > 0) {
                 it = fmt::format_to(it, ": fmt='{}'", fmt);
             }
-            return fmt::format_to(it, ": {}", ex);
+            return fmt::format_to(it, ": {}", seastar::formattable(ex));
         });
         do_log(log_level::error, writer);
     } catch (...) {

--- a/src/websocket/client.cc
+++ b/src/websocket/client.cc
@@ -159,7 +159,7 @@ future<> client<text_frame>::connect(socket_address addr, sstring resource, sstr
         try {
             co_await _conn->process();
         } catch (...) {
-            websocket_logger.debug("WebSocket client processing failed: {}", std::current_exception());
+            websocket_logger.debug("WebSocket client processing failed: {}", seastar::formattable(std::current_exception()));
         }
     }).handle_exception_type([] (const gate_closed_exception&) {});
 }
@@ -179,7 +179,7 @@ future<> client<text_frame>::connect(socket_address addr,
         try {
             co_await _conn->process();
         } catch (...) {
-            websocket_logger.debug("WebSocket client processing failed: {}", std::current_exception());
+            websocket_logger.debug("WebSocket client processing failed: {}", seastar::formattable(std::current_exception()));
         }
     }).handle_exception_type([] (const gate_closed_exception&) {});
 }

--- a/src/websocket/server.cc
+++ b/src/websocket/server.cc
@@ -73,7 +73,7 @@ future<stop_iteration> server::accept_one(server_socket &listener) {
         }
         return make_ready_future<stop_iteration>(stop_iteration::yes);
     }).handle_exception([](std::exception_ptr ex) {
-        websocket_logger.info("accept failed: {}", ex);
+        websocket_logger.info("accept failed: {}", seastar::formattable(ex));
         return make_ready_future<stop_iteration>(stop_iteration::yes);
     });
 }
@@ -104,7 +104,7 @@ void server_connection::on_new_connection() {
 
 future<> server_connection::process() {
     return when_all_succeed(read_loop(), response_loop()).discard_result().handle_exception([] (const std::exception_ptr& e) {
-        websocket_logger.debug("Processing failed: {}", e);
+        websocket_logger.debug("Processing failed: {}", seastar::formattable(e));
     });
 }
 

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -890,7 +890,7 @@ do_run_try_future_test(F underlying_func, int& ctor_dtor_counter, bool& run_past
             }
             run_past = true;
         } catch (...) {
-            BOOST_FAIL(fmt::format("Exception should be handled in try_future, bug caught: {}", std::current_exception()));
+            BOOST_FAIL(fmt::format("Exception should be handled in try_future, bug caught: {}", seastar::formattable(std::current_exception())));
         }
 
         if constexpr (is_void) {
@@ -935,7 +935,7 @@ future<> run_try_future_test(F underlying_func, std::optional<std::any> expected
     } catch (test_exception&) {
         BOOST_REQUIRE(throws);
     } catch (...) {
-        BOOST_FAIL(fmt::format("Unexpected exception {}", std::current_exception()));
+        BOOST_FAIL(fmt::format("Unexpected exception {}", seastar::formattable(std::current_exception())));
     }
 
     BOOST_REQUIRE_EQUAL(run_past, !throws);

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -450,7 +450,7 @@ SEASTAR_TEST_CASE(test_get_on_exceptional_promise) {
 }
 
 static void check_finally_exception(std::exception_ptr ex) {
-  BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
+  BOOST_REQUIRE_EQUAL(fmt::format("{}", seastar::formattable(ex)),
         "seastar::nested_exception: test_exception (bar) (while cleaning up after test_exception (foo))");
   try {
       // convert to the concrete type nested_exception
@@ -1707,7 +1707,7 @@ static void check_failed_with(future<T...>&& f) {
     } catch (const E& e) {
         // expected
     } catch (...) {
-        BOOST_FAIL(format("wrong exception: {}", std::current_exception()));
+        BOOST_FAIL(format("wrong exception: {}", seastar::formattable(std::current_exception())));
     }
 }
 

--- a/tests/unit/gate_test.cc
+++ b/tests/unit/gate_test.cc
@@ -49,7 +49,7 @@ static future<> check_gate_closed_exception(Func func) {
     } catch (const gate_closed_exception& e) {
         BOOST_REQUIRE_EQUAL(e.what(), "gate closed");
     } catch (...) {
-        BOOST_FAIL(format("unexpected exception: {}", std::current_exception()));
+        BOOST_FAIL(format("unexpected exception: {}", seastar::formattable(std::current_exception())));
     }
 }
 
@@ -115,7 +115,7 @@ static future<> check_named_gate_closed_exception(Func func, sstring name) {
     } catch (const gate_closed_exception& e) {
         BOOST_REQUIRE_EQUAL(e.what(), fmt::format("{} gate closed", name));
     } catch (...) {
-        BOOST_FAIL(format("unexpected exception: {}", std::current_exception()));
+        BOOST_FAIL(format("unexpected exception: {}", seastar::formattable(std::current_exception())));
     }
 }
 

--- a/tests/unit/locking_test.cc
+++ b/tests/unit/locking_test.cc
@@ -496,7 +496,7 @@ SEASTAR_TEST_CASE(test_shared_mutex_exception_locks) {
         BOOST_REQUIRE(sm.try_lock());
         sm.unlock();
     } catch (...) {
-        BOOST_FAIL(format("Unexpected exception type: {}", std::current_exception()));
+        BOOST_FAIL(format("Unexpected exception type: {}", seastar::formattable(std::current_exception())));
     }
 
     try {
@@ -506,7 +506,7 @@ SEASTAR_TEST_CASE(test_shared_mutex_exception_locks) {
         BOOST_REQUIRE(sm.try_lock());
         sm.unlock();
     } catch (...) {
-        BOOST_FAIL(format("Unexpected exception type: {}", std::current_exception()));
+        BOOST_FAIL(format("Unexpected exception type: {}", seastar::formattable(std::current_exception())));
     }
 
     BOOST_REQUIRE(sm.try_lock());

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -780,7 +780,7 @@ static future<> test_rpc_connection_send_glitch(bool on_client) {
                         auto id = call(c1).get();
                         fmt::print("    response: {}\n", id);
                     } catch (...) {
-                        fmt::print("    responce: ex {}\n", std::current_exception());
+                        fmt::print("    responce: ex {}\n", seastar::formattable(std::current_exception()));
                         ctx.no_failures = false;
                         ctx.limit++;
                         break;
@@ -1917,7 +1917,7 @@ SEASTAR_THREAD_TEST_CASE(test_rpc_stream_backpressure_across_shards) {
                 } catch (const rpc::stream_closed&) {
                     log.debug("cl_rep_loop: stream closed");
                 } catch (...) {
-                    auto msg = format("cl_rep_loop: unexpected exception: {}", std::current_exception());
+                    auto msg = format("cl_rep_loop: unexpected exception: {}", seastar::formattable(std::current_exception()));
                     log.error("{}", msg);
                     throw std::runtime_error(msg);
                 }

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -245,7 +245,7 @@ SEASTAR_TEST_CASE(socket_connect_abort_test) {
             fmt::print("Connected\n");
             BOOST_REQUIRE(false);
         }).handle_exception([&too_late] (auto ex) {
-            fmt::print("Cannot connect {}\n", ex);
+            fmt::print("Cannot connect {}\n", seastar::formattable(ex));
             BOOST_REQUIRE(!too_late);
         });
 


### PR DESCRIPTION
Split out of #3559 (one deprecation fix per PR). Stephan's commit, cherry-picked verbatim onto master.

`fmt::formatter<std::exception_ptr>` was deprecated in c0e72e546 in favour of `seastar::formattable()`; this stops Seastar formatting exception_ptr through it. libseastar instantiates the deprecated formatter in 62 places across 14 translation units before this change, and none after.

Worth noting for reviewers that those 62 are not visible as warnings in every build. The deprecation sits on `formatter::parse()`, which {fmt} only ever calls from inside `fmt/base.h`, so the diagnostic's primary location is a {fmt} header rather than the offending call site. Where {fmt} is included with `-isystem`, as it is when cooked, clang-22 does not report it and the build looks clean. They do show up with `-Wsystem-headers`, for builds that have {fmt} on a plain `-I` include path, and on clang-23, which reports this class of diagnostic where clang-22 stays silent.

Verified by building `libseastar` plus `iotune`, `rpc_tester`, `httpd`, `http_client_demo` and the six changed unit tests: no errors, and zero remaining exception_ptr deprecation diagnostics under `-Wsystem-headers`.