### PR TITLE
memory: back shard memory with a memfd and expose it

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -162,10 +162,32 @@ size_t per_shard_memory(size_t total_memory, unsigned nr_shards);
 
 void global_setup(unsigned nr_shards);
 
+/// Returns \p true if memfd_create() is available on the running kernel.
+bool memfd_create_available();
+
+/// Returns \p true if transparent hugepages are enabled for memfd (shmem)
+/// memory on the running system, i.e., if
+/// /sys/kernel/mm/transparent_hugepage/shmem_enabled selects a value
+/// (always, within_size, advise or force) under which a memfd mapping we
+/// madvise() with MADV_HUGEPAGE can be backed by transparent hugepages.
+bool transparent_hugepages_enabled_for_memfd();
+
 }
 
+/// Configures the memory allocator for the current shard.
+///
+/// \param m NUMA-aware description of the memory assigned to this shard.
+/// \param mbind whether to bind the memory to its NUMA node.
+/// \param transparent_hugepages whether to madvise(MADV_HUGEPAGE) the memory.
+/// \param use_memfd whether to back the shard's memory with a memfd (see
+///        \ref get_memory_layout() to obtain the resulting file descriptor).
+///        Ignored when \p hugetlbfs_path is set, since hugetlbfs provides its
+///        own backing file.
+/// \param hugetlbfs_path optional path to a hugetlbfs mount used to back the
+///        shard's memory with explicit huge pages.
 internal::numa_layout configure(std::vector<resource::memory> m, bool mbind,
         bool transparent_hugepages,
+        bool use_memfd = false,
         std::optional<std::string> hugetlbfs_path = {});
 
 void configure_minimal();
@@ -353,6 +375,13 @@ public:
 struct memory_layout {
     uintptr_t start;
     uintptr_t end;
+    /// File descriptor backing the shard's memory, or disengaged if the memory
+    /// is anonymous. This is set when the memory is backed by a memfd (see the
+    /// \p use_memfd parameter of \ref configure()), letting other components
+    /// map the same physical memory (for example, into another process). The
+    /// descriptor is owned by the allocator and remains valid for the lifetime
+    /// of the shard; users that wish to keep it beyond that must dup() it.
+    std::optional<int> memfd;
 };
 
 // Discover virtual address range used by the allocator on current shard.

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -25,11 +25,14 @@
 #include <seastar/core/bitops.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/sampler.hh>
+#include <algorithm>
 #include <new>
 #include <cstdint>
+#include <span>
 #include <functional>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace seastar {
@@ -387,6 +390,104 @@ struct memory_layout {
 // Discover virtual address range used by the allocator on current shard.
 // Supported only when seastar allocator is enabled.
 memory::memory_layout get_memory_layout();
+
+/// A contiguous range of address space aliasing discontiguous shard memory.
+///
+/// When the shard's memory is backed by a file (see the \p use_memfd parameter
+/// of \ref configure()) it can be mapped more than once, unlike anonymous
+/// memory. This makes it possible to recover a large contiguous range of
+/// address space from a set of smaller, scattered allocations: the allocations
+/// keep their original addresses, and in addition appear back-to-back in the
+/// range owned by this object. Both mappings refer to the same physical
+/// memory, so a store through one is visible through the other.
+///
+/// The object owns a fixed-size reservation of address space, which is filled
+/// in, from its start, by one or more calls to \ref append(). The reservation
+/// beyond the appended ranges is inaccessible, so the mapping never has to be
+/// relocated as it grows, and accesses beyond \ref size() trap. This makes the
+/// tail of the reservation usable as a guard region.
+///
+/// The contiguous mapping cannot use transparent hugepages (its constituent
+/// ranges are not hugepage aligned in the backing file), so accessing memory
+/// through it is more TLB-expensive than accessing it through the allocator's
+/// own mapping.
+///
+/// The appended ranges must remain allocated for as long as the mapping exists.
+class contiguous_mapping {
+    char* _addr = nullptr;
+    size_t _capacity = 0;
+    size_t _size = 0;
+public:
+    /// Constructs an empty mapping, owning no address space.
+    contiguous_mapping() noexcept = default;
+    /// Reserves address space for the mapping. The reserved address space is
+    /// inaccessible until ranges are appended to it with \ref append().
+    ///
+    /// \param capacity number of bytes to reserve; must be a multiple of
+    ///        \ref page_size.
+    /// \throw std::invalid_argument if \p capacity is not page aligned.
+    /// \throw std::system_error if the address space cannot be reserved.
+    explicit contiguous_mapping(size_t capacity);
+    contiguous_mapping(contiguous_mapping&& x) noexcept
+            : _addr(std::exchange(x._addr, nullptr))
+            , _capacity(std::exchange(x._capacity, 0))
+            , _size(std::exchange(x._size, 0)) {
+    }
+    contiguous_mapping& operator=(contiguous_mapping&& x) noexcept {
+        if (this != &x) {
+            this->~contiguous_mapping();
+            new (this) contiguous_mapping(std::move(x));
+        }
+        return *this;
+    }
+    ~contiguous_mapping();
+    /// Maps more of the shard's memory at the end of the mapping, growing it by
+    /// the total size of \p ranges. The ranges are mapped in the order given,
+    /// with no gaps between them, and the memory they alias is not modified.
+    ///
+    /// \param ranges address ranges within the shard's memory; each range must
+    ///        start on, and have a size that is a multiple of, \ref page_size.
+    /// \throw std::runtime_error if the shard's memory is not backed by a file.
+    /// \throw std::invalid_argument if a range is not page aligned, or is not
+    ///        contained in the shard's memory.
+    /// \throw std::bad_alloc if the ranges do not fit in the remaining
+    ///        capacity.
+    /// \throw std::system_error if a range cannot be mapped.
+    void append(std::span<const std::span<char>> ranges);
+    /// Returns the start of the mapping, or \p nullptr if no address space is
+    /// reserved. The address does not change as the mapping grows.
+    char* data() const noexcept { return _addr; }
+    /// Returns the number of accessible bytes, i.e., the total size of the
+    /// ranges appended so far.
+    size_t size() const noexcept { return _size; }
+    /// Returns the number of bytes of address space reserved for the mapping.
+    size_t capacity() const noexcept { return _capacity; }
+    /// Returns the accessible part of the mapping.
+    std::span<char> range() const noexcept { return {_addr, _size}; }
+};
+
+/// Maps address ranges of the shard's memory into a single contiguous range of
+/// address space.
+///
+/// \param ranges address ranges within the shard's memory, in the order they
+///        are to appear in the result; each range must start on, and have a
+///        size that is a multiple of, \ref page_size.
+/// \param capacity number of bytes of address space to reserve, for later
+///        growth with \ref contiguous_mapping::append(); must be page aligned.
+///        Clamped up to the total size of \p ranges.
+/// \return a mapping of the concatenation of \p ranges.
+/// \throw see \ref contiguous_mapping::contiguous_mapping() and
+///        \ref contiguous_mapping::append().
+inline
+contiguous_mapping map_contiguous(std::span<const std::span<char>> ranges, size_t capacity = 0) {
+    size_t total = 0;
+    for (auto range : ranges) {
+        total += range.size();
+    }
+    auto ret = contiguous_mapping(std::max(capacity, total));
+    ret.append(ranges);
+    return ret;
+}
 
 /// Returns the size of free memory in bytes.
 size_t free_memory();

--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -136,6 +136,11 @@ public:
         throw_system_error_on(fd == -1, "timerfd_create");
         return file_desc(fd);
     }
+    static file_desc memfd_create(sstring name, unsigned int flags) {
+        int fd = ::memfd_create(name.c_str(), flags);
+        throw_system_error_on(fd == -1, "memfd_create");
+        return file_desc(fd);
+    }
     static file_desc temporary(sstring directory);
     file_desc dup() const {
         int fd = ::dup(get());

--- a/include/seastar/core/smp_options.hh
+++ b/include/seastar/core/smp_options.hh
@@ -53,6 +53,14 @@ struct smp_options : public program_options::option_group {
     program_options::value<std::string> reserve_memory;
     /// Path to accessible hugetlbfs mount (typically /dev/hugepages/something).
     program_options::value<std::string> hugepages;
+    /// Back shard memory with a memfd, exposing it via
+    /// \ref memory::memory_layout::memfd.
+    ///
+    /// When unset, memfd backing is enabled by default whenever transparent
+    /// hugepages are available for memfd (see
+    /// /sys/kernel/mm/transparent_hugepage/shmem_enabled) or the reactor is
+    /// \ref reactor_options::overprovisioned. Ignored when \ref hugepages is set.
+    program_options::value<bool> memfd;
     /// Lock all memory (prevents swapping).
     program_options::value<bool> lock_memory;
     /// Pin threads to their cpus (disable for overprovisioning).

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1289,6 +1289,9 @@ allocate_hugetlbfs_memory(file_desc& fd, void* where, size_t how_much) {
 
 mmap_area
 static allocate_memfd_memory(file_desc& fd, void* where, size_t how_much) {
+    // The file grows in step with the shard's memory, which grows upwards, so
+    // the file offset of an address is its distance from the start of the
+    // shard's memory. contiguous_mapping::append() relies on that.
     auto pos = fd.size();
     fd.truncate(pos + how_much);
     auto ret = fd.map(
@@ -2044,6 +2047,62 @@ bool drain_cross_cpu_freelist() {
 
 memory_layout get_memory_layout() {
     return get_cpu_mem().memory_layout();
+}
+
+contiguous_mapping::contiguous_mapping(size_t capacity) {
+    if (capacity % page_size != 0) {
+        throw std::invalid_argument("contiguous_mapping: capacity is not page aligned");
+    }
+    if (capacity == 0) {
+        return;
+    }
+    // Reserve address space only; append() maps the shard's memory into it. The
+    // still-unused tail stays inaccessible, so it also serves as a guard region.
+    auto p = ::mmap(nullptr, capacity, PROT_NONE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    throw_system_error_on(p == MAP_FAILED, "contiguous_mapping: mmap");
+    _addr = reinterpret_cast<char*>(p);
+    _capacity = capacity;
+}
+
+contiguous_mapping::~contiguous_mapping() {
+    if (_addr) {
+        ::munmap(_addr, _capacity);
+    }
+}
+
+void contiguous_mapping::append(std::span<const std::span<char>> ranges) {
+    auto layout = get_memory_layout();
+    if (!layout.memfd) {
+        throw std::runtime_error("contiguous_mapping: the shard's memory is not backed by a file"
+                " (see the --memfd option)");
+    }
+    // Validate everything before mapping anything, so a bad request leaves the
+    // mapping unchanged.
+    size_t total = 0;
+    for (auto range : ranges) {
+        auto start = reinterpret_cast<uintptr_t>(range.data());
+        if (start % page_size != 0 || range.size() % page_size != 0) {
+            throw std::invalid_argument("contiguous_mapping: address range is not page aligned");
+        }
+        if (start < layout.start || start > layout.end || range.size() > layout.end - start) {
+            throw std::invalid_argument("contiguous_mapping: address range is outside the shard's memory");
+        }
+        total += range.size();
+    }
+    if (total > _capacity - _size) {
+        throw std::bad_alloc();
+    }
+    for (auto range : ranges) {
+        // The allocator maps its memory from the backing file in address order,
+        // starting at offset zero, so an address maps to a file offset simply by
+        // subtracting the start of the shard's memory.
+        auto offset = reinterpret_cast<uintptr_t>(range.data()) - layout.start;
+        auto p = ::mmap(_addr + _size, range.size(), PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_FIXED, *layout.memfd, offset);
+        throw_system_error_on(p == MAP_FAILED, "contiguous_mapping::append: mmap");
+        _size += range.size();
+    }
 }
 
 size_t min_free_memory() {
@@ -2824,6 +2883,17 @@ bool drain_cross_cpu_freelist() {
 
 memory_layout get_memory_layout() {
     throw std::runtime_error("get_memory_layout() not supported");
+}
+
+contiguous_mapping::contiguous_mapping(size_t) {
+    throw std::runtime_error("contiguous_mapping is not supported with the default allocator");
+}
+
+contiguous_mapping::~contiguous_mapping() {
+}
+
+void contiguous_mapping::append(std::span<const std::span<char>>) {
+    throw std::runtime_error("contiguous_mapping is not supported with the default allocator");
 }
 
 size_t min_free_memory() {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -545,6 +545,10 @@ struct cpu_pages {
     uint32_t nr_pages;
     uint32_t nr_free_pages;
     uint32_t current_min_free_pages = 0;
+    // When the shard's memory is backed by a memfd (see configure()), this
+    // holds the descriptor. It is kept open for the lifetime of the shard so
+    // it can be exposed via memory_layout::memfd.
+    std::optional<file_desc> memfd;
     struct {
         size_t warn = std::numeric_limits<size_t>::max();
         size_t check = std::numeric_limits<size_t>::max();
@@ -1283,6 +1287,22 @@ allocate_hugetlbfs_memory(file_desc& fd, void* where, size_t how_much) {
     return ret;
 }
 
+mmap_area
+static allocate_memfd_memory(file_desc& fd, void* where, size_t how_much) {
+    auto pos = fd.size();
+    fd.truncate(pos + how_much);
+    auto ret = fd.map(
+            how_much,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED | (where ? MAP_FIXED : 0),
+            pos,
+            where);
+    // Unlike anonymous memory, a fresh memfd mapping does not inherit the
+    // MADV_HUGEPAGE hint applied to the bootstrap region, so (re-)apply it here.
+    maybe_enable_transparent_hugepages(ret.get(), how_much);
+    return ret;
+}
+
 void cpu_pages::replace_memory_backing(allocate_system_memory_fn alloc_sys_mem) {
     // We would like to use ::mremap() to atomically replace the old anonymous
     // memory with hugetlbfs backed memory, but mremap() does not support hugetlbfs
@@ -1384,7 +1404,8 @@ memory::memory_layout cpu_pages::memory_layout() {
     SEASTAR_ASSERT(is_initialized());
     return {
         reinterpret_cast<uintptr_t>(memory),
-        reinterpret_cast<uintptr_t>(memory) + nr_pages * page_size
+        reinterpret_cast<uintptr_t>(memory) + nr_pages * page_size,
+        memfd.transform(&file_desc::get),
     };
 }
 
@@ -1894,9 +1915,50 @@ internal::global_setup(unsigned nr_shards) {
     cpu_id_and_mem_base_mask = ~((uintptr_t(1) << cpu_id_shift) - 1);
 }
 
+bool
+internal::memfd_create_available() {
+    // Probe the kernel by actually creating (and immediately closing) a memfd.
+    // memfd_create() has been available since Linux 3.17; older kernels fail
+    // with ENOSYS.
+    int fd = ::memfd_create("seastar_probe", MFD_CLOEXEC);
+    if (fd == -1) {
+        return false;
+    }
+    ::close(fd);
+    return true;
+}
+
+bool
+internal::transparent_hugepages_enabled_for_memfd() {
+    // The sysfs knob reports the available policies with the active one in
+    // brackets, e.g. "always within_size [advise] never deny force". Any value
+    // other than "never" or "deny" allows a memfd mapping that we madvise() with
+    // MADV_HUGEPAGE to be backed by transparent hugepages.
+    int fd = ::open("/sys/kernel/mm/transparent_hugepage/shmem_enabled", O_RDONLY | O_CLOEXEC);
+    if (fd == -1) {
+        return false;
+    }
+    char buf[128] = {};
+    auto n = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    if (n <= 0) {
+        return false;
+    }
+    std::string_view contents(buf, n);
+    auto open_bracket = contents.find('[');
+    auto close_bracket = contents.find(']');
+    if (open_bracket == std::string_view::npos || close_bracket == std::string_view::npos
+            || close_bracket <= open_bracket) {
+        return false;
+    }
+    auto active = contents.substr(open_bracket + 1, close_bracket - open_bracket - 1);
+    return active != "never" && active != "deny";
+}
+
 internal::numa_layout
 configure(std::vector<resource::memory> m, bool mbind,
         bool transparent_hugepages,
+        bool use_memfd,
         optional<std::string> hugetlbfs_path) {
     // we need to make sure cpu_mem is initialize since configure calls cpu_mem.resize
     // and we might reach configure without ever allocating, hence without ever calling
@@ -1923,6 +1985,16 @@ configure(std::vector<resource::memory> m, bool mbind,
         auto fdp = make_lw_shared<file_desc>(file_desc::temporary(*hugetlbfs_path));
         sys_alloc = [fdp] (void* where, size_t how_much) {
             return allocate_hugetlbfs_memory(*fdp, where, how_much);
+        };
+        get_cpu_mem().replace_memory_backing(sys_alloc);
+    } else if (use_memfd) {
+        // Back the shard's memory with a memfd so it can be exposed to users
+        // via memory_layout::memfd. The descriptor lives in get_cpu_mem() and
+        // stays open for the lifetime of the shard; the mapping is otherwise
+        // equivalent to anonymous memory (transparent hugepages included).
+        auto& fd = get_cpu_mem().memfd.emplace(file_desc::memfd_create("seastar_memory", MFD_CLOEXEC));
+        sys_alloc = [&fd] (void* where, size_t how_much) {
+            return allocate_memfd_memory(fd, where, how_much);
         };
         get_cpu_mem().replace_memory_backing(sys_alloc);
     }
@@ -2722,12 +2794,21 @@ void set_reclaim_hook(std::function<void (std::function<void ()>)> hook) {
 internal::numa_layout
 configure(std::vector<resource::memory> m, bool mbind,
         bool transparent_hugepages,
+        bool use_memfd,
         std::optional<std::string> hugepages_path) {
     return {};
 }
 
 void configure_minimal()
 {}
+
+bool internal::memfd_create_available() {
+    return false;
+}
+
+bool internal::transparent_hugepages_enabled_for_memfd() {
+    return false;
+}
 
 statistics stats() {
     return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0, 0, 0};

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4090,6 +4090,7 @@ smp_options::smp_options(program_options::option_group* parent_group)
     , memory(*this, "memory", std::nullopt, "memory to use, in bytes (ex: 4G) (default: all)")
     , reserve_memory(*this, "reserve-memory", {}, "memory reserved to OS (if --memory not specified)")
     , hugepages(*this, "hugepages", {}, "path to accessible hugetlbfs mount (typically /dev/hugepages/something)")
+    , memfd(*this, "memfd", {}, "back shard memory with a memfd, exposing it to users (default: enabled when transparent hugepages are available for memfd, or when overprovisioned)")
     , lock_memory(*this, "lock-memory", {}, "lock all memory (prevents swapping)")
     , thread_affinity(*this, "thread-affinity", true, "pin threads to their cpus (disable for overprovisioning)")
 #ifdef SEASTAR_HAVE_HWLOC
@@ -4529,6 +4530,20 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     if (smp_opts.hugepages) {
         hugepages_path = smp_opts.hugepages.get_value();
     }
+    // Back shard memory with a memfd (unless hugetlbfs is used, which provides
+    // its own backing file). When --memfd is not given explicitly, enable it by
+    // default whenever transparent hugepages are available for memfd, or when
+    // overprovisioned (where THP is disabled but memfd is still desirable).
+    bool use_memfd = false;
+    if (!hugepages_path && smp_opts.memory_allocator == memory_allocator::seastar) {
+        if (smp_opts.memfd) {
+            use_memfd = smp_opts.memfd.get_value();
+        } else {
+            use_memfd = memory::internal::memfd_create_available()
+                    && (memory::internal::transparent_hugepages_enabled_for_memfd()
+                        || reactor_opts.overprovisioned);
+        }
+    }
     auto mlock = false;
     if (smp_opts.lock_memory) {
         mlock = smp_opts.lock_memory.get_value();
@@ -4575,7 +4590,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
     std::optional<memory::internal::numa_layout> layout;
     if (smp_opts.memory_allocator == memory_allocator::seastar) {
-        layout = memory::configure(allocations[0].mem, mbind, use_transparent_hugepages, hugepages_path);
+        layout = memory::configure(allocations[0].mem, mbind, use_transparent_hugepages, use_memfd, hugepages_path);
     } else {
         // #2148 - if running seastar allocator but options that contradict this, we still need to
         // init memory at least minimally, otherwise a bunch of stuff breaks.
@@ -4757,7 +4772,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     smp::_this_smp = this;
     for (i = 1; i < _shard_count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages, allocate_qs_owner, allocate_smp_queues, backend_configurator, &backend_configuration_initialized] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg, &mtx, &layout, use_transparent_hugepages, use_memfd, allocate_qs_owner, allocate_smp_queues, backend_configurator, &backend_configuration_initialized] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4768,7 +4783,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
                 smp::pin(allocation.cpu_id);
             }
             if (smp_opts.memory_allocator == memory_allocator::seastar) {
-                auto another_layout = memory::configure(allocation.mem, mbind, use_transparent_hugepages, hugepages_path);
+                auto another_layout = memory::configure(allocation.mem, mbind, use_transparent_hugepages, use_memfd, hugepages_path);
                 auto guard = std::lock_guard(mtx);
                 *layout = memory::internal::merge(std::move(*layout), std::move(another_layout));
             } else {

--- a/src/seastar.cppm
+++ b/src/seastar.cppm
@@ -687,6 +687,7 @@ using seastar::log_cli::options;
 export namespace seastar::memory {
 
 using seastar::memory::allocation_site;
+using seastar::memory::contiguous_mapping;
 using seastar::memory::disable_abort_on_alloc_failure_temporarily;
 using seastar::memory::free_memory;
 using seastar::memory::generate_memory_diagnostics_report;
@@ -694,6 +695,7 @@ using seastar::memory::get_large_allocation_warning_threshold;
 using seastar::memory::get_memory_layout;
 using seastar::memory::is_abort_on_allocation_failure;
 using seastar::memory::local_failure_injector;
+using seastar::memory::map_contiguous;
 using seastar::memory::memory_diagnostics_writer;
 using seastar::memory::memory_layout;
 using seastar::memory::min_free_memory;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -311,6 +311,10 @@ seastar_add_test (allocator
 seastar_add_app_test (alien
   SOURCES alien_test.cc)
 
+seastar_add_test (contiguous_mapping
+  SOURCES contiguous_mapping_test.cc
+  RUN_ARGS --memfd 1)
+
 seastar_add_test (checked_ptr
   SOURCES checked_ptr_test.cc)
 

--- a/tests/unit/contiguous_mapping_test.cc
+++ b/tests/unit/contiguous_mapping_test.cc
@@ -1,0 +1,268 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/log.hh>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace seastar;
+
+static logger testlog("contiguous_mapping_test");
+
+// Returns the shard's memory layout, or nothing if the shard's memory is not
+// backed by a file (the default allocator is disabled, memfd backing is off, or
+// hugetlbfs is used) and contiguous_mapping therefore cannot work.
+static std::optional<memory::memory_layout> file_backed_memory_layout() {
+    try {
+        auto layout = memory::get_memory_layout();
+        if (!layout.memfd) {
+            return std::nullopt;
+        }
+        return layout;
+    } catch (const std::runtime_error&) {
+        // get_memory_layout() is not supported with the default allocator.
+        return std::nullopt;
+    }
+}
+
+// A page-aligned allocation to be aliased by a contiguous_mapping.
+class chunk {
+    std::unique_ptr<char[], free_deleter> _mem;
+    size_t _size;
+public:
+    explicit chunk(size_t size)
+            : _mem(allocate_aligned_buffer<char>(size, memory::page_size))
+            , _size(size) {
+    }
+    std::span<char> range() const noexcept { return {_mem.get(), _size}; }
+    char* data() const noexcept { return _mem.get(); }
+    size_t size() const noexcept { return _size; }
+};
+
+// Tests whether \p p can be read, without risking a fatal SIGSEGV: a syscall
+// reading from an inaccessible address fails with EFAULT instead of faulting.
+static bool readable(const char* p) {
+    int fds[2];
+    if (::pipe2(fds, O_CLOEXEC) != 0) {
+        throw std::system_error(errno, std::system_category(), "pipe2");
+    }
+    auto n = ::write(fds[1], p, 1);
+    auto err = errno;
+    ::close(fds[0]);
+    ::close(fds[1]);
+    if (n == 1) {
+        return true;
+    }
+    BOOST_REQUIRE_EQUAL(err, EFAULT);
+    return false;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_map_contiguous_aliases_its_ranges) {
+    if (!file_backed_memory_layout()) {
+        testlog.info("skipping: the shard's memory is not backed by a file");
+        return;
+    }
+    constexpr size_t chunk_size = 128 * 1024;
+    constexpr unsigned nr_chunks = 8;
+    auto chunks = std::vector<chunk>();
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        chunks.emplace_back(chunk_size);
+    }
+    // Map the chunks in an order unrelated to their addresses, to be sure the
+    // mapping follows the requested order rather than the address order.
+    auto ranges = std::vector<std::span<char>>();
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        ranges.push_back(chunks[(i * 5) % nr_chunks].range());
+    }
+    auto mapping = memory::map_contiguous(ranges);
+    BOOST_REQUIRE_EQUAL(mapping.size(), nr_chunks * chunk_size);
+    BOOST_REQUIRE_EQUAL(mapping.capacity(), nr_chunks * chunk_size);
+    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(mapping.data()) % memory::page_size, 0u);
+    // A store through the original mapping is visible in the contiguous one...
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        std::memset(ranges[i].data(), 'a' + i, ranges[i].size());
+    }
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        auto alias = mapping.range().subspan(i * chunk_size, chunk_size);
+        BOOST_REQUIRE(std::all_of(alias.begin(), alias.end(), [c0 = char('a' + i)] (char c) { return c == c0; }));
+    }
+    // ... and vice versa.
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        std::memset(mapping.data() + i * chunk_size, 'A' + i, chunk_size);
+    }
+    for (unsigned i = 0; i < nr_chunks; ++i) {
+        auto range = ranges[i];
+        BOOST_REQUIRE(std::all_of(range.begin(), range.end(), [c0 = char('A' + i)] (char c) { return c == c0; }));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_contiguous_mapping_grows_in_place) {
+    if (!file_backed_memory_layout()) {
+        testlog.info("skipping: the shard's memory is not backed by a file");
+        return;
+    }
+    constexpr size_t chunk_size = 128 * 1024;
+    auto mapping = memory::contiguous_mapping(4 * chunk_size);
+    BOOST_REQUIRE_EQUAL(mapping.size(), 0u);
+    BOOST_REQUIRE_EQUAL(mapping.capacity(), 4 * chunk_size);
+    auto chunks = std::vector<chunk>();
+    auto base = mapping.data();
+    for (unsigned i = 0; i < 4; ++i) {
+        chunks.emplace_back(chunk_size);
+        std::memset(chunks.back().data(), 'a' + i, chunk_size);
+        auto range = chunks.back().range();
+        mapping.append(std::span(&range, 1));
+        // Growing does not relocate the mapping.
+        BOOST_REQUIRE(mapping.data() == base);
+        BOOST_REQUIRE_EQUAL(mapping.size(), (i + 1) * chunk_size);
+        // Everything mapped so far is still there.
+        for (unsigned j = 0; j <= i; ++j) {
+            BOOST_REQUIRE_EQUAL(mapping.data()[j * chunk_size], char('a' + j));
+        }
+        // The rest of the reservation is inaccessible.
+        if (i != 3) {
+            BOOST_REQUIRE(!readable(mapping.data() + mapping.size()));
+        }
+    }
+    auto one_too_many = chunk(chunk_size);
+    auto range = one_too_many.range();
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&range, 1)), std::bad_alloc);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_contiguous_mapping_rejects_bad_ranges) {
+    auto layout = file_backed_memory_layout();
+    if (!layout) {
+        testlog.info("skipping: the shard's memory is not backed by a file");
+        return;
+    }
+    auto mapping = memory::contiguous_mapping(4 * memory::page_size);
+    auto c = chunk(2 * memory::page_size);
+    auto misaligned_start = std::span<char>(c.data() + 1, memory::page_size);
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&misaligned_start, 1)), std::invalid_argument);
+    auto misaligned_size = std::span<char>(c.data(), memory::page_size + 1);
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&misaligned_size, 1)), std::invalid_argument);
+    // Static storage is not part of the shard's memory (nor is the stack of a
+    // seastar thread, which is allocated by the shard's allocator).
+    alignas(memory::page_size) static char outside_the_heap[memory::page_size];
+    auto foreign = std::span<char>(outside_the_heap, memory::page_size);
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&foreign, 1)), std::invalid_argument);
+    auto past_the_end = std::span<char>(reinterpret_cast<char*>(layout->end), memory::page_size);
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&past_the_end, 1)), std::invalid_argument);
+    auto way_past_the_end = std::span<char>(reinterpret_cast<char*>(layout->end + (1 << 30)),
+            memory::page_size);
+    BOOST_REQUIRE_THROW(mapping.append(std::span(&way_past_the_end, 1)), std::invalid_argument);
+    // A rejected request leaves the mapping alone.
+    BOOST_REQUIRE_EQUAL(mapping.size(), 0u);
+    BOOST_REQUIRE_THROW(memory::contiguous_mapping(memory::page_size + 1), std::invalid_argument);
+}
+
+// A stand-in for a wasmtime guest memory, following the contract of
+// wasmtime::LinearMemory (wasmtime_linear_memory_t in the C API), as created by
+// wasmtime::MemoryCreator::new_memory() (wasmtime_new_memory_callback_t):
+//
+//  - the memory is page aligned and a multiple of the page size,
+//  - it is zero-filled,
+//  - byte_size() bytes are accessible, byte_capacity() bytes can be reached by
+//    growing without relocating as_ptr(),
+//  - the guard region past the capacity is unmapped, so that compiled guest
+//    code can elide bounds checks and rely on a trap instead.
+//
+// The guest memory is assembled out of ordinary allocations, so that a wasm
+// guest uses memory that is accounted for, and reclaimable, like the rest of
+// the shard's memory. This was verified against the wasmtime 48 C API, running
+// a wasm module whose memory is served by a contiguous_mapping.
+class wasm_linear_memory {
+    // A wasm page, the granularity in which a guest grows its memory.
+    static constexpr size_t wasm_page_size = 64 * 1024;
+    std::vector<chunk> _chunks;
+    size_t _capacity;
+    memory::contiguous_mapping _mapping;
+public:
+    // Arguments as passed to wasmtime_new_memory_callback_t, with zero meaning
+    // "unspecified" for maximum and reserved_size.
+    wasm_linear_memory(size_t minimum, size_t maximum, size_t reserved_size, size_t guard_size)
+            : _capacity(reserved_size ? reserved_size : std::max(minimum, maximum))
+            , _mapping(_capacity + guard_size) {
+        grow_to(minimum);
+    }
+    char* as_ptr() const noexcept { return _mapping.data(); }
+    size_t byte_size() const noexcept { return _mapping.size(); }
+    size_t byte_capacity() const noexcept { return _capacity; }
+    void grow_to(size_t new_size) {
+        auto ranges = std::vector<std::span<char>>();
+        for (auto size = byte_size(); size < new_size; size += wasm_page_size) {
+            _chunks.emplace_back(wasm_page_size);
+            // wasmtime requires the guest memory to be zero-filled.
+            std::memset(_chunks.back().data(), 0, wasm_page_size);
+            ranges.push_back(_chunks.back().range());
+        }
+        _mapping.append(ranges);
+    }
+};
+
+SEASTAR_THREAD_TEST_CASE(test_usable_as_wasmtime_guest_memory) {
+    if (!file_backed_memory_layout()) {
+        testlog.info("skipping: the shard's memory is not backed by a file");
+        return;
+    }
+    constexpr size_t wasm_page_size = 64 * 1024;
+    // What wasmtime asks for on x86-64 for a guest declaring (memory 4 100).
+    constexpr size_t reserved_size = 4ull << 30;
+    constexpr size_t guard_size = 32 << 20;
+    auto mem = wasm_linear_memory(4 * wasm_page_size, 100 * wasm_page_size, reserved_size, guard_size);
+    BOOST_REQUIRE_EQUAL(mem.byte_size(), 4 * wasm_page_size);
+    BOOST_REQUIRE_EQUAL(mem.byte_capacity(), reserved_size);
+    BOOST_REQUIRE_EQUAL(reinterpret_cast<uintptr_t>(mem.as_ptr()) % memory::page_size, 0u);
+    auto guest = std::span(mem.as_ptr(), mem.byte_size());
+    BOOST_REQUIRE(std::all_of(guest.begin(), guest.end(), [] (char c) { return c == 0; }));
+    // The guest stores across the seams between the allocations backing it.
+    for (size_t i = 0; i < mem.byte_size(); ++i) {
+        guest[i] = char(i);
+    }
+    // memory.grow keeps the base pointer, so compiled code needs no fixups.
+    auto base = mem.as_ptr();
+    mem.grow_to(100 * wasm_page_size);
+    BOOST_REQUIRE(mem.as_ptr() == base);
+    BOOST_REQUIRE_EQUAL(mem.byte_size(), 100 * wasm_page_size);
+    for (size_t i = 0; i < 4 * wasm_page_size; ++i) {
+        BOOST_REQUIRE_EQUAL(guest[i], char(i));
+    }
+    auto grown = std::span(mem.as_ptr() + 4 * wasm_page_size, 96 * wasm_page_size);
+    BOOST_REQUIRE(std::all_of(grown.begin(), grown.end(), [] (char c) { return c == 0; }));
+    // Everything from byte_size() to the end of the guard region traps, which is
+    // what lets compiled guest code skip bounds checks.
+    BOOST_REQUIRE(!readable(mem.as_ptr() + mem.byte_size()));
+    BOOST_REQUIRE(!readable(mem.as_ptr() + mem.byte_capacity()));
+    BOOST_REQUIRE(!readable(mem.as_ptr() + mem.byte_capacity() + guard_size - 1));
+}


### PR DESCRIPTION
Add the ability to back each shard's memory allocator with a memfd instead of anonymous memory. This lets the shard's memory be exposed to users (via memory_layout::memfd), so other components can map the same physical memory, for example into another process.

The memfd path mirrors the existing hugetlbfs path: a per-shard file is grown with ftruncate() and mapped MAP_SHARED in place, with MADV_HUGEPAGE re-applied on each mapping since a fresh memfd mapping does not inherit the bootstrap region's transparent-hugepage hint.

memfd backing is enabled by default when memfd_create() is available and either transparent hugepages are enabled for memfd (per /sys/kernel/mm/transparent_hugepage/shmem_enabled) or the reactor is overprovisioned. The new --memfd option overrides the default. It is ignored when --hugepages is given, since hugetlbfs provides its own backing file.

The motivation for this is the ability to recover contiguous memory from a bunch of 128k allocations, by mmaping those allocations using the memfd as a reference. Since a file can be allocated in multiple mappings (unlike anonymous memory), one can have a multi-megabyte contiguous mmap that points at several discontiguous 128k chunks. This contiguous mmap won't use transparent hugepages, but sometimes it's a reasonable tradeoff.

Add a helper to take advantage of this: the helper receives a range of contiguous spans, and remaps it
into a contiguous scans. The helper supports growing.