### PR TITLE
github: treat deprecation warnings as errors in CI

### DIFF
--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -100,6 +100,12 @@ if [[ "$COMPILER" == clang++-* && "$clang_ver" -ge 20 || "$STANDARD" -ge 26 ]] ;
     cook_args=(--cook fmt)
 fi
 
+# Deprecation diagnostics are errors in CI only. The flags land in
+# Seastar_CXX_FLAGS, which is appended after the -Wno-error demotions
+# in CMakeLists.txt, so the -Werror here wins. GCC's -Wdeprecated
+# does not include -Wdeprecated-declarations, hence both.
+deprecation_errors='-Werror=deprecated -Werror=deprecated-declarations'
+
 group "configure.py"
 # OPTIONS / ENABLES intentionally unquoted: each carries multiple
 # whitespace-separated args (e.g. "--cook dpdk --dpdk-machine corei7-avx").
@@ -109,6 +115,7 @@ group "configure.py"
     --compiler "$CPP"           \
     --c-compiler "$CC"          \
     --mode "$MODE"              \
+    --cflags "$deprecation_errors" \
     "${cook_args[@]}"           \
     "${ccache_opt[@]}"          \
     $OPTIONS                    \

--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -100,6 +100,12 @@ if [[ "$COMPILER" == clang++-* && "$clang_ver" -ge 20 || "$STANDARD" -ge 26 ]] ;
     cook_args=(--cook fmt)
 fi
 
+# Deprecation diagnostics are errors in CI only. The flags land in
+# Seastar_CXX_FLAGS, which is appended after the -Wno-error demotions
+# in CMakeLists.txt, so the -Werror here wins. GCC's -Wdeprecated
+# does not include -Wdeprecated-declarations, hence both.
+deprecation_errors='-Werror=deprecated -Werror=deprecated-declarations'
+
 group "configure.py"
 # Both TLS backends are requested explicitly rather than left to cmake's
 # auto-detection, so that a TLS development package going missing from the
@@ -116,6 +122,7 @@ group "configure.py"
     --mode "$MODE"              \
     --enable-gnutls             \
     --enable-openssl            \
+    --cflags "$deprecation_errors" \
     "${cook_args[@]}"           \
     "${ccache_opt[@]}"          \
     $OPTIONS                    \


### PR DESCRIPTION
Uses of deprecated entities within the seastar tree have produced warnings without failing the build since 861da6e37 ("build: Allow deprecated declarations internally"). In practice warnings in an otherwise green build go unread, so in-tree uses of deprecated APIs accumulate silently: the fmt 12 bump surfaced dozens of them (see the fixes split out of #3559: #3568, #3575, #3579 and 37ed95ad8).

With those merged the tree builds deprecation-clean, so keep it that way by promoting the deprecation diagnostics to errors in CI, by passing the `-Werror` flags to `configure.py --cflags` in the CI build script. They land in `Seastar_CXX_FLAGS`, which CMakeLists.txt appends after its `-Wno-error` demotions, so the `-Werror` additions win. `-Werror=deprecated-declarations` is passed separately because GCC's `-Wdeprecated` group does not include it (clang's does).

Only CI is affected: a default build keeps deprecations as warnings, so compilers outside the CI matrix that diagnose additional deprecations (e.g. clang trunk reaches deprecated formatters through fmt's constexpr parse machinery that clang 22 does not diagnose) do not break developer builds. Intentional in-tree uses of deprecated APIs (implementation details and tests of deprecated code paths) already suppress the diagnostic locally with pragmas.

Note that configure.py also forwards `--cflags` to the cooked ingredients, so the fmt cook (and dpdk in the dpdk job) builds with these flags as well; they are clean under them today and CI would catch a regression there the same way.

An earlier revision of this PR, which unconditionally dropped the `-Wno-error` demotions for all builds, passed the full CI matrix green (16/16 checks), confirming the tree is currently deprecation-clean under errors.
