### PR TITLE
tls: hoist identical session logic into a session_base class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,6 +793,7 @@ add_library (seastar
   src/net/stack.cc
   src/net/tcp.cc
   src/net/tls-impl.cc
+  src/net/tls-session-base.cc
   src/net/udp.cc
   src/net/unix_address.cc
   src/net/virtio.cc

--- a/src/net/tls-session-base.cc
+++ b/src/net/tls-session-base.cc
@@ -1,0 +1,245 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015 Cloudius Systems
+ * Copyright 2024 Redpanda Data
+ */
+#include "tls-session-base.hh"
+
+#include <algorithm>
+#include <numeric>
+
+#include <fmt/ostream.h>
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/net/stack.hh>
+
+namespace seastar {
+
+logger tls_log("tls");
+
+namespace tls {
+
+session_base::session_base(session_type t, std::unique_ptr<net::connected_socket_impl> sock,
+        tls_options options)
+    : _sock(std::move(sock))
+    , _local_address([this]() -> sstring {
+        try {
+            return fmt::to_string(_sock->local_address());
+        } catch (const std::system_error&) {
+            return "DISCONNECTED";
+        }
+    }())
+    , _remote_address([this]() -> sstring {
+        try {
+            return fmt::to_string(_sock->remote_address());
+        } catch (const std::system_error&) {
+            return "DISCONNECTED";
+        }
+    }())
+    , _in(_sock->source())
+    , _out(_sock->sink())
+    , _in_sem(1)
+    , _out_sem(1)
+    , _options(std::move(options))
+    , _type(t) {
+}
+
+// Used to push unencrypted data through the TLS engine, which will
+// encrypt it and then send it down the underlying socket.
+future<> session_base::put(std::span<temporary_buffer<char>> bufs) {
+    tls_log.trace("{} put", *this);
+    // The TLS default maximum record size (2^14 bytes). This only
+    // controls whether we linearize small writes below -- the backends
+    // still chunk the actual record sends to the negotiated record size.
+    constexpr size_t max_tls_record_size = 16 * 1024;
+    if (_error) {
+        return make_exception_future<>(_error);
+    }
+    if (_shutdown) {
+        return make_exception_future<>(std::system_error(EPIPE, std::system_category()));
+    }
+    if (!connected()) {
+        tls_log.trace("{} put: not connected, performing handshake", *this);
+        std::vector<temporary_buffer<char>> p;
+        p.reserve(bufs.size());
+        p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
+        return handshake().then([this, p = std::move(p)]() mutable {
+           return put(std::span(p));
+        });
+    }
+
+    if (bufs.size() == 1) {
+        return do_put(std::move(bufs.front()));
+    }
+
+    // We want to make sure that we hand the TLS engine as large packets
+    // as possible. This is because each write eventually translates to a
+    // sendmsg syscall. Further it results in larger TLS records which
+    // makes encryption/decryption faster. Hence to avoid cases where we
+    // would do an extra syscall for something like a 100 bytes header we
+    // linearize the packet if it's below the max TLS record size.
+    size_t size = std::accumulate(bufs.begin(), bufs.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.size(); });
+    if (size <= max_tls_record_size) {
+        temporary_buffer<char> linear(size);
+        char* pos = linear.get_write();
+        for (auto& buf : bufs) {
+            std::copy_n(buf.get(), buf.size(), pos);
+            pos += buf.size();
+        }
+        return do_put(std::move(linear));
+    }
+
+    std::vector<temporary_buffer<char>> p;
+    p.reserve(bufs.size());
+    p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
+    return do_put(std::move(p));
+}
+
+future<> session_base::do_put(std::vector<temporary_buffer<char>> bufs) {
+    auto i = bufs.begin();
+    auto e = bufs.end();
+    return with_semaphore(_out_sem, 1, [this, i, e] {
+        return do_for_each(i, e, [this](temporary_buffer<char>& b) {
+            return do_put_one(b.get(), b.size());
+        });
+    }).finally([b = std::move(bufs)] {});
+}
+
+future<> session_base::do_put(temporary_buffer<char> buf) {
+    auto ptr = buf.get();
+    auto size = buf.size();
+    return with_semaphore(_out_sem, 1, [this, ptr, size] {
+        return do_put_one(ptr, size);
+    }).finally([b = std::move(buf)] {});
+}
+
+// This function will attempt to pull data off of the _in stream
+// if there isn't already data needing to be processed first.
+future<> session_base::wait_for_input() {
+    tls_log.trace("{} wait_for_input", *this);
+    // If we already have data, then it needs to be processed
+    if (!_input.empty()) {
+        return make_ready_future<>();
+    }
+    return _in.get().then([this](temporary_buffer<char> buf) {
+        // Set EOF if it's empty
+        tls_log.debug("{} wait_for_input: buffer is {}empty", *this, buf.empty() ? "": "not ");
+        _eof |= buf.empty();
+        _input = std::move(buf);
+    }).handle_exception([this](auto ep) {
+        tls_log.debug("{} wait_for_input: exception: {}", *this, seastar::formattable(ep));
+        _error = ep;
+        return make_exception_future(ep);
+    });
+}
+
+// This function waits for eof() to occur on the input stream
+// Unless wait_for_data_on_shutdown is false
+future<> session_base::wait_for_eof() {
+    tls_log.trace("{} wait_for_eof", *this);
+    // read records until we get an eof alert
+    // since this call could time out, we must not ac
+    return with_semaphore(_in_sem, 1, [this] {
+        if (_error || !connected()) {
+            return make_ready_future();
+        }
+        if (!_options.wait_for_data_on_shutdown) {
+            // Read at most one record. If unread data arrives instead
+            // of EOF, abort the wait immediately rather than looping.
+            if (eof()) {
+                return make_ready_future<>();
+            }
+            return do_get().discard_result();
+        }
+        return do_until(
+            [this] { return eof(); },
+            [this] { return do_get().discard_result(); });
+    });
+}
+
+future<> session_base::shutdown() {
+    tls_log.trace("{} shutdown", *this);
+    // first, make sure any pending write is done.
+    // bye handshake is a flush operation, but this
+    // allows us to not pay extra attention to output state
+    //
+    // we only send a simple "bye" alert packet. Then we
+    // read from input until we see EOF. Any other reader
+    // before us will get it instead of us, and mark _eof = true
+    // in which case we will be no-op.
+    return with_semaphore(_out_sem, 1, [this] {
+                            return do_shutdown();
+                          }).then([this] {
+                            return wait_for_eof();
+                          }).finally([me = shared_from_this()] {});
+    // note moved finally clause above. It is theorethically possible
+    // that we could complete do_shutdown just before the close calls
+    // below, get pre-empted, have "close()" finish, get freed, and
+    // then call wait_for_eof on stale pointer.
+}
+
+void session_base::close() noexcept {
+    tls_log.trace("{} close", *this);
+    // only do once.
+    if (!std::exchange(_shutdown, true)) {
+        auto me = shared_from_this();
+        auto f = _options.bye_timeout.count() > 0 && (_options.wait_for_eof_on_shutdown._value == true)
+            // try to bye-handshake us nicely, but after a timeout we forcefully close.
+            ? with_timeout(timer<>::clock::now() + _options.bye_timeout, shutdown())
+            : make_ready_future<>();
+        engine().run_in_background(std::move(f).finally([this] {
+            _eof = true;
+            return _in.close(); // should wake any waiters
+        }).finally([this] {
+            return _out.close();
+        }).finally([this] {
+            // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
+            // handshake aqcuire, because in worst case, we get here while a reader is attempting
+            // re-handshake.
+            return with_semaphore(_in_sem, 1, [this] {
+                return with_semaphore(_out_sem, 1, [] {});
+            });
+        }).handle_exception([me = std::move(me)](std::exception_ptr) { // must keep object alive until here.
+        }).discard_result());
+    }
+}
+
+// helper for sink
+future<> session_base::flush() noexcept {
+    return with_semaphore(_out_sem, 1, [this] {
+        return _out.flush();
+    });
+}
+
+seastar::net::connected_socket_impl& session_base::socket() const {
+    return *_sock;
+}
+
+} // namespace tls
+} // namespace seastar
+
+auto fmt::formatter<seastar::tls::session_base>::format(
+    const seastar::tls::session_base& s, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+
+    return fmt::format_to(ctx.out(), "{}:{}:{} -",
+        s.get_type_string(), s.local_address(), s.remote_address());
+}

--- a/src/net/tls-session-base.hh
+++ b/src/net/tls-session-base.hh
@@ -1,0 +1,242 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2015 Cloudius Systems
+ * Copyright 2024 Redpanda Data
+ */
+#pragma once
+
+#include <cerrno>
+#include <span>
+#include <system_error>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/tls.hh>
+#include <seastar/util/log.hh>
+
+#include "tls-impl.hh"
+
+namespace seastar {
+
+extern logger tls_log;
+
+namespace tls {
+
+/**
+ * Common base for the backend TLS session implementations
+ * (GnuTLS, OpenSSL).
+ *
+ * A TLS session is the conduit for one TLS/SSL data flow: it owns the
+ * underlying connected_socket and its source/sink (we keep ownership
+ * because we drive the handshake, re-handshakes and the shutdown
+ * sequence ourselves), pumps plaintext between the caller and the
+ * backend's TLS engine, and pumps ciphertext between the engine and
+ * the socket.
+ *
+ * The class splits along that line (template-method style):
+ *
+ *  - session_base implements, once, the async plumbing that is
+ *    independent of the TLS library: the put()/linearization path, the
+ *    read/write semaphore protocol, waiting for input, the
+ *    shutdown/close lifecycle, and the error/eof bookkeeping.
+ *
+ *  - The backend implements the engine-shaped pieces via the protected
+ *    virtual hooks below: the actual handshake/read/write/shutdown
+ *    state machines, engine error decoding, and certificate
+ *    introspection. Hooks are called at record granularity, so the
+ *    virtual dispatch cost is noise.
+ *
+ * Note that the pending-output future (_output_pending in both
+ * backends) deliberately remains backend-owned: its semantics
+ * currently differ between the backends (plain future vs shared_future
+ * acting as a circuit breaker), and no method here needs to touch it.
+ */
+class session_base : public enable_shared_from_this<session_base>, public session_impl {
+public:
+    session_base(session_type t, std::unique_ptr<net::connected_socket_impl> sock,
+            tls_options options);
+
+    // Send plaintext: handshakes first if needed, linearizes small
+    // scattered writes, then encrypts via do_put_one() under _out_sem.
+    future<> put(std::span<temporary_buffer<char>> bufs) override;
+    // Flush the underlying sink, serialized against the write path.
+    future<> flush() noexcept override;
+    // Idempotent, non-blocking teardown: runs the bye handshake in the
+    // background (bounded by _options.bye_timeout), then closes both
+    // streams and waits for in-flight operations to leave.
+    void close() noexcept override;
+    // The wrapped transport, for socket options and addresses.
+    seastar::net::connected_socket_impl& socket() const override;
+
+    // True once we have observed end-of-stream on the input, either as
+    // a real socket EOF or because close() forced it.
+    bool eof() const {
+        return _eof;
+    }
+
+    // "Client" or "Server"; used in log messages.
+    const char* get_type_string() const {
+        return _type == session_type::CLIENT ? "Client" : "Server";
+    }
+
+    // Returns the local address formatted as a string (e.g. 'ip:port') or
+    // `DISCONNECTED` if not connected
+    const sstring& local_address() const noexcept {
+        return _local_address;
+    }
+
+    // Returns the remote address formatted as a string (e.g. 'ip:port') or
+    // `DISCONNECTED` if not connected
+    const sstring& remote_address() const noexcept {
+        return _remote_address;
+    }
+
+protected:
+    // -- backend hooks -------------------------------------------------
+
+    // True once the TLS handshake has completed on this session.
+    virtual bool connected() const = 0;
+    // Performs the handshake, including any backend-specific preparation
+    // (e.g. loading system trust), serializing via do_handshake_sync().
+    virtual future<> handshake() = 0;
+    // Reads and decrypts one chunk of data. Called with _in_sem held.
+    virtual future<temporary_buffer<char>> do_get() = 0;
+    // Encrypts and writes the given bytes. Called with _out_sem held.
+    virtual future<> do_put_one(const char* ptr, size_t size) = 0;
+    // Initiates the TLS shutdown (close alert). Called with _out_sem held.
+    virtual future<> do_shutdown() = 0;
+
+    // -- shared plumbing -----------------------------------------------
+
+    // Feed the buffer(s) to do_put_one() under _out_sem, keeping them
+    // alive until the write completes. put() dispatches here once the
+    // session is connected.
+    future<> do_put(std::vector<temporary_buffer<char>> bufs);
+    future<> do_put(temporary_buffer<char> buf);
+    // Resolves once ciphertext is available in _input (or on eof/error):
+    // reads from _in if the buffer is currently empty.
+    future<> wait_for_input();
+    // Drains records via do_get() until the peer's EOF (close alert) is
+    // seen, or, if !_options.wait_for_data_on_shutdown, for at most one
+    // record. Used by shutdown() to complete the bye handshake.
+    future<> wait_for_eof();
+    // Sends the close alert via do_shutdown() and then waits for the
+    // peer's EOF. close() runs this in the background, bounded by
+    // _options.bye_timeout.
+    future<> shutdown();
+
+    // Bytes of ciphertext currently buffered in _input.
+    size_t in_avail() const {
+        return _input.size();
+    }
+
+    // Runs \c func with both semaphores held (input, then output --
+    // everything serializing against both paths must use this order),
+    // recording the first error.
+    template<std::invocable Func>
+    future<> do_handshake_sync(Func func) {
+        return with_semaphore(_in_sem, 1, [this, func = std::move(func)]() mutable {
+            return with_semaphore(_out_sem, 1, [this, func = std::move(func)]() mutable {
+                return futurize_invoke(func).handle_exception([this](auto ep) {
+                    if (!_error) {
+                        _error = ep;
+                    }
+                    return make_exception_future<>(_error);
+                });
+            });
+        });
+    }
+
+    // Runs \c f once the session is usable: raises any recorded error,
+    // refuses shut-down sessions, and handshakes first if needed.
+    template<typename Func, typename... Args>
+    auto state_checked_access(Func&& f, Args&& ...args) {
+        using future_type = typename futurize<std::invoke_result_t<Func, Args...>>::type;
+        using result_t = typename future_type::value_type;
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!connected()) {
+            return handshake().then([this, f = std::move(f), ...args = std::forward<Args>(args)]() mutable {
+                // always recurse, in case malicious api caller does a shutdown while the above handshake is
+                // happening. I.e. misuses the api.
+                return state_checked_access(std::move(f), std::forward<Args>(args)...);
+            });
+        }
+        return futurize_invoke(f, std::forward<Args>(args)...);
+    }
+
+    // -- shared state --------------------------------------------------
+
+    // The transport under the TLS session. Owned by us: the sockets
+    // handed out to users wrap this session, not the raw socket.
+    std::unique_ptr<net::connected_socket_impl> _sock;
+    // Peer addresses as strings ('ip:port', or "DISCONNECTED"),
+    // captured at construction for use in log messages.
+    sstring _local_address;
+    sstring _remote_address;
+    // Ciphertext streams of _sock. All socket I/O goes through these;
+    // close() closes them to wake any waiters.
+    data_source _in;
+    data_sink _out;
+
+    // Reads and writes run concurrently (full duplex), serialized by two
+    // disjoint semaphores: _in_sem guards the read path (get()), _out_sem
+    // the write path (put(), plus flush, rehandshake and shutdown).
+    // Operations spanning both take them in the order _in_sem then
+    // _out_sem, so there is no deadlock.
+    semaphore _in_sem;
+    semaphore _out_sem;
+
+    // Per-session options (server name, ALPN, shutdown behavior, ...),
+    // fixed at construction.
+    tls_options _options;
+    // Whether this is the client or server end of the session.
+    session_type _type;
+
+    // Ciphertext read from _in but not yet consumed by the TLS engine.
+    // The backend's engine pull path (GnuTLS pull callback, OpenSSL
+    // read BIO) drains this; wait_for_input() refills it.
+    temporary_buffer<char> _input;
+    // First error observed on the session; once set, all subsequent
+    // operations fail with it.
+    std::exception_ptr _error;
+
+    // Input has reached end-of-stream (see eof()).
+    bool _eof = false;
+    // close() has been called; the session is (being) torn down and
+    // rejects new operations.
+    bool _shutdown = false;
+};
+
+} // namespace tls
+} // namespace seastar
+
+template <>
+struct fmt::formatter<seastar::tls::session_base> : public fmt::formatter<string_view> {
+    auto format(const seastar::tls::session_base& s, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -59,6 +59,7 @@
 #include <seastar/net/stack.hh>
 #include "../core/crypto.hh"
 #include "tls-impl.hh"
+#include "tls-session-base.hh"
 #include "tls_gnutls.hh"
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/variant_utils.hh>
@@ -475,28 +476,24 @@ namespace tls {
  * of these, since we handle handshake etc.
  *
  */
-class session : public enable_shared_from_this<session>, public tls::session_impl {
+class session : public session_base {
 public:
-    enum class type
-        : uint32_t {
-            CLIENT = GNUTLS_CLIENT, SERVER = GNUTLS_SERVER,
-    };
-
-    session(type t, shared_ptr<tls::certificate_credentials> creds,
+    session(session_type t, shared_ptr<tls::certificate_credentials> creds,
             std::unique_ptr<net::connected_socket_impl> sock, tls_options options = {})
-            : _type(t), _sock(std::move(sock)), _creds(static_pointer_cast<gnutls_provider_certificate_credentials_impl>(creds->_impl)),
-                    _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _options(std::move(options)), _output_pending(
-                    make_ready_future<>()), _session([t] {
+            : session_base(t, std::move(sock), std::move(options))
+            , _creds(static_pointer_cast<gnutls_provider_certificate_credentials_impl>(creds->_impl))
+            , _output_pending(make_ready_future<>())
+            , _session([t] {
                 gnutls_session_t session;
-                gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
+                gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK
+                        | uint32_t(t == session_type::CLIENT ? GNUTLS_CLIENT : GNUTLS_SERVER)));
                 return session;
             }(), &gnutls_deinit) {
         gtls_chk(gnutls_set_default_priority(*this));
         gtls_chk(
                 gnutls_credentials_set(*this, GNUTLS_CRD_CERTIFICATE,
                         *_creds));
-        if (_type == type::SERVER) {
+        if (_type == session_type::SERVER) {
             switch (_creds->get_client_auth()) {
                 case client_auth::NONE:
                 default:
@@ -532,18 +529,18 @@ public:
         // This would be nice, because we preferably want verification to
         // abort hand shake so peer immediately knows we bailed...
 #if GNUTLS_VERSION_NUMBER >= 0x030406
-        if (_type == type::CLIENT) {
+        if (_type == session_type::CLIENT) {
             gnutls_session_set_verify_function(*this, &verify_wrapper);
         }
 #endif
         // if we are a client, check if we have a session ticket to unpack.
-        if (_type == type::CLIENT && !_options.session_resume_data.empty()) {
+        if (_type == session_type::CLIENT && !_options.session_resume_data.empty()) {
             gtls_chk(gnutls_session_set_data(*this, _options.session_resume_data.data(), _options.session_resume_data.size()));
         }
         _options.session_resume_data.clear(); // no need to keep around
 
         // ALPN setup
-        auto& alpn_protocols = _type == type::CLIENT ? _options.alpn_protocols : _creds->_alpn_protocols;
+        auto& alpn_protocols = _type == session_type::CLIENT ? _options.alpn_protocols : _creds->_alpn_protocols;
         if (!alpn_protocols.empty()) {
             std::vector<gnutls_datum_t> alpn_datums;
             alpn_datums.reserve(alpn_protocols.size());
@@ -554,7 +551,7 @@ public:
             gtls_chk(gnutls_alpn_set_protocols(*this, alpn_datums.data(), alpn_datums.size(), 0));
         }
     }
-    session(type t, shared_ptr<certificate_credentials> creds,
+    session(session_type t, shared_ptr<certificate_credentials> creds,
             connected_socket sock,
             tls_options options = {})
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
@@ -564,8 +561,6 @@ public:
     ~session() {
         SEASTAR_ASSERT(_output_pending.available());
     }
-
-    typedef temporary_buffer<char> buf_type;
 
     sstring cert_status_to_string(gnutls_certificate_type_t type, unsigned int status) {
         gnutls_datum_t out;
@@ -599,7 +594,7 @@ public:
     }
 
     future<> do_handshake_invoke(int (*func)(gnutls_session_t)) {
-        if (_type == type::CLIENT && !_options.server_name.empty()) {
+        if (_type == session_type::CLIENT && !_options.server_name.empty()) {
             gnutls_server_name_set(*this, GNUTLS_NAME_DNS, _options.server_name.data(), _options.server_name.size());
         }
         try {
@@ -645,7 +640,7 @@ public:
                     });
                 }
             }
-            if (_type == type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
+            if (_type == session_type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
                 verify();
             }
             _connected = true;
@@ -667,19 +662,6 @@ public:
         }
         return do_handshake_invoke(&gnutls_handshake);
     }
-    future<> do_handshake_sync(future<> (session::*func)()) {
-        // acquire both semaphores to sync both read & write
-        return with_semaphore(_in_sem, 1, [this, func] {
-            return with_semaphore(_out_sem, 1, [this, func] {
-                return std::invoke(func, this).handle_exception([this](auto ep) {
-                    if (!_error) {
-                        _error = ep;
-                    }
-                    return make_exception_future<>(_error);
-                });
-            });
-        });
-    }
     future<> do_force_rehandshake() {
         return do_handshake_invoke(gnutls_rehandshake);
     }
@@ -688,13 +670,13 @@ public:
             return handshake();
         }
         // Note: only applicable to server.
-        if (_type == type::CLIENT) {
+        if (_type == session_type::CLIENT) {
             throw std::system_error(GNUTLS_E_INVALID_REQUEST, local_error_category(), "re-handshake only applicable for server socket");
         }
-        return do_handshake_sync(&session::do_force_rehandshake);
+        return do_handshake_sync([this] { return do_force_rehandshake(); });
     }
 
-    future<> handshake() {
+    future<> handshake() override {
         // maybe load system certificates before handshake, in case we
         // have not done so yet...
         if (_creds->need_load_system_trust()) {
@@ -702,27 +684,13 @@ public:
                return handshake();
             });
         }
-        return do_handshake_sync(&session::do_handshake);
+        return do_handshake_sync([this] { return do_handshake(); });
     }
 
-    size_t in_avail() const {
-        return _input.size();
+    bool connected() const override {
+        return _connected;
     }
-    bool eof() const {
-        return _eof;
-    }
-    future<> wait_for_input() {
-        if (!_input.empty()) {
-            return make_ready_future<>();
-        }
-        return _in.get().then([this](buf_type buf) {
-            _eof |= buf.empty();
-           _input = std::move(buf);
-        }).handle_exception([this](auto ep) {
-           _error = ep;
-           return make_exception_future(ep);
-        });
-    }
+
     future<> wait_for_output() {
         return std::exchange(_output_pending, make_ready_future()).handle_exception([this](auto ep) {
            _error = ep;
@@ -756,9 +724,9 @@ public:
         }
 
         unsigned int status;
-        auto res = gnutls_certificate_verify_peers3(*this, _type != type::CLIENT || _options.server_name.empty()
+        auto res = gnutls_certificate_verify_peers3(*this, _type != session_type::CLIENT || _options.server_name.empty()
                         ? nullptr : _options.server_name.c_str(), &status);
-        if (res == GNUTLS_E_NO_CERTIFICATE_FOUND && _type != type::CLIENT && _creds->get_client_auth() != client_auth::REQUIRE) {
+        if (res == GNUTLS_E_NO_CERTIFICATE_FOUND && _type != session_type::CLIENT && _creds->get_client_auth() != client_auth::REQUIRE) {
             return;
         }
         if (res < 0) {
@@ -787,19 +755,7 @@ public:
             auto dn = extract_dn_information();
             SEASTAR_ASSERT(dn.has_value()); // otherwise we couldn't have gotten here
 
-            // a switch here might look overelaborate, however,
-            // the compiler will warn us if someone alters the definition of type
-            session_type t;
-            switch (_type) {
-            case type::CLIENT:
-                t = session_type::CLIENT;
-                break;
-            case type::SERVER:
-                t = session_type::SERVER;
-                break;
-            }
-
-            _creds->_dn_callback(t, std::move(dn->subject), std::move(dn->issuer));
+            _creds->_dn_callback(_type, std::move(dn->subject), std::move(dn->issuer));
         }
     }
 
@@ -827,7 +783,7 @@ public:
         });
     }
 
-    future<temporary_buffer<char>> do_get() {
+    future<temporary_buffer<char>> do_get() override {
         // gnutls might have stuff in its buffers.
         auto avail = gnutls_record_check_pending(*this);
         if (avail == 0) {
@@ -872,27 +828,8 @@ public:
     }
 
 private:
-    future<> do_put(std::vector<temporary_buffer<char>> bufs) {
-        auto i = bufs.begin();
-        auto e = bufs.end();
-        return with_semaphore(_out_sem, 1, [this, i, e] {
-            SEASTAR_ASSERT(_output_pending.available());
-            return do_for_each(i, e, [this](temporary_buffer<char>& b) {
-                return do_put_one(b.get(), b.size());
-            });
-        }).finally([b = std::move(bufs)] {});
-    }
-
-    future<> do_put(temporary_buffer<char> buf) {
-        auto ptr = buf.get();
-        auto size = buf.size();
-        return with_semaphore(_out_sem, 1, [this, ptr, size] {
-            SEASTAR_ASSERT(_output_pending.available());
-            return do_put_one(ptr, size);
-        }).finally([b = std::move(buf)] {});
-    }
-
-    future<> do_put_one(const char* ptr, size_t size) {
+    future<> do_put_one(const char* ptr, size_t size) override {
+        SEASTAR_ASSERT(_output_pending.available());
         // #2859
         // Normally, gnutls_record_send will break up data into gnutls_record_get_max_size()
         // sized chunks for us (only processing the first 16k or so of provided buffer).
@@ -929,51 +866,6 @@ private:
     }
 
 public:
-    future<> put(std::span<temporary_buffer<char>> bufs) override {
-        if (_error) {
-            return make_exception_future<>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<>(std::system_error(EPIPE, std::system_category()));
-        }
-        if (!_connected) {
-            std::vector<temporary_buffer<char>> p;
-            p.reserve(bufs.size());
-            p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
-            return handshake().then([this, p = std::move(p)]() mutable {
-               return put(std::span(p));
-            });
-        }
-
-        if (bufs.size() == 1) {
-            return do_put(std::move(bufs.front()));
-        }
-
-        // We want to make sure that we call gnutls_record_send with as large
-        // packets as possible. This is because each call to gnutls_record_send
-        // translates to a sendmsg syscall. Further it results in larger TLS
-        // records which makes encryption/decryption faster. Hence to avoid
-        // cases where we would do an extra syscall for something like a 100
-        // bytes header we linearize the packet if it's below the max TLS record
-        // size.
-
-        size_t size = std::accumulate(bufs.begin(), bufs.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.size(); });
-        if (size <= gnutls_record_get_max_size(*this)) {
-            temporary_buffer<char> linear(size);
-            char* pos = linear.get_write();
-            for (auto& buf : bufs) {
-                std::copy_n(buf.get(), buf.size(), pos);
-                pos += buf.size();
-            }
-            return do_put(std::move(linear));
-        }
-
-        std::vector<temporary_buffer<char>> p;
-        p.reserve(bufs.size());
-        p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
-        return do_put(std::move(p));
-    }
-
     ssize_t pull(void* dst, size_t len) {
         if (eof()) {
             return 0;
@@ -1049,7 +941,7 @@ public:
             }
         });
     }
-    future<> do_shutdown() {
+    future<> do_shutdown() override {
         if (_error || !_connected) {
             return make_ready_future();
         }
@@ -1068,107 +960,6 @@ public:
             }
         }
         return wait_for_output();
-    }
-    future<> wait_for_eof() {
-        // read records until we get an eof alert
-        // since this call could time out, we must not ac
-        return with_semaphore(_in_sem, 1, [this] {
-            if (_error || !_connected) {
-                return make_ready_future();
-            }
-            if (!_options.wait_for_data_on_shutdown) {
-                if (eof()) {
-                    return make_ready_future<>();
-                }
-                return do_get().discard_result();
-            }
-
-            return repeat([this] {
-                if (eof()) {
-                    return make_ready_future<stop_iteration>(stop_iteration::yes);
-                }
-                return do_get().then([](auto buf) {
-                   return make_ready_future<stop_iteration>(stop_iteration::no);
-                });
-            });
-        });
-    }
-    future<> shutdown() {
-        // first, make sure any pending write is done.
-        // bye handshake is a flush operation, but this
-        // allows us to not pay extra attention to output state
-        //
-        // we only send a simple "bye" alert packet. Then we
-        // read from input until we see EOF. Any other reader
-        // before us will get it instead of us, and mark _eof = true
-        // in which case we will be no-op.
-        return with_semaphore(_out_sem, 1,
-                        std::bind(&session::do_shutdown, this)).then(
-                        std::bind(&session::wait_for_eof, this)).finally([me = shared_from_this()] {});
-        // note moved finally clause above. It is theorethically possible
-        // that we could complete do_shutdown just before the close calls
-        // below, get pre-empted, have "close()" finish, get freed, and
-        // then call wait_for_eof on stale pointer.
-    }
-    void close() noexcept override {
-        // only do once.
-        if (!std::exchange(_shutdown, true)) {
-            auto me = shared_from_this();
-            auto f = _options.bye_timeout.count() > 0 && (_options.wait_for_eof_on_shutdown._value == true)
-                // try to bye-handshake us nicely, but after a timeout we forcefully close.
-                ? with_timeout(timer<>::clock::now() + _options.bye_timeout, shutdown())
-                : make_ready_future<>();
-            engine().run_in_background(std::move(f).finally([this] {
-                _eof = true;
-                try {
-                    (void)_in.close().handle_exception([](std::exception_ptr) {}); // should wake any waiters
-                } catch (...) {
-                }
-                try {
-                    (void)_out.close().handle_exception([](std::exception_ptr) {});
-                } catch (...) {
-                }
-                // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
-                // handshake aqcuire, because in worst case, we get here while a reader is attempting
-                // re-handshake.
-                return with_semaphore(_in_sem, 1, [this] {
-                    return with_semaphore(_out_sem, 1, [] {});
-                });
-            }).then_wrapped([me = std::move(me)](future<> f) { // must keep object alive until here.
-                f.ignore_ready_future();
-            }));
-        }
-    }
-    // helper for sink
-    future<> flush() noexcept override {
-        return with_semaphore(_out_sem, 1, [this] {
-            return _out.flush();
-        });
-    }
-
-    seastar::net::connected_socket_impl& socket() const override {
-        return *_sock;
-    }
-
-    // helper routine.
-    template<typename Func, typename... Args>
-    auto state_checked_access(Func&& f, Args&& ...args) {
-        using future_type = typename futurize<std::invoke_result_t<Func, Args...>>::type;
-        using result_t = typename future_type::value_type;
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!_connected) {
-            return handshake().then([this, f = std::move(f), ...args = std::forward<Args>(args)]() mutable {
-                // always recurse, in case malicious api caller does a shutdown while the above handshake is
-                // happening. I.e. misuses the api.
-                return session::state_checked_access(std::move(f), std::forward<Args>(args)...);
-            });
-        }
-        return futurize_invoke(f, std::forward<Args>(args)...);
     }
 
     future<bool> is_resumed() override {
@@ -1349,24 +1140,11 @@ private:
         return session_dn{.subject=subject, .issuer=issuer};
     }
 
-    type _type;
-
-    std::unique_ptr<net::connected_socket_impl> _sock;
     shared_ptr<gnutls_provider_certificate_credentials_impl> _creds;
-    data_source _in;
-    data_sink _out;
 
-    semaphore _in_sem, _out_sem;
-
-    tls_options _options;
-
-    bool _eof = false;
-    bool _shutdown = false;
     bool _connected = false;
-    std::exception_ptr _error;
 
     future<> _output_pending;
-    buf_type _input;
 
     // modify this to a unique_ptr to handle exceptions in our constructor.
     std::unique_ptr<std::remove_pointer_t<gnutls_session_t>, void(*)(gnutls_session_t)> _session;
@@ -1383,8 +1161,7 @@ shared_ptr<tls::session_impl> tls::gnutls::make_session(
         shared_ptr<tls::certificate_credentials> creds,
         std::unique_ptr<net::connected_socket_impl> sock,
         const tls::tls_options& options) {
-    auto t = type == tls::session_type::CLIENT ? session::type::CLIENT : session::type::SERVER;
-    return seastar::make_shared<session>(t, std::move(creds), std::move(sock), options);
+    return seastar::make_shared<session>(type, std::move(creds), std::move(sock), options);
 }
 
 const std::error_category& tls::gnutls::error_category() {

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -63,6 +63,7 @@
 #include <seastar/util/log.hh>
 
 #include "tls-impl.hh"
+#include "tls-session-base.hh"
 #include "tls_openssl.hh"
 
 namespace seastar::tls {
@@ -74,8 +75,6 @@ template <> struct fmt::formatter<seastar::tls::openssl_session> : public fmt::f
 };
 
 namespace seastar {
-
-static logger tls_log("tls");
 
 enum class openssl_errc : int{};
 
@@ -749,7 +748,7 @@ int session_ticket_cb(SSL * s, unsigned char key_name[16],
  * The implmentation below relies on OpenSSL, for the gnutls implementation
  * see tls.cc and the CMake option 'Seastar_USE_OPENSSL'
  */
-class openssl_session : public enable_shared_from_this<openssl_session>, public session_impl {
+class openssl_session : public session_base {
 public:
     using buf_type = temporary_buffer<char>;
     using frag_iter = net::fragment*;
@@ -777,27 +776,8 @@ public:
 
     openssl_session(session_type t, shared_ptr<tls::certificate_credentials> creds,
             std::unique_ptr<net::connected_socket_impl> sock, tls_options options = {})
-      : _sock(std::move(sock))
-      , _local_address([this]() -> sstring {
-            try {
-                return fmt::to_string(_sock->local_address());
-            } catch(const std::system_error&) {
-                return "DISCONNECTED";
-            }
-        }())
-      , _remote_address([this]() -> sstring {
-            try {
-                return fmt::to_string(_sock->remote_address());
-            } catch(const std::system_error&) {
-                return "DISCONNECTED";
-            }
-        }())
+      : session_base(t, std::move(sock), std::move(options))
       , _creds(static_pointer_cast<openssl_provider_certificate_credentials_impl>(creds->_impl))
-      , _in(_sock->source())
-      , _out(_sock->sink())
-      , _in_sem(1)
-      , _out_sem(1)
-      , _options(std::move(options))
       , _output_pending(make_ready_future<>())
       , _ctx(make_ssl_context(t))
       , _ssl([this]() {
@@ -806,8 +786,7 @@ public:
               throw make_openssl_error("Failed to create SSL session");
           }
           return ssl;
-      }())
-      , _type(t) {
+      }()) {
         if (1 != SSL_set_ex_data(_ssl.get(), SSL_EX_DATA_SESSION, this)) {
             throw make_openssl_error("Failed to set EX data for SSL session");
         }
@@ -872,10 +851,6 @@ public:
 
     ~openssl_session() {
         SEASTAR_ASSERT(_output_pending.available());
-    }
-
-    const char * get_type_string() const {
-        return _type == session_type::CLIENT ? "Client": "Server";
     }
 
     // Waits for the put() currently tracked by _output_pending to drain. On
@@ -971,29 +946,11 @@ public:
         }
     }
 
-    future<> do_put(std::vector<temporary_buffer<char>> bufs) {
-        auto i = bufs.begin();
-        auto e = bufs.end();
-        return with_semaphore(_out_sem, 1, [this, i, e] {
-            return do_for_each(i, e, [this](temporary_buffer<char>& b) {
-                return do_put_one(b.get(), b.size());
-            });
-        }).finally([b = std::move(bufs)] {});
-    }
-
-    future<> do_put(temporary_buffer<char> buf) {
-        auto ptr = buf.get();
-        auto size = buf.size();
-        return with_semaphore(_out_sem, 1, [this, ptr, size] {
-            return do_put_one(ptr, size);
-        }).finally([b = std::move(buf)] {});
-    }
-
     // Called post locking of the _out_sem, which should be held until
     // the returned future resolves.
     // Will attempt to send the provided packet.  If a renegotiation is needed
     // any unprocessed part of the packet is returned.
-    future<> do_put_one(const char* ptr, size_t size) {
+    future<> do_put_one(const char* ptr, size_t size) override {
         tls_log.trace("{} do_put", *this);
 
         // A key-update put() from the read path (under _in_sem) may be in flight
@@ -1020,55 +977,6 @@ public:
                 co_await wait_for_output();
             }
         }
-    }
-
-    // Used to push unencrypted data through OpenSSL, which will
-    // encrypt it and then place it into the output bio.
-    future<> put(std::span<temporary_buffer<char>> bufs) override {
-        tls_log.trace("{} put", *this);
-        constexpr size_t openssl_max_record_size = 16 * 1024;
-        if (_error) {
-            return make_exception_future(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<>(
-              std::system_error(EPIPE, std::system_category()));
-        }
-        if (!connected()) {
-            tls_log.trace("{} put: not connected, performing handshake", *this);
-            std::vector<temporary_buffer<char>> p;
-            p.reserve(bufs.size());
-            p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
-            return handshake().then([this, p = std::move(p)]() mutable {
-               return put(std::span(p));
-            });
-        }
-
-        if (bufs.size() == 1) {
-            return do_put(std::move(bufs.front()));
-        }
-
-        // We want to make sure that we write to the underlying bio with as large
-        // packets as possible. This is because eventually this translates to a
-        // sendmsg syscall. Further it results in larger TLS records which makes
-        // encryption/decryption faster. Hence to avoid cases where we would do
-        // an extra syscall for something like a 100 bytes header we linearize the
-        // packet if it's below the max TLS record size.
-        size_t size = std::accumulate(bufs.begin(), bufs.end(), size_t(0), [] (size_t s, const auto& b) { return s + b.size(); });
-        if (size <= openssl_max_record_size) {
-            temporary_buffer<char> linear(size);
-            char* pos = linear.get_write();
-            for (auto& buf : bufs) {
-                std::copy_n(buf.get(), buf.size(), pos);
-                pos += buf.size();
-            }
-            return do_put(std::move(linear));
-        }
-
-        std::vector<temporary_buffer<char>> p;
-        p.reserve(bufs.size());
-        p.insert(p.end(), std::make_move_iterator(bufs.begin()), std::make_move_iterator(bufs.end()));
-        return do_put(std::move(p));
     }
 
     // Called after locking the _in_sem and _out_sem semaphores.
@@ -1170,34 +1078,11 @@ public:
         );
     }
 
-    // This function will attempt to pull data off of the _in stream
-    // if there isn't already data needing to be processed first.
-    future<> wait_for_input() {
-        tls_log.trace("{} wait_for_input", *this);
-        // If we already have data, then it needs to be processed
-        if (!_input.empty()) {
-            tls_log.trace("{} wait_for_input: input not empty", *this);
-            return make_ready_future();
-        }
-        return _in.get()
-          .then([this](buf_type buf) {
-              // Set EOF if it's empty
-              tls_log.debug("{} wait_for_input: buffer is {}empty", *this, buf.empty() ? "": "not ");
-              _eof |= buf.empty();
-              _input = std::move(buf);
-          })
-          .handle_exception([this](auto ep) {
-              tls_log.debug("{} wait_for_input: exception: {}", *this, seastar::formattable(ep));
-              _error = ep;
-              return make_exception_future(ep);
-          });
-    }
-
     // Called after locking the _in_sem semaphore
     // This function attempts to pull unencrypted data off of the
     // SSL session using SSL_read.  If ther eis no data, then
     // we will call perform_pull and wait for data to arrive.
-    future<buf_type> do_get() {
+    future<buf_type> do_get() override {
         tls_log.trace("{} do_get", *this);
         // Data is available to be pulled of the SSL session if there is pending
         // data on the SSL session or there is data in the in_bio() which SSL reads
@@ -1304,7 +1189,7 @@ public:
     }
 
     // Performs shutdown
-    future<> do_shutdown() {
+    future<> do_shutdown() override {
         tls_log.trace("{} do_shutdown", *this);
         if (_error || !connected()) {
             tls_log.trace("{} do_shutdown: error exists or not connected", *this);
@@ -1432,36 +1317,8 @@ public:
         }
     }
 
-    bool eof() const {
-        return _eof;
-    }
-
-    bool connected() const {
+    bool connected() const override {
         return SSL_is_init_finished(_ssl.get());
-    }
-
-    // This function waits for eof() to occur on the input stream
-    // Unless wait_for_eof_on_shutdown is false
-    future<> wait_for_eof() {
-        tls_log.trace("{} wait_for_eof", *this);
-        return with_semaphore(_in_sem, 1, [this] {
-            if (_error || !connected()) {
-                return make_ready_future();
-            }
-            if (!_options.wait_for_data_on_shutdown) {
-                // Read at most one record. If unread data arrives instead
-                // of EOF, abort the wait immediately rather than looping.
-                if (eof()) {
-                    return make_ready_future<>();
-                }
-                return do_get().discard_result();
-            }
-            return do_until(
-                [this] { return eof(); },
-                [this] { return do_get().discard_result(); });
-        }).finally([this] {
-            tls_log.trace("{} wait_for_eof: complete", *this);
-        });
     }
 
     future<> force_rehandshake() override {
@@ -1484,7 +1341,7 @@ public:
 
     // This function is called to kick off the handshake.  It will obtain
     // locks on the _in_sem and _out_sem semaphores and start the handshake.
-    future<> handshake() {
+    future<> handshake() override {
         tls_log.trace("{} handshake", *this);
         if (_creds->need_load_system_trust()) {
             if (!SSL_CTX_set_default_verify_paths(_ctx.get())) {
@@ -1494,73 +1351,7 @@ public:
             _creds->set_load_system_trust(false);
         }
 
-        return with_semaphore(_in_sem, 1, [this] {
-            return with_semaphore(_out_sem, 1, [this] {
-                return do_handshake().handle_exception([this](auto ep) {
-                    if (!_error) {
-                        _error = ep;
-                    }
-                    return make_exception_future<>(_error);
-                });
-            });
-        });
-    }
-
-    future<> shutdown() {
-        tls_log.trace("{} shutdown", *this);
-        // first, make sure any pending write is done.
-        // bye handshake is a flush operation, but this
-        // allows us to not pay extra attention to output state
-        //
-        // we only send a simple "bye" alert packet. Then we
-        // read from input until we see EOF. Any other reader
-        // before us will get it instead of us, and mark _eof = true
-        // in which case we will be no-op. This is performed all
-        // within do_shutdown
-        return with_semaphore(_out_sem, 1, [this] {
-                                return do_shutdown();
-                              }).then([this] {
-                                return wait_for_eof();
-                              }).finally([me = shared_from_this()]{});
-        // note moved finally clause above. It is theorethically possible
-        // that we could complete do_shutdown just before the close calls
-        // below, get pre-empted, have "close()" finish, get freed, and
-        // then call wait_for_eof on stale pointer.
-    }
-
-    void close() noexcept override {
-        tls_log.trace("{} close", *this);
-        // only do once.
-        if (!std::exchange(_shutdown, true)) {
-            tls_log.trace("{} close: performing shutdown", *this);
-            auto me = shared_from_this();
-            auto f = _options.bye_timeout.count() > 0 && (_options.wait_for_eof_on_shutdown._value == true)
-                // try to bye-handshake us nicely, but after a timeout we forcefully close.
-                ? with_timeout(timer<>::clock::now() + _options.bye_timeout, shutdown())
-                : make_ready_future<>();
-            engine().run_in_background(std::move(f).finally([this] {
-                  _eof = true;
-                  return _in.close();
-              }).finally([this] {
-                  return _out.close();
-              }).finally([this] {
-                  // make sure to wait for handshake attempt to leave semaphores. Must be in same order as
-                  // handshake aqcuire, because in worst case, we get here while a reader is attempting
-                  // re-handshake.
-                  return with_semaphore(_in_sem, 1, [this] {
-                      return with_semaphore(_out_sem, 1, [] { });
-                  });
-              }).handle_exception([me = std::move(me)](std::exception_ptr){
-              }).discard_result());
-        }
-    }
-    // helper for sink
-    future<> flush() noexcept override {
-        return with_semaphore(_out_sem, 1, [this] { return _out.flush(); });
-    }
-
-    seastar::net::connected_socket_impl& socket() const override {
-        return *_sock;
+        return do_handshake_sync([this] { return do_handshake(); });
     }
 
     future<std::optional<session_dn>> get_distinguished_name() override {
@@ -1603,24 +1394,6 @@ public:
         }
         return make_ready_future<result_t>(
           do_get_alt_name_information(peer_cert, types));
-    }
-
-    template<typename Func, typename... Args>
-    auto state_checked_access(Func&& f, Args&& ...args) {
-        using future_type = typename futurize<std::invoke_result_t<Func, Args...>>::type;
-        using result_t = typename future_type::value_type;
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!connected()) {
-            return handshake().then([this, f = std::move(f), ...args = std::forward<Args>(args)]() mutable {
-                return openssl_session::state_checked_access(std::move(f), std::forward<Args>(args)...);
-            });
-        }
-        return futurize_invoke(f, std::forward<Args>(args)...);
     }
 
     future<sstring> get_cipher_suite() override {
@@ -1667,18 +1440,6 @@ public:
             i2d_SSL_SESSION(sess, &data_ptr);
             return data;
         });
-    }
-
-    // Returns the local address formatted as a string (e.g. 'ip:port') or
-    // `DISCONNECTED` if not connected
-    const sstring& local_address() const noexcept {
-        return _local_address;
-    }
-
-    // Returns the remote address formatted as a string (e.g. 'ip:port') or
-    // `DISCONNECTED` if not connected
-    const sstring& remote_address() const noexcept {
-        return _remote_address;
     }
 
 private:
@@ -2095,34 +1856,18 @@ private:
         return sstring(bio_ptr, len);
     }
 
-    size_t in_avail() const { return _input.size(); }
-
     BIO* in_bio() { return SSL_get_rbio(_ssl.get()); }
     BIO* out_bio() { return SSL_get_wbio(_ssl.get()); }
 
 private:
-    std::unique_ptr<net::connected_socket_impl> _sock;
-    sstring _local_address;
-    sstring _remote_address;
     shared_ptr<openssl_provider_certificate_credentials_impl> _creds;
-    data_source _in;
-    data_sink _out;
-    std::exception_ptr _error;
 
-    // Reads and writes run concurrently (full duplex), serialized by two
-    // disjoint semaphores: _in_sem guards the read path (get()/SSL_read_ex),
-    // _out_sem the write path (put()/SSL_write_ex, plus flush, rehandshake and
-    // shutdown). Operations spanning both take them in the order _in_sem then
-    // _out_sem, so there is no deadlock.
+    // Because _in_sem and _out_sem are disjoint, a read and a write can both
+    // write to the socket at once: the write path always does, and the read
+    // path does too when SSL_read_ex emits a TLS key-update/renegotiation
+    // message. Neither semaphore serializes those socket writes;
+    // _output_pending does.
     //
-    // Because the semaphores are disjoint, a read and a write can both write to
-    // the socket at once: the write path always does, and the read path does too
-    // when SSL_read_ex emits a TLS key-update/renegotiation message. Neither
-    // semaphore serializes those socket writes; _output_pending does.
-    semaphore _in_sem;
-    semaphore _out_sem;
-    tls_options _options;
-
     // The put() currently in flight on _out, or a resolved future when _out is
     // idle. _out is a data_sink, which permits only one put() at a time
     // (posix_data_sink_impl asserts !_p); both the read and write paths can reach
@@ -2145,7 +1890,6 @@ private:
     // bio_write_ex() issues no further puts and re-raises. The failure is terminal
     // (the socket is gone), so _output_pending is never reset.
     shared_future<> _output_pending;
-    buf_type _input;
     // ALPN protocols in OPENSSL format
     // This is a sequence of length-prefixed strings, where the first byte is the length
     // of the first string, followed by the string data, then the length of the second string,
@@ -2153,9 +1897,6 @@ private:
     std::vector<unsigned char> _alpn_protocols;
     ssl_ctx_ptr _ctx;
     ssl_ptr _ssl;
-    session_type _type;
-    bool _eof = false;
-    bool _shutdown = false;
     // Description of the last TLS alert read from the peer, recorded by the
     // info callback registered in the constructor.
     std::optional<uint8_t> _alert_read;


### PR DESCRIPTION
The GnuTLS and OpenSSL session implementations duplicate the entire async orchestration layer around their respective TLS engines, and this is where the historically tricky concurrency behavior lives (#453, #474, #2859). The copies had already quietly diverged in a few places.

This is step 1 of an incremental unification: introduce `tls::session_base`, holding the shared state (socket, source/sink, read/write semaphores, options, input buffer, error/eof/shutdown flags, session type) and only the methods that were identical or near-identical in both backends. The backends implement five virtual hooks: `connected()`, `handshake()`, `do_get()`, `do_put_one()` and `do_shutdown()`.

## What moved into `session_base`, and how identical it was before

**Verbatim identical** (only formatting/`std::bind`-vs-lambda differences):

- `flush()`, `socket()`, `eof()`, `in_avail()`
- `state_checked_access()`: character-identical member template in both files.
- `shutdown()`: identical including comments; the base uses the lambda form rather than GnuTLS's `std::bind`.

**Identical logic, differing only in tracing** (OpenSSL had `tls_log` trace/debug lines, GnuTLS had none):

- `wait_for_input()`
- `wait_for_eof()`: also GnuTLS used a `repeat` loop where OpenSSL used `do_until`; these are equivalent and the base keeps the `do_until` form. OpenSSL's trailing trace-only `.finally` was dropped, the entry trace kept.

Decision for this class: the tracing is kept in the base, so the GnuTLS backend gains the logging the OpenSSL backend already had. To support that, the session identity previously private to the OpenSSL file also moves to the base: the `_local_address`/`_remote_address` capture, `get_type_string()`, the fmt formatter, and the `tls` logger definition itself.

**Near-identical, with a real decision taken:**

- `put()`: identical except for the linearization threshold: GnuTLS used `gnutls_record_get_max_size()` (dynamic), OpenSSL a hardcoded 16 KiB. Decision: fixed 16 KiB constant for both. GnuTLS's default max record size is exactly 16384, so this only differs when the peer negotiates a smaller record size, and even then the threshold only controls whether small writes are copied into one buffer; `gnutls_record_send` still chunks to the real record size inside `do_put_one()`. Worst case is an occasional extra copy, never incorrect framing.
- `do_put()` (both overloads): identical except GnuTLS asserted `_output_pending.available()` inside the semaphore. Since `_output_pending` stays backend-owned (see below), the base cannot assert it; the assert is relocated to the top of GnuTLS's `do_put_one()`, which is entered at exactly the points the old assert covered (immediately after semaphore grant, and after each `wait_for_output()` round trip), so the check is preserved, not weakened.
- `close()`: same logic, but the error handling had diverged in style. GnuTLS wraps each of `_in.close()`/`_out.close()` in try/catch plus a per-future `handle_exception` (added in 60892e8ce for #474, where the bare discarded close futures caused abandoned-exceptional-future reports and a possible half-close); OpenSSL, written six years later explicitly mirroring the already-fixed GnuTLS code, restyled it as a `.finally` chain. Decision: the base takes the `.finally` chain, which is protection-equivalent by construction: a synchronous throw inside a `finally` body is captured into the resulting future and cannot escape, the subsequent `finally` runs regardless (so the second stream is always closed, no half-close), and the trailing `handle_exception` swallows the outcome (no abandoned futures). GnuTLS's final `then_wrapped`+`ignore_ready_future()` and OpenSSL's `handle_exception().discard_result()` are likewise equivalent; the latter is kept.
- `handshake()` serialization (`do_handshake_sync`): the acquire-both-semaphores-and-record-first-error body was identical, but GnuTLS had it as a separate method taking a member-function pointer (reused by `force_rehandshake()`), while OpenSSL had the same body inlined in `handshake()` with `do_handshake()` hard-coded. Decision: the base exposes `do_handshake_sync(func)` as a template over any invocable; both backends now pass lambdas, and `handshake()` itself remains a backend hook because its system-trust preamble genuinely differs (async semaphore-guarded load vs synchronous `SSL_CTX_set_default_verify_paths`).
- GnuTLS's private `session::type` enum (values `GNUTLS_CLIENT`/`GNUTLS_SERVER`) is replaced by the common `session_type` held in the base, mapped to the GnuTLS constants at the single `gnutls_init()` call. This also deletes the enum-to-`session_type` mapping switch inside GnuTLS's `verify()`.

## What deliberately did not move

- `_output_pending`, `wait_for_output()`, `handle_output_error()`: genuinely divergent. GnuTLS uses a plain `future<>` reset on every wait; OpenSSL uses a `shared_future<>` that acts as a terminal circuit breaker after an output failure (see the comment block on the member). `handle_output_error()` additionally differs in signature (GnuTLS takes an error code, OpenSSL an exception object). Converging these is a semantic change, not a refactor, and is left for a later step. Notably, none of the moved methods touch `_output_pending` directly, so no hook was needed for it.
- `get()`: GnuTLS has an empty-buffer-means-rehandshake retry loop with no OpenSSL counterpart; giving OpenSSL that loop could spin, since its `do_get()` can return an empty non-eof buffer on `SSL_ERROR_NONE`.
- The engine-shaped code: `do_handshake`/`do_get`/`do_put_one`/`do_shutdown` state machines and error decoding, `verify()`, certificate/DN/SAN introspection, the transport callbacks (GnuTLS push/pull, OpenSSL BIO), and the destructors (which assert on the backend-owned `_output_pending`).

Net delta: +6 lines, with the two backends shedding 576 lines in favor of 487 written once (about a quarter of the new-file line count is documentation of the class, hooks and members).

Tested: `tests/unit/tls_test` passes with both `--crypto-provider gnutls` and `--crypto-provider openssl`.
