### PR TITLE
log: drop formatter for exception_ptr for fmt >= 12.2.1

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -609,6 +609,8 @@ std::ostream& operator<<(std::ostream&, const std::system_error&);
 }
 #endif
 
+#if FMT_VERSION < 120201
+
 // Seastar has no business defining a {fmt} formatter for std::exception_ptr,
 // a type it does not own; that is for the standard library or {fmt} to do (see
 // https://github.com/fmtlib/fmt/issues/4808). Until then we provide one, but
@@ -623,5 +625,7 @@ struct fmt::formatter<std::exception_ptr> {
         return fmt::format_to(ctx.out(), "{}", seastar::formattable(eptr));
     }
 };
+
+#endif
 
 /// @}


### PR DESCRIPTION
fmt 12.2.1 and above has a formatter for exception_ptr [1]. Drop our exception_ptr formatter to avoid a clash.

[1] https://github.com/fmtlib/fmt/commit/6dac6cad052d6593f5fa07529d912f3bd0d6bb11