### PR TITLE
net/tls: unify the put() linearization threshold across backends

### DIFF
--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -164,6 +164,18 @@ public:
     bool _load_system_trust = false;
 };
 
+/// Threshold below which put() linearizes a multi-buffer packet into a
+/// single contiguous buffer before handing it to the TLS backend.
+///
+/// Each buffer passed to the backend becomes a separate record_send /
+/// BIO write and ultimately a separate sendmsg syscall, so coalescing
+/// small fragments (e.g. a ~100 byte header preceding a payload) avoids
+/// that per-call overhead and also produces larger TLS records, which
+/// encrypt/decrypt more efficiently. Note that this value is not tied to
+/// the TLS record size: it bounds how much we are willing to copy to
+/// save those overheads, a tradeoff independent of the record size.
+constexpr size_t linearize_put_threshold = 16 * 1024;
+
 /// Abstract interface for a TLS session.
 ///
 /// This is the primary abstraction that TLS backends (GnuTLS, OpenSSL)

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -952,13 +952,11 @@ public:
         // We want to make sure that we call gnutls_record_send with as large
         // packets as possible. This is because each call to gnutls_record_send
         // translates to a sendmsg syscall. Further it results in larger TLS
-        // records which makes encryption/decryption faster. Hence to avoid
-        // cases where we would do an extra syscall for something like a 100
-        // bytes header we linearize the packet if it's below the max TLS record
-        // size.
+        // records which makes encryption/decryption faster. Hence we linearize
+        // small packets; see linearize_put_threshold for the rationale.
 
         size_t size = std::accumulate(bufs.begin(), bufs.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.size(); });
-        if (size <= gnutls_record_get_max_size(*this)) {
+        if (size <= linearize_put_threshold) {
             temporary_buffer<char> linear(size);
             char* pos = linear.get_write();
             for (auto& buf : bufs) {

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -995,7 +995,6 @@ public:
     // encrypt it and then place it into the output bio.
     future<> put(std::span<temporary_buffer<char>> bufs) override {
         tls_log.trace("{} put", *this);
-        constexpr size_t openssl_max_record_size = 16 * 1024;
         if (_error) {
             return make_exception_future(_error);
         }
@@ -1020,11 +1019,10 @@ public:
         // We want to make sure that we write to the underlying bio with as large
         // packets as possible. This is because eventually this translates to a
         // sendmsg syscall. Further it results in larger TLS records which makes
-        // encryption/decryption faster. Hence to avoid cases where we would do
-        // an extra syscall for something like a 100 bytes header we linearize the
-        // packet if it's below the max TLS record size.
+        // encryption/decryption faster. Hence we linearize small packets; see
+        // linearize_put_threshold for the rationale.
         size_t size = std::accumulate(bufs.begin(), bufs.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.size(); });
-        if (size <= openssl_max_record_size) {
+        if (size <= linearize_put_threshold) {
             temporary_buffer<char> linear(size);
             char* pos = linear.get_write();
             for (auto& buf : bufs) {


### PR DESCRIPTION
Both TLS backends linearize a multi-buffer packet in `put()` before handing it to the backend, but they used different thresholds: GnuTLS used the runtime `gnutls_record_get_max_size()`, while OpenSSL used a local 16 KiB "max record size" constant.

The threshold is not really about the TLS record size. Linearization is useful because it amortizes the per-call overhead of pushing many small fragments through the backend, each of which ultimately becomes a sendmsg syscall (and small fragments also produce small TLS records, which encrypt/decrypt less efficiently). How much copying is worth doing to save that overhead does not depend on the negotiated record size.

This change introduces a single shared `linearize_put_threshold` constant (16 KiB) in `tls-impl.hh`, documented as such, and uses it in both backends. For GnuTLS this is a slight behavior change only when a session negotiates a smaller max record size, in which case it previously linearized less.

This is a precursor to a more unified `put()` implementation across the two backends.

cc @StephanDollberg