### PR TITLE
tests/alloc: give the sampled profile tests a real sampling margin

### DIFF
--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -481,7 +481,15 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
-    std::size_t count = 100;
+    // The two loops below are distinct call sites and the assertions require
+    // both of them to be sampled, so each loop has to cover enough sampling
+    // intervals that missing one entirely is not plausible. The sampler draws
+    // the gap to the next sample from an exponential distribution whose mean is
+    // the sampling interval, so a loop allocating N intervals worth of bytes
+    // records nothing with probability e^-N. count/2 * 10 bytes against the 100
+    // byte interval below is N=50, putting the chance of recording one call
+    // site instead of two at about 2*e^-50.
+    std::size_t count = 1000;
     std::vector<volatile char*> ptrs(count);
 
     seastar::memory::set_heap_profiling_sampling_rate(100);
@@ -558,7 +566,16 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     std::size_t count = 100;
     std::vector<volatile char*> ptrs(count);
 
-    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+    // Both loops have to be sampled, as in
+    // test_sampled_profile_collection_small: count/2 * 100000 bytes against
+    // this interval is N=25 intervals per loop, so the chance of recording one
+    // call site instead of two is about 2*e^-25. The interval also has to stay
+    // above the 131072 bytes that a 100000 byte request actually allocates, so
+    // that sample_size() accounts each sample as one full interval and the
+    // size == count * sample_rate check below holds.
+    std::size_t sample_rate = 200000;
+
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
 
 #ifdef __clang__
     #pragma nounroll
@@ -580,10 +597,10 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     {
         auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 2);
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
     }
 
-    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
 
     for (auto ptr : ptrs) {
         free((void*)ptr);


### PR DESCRIPTION
`test_sampled_profile_collection_small` and `test_sampled_profile_collection_large` each run two identical allocation loops so that there are two distinct call sites, then require `sampled_memory_profile()` to report exactly 2 sites. Whether a given loop gets sampled at all is probabilistic, and both tests were sized with almost no margin, so each of them fails about 1.3% of the time with:

```
alloc_test.cc(582): fatal error: in "test_sampled_profile_collection_large":
  critical check stats.size() == 2 has failed [1 != 2]
```

### The math

`sampler::next_sampling_interval()` draws the gap to the next sample from `std::exponential_distribution` with mean = the sampling interval, seeded from `std::random_device`, so it is independent of the test harness `random-seed` and varies per process. A loop that allocates `N` intervals worth of bytes therefore records no sample at all with probability `e^-N`, and the test needs *both* loops to record one.

Both tests were at `N=5`:

| test | interval | per alloc | bytes per loop | N | P(fail) ≈ 2·e^-N |
| --- | --- | --- | --- | --- | --- |
| `_small` | 100 | 10 | 50 × 10 = 500 | 5 | 1.35% |
| `_large` | 1000000 | 100000 | 50 × 100000 = 5000000 | 5 | 1.35% |

Driving the `sampler` class directly with each test's allocation pattern over 2M trials agrees with the closed form, and confirms the failure is one missing site rather than zero:

```
small  rate 100      10B   x100    sites=0: 0.005%   sites=1: 1.333%   => FAIL 1.356%
large  rate 1000000  100kB x100    sites=0: 0.006%   sites=1: 1.325%   => FAIL 1.333%
```

### The fix

Widen the margin in both tests:

- `_small`: `count` 100 → 1000, giving `N=50` (`2·e^-50` ≈ 3e-22). 10 kB of allocations, no meaningful cost.
- `_large`: lower the interval 1000000 → 200000 instead of raising `count`, giving `N=25` (`2·e^-25` ≈ 3e-11) while leaving the allocation size and the 10 MB footprint untouched. Raising `count` to reach the same margin would need a 500 MB live set.

The interval cannot go lower than 131072 here: `sampler::sample_size()` accounts a sample as `max(allocated_size, interval)`, and a 100000 byte request actually allocates 131072, so a smaller interval breaks the neighbouring `stats[0].size == stats[0].count * sample_rate` assertion. 200000 keeps a comfortable margin over that bound. Threading the rate through the variable also keeps it consistent with the rate set for the deallocation half of the test.

### Verification

Built `dev` with `--heap-profiling` (clang-22, C++23) and ran each test 500 times, plus the whole `alloc_test` binary 30 times:

| | before | after |
| --- | --- | --- |
| `test_sampled_profile_collection_large` | 8 / 400 | **0 / 500** |
| `test_sampled_profile_collection_small` | 1 / 400 | **0 / 500** |
| full `alloc_test` | | **0 / 30** |

The other two `SEASTAR_HEAPPROF` tests, `test_sampled_profile_collection_max_sites` and `test_change_sample_rate`, are structurally immune (both assert on a single call site over 1010 / 10000 allocations) and were clean over 200 runs each; they are left alone.

### Relation to #3565

These tests are behind `SEASTAR_HEAPPROF`, which nothing in the CI matrix currently defines, so the flake is invisible today. #3565 enables `--heap-profiling` on the dev job, which is what will start exposing it. That PR is also needed for `alloc_test.cc` to compile at all under `SEASTAR_HEAPPROF`; this branch is based on plain master, so verifying it locally meant applying #3565's `alloc_test.cc` hunk on top of this commit. Merge order does not matter, but until #3565 lands CI here will not compile these tests.
