### PR TITLE
doc: update the supported C++ standards to C++23 and C++26

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ There are also instructions for building on any host that supports [Docker](doc/
 
 Use of the [DPDK](http://dpdk.org) is [optional](doc/building-dpdk.md).
 
-#### Seastar's C++ standard: C++20 or C++23
+#### <a id="cxx-standard"></a>Seastar's C++ standard: C++23 or C++26
 
-Seastar supports both C++20, and C++23. The build defaults to the latest
+Seastar supports both C++23, and C++26. The build defaults to the latest
 standard supported by your compiler, but can be explicitly selected with
-the `--c++-standard` configure option, e.g., `--c++-standard=20`,
+the `--c++-standard` configure option, e.g., `--c++-standard=23`,
 or if using CMake directly, by setting on the `CMAKE_CXX_STANDARD` CMake
 variable.
 

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -14,9 +14,10 @@ Language standards
 ==================
 
 Seastar will support the last two standards approved by the
-ISO C++ committee. For example, after C++20 is released,
-Seastar supports C++17 and C++20.  Similarly, when C++23 is released,
-Seastar will support C++20 and C++23.
+ISO C++ committee. Each time a new standard is approved, support
+for the older of the two is retired. See
+[Seastar's C++ standard](../README.md#cxx-standard)
+in the README for the pair currently supported.
 
 Some features may only be enabled for newer dialects.
 


### PR DESCRIPTION
d9cbd5a20 ("build: update supported C++ standards to C++23, C++26") retired
C++20 and introduced C++26, but left `README.md` describing the old pair.

The stale text matters because it is actively misleading: it names
`--c++-standard=20` as the example, and C++20 is no longer a supported
standard. `CMAKE_CXX_STANDARD` now defaults to 26 and `configure.py` selects
the first of C++26, C++23 that the compiler accepts, so nothing auto-selects
C++20 any more.

`doc/compatibility.md` stated the policy generically ("the last two standards
approved by the ISO C++ committee") but illustrated it with a worked C++17 /
C++20 example, which now reads as a claim about what is supported. The example
is dropped and replaced with a pointer to the README section, so the standards
are named in exactly one place and the policy text survives the next bump.

Not touched: `doc/tutorial.md` mentions C++20 only as the standard that
introduced coroutines, which is still accurate.
