### PR TITLE
tests: run unit tests in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     container:
       image: ubuntu:26.04
+      # --privileged: needed to raise fs.aio-max-nr (below) for -j4 test runs.
+      options: --privileged
     steps:
       - name: Show parameters
         run: |
@@ -100,4 +102,10 @@ jobs:
 
       - name: Test
         if: ${{ ! contains(inputs.enables, 'cxx-modules') }}
-        run: ./test.py --mode=${{ inputs.mode }} ${{ inputs.test-args }}
+        # aio-max-nr is a single global (non-namespaced) counter shared by
+        # every concurrently-running Seastar process in the container; the
+        # default is too low for several test binaries opening AIO contexts
+        # at once under -j4.
+        run: |
+          echo 1048576 > /proc/sys/fs/aio-max-nr
+          ./test.py --mode=${{ inputs.mode }} -j4 ${{ inputs.test-args }}

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -1053,16 +1053,46 @@ class metrics_handler : public httpd::handler_base  {
      * A filter function filter what metrics should be included.
      * It returns true if a metric should be included, or false otherwise.
      * The filters are created from the request query parameters.
+     *
+     * Metrics are aggregated from all shards (see get_map_value()), but a
+     * given metric's labels may only be registered on some shards. Since the
+     * request itself can be handled by any shard, a query param unknown to
+     * the local shard isn't necessarily unknown cluster-wide: fall back to
+     * checking the other shards, but only for params the local shard didn't
+     * recognize, so the common case stays a local, allocation-free lookup.
      */
-    std::function<bool(const mi::labels_type&)> make_filter(const http::request& req) {
+    static future<std::set<sstring>> get_labels_all_shards() {
+        auto labels = std::set<sstring>();
+        co_await parallel_for_each(std::views::iota(0u, this_smp_shard_count()), [&labels] (auto cpu) {
+            return smp::submit_to(cpu, [] {
+                return mi::get_local_impl()->get_labels();
+            }).then([&labels] (auto shard_labels) {
+                labels.merge(std::move(shard_labels));
+            });
+        });
+        co_return labels;
+    }
+
+    future<std::function<bool(const mi::labels_type&)>> make_filter(const http::request& req) {
         std::unordered_map<sstring, std::regex> matcher;
-        auto labels = mi::get_local_impl()->get_labels();
+        auto local_labels = mi::get_local_impl()->get_labels();
+        std::vector<std::pair<sstring, sstring>> unresolved;
         for (auto&& qp : req.get_query_params()) {
-            if (labels.find(qp.first) != labels.end()) {
+            if (local_labels.find(qp.first) != local_labels.end()) {
                 matcher.emplace(qp.first, std::regex(qp.second.back().c_str()));
+            } else {
+                unresolved.emplace_back(qp.first, qp.second.back());
             }
         }
-        return (matcher.empty()) ? _true_function : [matcher](const mi::labels_type& labels) {
+        if (!unresolved.empty()) {
+            auto all_labels = co_await get_labels_all_shards();
+            for (auto&& [name, value] : unresolved) {
+                if (all_labels.find(name) != all_labels.end()) {
+                    matcher.emplace(name, std::regex(value.c_str()));
+                }
+            }
+        }
+        co_return (matcher.empty()) ? _true_function : [matcher](const mi::labels_type& labels) {
             for (auto&& m : matcher) {
                 auto l = labels.find(m.first);
                 if (!std::regex_match((l == labels.end())? "" : l->second.value().c_str(), m.second)) {
@@ -1087,7 +1117,7 @@ public:
             }
         }
         write_body_args args{
-            .filter = make_filter(*req),
+            .filter = co_await make_filter(*req),
             .family_filter = details::make_family_filter(std::move(name_filters), _ctx.prefix),
             .use_protobuf_format = _ctx.allow_protobuf && is_accept_protobuf(req->get_header("Accept")),
             .show_help = req->get_query_param("__help__") != "false",
@@ -1096,7 +1126,7 @@ public:
         rep->write_body(args.use_protobuf_format ? "proto" : "txt", [this, args = std::move(args)](output_stream<char>&& s) {
             return write_body(std::move(args), std::move(s));
         });
-        return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
+        co_return std::move(rep);
     }
 
 private:

--- a/test.py
+++ b/test.py
@@ -33,6 +33,8 @@ if __name__ == "__main__":
     parser.add_argument('--timeout', action="store",default="300",type=int, help="timeout value for test execution")
     parser.add_argument('--jenkins', action="store",help="jenkins output file prefix")
     parser.add_argument('--smp', '-c', action="store",default='2',type=int,help="Number of threads for multi-core tests")
+    parser.add_argument('--jobs', '-j', action="store", default=None, type=int,
+                        help="Run up to this many tests in parallel (default: number of CPUs)")
     parser.add_argument('--verbose', '-v', action = 'store_true', default = False,
                         help = 'Verbose reporting')
     parser.add_argument('--offline', action="store_true", default = False,
@@ -66,6 +68,8 @@ if __name__ == "__main__":
             TRANSLATED_CTEST_ARGS += ['--verbose']
         if args.name:
             TRANSLATED_CTEST_ARGS += ['-R', args.name]
+        if args.jobs:
+            TRANSLATED_CTEST_ARGS += ['--parallel', str(args.jobs)]
 
         CTEST_ARGS = ['ctest', BUILD_PATH] + TRANSLATED_CTEST_ARGS + args.ctest_forward
         print(CTEST_ARGS)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -285,7 +285,7 @@ function (prepend_each var prefix)
 endfunction ()
 
 add_custom_target (test_unit
-  COMMAND ctest --verbose -R Seastar.unit
+  COMMAND ctest --verbose --parallel -R Seastar.unit
   USES_TERMINAL)
 
 seastar_add_test (abort_source
@@ -379,6 +379,9 @@ seastar_add_test (abortable_fifo
 
 seastar_add_test (io_queue
   SOURCES io_queue_test.cc)
+set_tests_properties (Seastar.unit.io_queue
+  PROPERTIES
+    RUN_SERIAL TRUE)
 
 if (Seastar_LTTNG)
   add_custom_target (test_unit_io_trace_lttng_run
@@ -852,6 +855,10 @@ seastar_add_test (tls
   SOURCES tls_test.cc
   LIBRARIES Boost::filesystem
   WORKING_DIRECTORY ${Seastar_BINARY_DIR})
+set_tests_properties (Seastar.unit.tls
+  PROPERTIES
+    ENVIRONMENT SEASTAR_TLS_TEST_PORT=4711
+    RESOURCE_LOCK tls_listen_ports)
 
 # Re-run an existing test against one named crypto provider. The test binary
 # is reused via CUSTOM rather than compiled a second time, so the extra run
@@ -883,10 +890,18 @@ endif ()
 list (REMOVE_AT crypto_providers 0)
 
 # Whatever backends are left are exercised by re-running the tests which
-# actually speak TLS against each of them.
+# actually speak TLS against each of them. tls_test.cc listens on a single
+# fixed port per process (SEASTAR_TLS_TEST_PORT), so each provider run needs
+# its own port plus a shared lock to keep them from ever overlapping.
+set (tls_test_port 4712)
 foreach (provider ${crypto_providers})
   seastar_add_crypto_provider_test (tls ${provider}
     DEPENDS tls_files testcrt othercrt mtls_certs https_server)
+  set_tests_properties (Seastar.unit.tls_${provider}
+    PROPERTIES
+      ENVIRONMENT SEASTAR_TLS_TEST_PORT=${tls_test_port}
+      RESOURCE_LOCK tls_listen_ports)
+  math (EXPR tls_test_port "${tls_test_port} + 1")
   seastar_add_crypto_provider_test (httpd ${provider}
     DEPENDS testcrt mtls_certs)
 endforeach ()
@@ -952,6 +967,7 @@ add_test (
   COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target test_unit_json2code_run)
 set_tests_properties (Seastar.unit.json2code
   PROPERTIES
+    RESOURCE_LOCK json2code_listen_port
     TIMEOUT ${Seastar_TEST_TIMEOUT})
 
 add_executable (metrics_tester
@@ -974,6 +990,7 @@ add_test (
   COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target test_unit_prometheus_run)
 set_tests_properties (Seastar.unit.prometheus
   PROPERTIES
+    RESOURCE_LOCK prometheus_listen_port
     TIMEOUT ${Seastar_TEST_TIMEOUT})
 
 seastar_add_test (gate

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -96,7 +96,7 @@ function (seastar_add_test name)
 
   cmake_parse_arguments (parsed_args
     ""
-    "WORKING_DIRECTORY;KIND"
+    "WORKING_DIRECTORY;KIND;FILTER;TARGET"
     "RUN_ARGS;SOURCES;LIBRARIES;DEPENDS"
     ${ARGN})
 
@@ -112,7 +112,17 @@ function (seastar_add_test name)
     return ()
   endif ()
 
-  if (parsed_args_SOURCES)
+  if (parsed_args_TARGET)
+    # Run a filtered subset of cases from another test's already-built
+    # executable, so independent subsets can execute concurrently without
+    # rebuilding the shared binary.
+    if (NOT parsed_args_FILTER)
+      message (FATAL_ERROR "TARGET requires FILTER for ${name}")
+    endif ()
+
+    set (executable_target test_unit_${parsed_args_TARGET})
+    set (test_name_prefix Seastar.unit)
+  elseif (parsed_args_SOURCES)
     # These may be unused.
     seastar_jenkins_arguments (${name} jenkins_args)
 
@@ -214,6 +224,38 @@ function (seastar_add_test name)
     set (executable_target test_unit_${name})
     set (test_name_prefix Seastar.unit)
     set (forwarded_args COMMAND ${CMAKE_COMMAND} -E env "${Seastar_TEST_ENVIRONMENT}" ${parsed_args_RUN_ARGS})
+  endif ()
+
+  if (parsed_args_FILTER)
+    # Build the (possibly shared) executable once via a fixture, so shards
+    # that reuse it via TARGET don't race to rebuild it concurrently.
+    set (build_test Seastar.unit.${executable_target}_build)
+    set (build_fixture ${executable_target}_ctest_build)
+    if (NOT TEST ${build_test})
+      add_test (
+        NAME ${build_test}
+        COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target ${executable_target} --parallel 4)
+      set_tests_properties (${build_test}
+        PROPERTIES
+          FIXTURES_SETUP ${build_fixture}
+          TIMEOUT 1800
+          PROCESSORS 4)
+    endif ()
+
+    add_test (
+      NAME ${test_name_prefix}.${name}
+      # Unquoted: Seastar_TEST_ENVIRONMENT is a ;-separated list that must
+      # expand to multiple `-E env` arguments, not a single literal string.
+      COMMAND ${CMAKE_COMMAND} -E env ${Seastar_TEST_ENVIRONMENT}
+        $<TARGET_FILE:${executable_target}>
+        --run_test=${parsed_args_FILTER}
+        -- -c ${Seastar_UNIT_TEST_SMP})
+
+    set_tests_properties (${test_name_prefix}.${name}
+      PROPERTIES
+        FIXTURES_REQUIRED ${build_fixture}
+        TIMEOUT ${Seastar_TEST_TIMEOUT})
+    return ()
   endif ()
 
   #
@@ -499,10 +541,26 @@ seastar_add_test (queue
 seastar_add_test (request_parser
   SOURCES request_parser_test.cc)
 
-seastar_add_test (rpc
+seastar_add_test (rpc_core
   SOURCES
     loopback_socket.hh
-    rpc_test.cc)
+    rpc_test.cc
+  FILTER "test_rpc_connect*,test_rpc_connect_multi_compression_algo*,test_rpc_connect_abort*,test_rpc_cancel*,test_message_to_big*,test_rpc_remote_verb_error*")
+seastar_add_test (rpc_stream
+  TARGET rpc_core
+  FILTER "test_stream_*")
+seastar_add_test (rpc_scheduling
+  TARGET rpc_core
+  FILTER "test_rpc_client_send_glitch*,test_rpc_server_send_glitch*,test_rpc_scheduling*")
+seastar_add_test (rpc_compression
+  TARGET rpc_core
+  FILTER "test_lz4_*,test_compressor_empty_frames*")
+seastar_add_test (rpc_timeouts
+  TARGET rpc_core
+  FILTER "test_max_absolute_timeout*,test_max_relative_timeout*,test_rpc_send_timeout*,test_rpc_abort_connection*,test_timeout_cancel*")
+seastar_add_test (rpc_misc
+  TARGET rpc_core
+  FILTER "test_rpc_tuple*,test_handler_registration*,test_unregister_handler*,test_loggers*,test_connection_id_format*,test_client_info*,test_retrieve_missing_auxiliary_*,test_rpc_metric_domains*,test_rpc_stream_backpressure_across_shards*")
 
 seastar_add_test (semaphore
   SOURCES

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -437,7 +437,10 @@ if (Seastar_LTTNG)
     COMMAND ${CMAKE_COMMAND} --build ${Seastar_BINARY_DIR} --target test_unit_io_trace_lttng_run)
   set_tests_properties (Seastar.unit.io_trace_lttng
     PROPERTIES
-      TIMEOUT ${Seastar_TEST_TIMEOUT})
+      TIMEOUT ${Seastar_TEST_TIMEOUT}
+      # Exclusive host-wide LTTng session; concurrent I/O from other
+      # tests can starve its event stream and drop trace events.
+      RUN_SERIAL TRUE)
 endif ()
 
 seastar_add_test (fair_queue
@@ -620,6 +623,11 @@ seastar_add_test (scheduling_group
 
 seastar_add_test (scheduling_group_nesting
   SOURCES scheduling_group_nesting_test.cc)
+set_tests_properties (Seastar.unit.scheduling_group_nesting
+  PROPERTIES
+    # test_fairness measures CPU-share ratios; contention from other tests
+    # running in parallel skews it past its deviation tolerance.
+    RUN_SERIAL TRUE)
 
 seastar_add_test (timer
   SOURCES timer_test.cc)

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -22,6 +22,9 @@
 
 #include <ranges>
 #include <iostream>
+#include <limits>
+#include <cstdlib>
+#include <stdexcept>
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/sstring.hh>
@@ -76,6 +79,21 @@ using namespace seastar;
 
 static bool using_gnutls() {
     return std::string_view(tls::backend_name()) == "gnutls";
+}
+
+static uint16_t tls_test_port() {
+    if (const char* port = std::getenv("SEASTAR_TLS_TEST_PORT")) {
+        try {
+            auto value = std::stoul(port);
+            if (value == 0 || value > std::numeric_limits<uint16_t>::max()) {
+                throw std::out_of_range(port);
+            }
+            return static_cast<uint16_t>(value);
+        } catch (const std::exception&) {
+            throw std::invalid_argument("invalid SEASTAR_TLS_TEST_PORT");
+        }
+    }
+    return 4712;
 }
 
 // Number of attempts made by the tests that reach a real server over the
@@ -269,7 +287,7 @@ SEASTAR_TEST_CASE(test_alpn_client_server) {
 
     ::listen_options opts;
     opts.reuse_address = true;
-    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto addr = ::make_ipv4_address({0x7f000001, tls_test_port()});
     auto server = tls::listen(certs, addr, opts);
 
     co_await when_all(
@@ -448,7 +466,7 @@ SEASTAR_TEST_CASE(test_failed_connect) {
 SEASTAR_TEST_CASE(test_non_tls) {
     ::listen_options opts;
     opts.reuse_address = true;
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = server_socket(seastar::listen(addr, opts));
 
     auto c = server.accept();
@@ -494,7 +512,7 @@ SEASTAR_TEST_CASE(test_abort_accept_before_handshake) {
     return certs->set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).then([certs] {
         ::listen_options opts;
         opts.reuse_address = true;
-        auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+        auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
         auto server = server_socket(tls::listen(certs, addr, opts));
         auto c = server.accept();
         BOOST_CHECK(!c.available()); // should not be finished
@@ -514,7 +532,7 @@ SEASTAR_TEST_CASE(test_abort_accept_after_handshake) {
 
         ::listen_options opts;
         opts.reuse_address = true;
-        auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+        auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
         auto server = tls::listen(certs, addr, opts);
         auto sa = server.accept();
 
@@ -542,7 +560,7 @@ SEASTAR_TEST_CASE(test_abort_accept_on_server_before_handshake) {
     return async([] {
         ::listen_options opts;
         opts.reuse_address = true;
-        auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+        auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
         auto server = server_socket(seastar::listen(addr, opts));
         auto sa = server.accept();
 
@@ -709,12 +727,10 @@ static future<> run_echo_test(sstring message,
                 tls::dn_callback distinguished_name_callback = {}
 )
 {
-    static const auto port = 4711;
-
     auto msg = ::make_shared<sstring>(std::move(message));
     auto certs = ::make_shared<tls::certificate_credentials>();
     auto server = ::make_shared<seastar::sharded<echoserver>>();
-    auto addr = ::make_ipv4_address( {0x7f000001, port});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
 
     SEASTAR_ASSERT(do_read || loops == 1);
 
@@ -1010,7 +1026,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
 
     ::listen_options opts;
     opts.reuse_address = true;
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(certs, addr, opts);
 
     tls::credentials_builder b2;
@@ -1304,7 +1320,7 @@ SEASTAR_THREAD_TEST_CASE(test_closed_write) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     auto check_same_message_two_writes = [](output_stream<char>& out) {
@@ -1424,7 +1440,7 @@ SEASTAR_THREAD_TEST_CASE(test_dn_name_handling) {
     // and the second one uses mtls_client2.crt. Every client sends a short string
     // that server receives and tries to find it in the DN string.
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
 
     auto client1_creds = [] {
         tls::credentials_builder builder;
@@ -1502,7 +1518,7 @@ SEASTAR_THREAD_TEST_CASE(test_alt_names) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     {
@@ -1569,7 +1585,7 @@ SEASTAR_THREAD_TEST_CASE(test_peer_certificate_chain_handling) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     {
@@ -1635,7 +1651,7 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto addr = ::make_ipv4_address({0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     {
@@ -1692,7 +1708,7 @@ static void do_test_tls13_session_tickets(bool reset_server) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     tls::session_data sess_data;
@@ -1829,7 +1845,7 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets_invalidated_by_reload) {
     opts.reuse_address = true;
     opts.set_fixed_cpu(this_shard_id());
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     tls::session_data sess_data;
@@ -1969,7 +1985,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_only_shard0_notify) {
 
     ::listen_options opts;
     opts.reuse_address = true;
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(certs, addr, opts);
 
     tls::credentials_builder b2;
@@ -2115,7 +2131,7 @@ SEASTAR_THREAD_TEST_CASE(test_send_recv_alloc_limits) {
     auto stats_before = memory::stats();
     memory::scoped_large_allocation_warning_threshold sct(size_limit);
 
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto server = tls::listen(serv, addr, opts);
 
     {
@@ -2382,7 +2398,7 @@ static std::pair<connected_socket, connected_socket> tls_socketpair() {
 
     ::listen_options opts;
     opts.reuse_address = true;
-    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto addr = ::make_ipv4_address( {0x7f000001, tls_test_port()});
     auto ss = tls::listen(certs, addr, opts);
     tls::credentials_builder b;
     b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();


### PR DESCRIPTION
Motivation
- Reduce unit-test wall-clock time without allowing shared-resource races.

Changes
- Run unit tests in parallel with CTest resource protection.
- Use separate TLS provider ports with validated configuration.
- Split RPC tests into six parallel shards.
- Serialize the shared RPC build fixture and cap builds at 4 jobs.

Tests
- 9/9 focused RPC/TLS tests passed.
- RPC shards: 23.96s serial, 12.44s parallel.
- Full serial unit suite: 95/95 passed.
---

**Update:** A pre-existing `Seastar.unit.prometheus` flake was uncovered while enabling parallel ctest execution here (the exporter listens on `--smp=2`, and a `/metrics` request can land on a shard that hasn't seen a given metric's label, silently dropping the filter). This is a bug independent of the parallelism changes in this PR, so it has been split out into a standalone commit/PR: see the fix for review and merge separately. This PR's history has been reordered so the fix commit ("prometheus: build label filter from all shards, not just the local one") lands before "tests: run CI ctest in parallel", keeping bisectability correct.
