### PR TITLE
core: make nested_exception transparent to {fmt} and std::rethrow_if_nested

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <source_location>
@@ -45,7 +46,15 @@
 
 namespace seastar {
 
-struct nested_exception : public std::exception {
+// Derives from std::nested_exception with its nested pointer set to \ref inner
+// (see the constructor), so that std::rethrow_if_nested() and {fmt}'s exception
+// formatter unwrap to the original cause. {fmt} follows only that single nested
+// pointer, so \ref what() additionally renders \ref outer (the exception that
+// was in flight while \ref inner was being handled); {fmt} appends \ref inner
+// after it, reproducing the full "<outer> ... <inner>" chain without duplication.
+class nested_exception : public std::exception, public std::nested_exception {
+    std::string _what;
+public:
     std::exception_ptr inner;
     std::exception_ptr outer;
     nested_exception(std::exception_ptr inner, std::exception_ptr outer) noexcept;

--- a/src/core/future.cc
+++ b/src/core/future.cc
@@ -151,15 +151,47 @@ void future_state_base::ignore() noexcept {
     }
 }
 
+static std::string describe_exception(const std::exception_ptr& e) noexcept {
+    try {
+        std::rethrow_exception(e);
+    } catch (const std::exception& ex) {
+        return ex.what();
+    } catch (...) {
+        return "unknown exception";
+    }
+}
+
 nested_exception::nested_exception(std::exception_ptr inner, std::exception_ptr outer) noexcept
-    : inner(std::move(inner)), outer(std::move(outer)) {}
+    : inner(std::move(inner)), outer(std::move(outer)) {
+    // The std::nested_exception base captures std::current_exception() in its
+    // constructor, which is not necessarily our `inner`. It exposes no setter,
+    // so make `inner` the current exception (by rethrowing it inside a handler)
+    // and copy-assign a freshly captured base, so that std::rethrow_if_nested()
+    // and {fmt} unwrap us to the original cause rather than stopping at what().
+    if (this->inner) {
+        try {
+            std::rethrow_exception(this->inner);
+        } catch (...) {
+            static_cast<std::nested_exception&>(*this) = std::nested_exception();
+        }
+    }
+    // {fmt} follows only the single std::nested_exception pointer (`inner`),
+    // which it appends after what(); render `outer` here so the full chain shows.
+    try {
+        _what = this->outer
+                ? "seastar::nested_exception (while cleaning up after " + describe_exception(this->outer) + ")"
+                : "seastar::nested_exception";
+    } catch (...) {
+        _what = "seastar::nested_exception";
+    }
+}
 
 nested_exception::nested_exception(nested_exception&&) noexcept = default;
 
 nested_exception::nested_exception(const nested_exception&) noexcept = default;
 
 const char* nested_exception::what() const noexcept {
-    return "seastar::nested_exception";
+    return _what.c_str();
 }
 
 [[noreturn]] void nested_exception::rethrow_nested() const {

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -665,6 +665,11 @@ auto fmt::formatter<seastar::internal::formattable_exception_ptr>::format(
 
         try {
             throw;
+        } catch (const seastar::nested_exception&) {
+            // Already fully rendered (inner and outer) by the branch above.
+            // seastar::nested_exception also derives from std::nested_exception,
+            // so without this catch it would fall into the branch below and print
+            // its inner exception a second time.
         } catch (const std::nested_exception& ne) {
             out = fmt::format_to(out, ": {}", seastar::formattable(ne.nested_ptr()));
         } catch (...) {

--- a/tests/unit/futures_test.cc
+++ b/tests/unit/futures_test.cc
@@ -456,6 +456,18 @@ static void check_finally_exception(std::exception_ptr ex) {
       // convert to the concrete type nested_exception
       std::rethrow_exception(ex);
   } catch (seastar::nested_exception& ex) {
+    // {fmt}'s own std::exception formatter renders the concrete object via
+    // what(), which names `outer`. Since seastar::nested_exception derives from
+    // std::nested_exception, {fmt} 12.2.1 additionally follows the single nested
+    // pointer (`inner`) and appends it, reproducing the full chain much like our
+    // own formatter above; earlier {fmt} stops at what().
+#if FMT_VERSION >= 120201
+    BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
+        "seastar::nested_exception (while cleaning up after foo): bar");
+#else
+    BOOST_REQUIRE_EQUAL(fmt::format("{}", ex),
+        "seastar::nested_exception (while cleaning up after foo)");
+#endif
     try {
         std::rethrow_exception(ex.inner);
     } catch (test_exception& inner) {


### PR DESCRIPTION
Seastar deprecated its {fmt} formatter for std::exception_ptr in favor
of the formatter provided by {fmt}. But {fmt} (like std::rethrow_if_nested)
can only see through a nested exception via std::nested_exception, and
seastar::nested_exception neither derived from it nor exposed the wrapped
exceptions in what() -- it returned the opaque string
"seastar::nested_exception", so formatting one dropped the actual
cause entirely.

Derive nested_exception from std::nested_exception with its nested pointer
set to `inner` (the std::nested_exception base captures the currently-handled
exception, so we rethrow `inner` and copy-assign a freshly captured base
rather than poking at libstdc++ internals). {fmt} follows only that single
pointer, so render `outer` in what() as well; {fmt} appends `inner` after it,
reproducing the full chain without duplication:

    seastar::nested_exception (while cleaning up after <outer>): <inner>

Deriving from std::nested_exception has a side effect on Seastar's own
(deprecated) exception_ptr formatter in util/log.cc: it already had a
special case that renders a seastar::nested_exception as
"<inner> (while cleaning up after <outer>)", and it also has a generic
std::nested_exception case that appends the nested pointer. A
seastar::nested_exception now matches both, so `inner` was printed twice.
Skip the generic case when the exception is a seastar::nested_exception,
which has already been rendered in full.

futures_test additionally checks formatting the concrete object with {fmt}'s
own std::exception formatter, which names `outer` via what() and -- as of
{fmt} 12.2.1 (https://github.com/fmtlib/fmt/pull/4844, post-12.2.0) -- also follows the single nested
pointer and appends `inner`, reproducing the full chain much like our
formatter does. The expected string is selected on FMT_VERSION, since earlier
{fmt} stops at what().

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Fixes https://github.com/scylladb/seastar/issues/3571