### PR TITLE
core/iostream: assert data_sink put() lifetime rules in debug builds

### DIFF
--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -133,6 +133,10 @@ public:
     // The caller assumes that the storage that backs this span can be released
     // once this method returns, so implementations should move the buffers into
     // stable storage on their own early, before the returned future resolves.
+    //
+    // The caller will not issue another put() until the returned future resolves,
+    // and will not destroy the sink before then, so implementations may keep
+    // per-put state in the sink for the duration of the operation.
     virtual future<> put(std::span<temporary_buffer<char>> data) = 0;
 #else
     virtual future<> put(net::packet data) = 0;
@@ -210,6 +214,12 @@ protected:
 #endif
 };
 
+/// Pushes bulk data to a provider, such as a TCP connection, a disk file or a
+/// memory buffer.
+///
+/// \note All methods must be called sequentially.  That is, no method may be
+/// invoked before the previous method's returned future is resolved, and the
+/// sink may not be destroyed while a put() is outstanding.
 class data_sink {
     std::unique_ptr<data_sink_impl> _dsi;
 public:

--- a/include/seastar/core/iostream.hh
+++ b/include/seastar/core/iostream.hh
@@ -40,12 +40,19 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/util/assert.hh>
+#include <seastar/util/defer.hh>
 #include <boost/intrusive/slist.hpp>
 #include <memory>
 #include <optional>
 #include <variant>
 #include <utility>
 #include <vector>
+
+// The put() bookkeeping below relies on data_sink::put() being the sole caller
+// of data_sink_impl::put(), which only holds at API level 9 and above.
+#if defined(SEASTAR_DEBUG) && SEASTAR_API_LEVEL >= 9
+#define SEASTAR_DATA_SINK_PUT_DEBUG
+#endif
 
 namespace bi = boost::intrusive;
 
@@ -102,8 +109,23 @@ public:
 };
 
 class data_sink_impl {
+#ifdef SEASTAR_DATA_SINK_PUT_DEBUG
+    // Set while a put() issued through data_sink has not resolved yet.
+    // Implementations are allowed to hold per-sink state for the duration of a
+    // put, which makes two things errors: destroying the sink while this is set,
+    // which leaves the operation and the continuation that cleans up after it
+    // pointing at freed memory, and issuing a second put while it is set, which
+    // makes the two puts share that state.
+    bool _put_in_flight = false;
+
+    friend class data_sink;
+#endif
 public:
-    virtual ~data_sink_impl() {}
+    virtual ~data_sink_impl() {
+#ifdef SEASTAR_DATA_SINK_PUT_DEBUG
+        SEASTAR_DEBUG_ASSERT(!_put_in_flight);
+#endif
+    }
     virtual temporary_buffer<char> allocate_buffer(size_t size) {
         return temporary_buffer<char>(size);
     }
@@ -201,7 +223,18 @@ public:
 #if SEASTAR_API_LEVEL >= 9
     future<> put(std::span<temporary_buffer<char>> data) noexcept {
         try {
+#ifdef SEASTAR_DATA_SINK_PUT_DEBUG
+            auto* dsi = _dsi.get();
+            // this guard enforces the general contract of the data sink that
+            // (1) there are never > 1 puts in flight
+            // (2) we never destroy the sink with a put in flight
+            SEASTAR_DEBUG_ASSERT(!dsi->_put_in_flight);
+            dsi->_put_in_flight = true;
+            auto guard = defer([dsi] () noexcept { dsi->_put_in_flight = false; });
+            return dsi->put(data).finally([guard = std::move(guard)] {});
+#else
             return _dsi->put(data);
+#endif
         } catch (...) {
             return current_exception_as_future();
         }

--- a/include/seastar/util/assert.hh
+++ b/include/seastar/util/assert.hh
@@ -34,3 +34,11 @@ namespace seastar::internal {
                                            __PRETTY_FUNCTION__);      \
         }                                                             \
     } while (0)
+
+/// Like SEASTAR_ASSERT(), but only active in SEASTAR_DEBUG builds. For checks
+/// whose cost is only worth paying while debugging.
+#ifdef SEASTAR_DEBUG
+#define SEASTAR_DEBUG_ASSERT(x) SEASTAR_ASSERT(x)
+#else
+#define SEASTAR_DEBUG_ASSERT(x) do { } while (0)
+#endif

--- a/tests/unit/output_stream_test.cc
+++ b/tests/unit/output_stream_test.cc
@@ -393,3 +393,51 @@ SEASTAR_THREAD_TEST_CASE(test_memory_data_sink) {
     do_test_memory_data_sink<std::list>();
     do_test_memory_data_sink<std::deque>();
 }
+
+#ifdef SEASTAR_DATA_SINK_PUT_DEBUG
+
+// Hands out a future the test controls, so a caller that drops it leaves the put
+// in flight for as long as the sink lives.
+class pending_put_sink final : public data_sink_impl {
+    promise<>& _pending;
+public:
+    explicit pending_put_sink(promise<>& pending) noexcept : _pending(pending) { }
+
+    future<> put(std::span<temporary_buffer<char>> bufs) override {
+        return _pending.get_future();
+    }
+
+    future<> close() override { return make_ready_future<>(); }
+    size_t buffer_size() const noexcept override { return 4096; }
+};
+
+class throwing_put_sink final : public data_sink_impl {
+public:
+    future<> put(std::span<temporary_buffer<char>> bufs) override {
+        throw std::runtime_error("put failed");
+    }
+
+    future<> close() override { return make_ready_future<>(); }
+    size_t buffer_size() const noexcept override { return 4096; }
+};
+
+// The abandoned put the assert catches aborts the process, so it has no test case
+// here; what these two cover is the other half, that draining a put and failing to
+// issue one both leave the sink destructible.
+
+// A put that throws unwinds the guard, which clears the flag again.
+SEASTAR_THREAD_TEST_CASE(test_throwing_put_leaves_sink_destructible) {
+    data_sink sink(std::make_unique<throwing_put_sink>());
+    auto f = sink.put(temporary_buffer<char>(8));
+    BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_drained_put_leaves_sink_destructible) {
+    promise<> pending;
+    data_sink sink(std::make_unique<pending_put_sink>(pending));
+    auto f = sink.put(temporary_buffer<char>(8));
+    pending.set_value();
+    f.get();
+}
+
+#endif


### PR DESCRIPTION
A `data_sink_impl` may hold per-sink state for the duration of a `put()`. At API level 9 and above `posix_data_sink_impl::put()` hands the kernel a pointer into its own `_vecs.v` and chains a deleter that captures `this`; the API < 9 `put(packet)` overload keeps the packet in `_p`.

That gives the sink two rules, neither of which was checked in a way that covers all sinks:

1. **Do not destroy an owner with a put in flight.** Both the pending operation and the continuation that cleans up after it point into the sink, so this dangles twice. Only TLS guarded against it, in `~openssl_session`, even though the memory at risk belongs to the *sink* rather than the session.
2. **Do not issue a put while one is in flight.** `wrapped_iovecs::populate()` reports `"wrapped_iovecs are re-populated live"` and the API < 9 overload asserts `!_p`, but both are posix-sink-only. `output_stream` already serializes deliberately, yet nothing verified the rule at the sink.

## Approach

`data_sink::put()` is a non-virtual forwarder and, at API level 9 and above, the only caller of `data_sink_impl::put()` anywhere in the tree. That makes it a ready-made choke point: set a flag on the impl for as long as a put is unresolved, assert it is clear on entry to `put()`, and assert it is clear in `~data_sink_impl`. This covers all 18 `data_sink_impl` subclasses without editing any of them.

The flag is cleared by an `ss::defer` guard moved into the continuation that observes the put, so it stays accurate on every path: it is set before the sink is called, so a put re-entered from inside `put()`, or a sink destroyed there, is covered too; a `put()` that throws clears it by unwinding the guard; otherwise it is cleared when the continuation resolves.

The two asserts lean on each other: a `bool` is only sufficient for rule 1 because rule 2 is enforced. Without it, overlapping puts would let the inner guard clear the flag while the outer put was still in flight.

## Documentation

Both rules were unstated at the sink layer, even though implementations depend on them. The last commit states them next to the existing note about buffer storage on `data_sink_impl::put()`, where an implementer will read them, and on `data_sink` in the same words `input_stream` and `output_stream` use for their own sequential-access rules.

Note `data_source_impl::get()` has the same unstated contract. Left for a separate change.

## Cost

Everything is confined to `SEASTAR_DEBUG` builds: no member, no `.finally()`, no branch otherwise. Verified rather than assumed: compiling `posix-stack.cc`, `tls_openssl.cc` and `fstream.cc` against pristine master and against this branch, non-debug and `-g0`, gives a byte-identical `tls_openssl.o` and two objects whose only differing bytes are `__LINE__` immediates that pre-existing asserts pass to `assert_fail`. Symbols and all section sizes are identical.

The first commit adds `SEASTAR_DEBUG_ASSERT`, since the `#ifdef SEASTAR_DEBUG` + `SEASTAR_ASSERT` pattern had no name yet.

## Testing

Debug build, 8 suites (`output_stream`, `tls` with both crypto providers, `socket`, `fstream`, `httpd`, `websocket`, `rpc`) under both `io_uring` and `asymmetric_io_uring`, 16 runs, all clean: neither rule is violated anywhere in those suites today. `tls_test`'s `test_output_pending_exception_on_destroy`, the sharpest false-positive probe in the tree, stays quiet, as it must: resolved means the cleanup has already run.

Both asserts were confirmed to actually fire, via throwaway tests not included here, including one where a sink synchronously re-enters `data_sink::put` on itself.

## Limitations

- **Neither assert has automated regression coverage, and the committed tests would pass against unpatched master.** An assert that terminates cannot be observed in-process, and seastar has no death-test facility today, so the two committed cases only check that draining a put and failing to issue one leave the sink destructible. Both aborts were verified by hand instead, as noted above. This is because we don't have "death tests".
- API level < 9 is not covered, since `data_sink::put()` is not a single choke point there.
