### PR TITLE
core: cap asymmetric_io_uring writev at IOV_MAX iovecs

### DIFF
--- a/include/seastar/core/internal/io_request.hh
+++ b/include/seastar/core/internal/io_request.hh
@@ -34,6 +34,14 @@ extern logger io_log;
 
 namespace internal {
 
+// A trivially-copyable description of one kernel I/O operation. It refers to
+// buffers, iovec arrays and socket addresses by pointer and never owns them:
+// whoever creates a request must keep the pointed-to storage alive, and
+// unmodified, until the operation completes, not merely until the request is
+// built or submitted. Requests are typically queued (see io_sink) and reach
+// the kernel later, from a different stack. See iovec_keeper and
+// io_request::part for the usual way to pair a request with the storage that
+// keeps it valid.
 class io_request {
 public:
     enum class operation : char { read, readv, write, writev, fdatasync, recv, recvmsg, send, sendmsg, accept, connect, poll_add, poll_remove, cancel };
@@ -140,6 +148,10 @@ public:
         return req;
     }
 
+    // The returned request points at iov's heap buffer, which must stay alive
+    // and unresized until the operation completes. Moving the vector, e.g.
+    // into an iovec_keeper or a completion object, is fine: a move transfers
+    // the buffer without relocating it.
     static io_request make_readv(int fd, uint64_t pos, std::vector<iovec>& iov, bool nowait_works) {
         io_request req;
         req._readv = {
@@ -212,6 +224,7 @@ public:
         return req;
     }
 
+    // Same iovec lifetime contract as make_readv above.
     static io_request make_writev(int fd, uint64_t pos, std::vector<iovec>& iov, bool nowait_works) {
         io_request req;
         req._writev = {

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -60,6 +60,10 @@ class queued_io_request;
 class io_group;
 
 using io_group_ptr = std::shared_ptr<io_group>;
+// Owns the iovec array that an internal::io_request points at, keeping it
+// alive until the operation completes; the request itself only borrows it
+// (see internal::io_request). Passed alongside a request through the
+// submission path and stored in the completion descriptor.
 using iovec_keeper = std::vector<::iovec>;
 
 namespace internal {

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1615,6 +1615,9 @@ protected:
         ::msghdr _mh = {};
         const size_t _to_write;
     public:
+        // Points at the caller's iovec array rather than copying it, relying
+        // on the reactor_backend contract that the caller keeps the array
+        // alive until the returned future resolves.
         sendmsg_completion_base(std::span<iovec> iovs, size_t to_write)
             : _to_write(to_write) {
             _mh.msg_iov = iovs.data();

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1638,8 +1638,11 @@ protected:
     protected:
         std::vector<iovec> _iov;
     public:
+        // Submits at most IOV_MAX iovecs, as the kernel rejects anything longer
+        // with EINVAL; an oversized call becomes a short write, matching
+        // sendmsg_completion_base and reactor::do_writev.
         explicit writev_completion_base(std::span<iovec> iovs)
-            : _iov(iovs.begin(), iovs.end()) {}
+            : _iov(iovs.begin(), iovs.begin() + std::min<size_t>(iovs.size(), IOV_MAX)) {}
         std::vector<iovec>& iovs() noexcept {
             return _iov;
         }

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1628,6 +1628,20 @@ protected:
         }
     };
 
+    // io_request refers to the iovec array by pointer, and requests are submitted
+    // asynchronously, so the array must live as long as the operation rather than
+    // as long as the call that builds it.
+    class writev_completion_base : public sized_promise_completion_base {
+    protected:
+        std::vector<iovec> _iov;
+    public:
+        explicit writev_completion_base(std::span<iovec> iovs)
+            : _iov(iovs.begin(), iovs.end()) {}
+        std::vector<iovec>& iovs() noexcept {
+            return _iov;
+        }
+    };
+
     class send_completion_base : public sized_promise_completion_base {
     protected:
         const size_t _to_write;
@@ -2535,10 +2549,9 @@ public:
     }
 
     virtual future<size_t> writev(pollable_fd_state& fd, std::span<iovec> iovs) override {
-        auto desc = std::make_unique<sized_promise_completion_base>();
+        auto desc = std::make_unique<writev_completion_base>(iovs);
         const uint64_t position_file_offset = -1;
-        std::vector<iovec> iov(iovs.begin(), iovs.end());
-        auto req = internal::io_request::make_writev(fd.fd.get(), position_file_offset, iov, false);
+        auto req = internal::io_request::make_writev(fd.fd.get(), position_file_offset, desc->iovs(), false);
         return submit_request(std::move(desc), std::move(req));
     }
 };

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -228,6 +228,13 @@ public:
     virtual future<> poll_rdhup(pollable_fd_state& fd) = 0;
     virtual void forget(pollable_fd_state& fd) noexcept = 0;
 
+    // For all the data-path methods below, buffer and iovec-array arguments
+    // are borrowed: the caller must keep them alive and unmodified until the
+    // returned future resolves. This includes the iovec array itself, not
+    // just the buffers it points at. Polling backends read the array before
+    // the future resolves anyway, but backends that submit asynchronously
+    // (asymmetric_io_uring) may hand it to the kernel after the calling
+    // function has returned.
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -235,6 +235,10 @@ public:
     // the future resolves anyway, but backends that submit asynchronously
     // (asymmetric_io_uring) may hand it to the kernel after the calling
     // function has returned.
+    //
+    // sendmsg() and writev() submit at most IOV_MAX iovecs per operation, so a
+    // longer span is a short write rather than an error; callers loop until the
+    // whole span is consumed (see pollable_fd_state::write_all).
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;

--- a/tests/unit/pipe_stream_test.cc
+++ b/tests/unit/pipe_stream_test.cc
@@ -22,9 +22,12 @@
 #include <sys/ioctl.h>
 #include <termios.h>
 
+#include <algorithm>
+
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/thread.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -54,6 +57,46 @@ SEASTAR_THREAD_TEST_CASE(pipe_stream_roundtrip) {
 
     auto buf = in.read_exactly(payload.size()).get();
     BOOST_REQUIRE_EQUAL(sstring(buf.get(), buf.size()), payload);
+
+    out.close().get();
+    in.close().get();
+}
+
+// ---------------------------------------------------------------------------
+// pipe_stream_large_roundtrip
+//
+// A payload much larger than the OS pipe buffer, so the sink issues many
+// writes and hits the partial-write path, where the remaining iovecs are
+// trimmed and resubmitted.  The writer runs concurrently with the reader
+// because a write that fills the pipe buffer cannot complete until the reader
+// drains it.
+// ---------------------------------------------------------------------------
+SEASTAR_THREAD_TEST_CASE(pipe_stream_large_roundtrip) {
+    auto [read_fd, write_fd] = make_pipe().get();
+
+    auto in  = make_pipe_input_stream (std::move(read_fd));
+    auto out = make_pipe_output_stream(std::move(write_fd));
+
+    constexpr size_t payload_size = 4 * 1024 * 1024;
+    sstring payload(sstring::initialized_later(), payload_size);
+    for (size_t i = 0; i < payload_size; ++i) {
+        payload[i] = char('a' + (i % 26));
+    }
+
+    auto writer = async([&out, &payload] {
+        out.write(payload).get();
+        out.flush().get();
+    });
+
+    auto buf = in.read_exactly(payload_size).get();
+    writer.get();
+
+    BOOST_REQUIRE_EQUAL(buf.size(), payload_size);
+    // Compared by offset rather than with BOOST_REQUIRE_EQUAL so that a
+    // mismatch reports one position instead of printing both payloads.
+    auto [it, _] = std::mismatch(buf.get(), buf.get() + buf.size(), payload.begin());
+    BOOST_REQUIRE_MESSAGE(it == buf.get() + buf.size(),
+                          "payload differs at offset " << (it - buf.get()));
 
     out.close().get();
     in.close().get();

--- a/tests/unit/reactor_backend_test.cc
+++ b/tests/unit/reactor_backend_test.cc
@@ -19,9 +19,16 @@
  * Copyright (C) 2026 Kefu Chai (tchaikov@gmail.com)
  */
 
+#include <limits.h>
+#include <sys/uio.h>
+
+#include <algorithm>
+#include <vector>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/testing/test_case.hh>
 
@@ -63,3 +70,63 @@ SEASTAR_TEST_CASE(pollable_fd_state_completion_reuse_test) {
     ::close(sv[1]);
     co_return;
 }
+
+#if SEASTAR_API_LEVEL >= 9
+
+// One 1-byte iovec per element, each holding a distinct byte value, so the
+// bytes that arrive at the other end identify which iovecs were submitted.
+// The total stays under PIPE_BUF, which makes a pipe write of the whole set
+// atomic: with an empty pipe it either writes everything or nothing, so the
+// byte counts below are exact rather than best-effort.
+static std::vector<iovec> make_iovecs(std::vector<char>& data) {
+    std::vector<iovec> iovs;
+    iovs.reserve(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = char('a' + i % 26);
+        iovs.push_back({&data[i], 1});
+    }
+    return iovs;
+}
+
+// The kernel rejects a vectored I/O with more than IOV_MAX iovecs: both
+// writev(2) and IORING_OP_WRITEV fail such a call with EINVAL. Backends
+// therefore submit only the first IOV_MAX iovecs and report a short write,
+// which is what every caller already handles.
+//
+// The bug this guards against was specific to the asymmetric_io_uring backend,
+// which passed the whole span to the kernel and failed the write outright, but
+// the semantic is common to all backends so the test is backend-agnostic. To
+// exercise the backend that regressed, run it with
+// `--reactor-backend=asymmetric_io_uring --async-workers-cpuset=<cpus>`.
+SEASTAR_TEST_CASE(writev_over_iov_max_is_short_write) {
+    auto [read_fd, write_fd] = co_await make_pipe();
+    pollable_fd writer(std::move(write_fd));
+
+    std::vector<char> data(IOV_MAX + 1);
+    auto iovs = make_iovecs(data);
+
+    const size_t written = co_await writer.write_some(iovs);
+    BOOST_REQUIRE_EQUAL(written, IOV_MAX);
+
+    std::vector<char> buf(data.size());
+    BOOST_REQUIRE_EQUAL(::read(read_fd.get(), buf.data(), buf.size()), ssize_t(IOV_MAX));
+    BOOST_REQUIRE(std::equal(buf.begin(), buf.begin() + IOV_MAX, data.begin()));
+}
+
+// The short write above loses no data: write_all() trims the completed prefix
+// and resubmits the rest, so an oversized span still arrives in full.
+SEASTAR_TEST_CASE(write_all_over_iov_max_writes_everything) {
+    auto [read_fd, write_fd] = co_await make_pipe();
+    pollable_fd writer(std::move(write_fd));
+
+    std::vector<char> data(2 * IOV_MAX);
+    auto iovs = make_iovecs(data);
+
+    co_await writer.write_all(iovs);
+
+    std::vector<char> buf(data.size());
+    BOOST_REQUIRE_EQUAL(::read(read_fd.get(), buf.data(), buf.size()), ssize_t(data.size()));
+    BOOST_REQUIRE(buf == data);
+}
+
+#endif


### PR DESCRIPTION
Our existing write paths clamp writev type writes at IOV_MAX, returning a 
short write if you have more... except the new async ioruing backend, which
will return EINVAL.

Fix it: copies at most `IOV_MAX` iovecs into the completion descriptor, matching
`sendmsg_completion_base`, and states the short-write semantic on the
`reactor_backend` interface so it is a property of the interface rather than a
coincidence of each implementation. No data is lost: `write_all` trims the
completed prefix and resubmits.

Two new test cases cover it, both backend-agnostic: an oversized `write_some` is a
short write of exactly the first `IOV_MAX` iovecs, and `write_all` over the same
span still delivers everything. Each iovec holds a distinct byte so the payload
identifies which iovecs were submitted, and the total stays under `PIPE_BUF` so
the pipe write is atomic and the byte counts are exact. Verified on epoll,
linux-aio, io_uring and asymmetric_io_uring; without the clamp both fail with
`EINVAL` under asymmetric_io_uring.

Note the tests only exercise the backend that diverged when run with
`--reactor-backend=asymmetric_io_uring --async-workers-cpuset=<cpus>`; under the
default backend they guard the documented semantic only. A parallel change
adds async backend to the CI.
