### PR TITLE
core: cap asymmetric_io_uring writev at IOV_MAX iovecs

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <ranges>
 #include <vector>
 #include <fcntl.h>
 #include <signal.h>
@@ -1637,8 +1638,11 @@ protected:
     protected:
         std::vector<iovec> _iov;
     public:
+        // Submits at most IOV_MAX iovecs, as the kernel rejects anything longer
+        // with EINVAL; an oversized call becomes a short write, matching
+        // sendmsg_completion_base and reactor::do_writev.
         explicit writev_completion_base(std::span<iovec> iovs)
-            : _iov(iovs.begin(), iovs.end()) {}
+            : _iov(std::from_range, iovs.first(std::min<size_t>(iovs.size(), IOV_MAX))) {}
         std::vector<iovec>& iovs() noexcept {
             return _iov;
         }

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -235,6 +235,10 @@ public:
     // the future resolves anyway, but backends that submit asynchronously
     // (asymmetric_io_uring) may hand it to the kernel after the calling
     // function has returned.
+    //
+    // sendmsg() and writev() submit at most IOV_MAX iovecs per operation, so a
+    // longer span is a short write rather than an error; callers loop until the
+    // whole span is consumed (see pollable_fd_state::write_all).
     virtual future<std::tuple<pollable_fd, socket_address>>
     accept(pollable_fd_state& listenfd) = 0;
     virtual future<> connect(pollable_fd_state& fd, socket_address& sa) = 0;

--- a/tests/unit/reactor_backend_test.cc
+++ b/tests/unit/reactor_backend_test.cc
@@ -19,9 +19,17 @@
  * Copyright (C) 2026 Kefu Chai (tchaikov@gmail.com)
  */
 
+#include <errno.h>
+#include <limits.h>
+#include <sys/uio.h>
+
+#include <algorithm>
+#include <vector>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/internal/pollable_fd.hh>
 #include <seastar/testing/test_case.hh>
 
@@ -63,3 +71,74 @@ SEASTAR_TEST_CASE(pollable_fd_state_completion_reuse_test) {
     ::close(sv[1]);
     co_return;
 }
+
+#if SEASTAR_API_LEVEL >= 9
+
+// One 1-byte iovec per element, each holding a distinct byte value, so the
+// bytes that arrive at the other end identify which iovecs were submitted.
+// The total stays under PIPE_BUF, which makes a pipe write of the whole set
+// atomic: with an empty pipe it either writes everything or nothing, so the
+// byte counts below are exact rather than best-effort.
+static std::vector<iovec> make_iovecs(std::vector<char>& data) {
+    std::vector<iovec> iovs;
+    iovs.reserve(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = char('a' + i % 26);
+        iovs.push_back({&data[i], 1});
+    }
+    return iovs;
+}
+
+// The kernel rejects a vectored I/O with more than IOV_MAX iovecs: both
+// writev(2) and IORING_OP_WRITEV fail such a call with EINVAL. Backends
+// therefore submit only the first IOV_MAX iovecs and report a short write,
+// which is what every caller already handles.
+SEASTAR_TEST_CASE(writev_over_iov_max_is_short_write) {
+    auto [read_fd, write_fd] = co_await make_pipe();
+    pollable_fd writer(std::move(write_fd));
+
+    std::vector<char> data(IOV_MAX + 1);
+    auto iovs = make_iovecs(data);
+
+    const size_t written = co_await writer.write_some(iovs);
+    BOOST_REQUIRE_EQUAL(written, IOV_MAX);
+
+    std::vector<char> buf(data.size());
+    BOOST_REQUIRE_EQUAL(::read(read_fd.get(), buf.data(), buf.size()), ssize_t(IOV_MAX));
+    BOOST_REQUIRE(std::equal(buf.begin(), buf.begin() + IOV_MAX, data.begin()));
+}
+
+// An empty span is a legal, reachable argument: pipe_data_sink_impl::put()
+// builds one iovec per buffer and does not special-case an empty batch, and
+// write_all() calls write_some() before testing for emptiness. Clamping the
+// span must not disturb that, so pin it: no write, no error.
+SEASTAR_TEST_CASE(writev_empty_span) {
+    auto [read_fd, write_fd] = co_await make_pipe();
+    pollable_fd writer(std::move(write_fd));
+
+    BOOST_REQUIRE_EQUAL(co_await writer.write_some(std::span<iovec>{}), 0u);
+    co_await writer.write_all(std::span<iovec>{});
+
+    // Nothing reached the pipe, so the read end has no data waiting.
+    char c;
+    BOOST_REQUIRE_EQUAL(::read(read_fd.get(), &c, 1), -1);
+    BOOST_REQUIRE_EQUAL(errno, EAGAIN);
+}
+
+// The short write above loses no data: write_all() trims the completed prefix
+// and resubmits the rest, so an oversized span still arrives in full.
+SEASTAR_TEST_CASE(write_all_over_iov_max_writes_everything) {
+    auto [read_fd, write_fd] = co_await make_pipe();
+    pollable_fd writer(std::move(write_fd));
+
+    std::vector<char> data(2 * IOV_MAX);
+    auto iovs = make_iovecs(data);
+
+    co_await writer.write_all(iovs);
+
+    std::vector<char> buf(data.size());
+    BOOST_REQUIRE_EQUAL(::read(read_fd.get(), buf.data(), buf.size()), ssize_t(data.size()));
+    BOOST_REQUIRE(buf == data);
+}
+
+#endif


### PR DESCRIPTION
Our existing write paths clamp writev type writes at IOV_MAX, returning a 
short write if you have more... except the new async ioruing backend, which
will return EINVAL.

Fix it: copies at most `IOV_MAX` iovecs into the completion descriptor, matching
`sendmsg_completion_base`, and states the short-write semantic on the
`reactor_backend` interface so it is a property of the interface rather than a
coincidence of each implementation. No data is lost: `write_all` trims the
completed prefix and resubmits.

Two new test cases cover it, both backend-agnostic: an oversized `write_some` is a
short write of exactly the first `IOV_MAX` iovecs, and `write_all` over the same
span still delivers everything. Each iovec holds a distinct byte so the payload
identifies which iovecs were submitted, and the total stays under `PIPE_BUF` so
the pipe write is atomic and the byte counts are exact. Verified on epoll,
linux-aio, io_uring and asymmetric_io_uring; without the clamp both fail with
`EINVAL` under asymmetric_io_uring.

Note the tests only exercise the backend that diverged when run with
`--reactor-backend=asymmetric_io_uring --async-workers-cpuset=<cpus>`; under the
default backend they guard the documented semantic only. A parallel change
adds async backend to the CI.

Stacked on #3604, which introduces the `writev_completion_base` this clamps and
whose lifetime fix the content assertions depend on, so **CI will be red until
that merges**.
