### PR TITLE
build: add opt-in precompiled-header support (Seastar_PRECOMPILE_HEAD…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,10 @@ option (Seastar_DPDK
   "Enable DPDK support."
   OFF)
 
+option (Seastar_PRECOMPILE_HEADERS
+  "Precompile the heaviest, near-universally included header (core/reactor.hh) to speed up building Seastar itself. Note for ccache users: requires 'sloppiness = pch_defines,time_macros' in ccache.conf."
+  OFF)
+
 option (Seastar_EXCLUDE_APPS_FROM_ALL
   "When enabled alongside Seastar_APPS, do not build applications by default."
   OFF)
@@ -865,6 +869,15 @@ target_include_directories (seastar
     $<BUILD_INTERFACE:${Seastar_GEN_BINARY_DIR}/src>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if (Seastar_PRECOMPILE_HEADERS)
+  target_precompile_headers (seastar PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/seastar/core/reactor.hh)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Instantiate templates once in the PCH instead of in every TU.
+    target_compile_options (seastar PRIVATE -fpch-instantiate-templates)
+  endif ()
+endif ()
 
 set (Seastar_PRIVATE_CXX_FLAGS
   -fno-semantic-interposition


### PR DESCRIPTION
…ERS)

Add an opt-in CMake option that precompiles core/reactor.hh - the heaviest, near-universally included header - for the seastar library target, and on Clang additionally passes -fpch-instantiate-templates so templates are instantiated once in the PCH instead of in every TU.

Measured on a 16-core machine (clang 22.1.7, libstdc++ 16, Dev mode, no compiler cache): a clean build of the seastar library target drops from 26.8s to 17.6s wall (-34%); the sum of per-TU compile durations drops from 428.9s to 198.6s (-54%). As part of a ScyllaDB clean build, this is worth about 8 seconds of end-to-end wall-clock time.

The option is OFF by default: PCH interacts with ccache (users need "sloppiness = pch_defines,time_macros" in ccache.conf), and GCC's PCH support (which CMake drives the same way) is unmeasured here - the -fpch-instantiate-templates flag itself is applied only for Clang.

Verified: with the option ON, the seastar target builds cleanly on current master (Dev mode, clang); with it OFF (the default), the generated build files are identical to before this change.