### PR TITLE
test: report exception chains through seastar::formattable()

### DIFF
--- a/src/testing/seastar_test.cc
+++ b/src/testing/seastar_test.cc
@@ -33,55 +33,37 @@
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/testing/on_internal_error.hh>
+#include <seastar/util/log.hh>
 
 namespace seastar {
 
 namespace testing {
 
 // #3165 - build a message for a possibly nested exception chain.
-static boost::execution_exception::location
-add_exception_message(const std::exception* ep, bool rec, char *out, char *end) {
-    auto pfx = rec ? "; Caused by " : "";
-
-    if (ep) {
-        out = fmt::format_to_n(out, end - out, "{}{}: {}", pfx, seastar::pretty_type_name(typeid(*ep)), ep->what()).out;
-    } else {
-        auto tp = abi::__cxa_current_exception_type();
-        out = fmt::format_to_n(out, end - out, "{}{}", pfx, tp ? seastar::pretty_type_name(*tp) : "<unknown>").out;
-    }
-
-    boost::execution_exception::location loc;
-    if (auto* be = dynamic_cast<const boost::exception*>(ep)) {
-        auto sloc = boost::exception_detail::get_exception_throw_location(*be);
-        if (rec) {
-            out = fmt::format_to_n(out, end - out, "({}:{}:{})", sloc.file_name(), sloc.function_name(), sloc.line()).out;
-        }
-        loc = boost::execution_exception::location(sloc.file_name(), sloc.line(), sloc.function_name());
-    }
-
-    *out = 0; // see initial invoke below. always valid
-
-    if (ep) {
-        try {
-            std::rethrow_if_nested(*ep);
-        } catch (std::exception& e) {
-            add_exception_message(&e, true, out, end);
-        } catch (...) {
-            add_exception_message(nullptr, true, out, end);
-        }
-    }
-
-    return loc;
-}
-
-static future<> repackage_exception_and_rethrow(const std::exception* ep) {
+static future<> repackage_exception_and_rethrow(std::exception_ptr eptr) {
     // Note: using a static buffer for formatting, same as boost::test code,
     // so we make it less prone to fail in failure handling for OOM
     // situations etc.
     static const int REPORT_ERROR_BUFFER_SIZE = 4096;
     static char buf[REPORT_ERROR_BUFFER_SIZE];
 
-    auto loc = add_exception_message(ep, false, buf, buf + sizeof(buf) - 1);
+    // Rendering the chain is left to seastar::formattable(), which already
+    // knows about nested exceptions of both the seastar and the std flavour,
+    // system_error details, backtraces, and objects not derived from
+    // std::exception.
+    *fmt::format_to_n(buf, sizeof(buf) - 1, "{}", seastar::formattable(eptr)).out = 0;
+
+    // Boost reports a single location, so only the outermost one is of
+    // interest here.
+    boost::execution_exception::location loc;
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const boost::exception& be) {
+        auto sloc = boost::exception_detail::get_exception_throw_location(be);
+        loc = boost::execution_exception::location(sloc.file_name(), sloc.line(), sloc.function_name());
+    } catch (...) {
+    }
+
     return make_exception_future<>(boost::execution_exception(boost::execution_exception::cpp_exception_error, buf, loc));
 }
 
@@ -99,13 +81,7 @@ void seastar_test::run() {
         // the info into an execution_exception, potentially including
         // nestedness etc.
         return futurize_invoke(std::bind(&seastar_test::run_test_case, this)).handle_exception([](std::exception_ptr e) {
-            try {
-                std::rethrow_exception(e);
-            } catch (std::exception& e) {
-                return repackage_exception_and_rethrow(&e);
-            } catch (...) {
-                return repackage_exception_and_rethrow(nullptr);
-            }
+            return repackage_exception_and_rethrow(std::move(e));
         });
     });
 }

--- a/tests/unit/test_fixture_test.cc
+++ b/tests/unit/test_fixture_test.cc
@@ -243,3 +243,37 @@ BOOST_AUTO_TEST_CASE(test_unknown_throw) {
     BOOST_REQUIRE(caught);
 }
 
+static bool do_throw_seastar_nested = false;
+
+// Dummy test that on its own does nothing.
+SEASTAR_TEST_CASE(test_seastar_nested_throw_helper) {
+    if (std::exchange(do_throw_seastar_nested, false)) {
+        return make_exception_future<>(std::make_exception_ptr(nested_exception(
+            std::make_exception_ptr(std::runtime_error("Message 1")),
+            std::make_exception_ptr(std::runtime_error("Message 2")))));
+    }
+    return make_ready_future<>();
+}
+
+// Cannot be a SEASTAR_TEST_CASE, because of recursion of seastar::test::run.
+BOOST_AUTO_TEST_CASE(test_seastar_nested_throw) {
+    do_throw_seastar_nested = true;
+    auto def = defer([]() noexcept {
+        do_throw_seastar_nested = false;
+    });
+
+    bool caught = false;
+    try {
+        using helper_type = std::remove_cvref_t<decltype(test_seastar_nested_throw_helper_instance)>;
+        const_cast<helper_type&>(test_seastar_nested_throw_helper_instance).run();
+    } catch (boost::execution_exception& e) {
+        caught = true;
+        // Should get a cpp exception failure
+        BOOST_REQUIRE_EQUAL(e.code(), boost::execution_exception::error_code::cpp_exception_error);
+        // Should have both causes, which what() alone cannot report
+        BOOST_REQUIRE(e.what().find("Message 1") != std::string::npos);
+        BOOST_REQUIRE(e.what().find("Message 2") != std::string::npos);
+    }
+    BOOST_REQUIRE(caught);
+}
+


### PR DESCRIPTION
### Why this code exists

When a C++ exception escapes a test case, Boost.Test reports its type and `what()`, and nothing more. For exceptions that keep their real detail somewhere other than `what()` - nested exceptions - that drops the actual cause, which is what #3165 was about.

`seastar_test::run()` therefore gets in ahead of boost. It is the function boost knows as the test case (registered with `make_test_case([this] { run(); }, ...)`), and rather than let the exception escape into boost's own translator, it catches it, formats a message, and throws a `boost::execution_exception` - boost's *already-translated* form. `unit_test_monitor_t::execute_and_translate()` catches that directly and logs it as-is, so the message seastar builds is what lands in

```
<location>: fatal error: in "<test name>": <message>
```

`add_exception_message()` builds that message. (The buffer is `static` because `execution_exception` keeps its message as a non-owning `const_string`.)

### The problem

`add_exception_message()` walks the chain itself, recursing with `std::rethrow_if_nested()`. That only knows `std::nested_exception`, and `seastar::nested_exception` does not derive from it, so the walk stops at the first one - and since its `what()` is a fixed string, everything below it is lost too:

```
before:  seastar::nested_exception: seastar::nested_exception
after:   seastar::nested_exception: std::runtime_error (cleanup failed) (while cleaning up
         after std::_Nested_exception<std::out_of_range> (Message 2): std::invalid_argument (Message 1))
```

`future::finally()` produces that shape whenever both the body and the cleanup fail, so it is not exotic; #3571 is a CI failure reporting exactly the first line and nothing more.

### The change

`seastar::formattable()` already renders all of it - both flavours of nested exception, `std::system_error` detail, `backtraced<>` frames, non-`std::exception` objects. This delegates to it rather than teaching a second walker about each type, leaving one renderer for exception chains. The recursion goes too: only the outermost location reaches boost, so a single `catch (const boost::exception&)` replaces the walk. Net +20/-44.

### Behaviour changes

Chains that already worked are restyled, as the message now comes from the same renderer as every seastar log line:

```
before:  std::_Nested_exception<std::out_of_range>: Message 2; Caused by std::invalid_argument: Message 1
after:   std::_Nested_exception<std::out_of_range> (Message 2): std::invalid_argument (Message 1)
```

The per-frame `(file:function:line)` annotation for *nested* `boost::exception` frames is lost - the formatter has no notion of frames. The outermost location, the one boost reports, is kept.

### Testing

New case fails a test with a `seastar::nested_exception` and requires both causes in the message; it fails without this change (`critical check e.what().find("Message 1") != std::string::npos has failed`). Full `tests/unit/test_fixture_test` passes in a dev ASan/UBSan build, pre-existing cases unmodified.

Related: #3574 fixes a reversed buffer bound in `add_exception_message()`, which this deletes. They are independent - either can land first.