### PR TITLE
reactor: probe reactor backend availability once, not three times

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -2643,20 +2643,33 @@ reactor_backend_selector reactor_backend_selector::default_backend() {
 }
 
 std::vector<reactor_backend_selector> reactor_backend_selector::available() {
-    std::vector<reactor_backend_selector> ret;
+    // Each of the checks below does a real, sometimes expensive kernel probe
+    // (e.g. io_uring detection creates and tears down actual io_uring
+    // instances). Probe once and cache the result: callers (the
+    // --reactor-backend candidates list, its default, and its description)
+    // must all agree on what's available, and repeated independent probing
+    // can give different answers under load.
+    static const std::vector<reactor_backend_selector> cached = [] {
+        std::vector<reactor_backend_selector> ret;
 #ifdef SEASTAR_HAVE_URING
-    if (detect_io_uring()) {
-        ret.push_back(reactor_backend_selector("io_uring"));
-    }
-    if (detect_asymmetric_io_uring()) {
-        ret.push_back(reactor_backend_selector("asymmetric_io_uring"));
-    }
+        if (detect_io_uring()) {
+            ret.push_back(reactor_backend_selector("io_uring"));
+            // asymmetric_io_uring requires a strict superset of what plain
+            // io_uring requires, so there's no point probing it (another
+            // real io_uring_setup(2) call, plus SQPOLL kernel worker thread
+            // creation) once the plain probe has already failed.
+            if (detect_asymmetric_io_uring()) {
+                ret.push_back(reactor_backend_selector("asymmetric_io_uring"));
+            }
+        }
 #endif
-    if (has_enough_aio_nr() && detect_aio_poll()) {
-        ret.push_back(reactor_backend_selector("linux-aio"));
-    }
-    ret.push_back(reactor_backend_selector("epoll"));
-    return ret;
+        if (has_enough_aio_nr() && detect_aio_poll()) {
+            ret.push_back(reactor_backend_selector("linux-aio"));
+        }
+        ret.push_back(reactor_backend_selector("epoll"));
+        return ret;
+    }();
+    return cached;
 }
 
 std::shared_ptr<reactor_backend_configurator> reactor_backend_selector::configurator(resource::cpuset cpu_set, const reactor_options& reactor_opts, const smp_options& smp_opts) const {


### PR DESCRIPTION
## Summary

`reactor_options`'s constructor called `reactor_backend_selector::available()` independently 3 times: to build the `reactor-backend` option's candidates list, via `default_backend()` for its default value,  3rd time to format its description. 
Each call performed a real `io_uring_setup(2)` probe (`detect_io_uring()` / `detect_asymmetric_io_uring()`).

If one of the 3 calls disagreed with another (e.g. the "default" call detected `io_uring` while the "candidates" call didn't), `selection_value`'s constructor performed `find_candidate(default_candidate)` against a candidates list that did not contain that name, and then threw `std::invalid_argument` uncaught during startup:

```
FATAL: Exception during startup, aborting: std::invalid_argument (find_candidate(): failed to find candidate io_uring)
```

## Fix

Probe `available()` exactly once ever, cached in a function-local static inside `available()` itself. Every caller (candidates list, `default_backend()`, description) agrees for free, regardless of why any single probe might vary. Also stop probing `asymmetric_io_uring` once plain `io_uring` has already failed: it requires a strict superset of the same required features, so a second, more expensive (SQPOLL, kernel-worker-thread-creating) probe can't succeed where the first already didn't.

**v2**: reworked from the original approach after review. v1 cached the probe result in a new `reactor_backend_setup` member added to `reactor_options` (flagged as an internal detail that shouldn't live in a public struct) and retried the underlying syscall on `-ENOMEM`/`-EAGAIN`. Both are gone now: the cache moved into `available()` itself, so `reactor_options`/`reactor_config.hh` are back to their original, unmodified form; the retry is dropped since neither errno is actually a documented, transient `io_uring_setup(2)` failure worth retrying (`EAGAIN` isn't even a documented return code for it), and probing once removes the possibility of disagreement outright rather than trying to paper over one occurrence of it.

## Verification

- Reproduced the original crash deterministically against the *unmodified* binary using an `LD_PRELOAD` shim that intercepts the real `io_uring_queue_init_params` and forces only the first of the process's three `entries=1` probe calls to fail.
- Applied the fix and confirmed the same shim no longer crashes the process: since there's now only one probe, `io_uring` is consistently excluded from (or included in) both the candidates and the default together.
- `program_options_test` and `reactor_backend_test` pass.
- `hello-world` demo builds and runs correctly with `--help-seastar`, listing consistent candidates/default.

## Root cause note

This fixes a definitively real, reproducible bug (three independent probes that can disagree with each other), confirmed via the LD_PRELOAD repro above. It is *not* confirmed to be the root cause of the specific incident reported in #3583 (a ScyllaDB node failing to join with `host_id <missing>`) -- the link between that incident and this bug is circumstantial, not evidenced by a captured log/stack trace. So: `Refs #3583` rather than `Fixes #3583` -- please keep that issue open until/unless the connection is actually confirmed.

Refs: #3583

