### PR TITLE
tests: run the TLS tests against every configured crypto provider

### DIFF
--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -101,6 +101,11 @@ if [[ "$COMPILER" == clang++-* && "$clang_ver" -ge 20 || "$STANDARD" -ge 26 ]] ;
 fi
 
 group "configure.py"
+# Both TLS backends are requested explicitly rather than left to cmake's
+# auto-detection, so that a TLS development package going missing from the
+# image fails the configure instead of quietly dropping that backend, and the
+# tests which cover it, from the run.
+#
 # OPTIONS / ENABLES intentionally unquoted: each carries multiple
 # whitespace-separated args (e.g. "--cook dpdk --dpdk-machine corei7-avx").
 # shellcheck disable=SC2086
@@ -109,6 +114,8 @@ group "configure.py"
     --compiler "$CPP"           \
     --c-compiler "$CC"          \
     --mode "$MODE"              \
+    --enable-gnutls             \
+    --enable-openssl            \
     "${cook_args[@]}"           \
     "${ccache_opt[@]}"          \
     $OPTIONS                    \

--- a/configure.py
+++ b/configure.py
@@ -216,6 +216,16 @@ add_tristate(
     help='Support io_uring via liburing')
 add_tristate(
     arg_parser,
+    name='gnutls',
+    dest='gnutls',
+    help='the GnuTLS TLS/crypto backend')
+add_tristate(
+    arg_parser,
+    name='openssl',
+    dest='openssl',
+    help='the OpenSSL TLS/crypto backend')
+add_tristate(
+    arg_parser,
     name='lttng',
     dest='lttng',
     help='LTTng-UST tracepoint support for IO tracing')
@@ -304,6 +314,8 @@ def configure_mode(mode):
         tr(args.dpdk_machine, 'DPDK_MACHINE'),
         tr(args.hwloc, 'HWLOC', value_when_none='yes'),
         tr(args.io_uring, 'IO_URING', value_when_none=None),
+        tr(args.gnutls, 'GNUTLS', value_when_none=None),
+        tr(args.openssl, 'OPENSSL', value_when_none=None),
         tr(args.lttng, 'LTTNG', value_when_none='yes'),
         tr(args.alloc_failure_injection, 'ALLOC_FAILURE_INJECTION', value_when_none='DEFAULT'),
         tr(args.task_backtrace, 'TASK_BACKTRACE'),

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -853,17 +853,43 @@ seastar_add_test (tls
   LIBRARIES Boost::filesystem
   WORKING_DIRECTORY ${Seastar_BINARY_DIR})
 
-# the `tls` test above runs with the default crypto provider, which by
-# convention is GnuTLS, if is available. When both GnuTLS and OpenSSL are
-# available this test provides coverage for the OpenSSL provider. This reuses
-# the tls_test binary built above via CUSTOM to avoid compiling it twice.
-if (Seastar_OPENSSL AND Seastar_GNUTLS)
-  seastar_add_test (tls_openssl
+# Re-run an existing test against one named crypto provider. The test binary
+# is reused via CUSTOM rather than compiled a second time, so the extra run
+# costs only its own runtime.
+function (seastar_add_crypto_provider_test name provider)
+  cmake_parse_arguments (parsed_args "" "" "DEPENDS" ${ARGN})
+
+  seastar_add_test (${name}_${provider}
     KIND CUSTOM
     WORKING_DIRECTORY ${Seastar_BINARY_DIR}
-    RUN_ARGS $<TARGET_FILE:test_unit_tls> -- -c ${Seastar_UNIT_TEST_SMP} --crypto-provider openssl)
-  add_dependencies (test_unit_tls_openssl_run test_unit_tls tls_files testcrt othercrt mtls_certs https_server)
+    RUN_ARGS $<TARGET_FILE:test_unit_${name}> -- -c ${Seastar_UNIT_TEST_SMP} --crypto-provider ${provider})
+  # DEPENDS cannot be forwarded to seastar_add_test: for a CUSTOM test it
+  # attaches them to test_unit_${name}_${provider}, which is not a target.
+  add_dependencies (test_unit_${name}_${provider}_run
+    test_unit_${name}
+    ${parsed_args_DEPENDS})
+endfunction ()
+
+# The tests registered above run with the default crypto provider, which is
+# the first candidate create_crypto_provider_option() compiles in, so this
+# list must stay in the order the #ifdefs there appear.
+set (crypto_providers "")
+if (Seastar_GNUTLS)
+  list (APPEND crypto_providers gnutls)
 endif ()
+if (Seastar_OPENSSL)
+  list (APPEND crypto_providers openssl)
+endif ()
+list (REMOVE_AT crypto_providers 0)
+
+# Whatever backends are left are exercised by re-running the tests which
+# actually speak TLS against each of them.
+foreach (provider ${crypto_providers})
+  seastar_add_crypto_provider_test (tls ${provider}
+    DEPENDS tls_files testcrt othercrt mtls_certs https_server)
+  seastar_add_crypto_provider_test (httpd ${provider}
+    DEPENDS testcrt mtls_certs)
+endforeach ()
 
 seastar_add_test (tuple_utils
   KIND BOOST


### PR DESCRIPTION
## BLUF

This takes some of the CI stuff from https://github.com/scylladb/seastar/pull/3400 without the other more controversial parts so we can improve our OpenSSL coverage "now".

Add explicit configuration to configure for OpenSSL and GnuTLS, rather that just always building in support for whatever you find on disk: that's too much magic. Folks should want to specify the backend they expect and get good errors if it can't be configured, not silently use the other backend.

Explicitly configure both TLS and GnuTLS in CI, so we definitely use both (we already do, but it's more fragile).

Actually run all the TLS related tests against OpenSSL in addition to GnuTLS. Previously only the "TLS" test was run that way, but there are several other tests that execercise TLS also.


## Details: 

## The gap

`tls_test` runs twice, once per crypto provider: normally under the default
(GnuTLS) and again as `Seastar.unit.tls_openssl`, a CUSTOM entry that reuses the
same binary with `--crypto-provider openssl`. That entry is guarded on
`Seastar_OPENSSL AND Seastar_GNUTLS`, and since `install-dependencies.sh`
installs both `libgnutls28-dev` and `libssl-dev`, it does run: in run
31612902816 `Seastar.unit.tls_openssl` passes in every job I sampled (x86 dev,
x86 release C++26, arm g++-16, x86 sanitize), and nothing in the matrix varies
the TLS packages, so it should hold for all of them.

`tls_test` is not the only test that speaks TLS, though. `httpd_test` does too:

- `test_https_server` (server credentials, `tls::connect` from the client side),
- `test_mtls_dn_propagation` (client auth REQUIRED, checks the subject DN
  reaches `request::tls_dn`),
- `test_mtls_san_propagation` (checks `request::tls_san`),
- `test_tls_handshake_error_metric`.

Those have only ever run against the default provider, so on any normal build
they are GnuTLS-only. The DN and SAN extraction they exercise is implemented
independently in `src/net/tls_gnutls.cc` and `src/net/tls_openssl.cc`, which is
the shape of code that stays green on one backend while broken on the other.

## The change

`tests: run the TLS tests against every configured crypto provider` replaces the
hardcoded `tls_openssl` entry with a helper that re-runs a named test against a
named provider, driven by the list of providers the build configured, minus the
first:

```cmake
set (crypto_providers "")
if (Seastar_GNUTLS)
  list (APPEND crypto_providers gnutls)
endif ()
if (Seastar_OPENSSL)
  list (APPEND crypto_providers openssl)
endif ()
list (REMOVE_AT crypto_providers 0)
```

The first entry is dropped because it is what `create_crypto_provider_option()`
defaults to, so the normally-registered tests already cover it. The list has to
stay in the order the `#ifdef`s in that function appear, which is noted in a
comment next to it.

Net effect:

- both backends configured (every CI job, and any normal developer build): the
  TLS tests run once per backend, as `tls` + `tls_openssl` + `httpd` +
  `httpd_openssl`. `Seastar.unit.httpd_openssl` is the new coverage.
- one backend configured: the TLS tests run once, against that backend. Today
  the `tls_openssl` entry vanishes entirely in that case, because the guard
  demands both.

Existing test names do not move.

`configure: add tristates for the TLS/crypto backends` adds
`--enable-/--disable-gnutls` and `--enable-/--disable-openssl`. `CMakeLists.txt`
has carried `Seastar_GNUTLS` and `Seastar_OPENSSL` since the OpenSSL backend
landed, and `set_option_if_package_is_found` returns early when the option is
already defined precisely so detection can be overridden, but `configure.py` had
no flag that reached them: which backends a build ends up with was decided
entirely by which development packages happened to be installed. Unspecified
still passes no `-D`, so auto-detection is unchanged.

`github: build both TLS backends explicitly` uses those flags in
`install-build-env.sh`. The point is that the OpenSSL coverage above should not
be contingent on a transitive package: if `libssl-dev` or `libgnutls28-dev` ever
stopped landing in the image, the build would succeed with one backend, the tests
covering the other would stop being registered, and CI would stay green.
`--enable-gnutls --enable-openssl` turns that into a configure failure via the
existing "is enabled but was not found" error.

## Cost

No new matrix jobs. One extra test run per job, which reuses the already-built
`httpd_test` binary, so the cost is its runtime: 2.1s locally.

## Testing

Local dev builds, clang++-22:

| configuration | registered TLS tests | result |
| --- | --- | --- |
| both backends | `tls`, `tls_openssl`, `httpd`, `httpd_openssl` | 4/4 passed. httpd 2.27s, httpd_openssl 2.09s, tls 37.4s, tls_openssl 28.4s |
| `--disable-gnutls` | `tls`, `httpd` | tls suite, 53 cases, passed in 28.5s |
| `--disable-openssl` | `tls`, `httpd` | tls suite passed in 37.7s |

The single-backend rows are there because the registration logic now depends on
that path being coherent; this PR does not add a CI job for either, and the
matrix keeps building both backends everywhere.

The CI part of #3400 was the original home for some of this. That PR keeps its
own jobs for now, so whichever of the two merges second takes a small rebase on
`gen-matrix.py`.
