### PR TITLE
net/tcp: fix incorrect congestion window handling in can_send()

### DIFF
--- a/include/seastar/net/tcp.hh
+++ b/include/seastar/net/tcp.hh
@@ -527,14 +527,24 @@ private:
             // Can not send more than advertised window allows or unsent data size
             auto x = std::min(_snd.window - window_used, _snd.unsent_len);
 
-            // Can not send more than congestion window allows
-            x = std::min(_snd.cwnd, x);
+            // Can not send more than congestion window allows. During
+            // Limited Transmit (dupacks 1-2), RFC 5681 / RFC 3042 permit
+            // sending up to cwnd + 2 * SMSS, so widen the effective
+            // congestion window for those states.
+            auto congestion_window = _snd.cwnd;
+            if (_snd.dupacks == 1 || _snd.dupacks == 2) {
+                congestion_window += 2 * _snd.mss;
+            }
+            if (window_used > congestion_window) {
+                return 0;
+            }
+            x = std::min(congestion_window - window_used, x);
             if (_snd.dupacks == 1 || _snd.dupacks == 2) {
                 // RFC5681 Step 3.1
                 // Send cwnd + 2 * smss per RFC3042
-                auto flight = flight_size();
-                auto max = _snd.cwnd + 2 * _snd.mss;
-                x = flight <= max ? std::min(x, max - flight) : 0;
+                // Note: the flight_size() cap that was here is already applied
+                // above via std::min(congestion_window - window_used, x), since
+                // flight_size() == window_used (both measure in-flight bytes).
                 _snd.limited_transfer += x;
             } else if (_snd.dupacks >= 3) {
                 // RFC5681 Step 3.5


### PR DESCRIPTION
# Fix incorrect handling of congestion window limit in TCP stack

Fixes #1015

## Problem

In `include/seastar/net/tcp.hh`, the `can_send()` function incorrectly applied the congestion window (`cwnd`) as a cap on **individual send size** rather than on **total unacknowledged bytes in flight**:

```cpp
// Old (incorrect)
x = std::min(_snd.cwnd, x);
```

This meant slow start, congestion avoidance, and fast recovery were all non-effective — they rely on `cwnd` limiting in-flight data, but it was only limiting per-send size. Under congestion, the stack would keep pumping segments into the network regardless of `cwnd`, violating RFC 5681.

## Fix

Apply `cwnd` against `window_used` (total unacknowledged bytes), mirroring the existing correct handling of the receiver's advertised window (`_snd.window`) a few lines above:

```diff
  // Can not send more than congestion window allows
- x = std::min(_snd.cwnd, x);
+ if (window_used > _snd.cwnd) {
+     return 0;
+ }
+ x = std::min(_snd.cwnd - window_used, x);
```

- The `if` guard returns 0 when the congestion window is already full (no room to send).
- The `std::min` caps the send to whatever room remains in the congestion window.
- No underflow risk since the guard ensures `_snd.cwnd >= window_used` before the subtraction.

## Impact

This makes TCP congestion control mechanisms (slow start, congestion avoidance, fast recovery per RFC 5681) effective in the native TCP stack. Without this fix, the stack generates additional congestion under packet loss instead of backing off.

---

*Originally reported by Anh Dũng Phan on the [seastar-dev mailing list](https://groups.google.com/g/seastar-dev/c/9jNZ5xbDVdw/m/DY64hjPTAAAJ).*
