### PR TITLE
github: only run push-triggered CI on long-lived branches

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,6 +1,11 @@
 name: Pre-commit
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'seastar-*-branch'
+  pull_request:
 
 jobs:
   pre-commit:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -1,6 +1,11 @@
 name: Python format
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'seastar-*-branch'
+  pull_request:
 
 jobs:
   python-format:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,12 @@ permissions:
 
 on:
   push:
+    # topic branches are covered by the pull_request trigger below; without
+    # this filter, a branch pushed to this repo (rather than to a fork) runs
+    # the whole matrix twice
+    branches:
+      - master
+      - 'seastar-*-branch'
   pull_request:
   workflow_dispatch:  # Allows manual triggering
 


### PR DESCRIPTION
Branches pushed to this repo rather than to a fork fire both the `push` and the `pull_request` event, so every check runs twice - including two full 14-config test matrices per push. The `concurrency` group does not collapse them, since `github.ref` is `refs/heads/<branch>` for the push run and `refs/pull/<n>/merge` for the PR run, and `cancel-in-progress` is gated on `refs/pull/` so the push-side matrix is not superseded by a later push either.

Scope the `push` trigger to `master` and `seastar-*-branch` in `tests.yaml`, `pre-commit.yaml` and `python-lint.yaml`. Topic branches keep full coverage via `pull_request`; post-merge CI on the long-lived branches is unchanged.

Example of the doubling: #3610 has two `Test` runs at the same SHA, [one from `push`](https://github.com/scylladb/seastar/actions/runs/31701688591) and [one from `pull_request`](https://github.com/scylladb/seastar/actions/runs/31701712518).