### PR TITLE
build: fetch cooked fmt from the release asset, not codeload

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -309,8 +309,8 @@ cooking_ingredient (dpdk
 
 cooking_ingredient (fmt
   EXTERNAL_PROJECT_ARGS
-    URL https://github.com/fmtlib/fmt/archive/12.2.0.tar.gz
-    URL_MD5 7be257d8bfad55bc9eabb1288ad895be
+    URL https://github.com/fmtlib/fmt/releases/download/12.2.0/fmt-12.2.0.zip
+    URL_HASH SHA256=a2f4a8d51178f954e4c339007f77edd76ba0cb2e36f87a48e5a5403d9be5878f
   CMAKE_ARGS
     -DFMT_DOC=OFF
     -DFMT_TEST=OFF)


### PR DESCRIPTION
The fmt ingredient fetches `github.com/fmtlib/fmt/archive/12.2.0.tar.gz`, which redirects to codeload. Codeload generates archives on demand and sheds load with HTTP 503, often enough to break CI runs that cook fmt.

A 503 is fatal, not just slow: ExternalProject only retries curl-level failures (`download_retry_codes` = 7, 6, 8, 15), so a 503 lands as curl status 0, the error body is written to disk, the hash check fails, and all remaining attempts are burned back to back with no backoff.

fmt attaches `fmt-12.2.0.zip` to the release, served from static blob storage behind `release-assets.githubusercontent.com` instead of the archive service. Same tree as the tag archive minus `.github/` and `.gitignore`, plus a prebuilt `doc-html/`; nothing the build touches differs. Integrity check moves to `URL_HASH SHA256` since the asset needs a new digest regardless.

Verified locally: `ExternalProject_Add` with this URL and hash downloads, verifies, configures, builds and installs fmt (`libfmt.a` + headers).

The SHA256 comes directly from the [releases page](https://github.com/fmtlib/fmt/releases/tag/12.2.0).