### PR TITLE
net: fix null pointer dereference in server_socket::accept() on never-initialized sockets

### DIFF
--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -212,7 +212,7 @@ server_socket::~server_socket() {
 }
 
 future<accept_result> server_socket::accept() {
-    if (_aborted) {
+    if (_aborted || !_ssi) {
         return make_exception_future<accept_result>(std::system_error(ECONNABORTED, std::system_category()));
     }
     return _ssi->accept();

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -301,6 +301,12 @@ SEASTAR_THREAD_TEST_CASE(socket_abort_accept_on_empty_test) {
     empty_ss.abort_accept();
     BOOST_CHECK(empty_ss.local_address().is_unspecified());
 
+    // accept() on a never-initialized server_socket (never listened,
+    // never aborted) must also fail cleanly with ECONNABORTED, rather
+    // than crash on a null server_socket_impl.
+    server_socket never_initialized;
+    BOOST_REQUIRE_THROW(never_initialized.accept().get(), std::system_error);
+
     server_socket live_ss = seastar::listen(ipv4_addr("127.0.0.1", 0), listen_options{ .reuse_address = true });
     server_socket moved_to = std::move(live_ss);
     // live_ss is now moved-from and empty; must still be safe to call.


### PR DESCRIPTION
## Context

While investigating the follow-up to #3597 (which fixed the equivalent
issue in `abort_accept()` and `local_address()`), I looked into
@avikivity's suggestion to deprecate `server_socket`'s default
constructor. Before implementing that, I checked whether it would
actually close the underlying safety gap, or just relocate it.

The candidate refactor (replacing internal default-constructed members
with `std::optional<server_socket>`) doesn't actually help: dereferencing
a disengaged `std::optional` via `operator->`/`operator*` is just as
unchecked as dereferencing a null `unique_ptr`, so it would move the same
risk into a different type rather than removing it.

While reasoning through this, I checked whether `accept()` -- the one
`server_socket` method #3597 did not touch -- had the same class of bug
as `abort_accept()`/`local_address()` did. It does.

## Problem

```cpp
future<accept_result> server_socket::accept() {
    if (_aborted) {
        return make_exception_future<accept_result>(std::system_error(ECONNABORTED, std::system_category()));
    }
    return _ssi->accept();
}
```

`_aborted` defaults to `false`, so a `server_socket` that has never been
initialized (default-constructed, or moved-from) and never had
`abort_accept()` called on it will fall straight through to `_ssi->accept()`
with a null `_ssi`, crashing instead of returning a clean error. This is a
distinct code path from the one #3597 fixed: that PR covered the case
where a socket had already been listening and was later moved-from or
aborted; this covers a socket that was never touched at all.

Minimal repro, confirmed to crash 100% of the time:

```cpp
seastar::server_socket ss;   // default-constructed, _ssi is null
ss.accept();                 // SEGV at stack.cc:218
```
runtime error: member access within null pointer of type 'struct server_socket_impl'
SUMMARY: AddressSanitizer: SEGV .../src/net/stack.cc:218 in seastar::server_socket::accept()

## Fix

```cpp
future<accept_result> server_socket::accept() {
    if (_aborted || !_ssi) {
        return make_exception_future<accept_result>(std::system_error(ECONNABORTED, std::system_category()));
    }
    return _ssi->accept();
}
```

Same error (`ECONNABORTED`) as the already-aborted case, since from the
caller's perspective "never had a real socket" and "had one but it's
gone now" both mean the same thing: there's nothing to accept from.

## Testing

Extended the existing `socket_abort_accept_on_empty_test` (added in #3597)
with a case for a never-initialized `server_socket`:

```cpp
server_socket never_initialized;
BOOST_REQUIRE_THROW(never_initialized.accept().get(), std::system_error);
```

- Confirmed this **fails** (SEGV at `stack.cc:218`) against the code
  before this fix.
- Confirmed it **passes** cleanly with the fix applied.