### PR TITLE
http: make client::close() wait for outstanding connections

### DIFF
--- a/include/seastar/http/client.hh
+++ b/include/seastar/http/client.hh
@@ -30,6 +30,7 @@
 #include <seastar/http/reply.hh>
 #include <seastar/http/retry_strategy.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/integrated-length.hh>
 
@@ -77,10 +78,11 @@ namespace internal {
 
 class client_ref {
     http::client* _c;
+    gate::holder _hold;
 public:
-    client_ref(http::client* c) noexcept;
+    client_ref(http::client* c, gate::holder hold) noexcept;
     ~client_ref();
-    client_ref(client_ref&& o) noexcept : _c(std::exchange(o._c, nullptr)) {}
+    client_ref(client_ref&& o) noexcept : _c(std::exchange(o._c, nullptr)), _hold(std::move(o._hold)) {}
     client_ref(const client_ref&) = delete;
 };
 
@@ -191,6 +193,7 @@ private:
     unsigned long _total_new_connections = 0;
     std::unique_ptr<retry_strategy> _retry_strategy;
     condition_variable _wait_con;
+    gate _gate;
     util::integrated_length<unsigned, lowres_clock, std::chrono::microseconds> _requests_queued;
     connections_list_t _pool;
     http::client_stats _http_stats;

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -457,15 +457,13 @@ future<> client::do_make_request(connection& con, const request& req, reply_hand
 }
 
 future<> client::close() noexcept {
-    if (_pool.empty()) {
+    return do_until([this] { return _pool.empty(); }, [this] {
+        connection_ptr con = _pool.front().shared_from_this();
+        _pool.pop_front();
+        http_log.trace("closing connection {}", con->_fd.local_address());
+        return con->close().finally([con] {});
+    }).then([this] {
         return _new_connections->close();
-    }
-
-    connection_ptr con = _pool.front().shared_from_this();
-    _pool.pop_front();
-    http_log.trace("closing connection {}", con->_fd.local_address());
-    return con->close().then([this, con] {
-        return close();
     });
 }
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -45,7 +45,7 @@ logger http_log("http");
 namespace http {
 namespace internal {
 
-client_ref::client_ref(http::client* c) noexcept : _c(c) {
+client_ref::client_ref(http::client* c, gate::holder hold) noexcept : _c(c), _hold(std::move(hold)) {
     _c->_nr_connections++;
 }
 
@@ -258,8 +258,9 @@ future<client::connection_ptr> client::get_connection(abort_source* as) {
 }
 
 future<client::connection_ptr> client::make_connection(abort_source* as) {
+    auto hold = _gate.hold();
     _total_new_connections++;
-    return _new_connections->make(as).then([cr = internal::client_ref(this)] (connected_socket cs) mutable {
+    return _new_connections->make(as).then([cr = internal::client_ref(this, std::move(hold))] (connected_socket cs) mutable {
         http_log.trace("created new http connection {}", cs.local_address());
         auto con = seastar::make_shared<connection>(std::move(cs), std::move(cr));
         return make_ready_future<connection_ptr>(std::move(con));

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -467,11 +467,18 @@ future<> client::do_make_request(connection& con, const request& req, reply_hand
 }
 
 future<> client::close() noexcept {
+    // Closing the gate rejects new connections from this point on. Requests
+    // parked in get_connection() are woken so they observe it and bail out.
+    auto all_connections_gone = _gate.close();
+    _wait_con.broadcast();
+
     return do_until([this] { return _pool.empty(); }, [this] {
         connection_ptr con = _pool.front().shared_from_this();
         _pool.pop_front();
         http_log.trace("closing connection {}", con->_fd.local_address());
         return con->close().finally([con] {});
+    }).then([all_connections_gone = std::move(all_connections_gone)] () mutable {
+        return std::move(all_connections_gone);
     }).then([this] {
         return _new_connections->close();
     });

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -234,6 +234,10 @@ client::client(std::unique_ptr<connection_factory> f, unsigned max_connections, 
 }
 
 future<client::connection_ptr> client::get_connection(abort_source* as) {
+    if (_gate.is_closed()) {
+        return make_exception_future<connection_ptr>(gate_closed_exception());
+    }
+
     if (!_pool.empty()) {
         connection_ptr con = _pool.front().shared_from_this();
         _pool.pop_front();
@@ -258,6 +262,11 @@ future<client::connection_ptr> client::get_connection(abort_source* as) {
 }
 
 future<client::connection_ptr> client::make_connection(abort_source* as) {
+    if (_gate.is_closed()) {
+        return make_exception_future<connection_ptr>(gate_closed_exception());
+    }
+
+    // Checked just above and nothing below preempts, so this cannot throw.
     auto hold = _gate.hold();
     _total_new_connections++;
     return _new_connections->make(as).then([cr = internal::client_ref(this, std::move(hold))] (connected_socket cs) mutable {
@@ -268,7 +277,7 @@ future<client::connection_ptr> client::make_connection(abort_source* as) {
 }
 
 future<> client::put_connection(connection_ptr con) {
-    if (con->_persistent && (_nr_connections <= _max_connections)) {
+    if (!_gate.is_closed() && con->_persistent && (_nr_connections <= _max_connections)) {
         http_log.trace("push http connection {} to pool", con->_fd.local_address());
         _pool.push_back(*con);
         _wait_con.signal();


### PR DESCRIPTION
`http::client::close()` reads as a barrier but is not one. It drains `_pool` and returns, leaving any connection that is currently checked out for an in-flight request alive. `client` also has no destructor that waits, so destroying it with `_nr_connections > 0` is silent — and a checked-out connection keeps itself alive through the self-reference installed in its constructor:

```cpp
_closed(_fd.wait_input_shutdown().finally([me = shared_from_this()] {}))
```

When that continuation is finally destroyed, `~connection` runs `~client_ref`, which touches `_c->_nr_connections` and `_c->_wait_con` through a raw `client*`. If the client is gone, that is a use-after-free:

```
#0 seastar::http::internal::client_ref::~client_ref()   src/http/client.cc:54
#1 seastar::http::connection::~connection()             include/seastar/http/client.hh:95
#2 seastar::continuation<...>::run_and_dispose()
#3 seastar::reactor::task_queue::run_tasks()
```

A caller cannot fix this from the outside, because the connection's lifetime is owned by a continuation inside `client` and is not observable. The only workaround is to make sure no request is ever in flight when `close()` runs, which means every caller reimplements the same gate and funnels all `http::client` use through a single chokepoint.

### Changes

Four commits, each independently correct:

1. `close()` drained the pool by calling itself once per pooled connection — rewritten as a `do_until()` loop so its body runs once. Pure refactor, and a prerequisite for 4 (the recursive call would re-enter `gate::close()`).
2. `client` gets a `gate`, held by `client_ref`. `client_ref` is created once per connection in `make_connection()` and destroyed in `~connection`, so the gate's count is exactly the set of live connections. Inert on its own.
3. Once the gate is closed, `get_connection()` and `make_connection()` fail with `gate_closed_exception`, and `put_connection()` stops returning connections to the pool. Both acquisition paths need a check: `get_connection()` covers handing out a pooled connection, and `make_connection()` needs its own because `with_new_connection()` calls it directly. Not re-pooling is required too — otherwise a request completing during a close repopulates `_pool` and its holder is never released. Also inert on its own.
4. `close()` closes the gate before draining and awaits it afterwards, so it returns only once every connection is gone. Requests parked on the `_max_connections` wait are woken so they observe the closed gate instead of sleeping until an unrelated connection is released.

### Behavior changes worth reviewing

These are the reason this is a draft — each is a deliberate tightening, and I would rather have them called out than discovered:

- **Requests issued after `close()` now fail** with `gate_closed_exception` instead of quietly creating a new connection on a closed client. This is the half that actually fixes the bug — a barrier alone is vacuous if the caller can re-arm it immediately after `close()` returns.
- **`~gate()` asserts `!_count`**, so destroying a `client` with live connections now aborts instead of corrupting memory later. This is the assert that would have caught the original bug at its source, but it is a new abort for any user that drops a client without closing it.
- **`gate::close()` asserts if called twice**, so a double `client::close()` now aborts where it was previously tolerated. If that is unacceptable, a plain `bool _closed` plus a `_wait_con` predicate wait gives identical semantics without either assert — say the word and I will switch it.
- **`internal::client_ref`'s constructor gained a parameter.** It lives in a public header but under `internal`, and there is exactly one construction site in the tree; no other user was found in seastar or in ScyllaDB.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3845
