### PR TITLE
tests/tls: retry the internet-facing TLS connections

### DIFF
--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/process.hh>
@@ -77,8 +78,15 @@ static bool using_gnutls() {
     return std::string_view(tls::backend_name()) == "gnutls";
 }
 
-static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> certs, socket_address addr, const sstring& name = {}) {
-    return repeat_until_value([=]() mutable {
+// Number of attempts made by the tests that reach a real server over the
+// internet. Local tests deliberately provoke failures and must not retry, so
+// max_attempts defaults to 1 (i.e. no retry) below.
+static constexpr int max_connect_attempts = 5;
+
+static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> certs, socket_address addr, const sstring& name = {}, int max_attempts = 1) {
+    return repeat_until_value([=, attempts = 0]() mutable {
+      ++attempts;
+      return futurize_invoke([=] {
         return tls::connect(certs, addr, tls::tls_options{.server_name = name}).then([](connected_socket s) {
             return do_with(std::move(s), [](connected_socket& s) {
                 return do_with(s.output(), [&s](auto& os) {
@@ -113,7 +121,20 @@ static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> c
                 });
             });
         });
-
+      }).then_wrapped([attempts, max_attempts](future<std::optional<bool>> f) -> future<std::optional<bool>> {
+        if (!f.failed() || attempts >= max_attempts) {
+            return f;
+        }
+        // When the peer is a real server out on the internet, a certain amount
+        // of transient failure (connection reset, abrupt close, throttling) is
+        // inherent and says nothing about what is being tested. Back off and
+        // try again; a failure that is not transient survives every attempt and
+        // is reported unchanged.
+        f.ignore_ready_future();
+        return sleep(std::chrono::milliseconds(100 * attempts)).then([] {
+            return make_ready_future<std::optional<bool>>(std::nullopt);
+        });
+      });
     }).discard_result();
 }
 
@@ -134,7 +155,7 @@ static future<socket_address> google_address() {
 
 static future<> connect_to_ssl_google(::shared_ptr<tls::certificate_credentials> certs) {
     return google_address().then([certs](socket_address addr) {
-        return connect_to_ssl_addr(std::move(certs), addr, google_name);
+        return connect_to_ssl_addr(std::move(certs), addr, google_name, max_connect_attempts);
     });
 }
 


### PR DESCRIPTION
The TLS tests that connect to a real `www.google.com` fail intermittently in CI when the connection
is reset or closed abruptly, which says nothing about what they are checking:

```
unknown location(0): fatal error: in "test_x509_client_with_builder_system_trust_multiple": seastar::nested_exception: seastar::nested_exception
/__w/seastar/seastar/tests/unit/tls_test.cc(105): last checkpoint
```

`connect_to_ssl_addr` already retries, but only the empty-read case from #1127; any exception
propagates and fails the test. This retries on failure too, bounded, with a short linear backoff.
A failure that is not transient survives every attempt and is reported unchanged, so no error is
masked and no classification of "transient" errors is needed.

The retry is opt-in via a `max_attempts` parameter defaulting to 1, because `connect_to_ssl_addr` is
shared with local tests that deliberately provoke failures - `test_failed_connect`, `test_non_tls`
and `test_x509_client_with_priority_strings_fail`. Those run with no internet involved, and
retrying their expected failures would only slow them down. Only the google path passes a higher
count, so they keep their current behaviour and timing exactly.

Fixes #3572

### Verification

- **Retry fires:** injecting 4 consecutive `ECONNRESET`s on the google path, the test passes on the
  5th attempt, with the expected ~1s of backoff visible in the runtime.
- **Gives up correctly:** injecting 5, the test fails reporting `std::system_error: Connection reset
  by peer`, i.e. the real error rather than a masked or synthetic one.
- **No local regression:** the three failure-expecting local tests take 5.806s with the patch vs
  5.727s without, i.e. within noise.
- **Full suite passes for both providers** (dev build): gnutls 36.5s, openssl 28.2s.

### Note

The empty-read path still retries without a bound, so a server persistently returning no data will
spin until the ctest timeout. That is pre-existing and not what was flaking, so I left it alone; happy
to bound it here too if preferred.
