### PR TITLE
coroutine: make future await preemption customizable 

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -251,10 +251,16 @@ struct [[nodiscard]] SEASTAR_CORO_AWAIT_ELIDABLE without_preemption_check : publ
 
 } // seastar::internal
 
+/// \brief Whether to check for preemption when awaiting a future value type.
+///
+/// Specialize this trait to inherit from \c std::false_type for value types
+/// whose ready futures should be handled immediately by \c co_await.
+template <typename T>
+struct future_await_checks_preemption : std::true_type {};
 
 template<typename T>
 auto operator co_await(future<T>&& f) noexcept {
-    return internal::awaiter<true, T>(std::move(f));
+    return internal::awaiter<future_await_checks_preemption<T>::value, T>(std::move(f));
 }
 
 namespace coroutine {

--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "future.hh"
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/timer.hh>
@@ -601,6 +602,9 @@ public:
         return _n != 0;
     }
 };
+
+template<typename ExceptionFactory, typename Clock>
+struct future_await_checks_preemption<semaphore_units<ExceptionFactory, Clock>> : std::false_type {};
 
 /// \brief Take units from semaphore temporarily
 ///

--- a/tests/unit/coroutines_test.cc
+++ b/tests/unit/coroutines_test.cc
@@ -70,6 +70,11 @@ using namespace seastar::tests;
 
 using namespace std::chrono_literals;
 
+struct future_await_without_preemption_check_type {};
+
+template <>
+struct seastar::future_await_checks_preemption<future_await_without_preemption_check_type> : std::false_type {};
+
 namespace {
 
 future<int> old_fashioned_continuations() {
@@ -326,6 +331,22 @@ SEASTAR_TEST_CASE(test_no_preemption) {
     co_await std::move(f);
     BOOST_REQUIRE(!save_x);
     co_return;
+}
+
+SEASTAR_TEST_CASE(test_future_await_without_preemption_check) {
+    bool yielded = false;
+    auto f = yield().then([&yielded] {
+        yielded = true;
+    });
+
+    unsigned preempted = 0;
+    while (preempted < 1000 && !yielded) {
+        preempted += need_preempt();
+        co_await make_ready_future<future_await_without_preemption_check_type>();
+    }
+    auto save_yielded = yielded;
+    co_await std::move(f);
+    BOOST_REQUIRE(!save_yielded);
 }
 
 SEASTAR_TEST_CASE(test_all_simple) {


### PR DESCRIPTION
One big difference between coroutines and continuation based code is
that `co_await` by default may preempt while an immediately available
`.then` won't.

A common pattern when acquiring a lock is the following:

```
ss::get_units(lock, 1).then([] (units) {
    ...
});
```

vs.

```
auto units = co_await ss::get_units(lock, 1);
...
```

Because of the aforementioned difference in behaviour between coroutines
and continuations the coroutine version can have a the weird side effect
where the lock is acquired and then we immediately suspend due to task
quota preemption.

While seastar offers manual work arounds for this like
`coroutine::without_preemption_check` adding this everywhere is very
cumbersome and easy to forget.

Hence, this patch introduces a trait that allows future value types to
categorically opt out of preemption.

We use a trait to allow for easy user customization and also allow for
opting in types that are not owned by the user.

In an ideal world the semaphore methods would return a custom awaiter
that would use preemption but because of the duality of future and its
use across legacy continuation style code and coroutines getting this
behaviour is difficult.

Apply this trait to `semaphore_units`.