### PR TITLE
net: fix null pointer dereference in server_socket::abort_accept() and local_address()

### DIFF
--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -219,11 +219,16 @@ future<accept_result> server_socket::accept() {
 }
 
 void server_socket::abort_accept() {
-    _ssi->abort_accept();
+    if (_ssi) {
+        _ssi->abort_accept();
+    }
     _aborted = true;
 }
 
 socket_address server_socket::local_address() const noexcept {
+    if (!_ssi) {
+        return {};
+    }
     return _ssi->local_address();
 }
 

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -291,6 +291,24 @@ SEASTAR_THREAD_TEST_CASE(socket_accept_abort_test) {
     when_all(std::move(f), std::move(abort), std::move(check)).get();
 }
 
+// Check that server_socket::abort_accept() and server_socket::local_address()
+// are safe to call on an "empty" server_socket -- one that is either
+// default-constructed or moved-from, and therefore has no underlying
+// server_socket_impl. Previously these two methods dereferenced the
+// underlying impl unconditionally and would crash.
+SEASTAR_THREAD_TEST_CASE(socket_abort_accept_on_empty_test) {
+    server_socket empty_ss;
+    empty_ss.abort_accept();
+    BOOST_CHECK(empty_ss.local_address().is_unspecified());
+
+    server_socket live_ss = seastar::listen(ipv4_addr("127.0.0.1", 0), listen_options{ .reuse_address = true });
+    server_socket moved_to = std::move(live_ss);
+    // live_ss is now moved-from and empty; must still be safe to call.
+    live_ss.abort_accept();
+    BOOST_CHECK(live_ss.local_address().is_unspecified());
+    moved_to.abort_accept();
+}
+
 SEASTAR_THREAD_TEST_CASE(socket_bufsize) {
 
     // Test that setting the send and recv buffer sizes on the listening


### PR DESCRIPTION
## Problem

`server_socket::abort_accept()` and `server_socket::local_address()` dereference the underlying `_ssi` (`unique_ptr<net::server_socket_impl>`) unconditionally. `_ssi` is null whenever a `server_socket` is default-constructed or moved-from, so calling either method in that state crashes with a null pointer dereference:
/home/.../src/net/stack.cc:222:23: runtime error: member access within null pointer of type 'struct server_socket_impl'

SUMMARY: AddressSanitizer: SEGV /home/.../src/net/stack.cc:222 in seastar::server_socket::abort_accept()
I first hit this intermittently while running the `tls` unit test suite under a sanitized (`--mode=sanitize`) build -- it did not reproduce reliably in that context, but a minimal standalone repro crashes 100% of the time:

```cpp
seastar::server_socket ss;   // default-constructed, _ssi is null
ss.abort_accept();           // SEGV
```

Notably, `server_socket::accept()` already guards against a related bad state via the `_aborted` flag:

```cpp
future<accept_result> server_socket::accept() {
    if (_aborted) {
        return make_exception_future<accept_result>(std::system_error(ECONNABORTED, std::system_category()));
    }
    return _ssi->accept();
}
```

but `abort_accept()` and `local_address()` have no equivalent guard, which looks like an oversight rather than intentional.

## Fix

Guard both methods against a null `_ssi`:

- `abort_accept()` becomes a no-op if there's nothing to abort.
- `local_address()` returns a default `socket_address{}` when there's no underlying implementation to query.

## Testing

Added `socket_abort_accept_on_empty_test` in `tests/unit/socket_test.cc`, covering both the default-constructed and moved-from cases.

- Confirmed the new test **fails** (SEGV at `stack.cc:222`) against the code before this fix.
- Confirmed it **passes** with the fix applied.
- Full `tls` and `tls_openssl` suites (100+ combined test cases) still pass with the fix in place.