### PR TITLE
rpc: fix use-after-free when a stream connection's last reference is dropped mid-flight

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -497,7 +497,9 @@ public:
 
 } // namespace internal
 
-class client : public rpc::connection, public weakly_referencable<client> {
+// Stream children are shared_ptr-managed (see make_stream_sink()); this lets
+// loop() self-keepalive for that case -- see loop().
+class client : public rpc::connection, public weakly_referencable<client>, public enable_shared_from_this<client> {
     socket _socket;
     id_type _message_id = 1;
     struct reply_handler_base {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -964,6 +964,17 @@ client::client(const logger& l, void* s, client_options ops, socket socket, cons
 }
 
 future<> client::loop(client_options ops, const socket_address& addr, const socket_address& local) {
+    // _streams[id] (see make_stream_sink()) can be a stream child's last
+    // reference; abort_all_streams()/deregister_this_stream() erase it and
+    // can free `this` while this coroutine is still suspended and will
+    // resume to touch it again. Self-keepalive for the whole coroutine
+    // avoids that, dropped only after _stopped.set_value(). Only stream
+    // children need this; is_stream() isn't set yet here, so check
+    // _options.stream_parent instead.
+    shared_ptr<client> self_keepalive;
+    if (ops.stream_parent) {
+        self_keepalive = shared_from_this();
+    }
     std::exception_ptr ep;
     try {
         connected_socket fd = co_await _socket.connect(addr, local);

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1122,11 +1122,16 @@ server::connection::negotiate(feature_map requested) {
                 _is_stream = true;
                 // remove stream connection from rpc connection list
                 get_server()._conns.erase(get_connection_id());
-                f = f.then([this, c = shared_from_this()] () mutable {
-                    return smp::submit_to(_parent_id.shard(), [this, c = make_foreign(static_pointer_cast<rpc::connection>(c))] () mutable {
-                        auto sit = _servers.find(*get_server()._options.streaming_domain);
+                // Read while still on this connection's own shard: get_server()
+                // dereferences a remote server object that must not be touched
+                // from _parent_id.shard() below (it can belong to a different,
+                // independently-lifetimed shard).
+                auto streaming_domain = *get_server()._options.streaming_domain;
+                f = f.then([this, c = shared_from_this(), streaming_domain] () mutable {
+                    return smp::submit_to(_parent_id.shard(), [this, c = make_foreign(static_pointer_cast<rpc::connection>(c)), streaming_domain] () mutable {
+                        auto sit = _servers.find(streaming_domain);
                         if (sit == _servers.end()) {
-                            throw std::logic_error(format("Shard {:d} does not have server with streaming domain {}", this_shard_id(), *get_server()._options.streaming_domain).c_str());
+                            throw std::logic_error(format("Shard {:d} does not have server with streaming domain {}", this_shard_id(), streaming_domain).c_str());
                         }
                         auto s = sit->second;
                         auto it = s->_conns.find(_parent_id);
@@ -1303,11 +1308,15 @@ server::connection::connection(server& s, connected_socket&& fd, socket_address&
 }
 
 future<> server::connection::deregister_this_stream() {
+    // Read while still on this connection's own shard (see negotiate()'s
+    // STREAM_PARENT case for the same reasoning): get_server() dereferences a
+    // remote server object that must not be touched from _parent_id.shard().
     if (!get_server()._options.streaming_domain) {
         return make_ready_future<>();
     }
-    return smp::submit_to(_parent_id.shard(), [this] () mutable {
-        auto sit = server::_servers.find(*get_server()._options.streaming_domain);
+    auto streaming_domain = *get_server()._options.streaming_domain;
+    return smp::submit_to(_parent_id.shard(), [this, streaming_domain] () mutable {
+        auto sit = server::_servers.find(streaming_domain);
         if (sit != server::_servers.end()) {
             auto s = sit->second;
             auto it = s->_conns.find(_parent_id);

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -702,6 +702,115 @@ SEASTAR_TEST_CASE(test_stream_stop_server) {
     });
 }
 
+// Reproducer for https://github.com/scylladb/seastar/issues/3618: dropping
+// sink+source without draining to EOS leaves _streams[id] as the child's
+// last reference; abort_all_streams() then frees it while its own loop()
+// coroutine is still suspended. Crashes under ASan on unfixed code.
+SEASTAR_THREAD_TEST_CASE(test_stream_abort_all_streams_uaf) {
+    rpc::server_options so;
+    so.streaming_domain = rpc::streaming_domain_type(1);
+    rpc_test_config cfg;
+    cfg.server_options = so;
+    rpc_test_env<>::do_with_thread(cfg, [] (rpc_test_env<>& env) {
+        constexpr int msg_id = 1;
+        env.register_handler(msg_id, [] (int i, rpc::source<int> source) {
+            // Server plays no active role; still must close its sink
+            // (sink_impl's destructor requires it) before dropping it.
+            auto sink = source.make_sink<serializer, sstring>();
+            return sink.close().then([sink] { return sink; });
+        }).get();
+        auto call = env.proto().make_client<rpc::source<sstring> (int, rpc::sink<int>)>(msg_id);
+
+        test_rpc_proto::client cl(env.proto(), {}, env.make_socket(), ipv4_addr());
+        std::optional<rpc::sink<int>> sink = cl.make_stream_sink<serializer, int>(env.make_socket()).get();
+        {
+            // Get the source and drop it immediately without reading it.
+            auto source = call(cl, 1, *sink).get();
+        }
+        sink->close().get();
+        // Source is already gone, so this may drop the child's last ref.
+        sink.reset();
+        cl.stop().get();
+        // Let the (unrelated) server-side connection tear down too.
+        env.invoke_on_all([] (rpc_test_env<>::rpc_test_service& s) {
+            return s.server().shutdown();
+        }).get();
+    }).get();
+}
+
+// Companion to test_stream_abort_all_streams_uaf: the self-keepalive fix
+// must not turn into a leak on a normal, fully-drained stream lifecycle.
+SEASTAR_THREAD_TEST_CASE(test_stream_normal_lifecycle_no_leak) {
+    rpc::server_options so;
+    so.streaming_domain = rpc::streaming_domain_type(1);
+    rpc_test_config cfg;
+    cfg.server_options = so;
+    rpc_test_env<>::do_with_thread(cfg, [] (rpc_test_env<>& env) {
+        constexpr int msg_id = 1;
+        env.register_handler(msg_id, [] (int i, rpc::source<int> source) {
+            auto sink = source.make_sink<serializer, sstring>();
+            // Fire-and-forget: drain the client's ints to EOS, then reply
+            // and close our own end. The client below drains this to EOS
+            // too, so both directions are fully closed before cl.stop().
+            (void)seastar::async([sink, source] () mutable {
+                while (source().get()) { }
+                sink("done").get();
+                sink.close().get();
+            });
+            return sink;
+        }).get();
+        auto call = env.proto().make_client<rpc::source<sstring> (int, rpc::sink<int>)>(msg_id);
+
+        rpc::client_options opt;
+        opt.metrics_domain = "test_stream_normal_lifecycle_no_leak_dom";
+        test_rpc_proto::client cl(env.proto(), opt, env.make_socket(), ipv4_addr());
+        {
+            // sink/source are themselves reference-counted handles onto the
+            // stream child's connection; they must be dropped (this scope
+            // exit) before the child can be destroyed.
+            auto sink = cl.make_stream_sink<serializer, int>(env.make_socket()).get();
+            auto source = call(cl, 1, sink).get();
+            sink(1).get();
+            sink.close().get();
+            while (source().get()) { } // drain to EOS
+        }
+        cl.stop().get();
+        // Let the server-side connection tear down too.
+        env.invoke_on_all([] (rpc_test_env<>::rpc_test_service& s) {
+            return s.server().shutdown();
+        }).get();
+
+        // Stream children register under "<domain>_stream" (see
+        // make_stream_sink()); their "count" metric tracks live instances.
+        // Poll briefly since the child's own teardown (stop_send_loop(),
+        // compressor close) completes asynchronously on its own coroutine,
+        // not synchronously within cl.stop().
+        auto live_stream_children = [] (const std::string& domain) -> int {
+            const auto& values = seastar::metrics::impl::get_value_map();
+            const auto& mf = values.find("rpc_client_count");
+            if (mf == values.end()) {
+                return -1;
+            }
+            for (auto&& mi : mf->second) {
+                for (auto&& li : mi.first.labels()) {
+                    if (li.first == "domain" && li.second.value() == domain) {
+                        return mi.second->get_function()().i();
+                    }
+                }
+            }
+            return -1;
+        };
+        auto domain = opt.metrics_domain + "_stream";
+        auto deadline = seastar::lowres_clock::now() + std::chrono::seconds(5);
+        int live = live_stream_children(domain);
+        while (live != 0 && seastar::lowres_clock::now() < deadline) {
+            sleep(std::chrono::milliseconds(10)).get();
+            live = live_stream_children(domain);
+        }
+        BOOST_REQUIRE_EQUAL(live, 0);
+    }).get();
+}
+
 SEASTAR_TEST_CASE(test_stream_connection_error) {
     rpc::server_options so;
     so.streaming_domain = rpc::streaming_domain_type(1);


### PR DESCRIPTION
## Summary

Two related but distinct use-after-free bugs, found while stress-testing a fix for the first:

- **#3618**: `client::abort_all_streams()` (parent-initiated) or `deregister_this_stream()` (self-initiated) can erase `_streams[id]`, which can be a stream child's last reference, freeing it while its own `loop()` coroutine is still suspended and will resume to touch it again. Fixed by giving `client` an `enable_shared_from_this` base and holding a self-keepalive for the whole `loop()` coroutine when it's a stream child, dropped only after `_stopped.set_value()`.
- **#3620**: found while stress-testing the above — `server::connection::negotiate()`'s `STREAM_PARENT` case and `deregister_this_stream()` both call `get_server()` *after* hopping to `_parent_id.shard()` via `smp::submit_to`, dereferencing a remote, independently-lifetimed server object from the wrong shard. Fixed by reading the needed value before the shard hop and capturing it into the submitted lambda.

Kept as two commits since they're genuinely separate, pre-existing bugs.

## Test plan
- [x] New regression test (`test_stream_abort_all_streams_uaf`) reliably crashes unfixed code under ASan; a companion test (`test_stream_normal_lifecycle_no_leak`) confirms the keepalive doesn't leak on a normal, fully-drained lifecycle.
- [x] The #3620 fix reduced an observed ~1-5%-of-runs ASan failure rate on those two new tests to 0/80.
- [x] Full `test.py --mode dev`: 93/94 (only the pre-existing, unrelated `Seastar.unit.sstring` flake).
- [x] Full `rpc_test` suite under `--mode sanitize`: clean.

Fixes #3618
Fixes #3620

🤖 Generated with [Claude Code](https://claude.com/claude-code)