### PR TITLE
rpc: don't abort the process on missing client_info auxiliary data

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -764,6 +764,7 @@ public:
     }
     friend connection;
     friend client;
+    friend struct client_info;
 };
 
 using rpc_handler_func = std::function<future<> (shared_ptr<server::connection>, std::optional<rpc_clock_type::time_point> timeout, int64_t msgid,

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -31,7 +31,6 @@
 #include <string>
 #include <any>
 #include <boost/intrusive/slist.hpp>
-#include <seastar/util/assert.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/variant_utils.hh>
 #include <seastar/core/timer.hh>
@@ -104,10 +103,22 @@ struct client_info {
     void attach_auxiliary(const sstring& key, T&& object) {
         user_data.emplace(key, std::any(std::forward<T>(object)));
     }
+    // Logs a warning, aborts the connection identified by conn_id and throws
+    // missing_auxiliary_error. Defined out of line because rpc::server is an
+    // incomplete type in this header.
+    [[noreturn]] void report_missing_auxiliary(const sstring& key) const;
+    /// Returns a reference to the auxiliary object attached under \c key.
+    ///
+    /// If nothing was attached under \c key (for example because the verb
+    /// that was supposed to call attach_auxiliary() failed before doing so),
+    /// the connection is aborted and missing_auxiliary_error is thrown.
+    /// Use retrieve_auxiliary_opt() to probe for a key without side effects.
     template <typename T>
     T& retrieve_auxiliary(const sstring& key) {
         auto it = user_data.find(key);
-        SEASTAR_ASSERT(it != user_data.end());
+        if (it == user_data.end()) {
+            report_missing_auxiliary(key);
+        }
         return std::any_cast<T&>(it->second);
     }
     template <typename T>
@@ -175,6 +186,13 @@ public:
 };
 
 class remote_verb_error : public error {
+    using error::error;
+};
+
+/// Thrown by client_info::retrieve_auxiliary() when no auxiliary object is
+/// attached under the requested key. The connection is aborted before the
+/// exception is thrown.
+class missing_auxiliary_error : public error {
     using error::error;
 };
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1400,6 +1400,16 @@ future<> server::stop() {
     ).discard_result();
 }
 
+[[noreturn]] void client_info::report_missing_auxiliary(const sstring& key) const {
+    server.abort_connection(conn_id);
+    auto msg = format("missing auxiliary data '{}' on connection {}", key, conn_id);
+    auto it = server._conns.find(conn_id);
+    if (it != server._conns.end()) {
+        it->second->get_logger()(*this, log_level::warn, msg);
+    }
+    throw missing_auxiliary_error(msg);
+}
+
 void server::abort_connection(connection_id id) {
     auto it = _conns.find(id);
     if (it == _conns.end()) {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1510,6 +1510,9 @@ SEASTAR_TEST_CASE(test_client_info) {
         BOOST_REQUIRE_EQUAL(info.retrieve_auxiliary_opt<int>("missing"), nullptr);
         BOOST_REQUIRE_EQUAL(const_info.retrieve_auxiliary_opt<int>("missing"), nullptr);
 
+        BOOST_REQUIRE_THROW(info.retrieve_auxiliary<int>("missing"), rpc::missing_auxiliary_error);
+        BOOST_REQUIRE_THROW(const_info.retrieve_auxiliary<int>("missing"), rpc::missing_auxiliary_error);
+
         return make_ready_future<>();
     });
 }
@@ -1571,6 +1574,81 @@ SEASTAR_TEST_CASE(test_rpc_abort_connection) {
         BOOST_REQUIRE_THROW(f(c1, 2).get(), rpc::closed_error);
         BOOST_REQUIRE_EQUAL(arrived, 2);
         c1.stop().get();
+    });
+}
+
+// A handler retrieving a never-attached auxiliary object must not reach the
+// code after the retrieval, and the connection must be aborted: the caller
+// of the verb sees closed_error, and so do all subsequent calls.
+SEASTAR_TEST_CASE(test_retrieve_missing_auxiliary_wait_handler) {
+    return rpc_test_env<>::do_with_thread(rpc_test_config(), [] (rpc_test_env<>& env) {
+        test_rpc_proto::client c1(env.proto(), {}, env.make_socket(), ipv4_addr());
+        bool reached_after_retrieve = false;
+        env.register_handler(1, [&] (rpc::client_info& cinfo, int) {
+            auto& v = cinfo.retrieve_auxiliary<int>("never_attached");
+            reached_after_retrieve = true;
+            return v;
+        }).get();
+        auto f = env.proto().make_client<int (int)>(1);
+        BOOST_REQUIRE_THROW(f(c1, 0).get(), rpc::closed_error);
+        BOOST_REQUIRE(!reached_after_retrieve);
+        // The connection was aborted server-side; further calls fail too.
+        BOOST_REQUIRE_THROW(f(c1, 1).get(), rpc::closed_error);
+        c1.stop().get();
+    });
+}
+
+// Same, for a one-way (no_wait) handler: the exception is logged and
+// swallowed by the reply path, the connection is aborted, and the process
+// survives.
+SEASTAR_TEST_CASE(test_retrieve_missing_auxiliary_no_wait_handler) {
+    using namespace std::chrono_literals;
+    static seastar::logger log("rpc");
+    return rpc_test_env<>::do_with_thread(rpc_test_config(), [] (rpc_test_env<>& env) {
+        // Attach a logger so the swallowed exception shows up in the test
+        // output. No assertion on the log contents; this is a smoke capture.
+        env.proto().set_logger(&log);
+        auto reset_logger = defer([&env] () noexcept { env.proto().set_logger(nullptr); });
+        test_rpc_proto::client c1(env.proto(), {}, env.make_socket(), ipv4_addr());
+        bool handler_entered = false;
+        env.register_handler(1, [&] (rpc::client_info& cinfo, int) {
+            handler_entered = true;
+            cinfo.retrieve_auxiliary<int>("never_attached");
+            return rpc::no_wait;
+        }).get();
+        env.register_handler(2, [] (int x) { return x; }).get();
+        auto one_way = env.proto().make_client<rpc::no_wait_type (int)>(1);
+        auto echo = env.proto().make_client<int (int)>(2);
+        // Sanity check: the connection works before the poisoned verb.
+        BOOST_REQUIRE_EQUAL(echo(c1, 7).get(), 7);
+        one_way(c1, 0).get(); // resolves once the request is sent
+        // The abort is asynchronous wrt. the client; poll (bounded) until
+        // it is observed.
+        bool closed = false;
+        for (int i = 0; i < 500 && !closed; ++i) {
+            try {
+                echo(c1, i).get();
+                seastar::sleep(10ms).get();
+            } catch (rpc::closed_error&) {
+                closed = true;
+            }
+        }
+        BOOST_REQUIRE(handler_entered);
+        BOOST_REQUIRE(closed);
+        c1.stop().get();
+    });
+}
+
+// Retrieving a missing auxiliary object outside of any connection (a
+// connection id unknown to the server) must still throw; aborting an unknown
+// connection is a no-op.
+SEASTAR_TEST_CASE(test_retrieve_missing_auxiliary_standalone) {
+    return rpc_test_env<>::do_with(rpc_test_config(), [] (rpc_test_env<>& env) {
+        rpc::client_info info{.server{env.server()}, .conn_id{0}};
+        const rpc::client_info& const_info = info;
+        BOOST_REQUIRE_THROW(info.retrieve_auxiliary<int>("missing"), rpc::missing_auxiliary_error);
+        BOOST_REQUIRE_THROW(const_info.retrieve_auxiliary<int>("missing"), rpc::missing_auxiliary_error);
+        return make_ready_future<>();
     });
 }
 


### PR DESCRIPTION
client_info::retrieve_auxiliary() asserts that the requested key is present in user_data. That is the wrong contract: an assert documents a programming error, and a missing key is not one - it is a data-dependent outcome the local process does not control. SEASTAR_ASSERT also fires in all build modes, so the miss aborts the whole process in production.

A miss is reachable: auxiliary data is typically attached by an initialization verb the peer sends right after connecting. If that handler fails before calling attach_auxiliary() - e.g. an allocation failure under memory pressure - the exception is logged and swallowed for one-way verbs and the connection stays up with empty user_data, permanently. Every later verb that retrieves the key then takes the server down. A transient std::bad_alloc on the peer's initialization path is thereby converted into a hard crash of a server that is otherwise healthy.

Instead, log a warning, abort the connection, and throw the new missing_auxiliary_error. Aborting (rather than only throwing) matters because the initialization verb is never re-sent on an established connection, so a connection that missed it can never heal: wait verbs would keep failing one by one and one-way verbs would be swallowed silently, forever. Tearing the connection down makes the failure self-healing - the client's next request opens a fresh connection and runs initialization again. The abort happens before the throw, so the reply path sees connection::error() and does not serialize the exception back over a connection already known to be broken; the warning is logged by report_missing_auxiliary() itself through the connection's logger (client_info is made a friend of rpc::server for the connection lookup), because that reply path logs nothing itself. No rate limiting is needed: after the first miss the connection is dead, so log volume is bounded at roughly one line per broken connection.

retrieve_auxiliary_opt() already provides a non-aborting lookup, but leaving retrieve_auxiliary() as it is and asking callers to switch is not equivalent: every existing and future call site has to remember to, and any one that does not reintroduces the process abort. Fixing the accessor makes the safe behaviour the default.

Fixes: SCYLLADB-3348