### PR TITLE
core: fix iovec lifetime in asymmetric_io_uring writev

### DIFF
--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -140,6 +140,8 @@ public:
         return req;
     }
 
+    // No copy of iov is made: the returned request points at iov's data(), whose lifetime must extend
+    // until the request is complete.
     static io_request make_readv(int fd, uint64_t pos, std::vector<iovec>& iov, bool nowait_works) {
         io_request req;
         req._readv = {
@@ -212,6 +214,8 @@ public:
         return req;
     }
 
+    // No copy of iov is made: the returned request points at iov's data(), whose lifetime must extend
+    // until the request is complete.
     static io_request make_writev(int fd, uint64_t pos, std::vector<iovec>& iov, bool nowait_works) {
         io_request req;
         req._writev = {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1615,6 +1615,8 @@ protected:
         ::msghdr _mh = {};
         const size_t _to_write;
     public:
+        // iovs is not copied, the span data must remain valid until the
+        // associated request completes.
         sendmsg_completion_base(std::span<iovec> iovs, size_t to_write)
             : _to_write(to_write) {
             _mh.msg_iov = iovs.data();

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1628,6 +1628,20 @@ protected:
         }
     };
 
+    // io_request refers to the iovec array by pointer, and requests are submitted
+    // asynchronously, so the array must live as long as the operation rather than
+    // as long as the call that builds it.
+    class writev_completion_base : public sized_promise_completion_base {
+    protected:
+        std::vector<iovec> _iov;
+    public:
+        explicit writev_completion_base(std::span<iovec> iovs)
+            : _iov(iovs.begin(), iovs.end()) {}
+        std::vector<iovec>& iovs() noexcept {
+            return _iov;
+        }
+    };
+
     class send_completion_base : public sized_promise_completion_base {
     protected:
         const size_t _to_write;
@@ -2535,10 +2549,9 @@ public:
     }
 
     virtual future<size_t> writev(pollable_fd_state& fd, std::span<iovec> iovs) override {
-        auto desc = std::make_unique<sized_promise_completion_base>();
+        auto desc = std::make_unique<writev_completion_base>(iovs);
         const uint64_t position_file_offset = -1;
-        std::vector<iovec> iov(iovs.begin(), iovs.end());
-        auto req = internal::io_request::make_writev(fd.fd.get(), position_file_offset, iov, false);
+        auto req = internal::io_request::make_writev(fd.fd.get(), position_file_offset, desc->iovs(), false);
         return submit_request(std::move(desc), std::move(req));
     }
 };

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -228,6 +228,13 @@ public:
     virtual future<> poll_rdhup(pollable_fd_state& fd) = 0;
     virtual void forget(pollable_fd_state& fd) noexcept = 0;
 
+    // For all the data-path methods below, buffer and iovec-array arguments
+    // are borrowed: the caller must keep them alive and unmodified until the
+    // returned future resolves. This includes the iovec array itself, not
+    // just the buffers it points at. Polling backends read the array before
+    // the future resolves anyway, but backends that submit asynchronously
+    // (asymmetric_io_uring) may hand it to the kernel after the calling
+    // function has returned.
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;

--- a/tests/unit/pipe_stream_test.cc
+++ b/tests/unit/pipe_stream_test.cc
@@ -22,9 +22,12 @@
 #include <sys/ioctl.h>
 #include <termios.h>
 
+#include <algorithm>
+
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/thread.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -54,6 +57,46 @@ SEASTAR_THREAD_TEST_CASE(pipe_stream_roundtrip) {
 
     auto buf = in.read_exactly(payload.size()).get();
     BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
+
+    out.close().get();
+    in.close().get();
+}
+
+// ---------------------------------------------------------------------------
+// pipe_stream_large_roundtrip
+//
+// A payload much larger than the OS pipe buffer, so the sink issues many
+// writes and hits the partial-write path, where the remaining iovecs are
+// trimmed and resubmitted.  The writer runs concurrently with the reader
+// because a write that fills the pipe buffer cannot complete until the reader
+// drains it.
+// ---------------------------------------------------------------------------
+SEASTAR_THREAD_TEST_CASE(pipe_stream_large_roundtrip) {
+    auto [read_fd, write_fd] = make_pipe().get();
+
+    auto in  = make_pipe_input_stream (std::move(read_fd));
+    auto out = make_pipe_output_stream(std::move(write_fd));
+
+    constexpr size_t payload_size = 4 * 1024 * 1024;
+    sstring payload(sstring::initialized_later(), payload_size);
+    for (size_t i = 0; i < payload_size; ++i) {
+        payload[i] = char('a' + (i % 26));
+    }
+
+    auto writer = async([&out, &payload] {
+        out.write(payload).get();
+        out.flush().get();
+    });
+
+    auto buf = in.read_exactly(payload_size).get();
+    writer.get();
+
+    BOOST_REQUIRE_EQUAL(buf.size(), payload_size);
+    // Compared by offset rather than with BOOST_REQUIRE_EQUAL so that a
+    // mismatch reports one position instead of printing both payloads.
+    auto [it, _] = std::mismatch(buf.get(), buf.get() + buf.size(), payload.begin());
+    BOOST_REQUIRE_MESSAGE(it == buf.get() + buf.size(),
+                          "payload differs at offset " << (it - buf.get()));
 
     out.close().get();
     in.close().get();


### PR DESCRIPTION
Pipe and PTY writes under `asymmetric_io_uring` delivered the right number of bytes with
garbage content, failing both cases of `pipe_stream_test` on that backend only.

`reactor_backend_asymmetric_uring::writev` built its `io_request` from a function-local
vector. `io_request` refers to the iovec array by pointer and `submit_request` only queues
the request, so the SQE was flushed from the poll loop after that vector had been destroyed,
leaving the kernel to read iovec descriptors out of freed memory.

The fix gives the iovecs the lifetime of the operation by storing them in the completion
descriptor, as `recvmsg_completion_base` already does. Only this backend was affected; the
others poll and then perform the syscall inline, where the caller's iovecs are still alive.

Also adds a large-payload pipe roundtrip test: every existing case writes a single small
iovec in one go, so the partial-write path had no coverage. It fails without the backend
change and passes with it.

Tested on a 32-core x86-64 box, `dev` mode, kernel 6.8:

- `pipe_stream_test` passes on all four backends; 3/3 repeats on `asymmetric_io_uring`.
- No regressions under `asymmetric_io_uring` in `fstream`, `socket`, `connect`,
  `output_stream`, `input_stream`, `websocket`.

Fixes #3601
