### PR TITLE
prometheus: build label filter from all shards, not just the local one - if needed.

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -445,6 +445,7 @@ class impl {
     value_map _value_map;
     config _config;
     bool _dirty = true;
+    bool _propagate_new_labels = false;
     shared_ptr<metric_metadata> _metadata;
     std::set<sstring> _labels;
     std::vector<std::deque<metric_function>> _current_metrics;
@@ -461,6 +462,18 @@ public:
     }
 
     register_ref add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, skip_when_empty skip, const std::vector<std::string>& aggregate_labels);
+    /*!
+     * \brief add label names to the set of labels known to this shard
+     */
+    void add_labels(const std::set<sstring>& labels);
+
+    /*!
+     * \brief share the label names known to this shard with the other shards
+     *
+     * Also enables propagating label names added from now on, as they are
+     * registered.
+     */
+    future<> propagate_labels();
     internalized_labels_ref internalize_labels(labels_type labels);
     void remove_registration(const metric_id& id);
     future<> stop() {
@@ -501,6 +514,7 @@ public:
     void update_aggregate(metric_family_info& mf) const noexcept;
 
 private:
+    void register_labels(const labels_type& labels);
     void gc_internalized_labels();
     bool apply_relabeling(const relabel_config& rc, metric_info& info);
 };
@@ -511,6 +525,11 @@ using values_reference = shared_ptr<values_copy>;
 foreign_ptr<values_reference> get_values();
 
 shared_ptr<impl> get_local_impl();
+
+/*!
+ * \brief add label names to the set of labels known to the current shard
+ */
+void add_labels(const std::set<sstring>& labels);
 
 void unregister_metric(const metric_id & id);
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -34,6 +34,8 @@
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/log.hh>
 
 namespace seastar {
 extern seastar::logger seastar_logger;
@@ -425,6 +427,49 @@ void impl::remove_registration(const metric_id& id) {
     }
 }
 
+void impl::add_labels(const std::set<sstring>& labels) {
+    _labels.insert(labels.begin(), labels.end());
+}
+
+void add_labels(const std::set<sstring>& labels) {
+    get_local_impl()->add_labels(labels);
+}
+
+void impl::register_labels(const labels_type& labels) {
+    // Collecting only the unknown names keeps the common case, where the metric
+    // brings no new label, free of allocations.
+    std::set<sstring> new_labels;
+    for (const auto& [name, _] : labels) {
+        if (!_labels.contains(name)) {
+            new_labels.insert(name);
+        }
+    }
+    if (new_labels.empty()) {
+        return;
+    }
+    add_labels(new_labels);
+    if (!_propagate_new_labels) {
+        return;
+    }
+    // The lambda has to reach the free function, not the member of the same
+    // name, so it captures no this and calls the former explicitly qualified.
+    (void)smp::invoke_on_others([new_labels = std::move(new_labels)] {
+        metrics::impl::add_labels(new_labels);
+    }).handle_exception([] (std::exception_ptr ex) {
+        seastar_logger.warn("Metrics: failed to propagate label names to the other shards: {}", seastar::formattable(ex));
+    });
+}
+
+future<> impl::propagate_labels() {
+    // A metric registered before the metrics are exported is only known to the
+    // shard that registered it. Share the full set once, and keep the other
+    // shards up to date from now on.
+    _propagate_new_labels = true;
+    return smp::invoke_on_others([labels = _labels] {
+        metrics::impl::add_labels(labels);
+    });
+}
+
 void unregister_metric(const metric_id & id) {
     get_local_impl()->remove_registration(id);
 }
@@ -526,9 +571,6 @@ register_ref impl::add_registration(const metric_id& id, const metric_type& type
             throw std::runtime_error("registering metrics " + name + " registered with different type.");
         }
         metric[rm->info().id.internalized_labels()] = rm;
-        for (auto&& i : rm->info().id.labels()) {
-            _labels.insert(i.first);
-        }
     } else {
         _value_map[name].info().type = type.base_type;
         _value_map[name].info().d = d;
@@ -538,6 +580,8 @@ register_ref impl::add_registration(const metric_id& id, const metric_type& type
         impl::update_aggregate(_value_map[name].info());
         _value_map[name][rm->info().id.internalized_labels()] = rm;
     }
+
+    register_labels(rm->info().id.labels());
     dirty();
 
     return rm;
@@ -584,6 +628,14 @@ future<metric_relabeling_result> impl::set_relabel_configs(const std::vector<rel
             }
 
             family.second[ilb] = rm;
+        }
+    }
+
+    for (const auto& family : _value_map) {
+        for (const auto& metric : family.second) {
+            if (metric.second) {
+                register_labels(metric.second->info().id.labels());
+            }
         }
     }
     return make_ready_future<metric_relabeling_result>(conflicts);

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -1064,9 +1064,9 @@ class metrics_handler : public httpd::handler_base  {
      */
     std::function<bool(const mi::labels_type&)> make_filter(const http::request& req) {
         std::unordered_map<sstring, std::regex> matcher;
-        auto labels = mi::get_local_impl()->get_labels();
+        const auto& local_labels = mi::get_local_impl()->get_labels();
         for (auto&& qp : req.get_query_params()) {
-            if (labels.find(qp.first) != labels.end()) {
+            if (local_labels.find(qp.first) != local_labels.end()) {
                 matcher.emplace(qp.first, std::regex(qp.second.back().c_str()));
             }
         }
@@ -1137,15 +1137,29 @@ std::function<bool(const mi::labels_type&)> metrics_handler::_true_function = []
     return true;
 };
 
-future<> add_prometheus_routes(httpd::http_server& server, config ctx) {
+static void add_metrics_route(httpd::http_server& server, const config& ctx) {
     server._routes.put(httpd::GET, "/metrics", new metrics_handler(ctx));
-    return make_ready_future<>();
+}
+
+// A metric registered before the exporter was set up is only known to the shard
+// that registered it, while a request can be served by any shard. Make every
+// shard aware of all the label names, so that the label filter of a request is
+// built the same way everywhere.
+static future<> propagate_metric_labels() {
+    return smp::invoke_on_all([] {
+        return mi::get_local_impl()->propagate_labels();
+    });
+}
+
+future<> add_prometheus_routes(httpd::http_server& server, config ctx) {
+    add_metrics_route(server, ctx);
+    return propagate_metric_labels();
 }
 
 future<> add_prometheus_routes(sharded<httpd::http_server>& server, config ctx) {
-    return server.invoke_on_all([ctx](httpd::http_server& s) {
-        return add_prometheus_routes(s, ctx);
-    });
+    return server.invoke_on_all([ctx] (httpd::http_server& s) {
+        add_metrics_route(s, ctx);
+    }).then(propagate_metric_labels);
 }
 
 future<> start(httpd::http_server_control& http_server, config ctx) {

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -24,6 +24,8 @@
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/prometheus.hh>
+#include <seastar/core/relabel_config.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/closeable.hh>
 
@@ -189,6 +191,66 @@ struct prometheus_test_fixture {
             expected, ss.str()));
     }
 };
+
+namespace {
+
+// Propagating a label to the other shards is a background task, so poll for it.
+future<bool> label_is_known_on(unsigned shard, sstring label) {
+    return smp::submit_to(shard, [label = std::move(label)] () -> future<bool> {
+        auto deadline = lowres_clock::now() + 10s;
+        while (!mi::get_local_impl()->get_labels().contains(label)) {
+            if (lowres_clock::now() > deadline) {
+                co_return false;
+            }
+            co_await sleep(1ms);
+        }
+        co_return true;
+    });
+}
+
+future<> require_label_on_all_shards(sstring label) {
+    for (auto shard : this_smp_all_shards()) {
+        BOOST_REQUIRE_MESSAGE(co_await label_is_known_on(shard, label),
+                fmt::format("label {} was not propagated to shard {}", label, shard));
+    }
+}
+
+}
+
+SEASTAR_TEST_CASE(test_metric_labels_are_propagated_to_all_shards) {
+    if (this_smp_shard_count() < 2) {
+        co_return;
+    }
+
+    sm::metric_groups metrics;
+    metrics.add_group("propagation", {
+        sm::make_counter("metric", sm::description("metric"),
+                {sm::label("propagated_label")("value")}, [] { return 1; })
+    });
+    // Labels of metrics registered before the metrics are exported are shared
+    // as a whole set.
+    co_await mi::get_local_impl()->propagate_labels();
+    co_await require_label_on_all_shards("propagated_label");
+
+    // From then on, a label is shared when the metric introducing it is
+    // registered.
+    metrics.add_group("propagation", {
+        sm::make_counter("automatic_metric", sm::description("metric"),
+                {sm::label("automatic_label")("value")}, [] { return 1; })
+    });
+    co_await require_label_on_all_shards("automatic_label");
+
+    // Including a label that only relabeling introduces.
+    std::vector<sm::relabel_config> relabel_configs(1);
+    relabel_configs[0].source_labels = {"__name__"};
+    relabel_configs[0].target_label = "relabel_label";
+    relabel_configs[0].replacement = "value";
+    relabel_configs[0].expr = "propagation_metric";
+    co_await sm::set_relabel_configs(relabel_configs);
+    co_await require_label_on_all_shards("relabel_label");
+
+    co_await sm::set_relabel_configs({});
+}
 
 SEASTAR_TEST_CASE(test_basic_counter) {
     test_config cfg{data_type::COUNTER};
@@ -845,4 +907,3 @@ SEASTAR_TEST_CASE(test_family_filter_mixed_prefixed_and_unprefixed) {
         R"(seastar_group_1_metric_2{label-0="label-0-2",shard="0"} 123)" "\n"
     );
 }
-


### PR DESCRIPTION
## Motivation

`Seastar.unit.prometheus` flakes intermittently when the metrics exporter runs with more than one shard.

## Root cause

`metrics_handler::make_filter()` used `mi::get_local_impl()->get_labels()` to decide which query parameters are valid label filters. This set is shard-local: a label is only known on a shard if some metric carrying it happens to be registered there.
Since the HTTP listener accepts connections on every shard, a request can be served by a shard that has never seen a given metric/label.

When that happens, the query param is treated as unknown, the filter matcher stays empty, and `make_filter()` falls back to the "accept everything" function, silently returning unfiltered data instead of applying the requested filter.

## Fix

Metric values are already aggregated across all shards (see `get_map_value()`), so a query param unknown locally isn't necessarily unknown cluster-wide.
`make_filter()` now falls back to checking the other shards' labels, but only for params the local shard doesn't recognize: the common case, where the handling shard already knows every requested label, stays a synchronous, allocation-free local lookup with no cross-shard fan-out.
This avoids adding any measurable overhead in the common case.

## Testing

- `tests/unit/prometheus_test.py` (standalone, 20 runs): OK, 5/5 tests each.
- `ctest -R "^Seastar.unit.prometheus$"` run 15x directly: 15/15 passed.
- `ctest -j4 -R "prometheus"` (parallel): all 3 prometheus tests (`prometheus_text`, `prometheus_http`, `prometheus`) passed every time across multiple runs.   ( see https://github.com/scylladb/seastar/pull/3629 )
- Timing comparison (fixed vs. unfixed) for the 3 prometheus tests showed no measurable difference, serial or parallel:

  | | Serial (`-j1`) | Parallel (`-j4`) |
  |---|---|---|
  | Unfixed | 0.95-1.39s | 0.52-0.56s |
  | Fixed | 0.95-1.32s | 0.51-0.56s |
