### PR TITLE
io_queue: Make io_sink non-moveable

### DIFF
--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -51,6 +51,8 @@ public:
 class io_sink {
     chunked_fifo<pending_io_request> _pending_io;
 public:
+    io_sink() = default;
+    io_sink(io_sink&&) = delete;
     void submit(io_completion* desc, internal::io_request req) noexcept;
 
     template <typename Fn>


### PR DESCRIPTION
It usually sits on reactor and thus doesn't move naturally. However, tests may accidentally std::move one, and it's better be prevented compil-time