### PR TITLE
ragel, http: migrate obsolete input_stream consumers to consumption_result

### DIFF
--- a/demos/line_count_demo.cc
+++ b/demos/line_count_demo.cc
@@ -42,14 +42,14 @@ public:
     size_t count = 0;
 
     // for input_stream::consume():
-    using unconsumed_remainder = std::optional<temporary_buffer<char>>;
-    future<unconsumed_remainder> operator()(temporary_buffer<char> data) {
+    using consumption_result_type = consumption_result<char>;
+    future<consumption_result_type> operator()(temporary_buffer<char> data) {
         if (data.empty()) {
-            return make_ready_future<unconsumed_remainder>(std::move(data));
+            return make_ready_future<consumption_result_type>(stop_consuming<char>{std::move(data)});
         } else {
             count += std::count(data.begin(), data.end(), '\n');
             // FIXME: last line without \n?
-            return make_ready_future<unconsumed_remainder>();
+            return make_ready_future<consumption_result_type>(continue_consuming{});
         }
     }
 };

--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <seastar/core/iostream.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/assert.hh>
@@ -124,17 +125,16 @@ protected:
         return std::move(_builder).get();
     }
 public:
-    using unconsumed_remainder = std::optional<temporary_buffer<char>>;
-    future<unconsumed_remainder> operator()(temporary_buffer<char> buf) {
+    future<consumption_result<char>> operator()(temporary_buffer<char> buf) {
         char* p = buf.get_write();
         char* pe = p + buf.size();
         char* eof = buf.empty() ? pe : nullptr;
         char* parsed = static_cast<ConcreteParser*>(this)->parse(p, pe, eof);
         if (parsed) {
             buf.trim_front(parsed - p);
-            return make_ready_future<unconsumed_remainder>(std::move(buf));
+            return make_ready_future<consumption_result<char>>(stop_consuming<char>{std::move(buf)});
         }
-        return make_ready_future<unconsumed_remainder>();
+        return make_ready_future<consumption_result<char>>(continue_consuming{});
     }
 };
 

--- a/include/seastar/http/internal/content_source.hh
+++ b/include/seastar/http/internal/content_source.hh
@@ -138,8 +138,8 @@ class chunked_source_impl : public data_source_impl {
             switch (_ps) {
             // "data" buffer is non-empty
             case parsing_state::size_and_ext:
-                return _size_and_ext_parser(std::move(data)).then([this] (std::optional<temporary_buffer<char>> res) {
-                    if (res.has_value()) {
+                return _size_and_ext_parser(std::move(data)).then([this] (consumption_result_type res) {
+                    if (auto* stop = std::get_if<stop_consuming<char>>(&res.get())) {
                         if (_size_and_ext_parser.failed()) {
                             return make_exception_future<consumption_result_type>(bad_request_exception("Can't parse chunk size and extensions"));
                         }
@@ -164,10 +164,10 @@ class chunked_source_impl : public data_source_impl {
                         } else {
                             _ps = parsing_state::body;
                         }
-                        if (res->empty()) {
+                        if (stop->get_buffer().empty()) {
                             return make_ready_future<consumption_result_type>(continue_consuming{});
                         }
-                        return this->operator()(std::move(res.value()));
+                        return this->operator()(std::move(stop->get_buffer()));
                     } else {
                         return make_ready_future<consumption_result_type>(continue_consuming{});
                     }
@@ -211,8 +211,8 @@ class chunked_source_impl : public data_source_impl {
                 }
                 return this->operator()(std::move(data));
             case parsing_state::trailer_part:
-                return _trailer_parser(std::move(data)).then([this] (std::optional<temporary_buffer<char>> res) {
-                    if (res.has_value()) {
+                return _trailer_parser(std::move(data)).then([this] (consumption_result_type res) {
+                    if (auto* stop = std::get_if<stop_consuming<char>>(&res.get())) {
                         if (_trailer_parser.failed()) {
                             return make_exception_future<consumption_result_type>(bad_request_exception("Can't parse chunked request trailer"));
                         }
@@ -220,7 +220,7 @@ class chunked_source_impl : public data_source_impl {
                         _trailing_headers = _trailer_parser.get_parsed_headers();
                         _end_of_request = true;
                         _remaining_bytes = 0;
-                        return make_ready_future<consumption_result_type>(stop_consuming(std::move(*res)));
+                        return make_ready_future<consumption_result_type>(std::move(*stop));
                     } else {
                         return make_ready_future<consumption_result_type>(continue_consuming{});
                     }

--- a/tests/unit/chunk_parsers_test.cc
+++ b/tests/unit/chunk_parsers_test.cc
@@ -29,6 +29,7 @@
 #include <seastar/testing/test_case.hh>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace seastar;
@@ -64,7 +65,8 @@ SEASTAR_TEST_CASE(test_size_and_extensions_parsing) {
     http_chunk_size_and_ext_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
+        // the parser is done once it hands back the unconsumed remainder
+        BOOST_REQUIRE(std::holds_alternative<stop_consuming<char>>(parser(tset.buf()).get().get()));
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             BOOST_REQUIRE_EQUAL(parser.get_size(), std::move(tset.size));
@@ -109,7 +111,8 @@ SEASTAR_TEST_CASE(test_trailer_headers_parsing) {
     http_chunk_trailer_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
+        // the parser is done once it hands back the unconsumed remainder
+        BOOST_REQUIRE(std::holds_alternative<stop_consuming<char>>(parser(tset.buf()).get().get()));
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto heads = parser.get_parsed_headers();

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -243,16 +243,16 @@ future<> test_consume_until_end(uint64_t size) {
             }).then([size, f] (size_t real_size) {
                 BOOST_REQUIRE_EQUAL(size, real_size);
             }).then([size, f] {
-                auto consumer = [offset = uint64_t(0), size] (temporary_buffer<char> buf) mutable -> future<input_stream<char>::unconsumed_remainder> {
+                auto consumer = [offset = uint64_t(0), size] (temporary_buffer<char> buf) mutable -> future<consumption_result<char>> {
                     if (!buf) {
-                        return make_ready_future<input_stream<char>::unconsumed_remainder>(temporary_buffer<char>());
+                        return make_ready_future<consumption_result<char>>(stop_consuming<char>{temporary_buffer<char>()});
                     }
                     BOOST_REQUIRE(offset + buf.size() <= size);
                     std::vector<char> expected(buf.size());
                     std::iota(expected.begin(), expected.end(), offset);
                     offset += buf.size();
                     BOOST_REQUIRE(std::equal(buf.begin(), buf.end(), expected.begin()));
-                    return make_ready_future<input_stream<char>::unconsumed_remainder>(std::nullopt);
+                    return make_ready_future<consumption_result<char>>(continue_consuming{});
                 };
                 return do_with(make_file_input_stream(f), std::move(consumer), [] (input_stream<char>& in, auto& consumer) {
                     return in.consume(consumer).then([&in] {

--- a/tests/unit/request_parser_test.cc
+++ b/tests/unit/request_parser_test.cc
@@ -28,6 +28,7 @@
 #include <seastar/testing/test_case.hh>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace seastar;
@@ -63,7 +64,8 @@ SEASTAR_TEST_CASE(test_header_parsing) {
     http_request_parser parser;
     for (auto& tset : tests) {
         parser.init();
-        BOOST_REQUIRE(parser(tset.buf()).get().has_value());
+        // the parser is done once it hands back the unconsumed remainder
+        BOOST_REQUIRE(std::holds_alternative<stop_consuming<char>>(parser(tset.buf()).get().get()));
         BOOST_REQUIRE_NE(parser.failed(), tset.parsable);
         if (tset.parsable) {
             auto req = parser.get_parsed_request();


### PR DESCRIPTION
Migrates seastar's own obsolete `input_stream` consumers to the current `consumption_result` protocol, so the deprecation added in b99bfdabc stops firing inside our own build.

### Why not just avoid the conversion in `consume()`

#3566 takes the other approach: keep the legacy consumers and stop `consume()` from routing them through the deprecated `consumption_result(optional<temporary_buffer>)` constructor. As noted in review there, that silences the deprecation for third-party legacy consumers too, which defeats its purpose. This PR removes the warnings by fixing the cause instead: seastar stops being a legacy consumer. The deprecation stays fully in force for everyone else.

### Scope

Sweeping all 426 TUs of a `dev` build with clang 23 (the only compiler I have that emits this diagnostic; clang 22 and gcc 13 are silent on it) found **22 warnings across 11 TUs**, and all of them trace back to one place: `ragel_parser_base::operator()` returning `future<std::optional<temporary_buffer<char>>>`.

| root | affected TUs |
| --- | --- |
| `ragel_parser_base` via `http_request_parser`, `http_response_parser`, `memcache_ascii_parser` | `src/http/httpd.cc`, `src/http/client.cc`, `src/websocket/client.cc`, `src/websocket/server.cc`, `tests/unit/httpd_test.cc`, `tests/unit/websocket_test.cc`, `apps/seawreck/seawreck.cc`, `apps/memcached/memcache.cc`, `apps/memcached/tests/test_ascii_parser.cc` |
| hand-written `reader` | `demos/line_count_demo.cc` |
| local lambda | `tests/unit/fstream_test.cc` |

(2 warnings per TU because both `consume(Consumer&&)` and `consume(Consumer&)` get instantiated.)

After this PR the same sweep reports **0 warnings across 429 TUs**.

A warning sweep only finds the sites that hand a legacy consumer to `consume()`. It is blind to code that calls a parser's `operator()` **directly** and destructures the returned `optional` itself: that produces no diagnostic today and only breaks once the return type changes. Those sites have to be found by building, not by reading warnings. There are five of them in three files:

| file | call sites |
| --- | --- |
| `include/seastar/http/internal/content_source.hh` | 2 |
| `tests/unit/chunk_parsers_test.cc` | 2 |
| `tests/unit/request_parser_test.cc` | 1 |

### Behaviour

The mapping is the one `consume()` was applying implicitly, so parser behaviour is unchanged: a completed parse (`parsed != nullptr`) becomes `stop_consuming` carrying the unconsumed remainder, an incomplete parse becomes `continue_consuming`.

### API impact

`ragel_parser_base::operator()` is public API in an installed header, so this is a source-breaking change, but a narrow and compile-time-loud one:

- Deriving a parser and passing it to `in.consume(parser)` needs **no change**. `operator()` is inherited and its type is never named at the call site.
- Calling a parser directly and destructuring the `optional` breaks, at the five sites tabulated above. The two in `content_source.hh` already dealt in `consumption_result`, so they lose a conversion step. The three in tests only ask whether the parse reached a terminal state, which becomes a check for `stop_consuming` rather than for an engaged `optional`.
- Naming `ragel_parser_base<X>::unconsumed_remainder` breaks. I dropped that alias with the old return type since it only described the obsolete protocol; happy to keep it if you would rather not break it. `input_stream<CharType>::unconsumed_remainder` still names the `optional` type regardless.

One incidental coupling: `ragel.hh` now includes `iostream.hh`, which it did not before, because that is where `consumption_result` lives.

### Testing

Full `dev` build with clang 22, whole tree rather than just the affected targets, since the direct-caller breakage above is invisible to a warning sweep and only a build finds it. These run clean:

- `test_unit_chunk_parsers`, `test_unit_request_parser` (the direct-caller tests)
- `test_unit_content_source`
- `test_unit_fstream`
- `test_unit_httpd` (covers the chunked-encoding path through `content_source.hh`)
- `test_unit_websocket`
- `app_memcached_test_ascii` (most direct exercise of the ragel change)

### Note on remaining coverage

`tests/unit/fstream_test.cc` was the last thing in the test suite exercising the obsolete consumer protocol at all, so after this PR nothing verifies that path still compiles. If you want it kept alive, it wants a deliberate small test in a TU built with `-Wno-deprecated-declarations`. Worth knowing that the warning cannot be suppressed at the call site with a `#pragma clang diagnostic` region, because the diagnostic's location lands inside libstdc++'s `invoke.h` rather than on the user's line; only the per-TU flag works.
