### PR TITLE
net: posix-stack: Fix conntrack load balancer skew (#3514)

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -59,24 +59,35 @@ using namespace seastar;
 // Right now this class is used by the posix_server_socket_impl, but it could be used by any other.
 class conntrack {
     class load_balancer {
-        std::vector<unsigned> _cpu_load;
+        std::unique_ptr<std::atomic<unsigned>[]> _cpu_load;
     public:
-        load_balancer() : _cpu_load(size_t(this_smp_shard_count()), 0) {}
+        load_balancer() : _cpu_load(new std::atomic<unsigned>[this_smp_shard_count()]()) {}
         void closed_cpu(shard_id cpu) {
-            _cpu_load[cpu]--;
+            _cpu_load[cpu].fetch_sub(1, std::memory_order_relaxed);
         }
         shard_id next_cpu() {
             // FIXME: The naive algorithm will just round robin the connections around the shards.
             // A more complex version can keep track of the amount of activity in each connection,
             // and use that information.
-            auto min_el = std::min_element(_cpu_load.begin(), _cpu_load.end());
-            auto cpu = shard_id(std::distance(_cpu_load.begin(), min_el));
-            _cpu_load[cpu]++;
-            return cpu;
+            unsigned min_val = std::numeric_limits<unsigned>::max();
+            shard_id min_cpu = 0;
+            unsigned count = this_smp_shard_count();
+            for (shard_id i = 0; i < count; ++i) {
+                unsigned val = _cpu_load[i].load(std::memory_order_relaxed);
+                if (val < min_val) {
+                    min_val = val;
+                    min_cpu = i;
+                }
+            }
+            _cpu_load[min_cpu].fetch_add(1, std::memory_order_relaxed);
+            return min_cpu;
         }
         shard_id force_cpu(shard_id cpu) {
-            _cpu_load[cpu]++;
+            _cpu_load[cpu].fetch_add(1, std::memory_order_relaxed);
             return cpu;
+        }
+        std::atomic<unsigned>* cpu_load_array() const {
+            return _cpu_load.get();
         }
     };
 
@@ -86,14 +97,14 @@ class conntrack {
     }
 public:
     class handle {
-        shard_id _host_cpu;
         shard_id _target_cpu;
+        std::atomic<unsigned>* _cpu_load_array;
         foreign_ptr<lw_shared_ptr<load_balancer>> _lb;
     public:
-        handle() : _lb(nullptr) {}
+        handle() : _cpu_load_array(nullptr), _lb(nullptr) {}
         handle(shard_id cpu, lw_shared_ptr<load_balancer> lb)
-            : _host_cpu(this_shard_id())
-            , _target_cpu(cpu)
+            : _target_cpu(cpu)
+            , _cpu_load_array(lb->cpu_load_array())
             , _lb(make_foreign(std::move(lb))) {}
 
         handle(const handle&) = delete;
@@ -104,10 +115,9 @@ public:
             if (!_lb) {
                 return;
             }
-            // FIXME: future is discarded
-            (void)smp::submit_to(_host_cpu, [cpu = _target_cpu, lb = std::move(_lb)] {
-                lb->closed_cpu(cpu);
-            });
+            if (_cpu_load_array) {
+                _cpu_load_array[_target_cpu].fetch_sub(1, std::memory_order_relaxed);
+            }
         }
         shard_id cpu() {
             return _target_cpu;


### PR DESCRIPTION
Fixes #3514.

Hey guys, taking a stab at the load balancer skew issue reported in #3514. 

The root cause here is that `conntrack::load_balancer` uses a plain `std::vector<unsigned>` to track connection counts. When a connection closes on any shard other than Shard 0, the handle's destructor fires off an `smp::submit_to` message back to Shard 0 to decrement the count.

The problem is that Shard 0 processes its own closed connections inline (synchronously), but handles the cross-core decrements asynchronously whenever it gets around to polling the message queue. Under heavy load with lots of short-lived connections, Shard 0's decrements happen instantly while the other shards' decrements get backed up in the queue. This makes the other shards look artificially bloated, so the load balancer just keeps dumping more and more new connections onto Shard 0, creating a vicious cycle.

### The Fix
To fix this, I swapped out the `std::vector` for a `std::unique_ptr<std::atomic<unsigned>[]>`. 

Now, when a connection closes on any core, the handle just does a direct `fetch_sub(1, std::memory_order_relaxed)` on the atomic array. By bypassing the SMP message queue entirely, Shard 0 always has an instantly accurate view of the load across all shards, stopping the feedback loop. 

I kept the `foreign_ptr` around so the load balancer object itself is still safely cleaned up on its home core when it's done.

Tested locally against the unit tests and it builds perfectly. Let me know what you think of this approach!
