### PR TITLE
perf: Add worst-case IO preemption latency test

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -192,6 +192,7 @@ public:
         std::chrono::milliseconds stall_threshold = std::chrono::milliseconds(100);
         std::chrono::microseconds tau = std::chrono::milliseconds(5);
         std::optional<uint32_t> physical_block_size; // Override for disks that lie about their physical block size
+        bool with_metrics = true;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -669,15 +669,17 @@ io_queue::io_queue(io_group_ptr group, internal::io_sink& sink)
     }
     _averaging_decay_timer.arm_periodic(std::chrono::duration_cast<std::chrono::milliseconds>(_group->io_latency_goal() * cfg.averaging_decay_ticks));
 
-    namespace sm = seastar::metrics;
-    auto owner_l = sm::shard_label(this_shard_id());
-    auto mnt_l = sm::label("mountpoint")(mountpoint());
-    auto group_l = sm::label("iogroup")(to_sstring(_group->_allocated_on));
-    _metric_groups.add_group("io_queue", {
-        sm::make_gauge("flow_ratio", [this] { return _flow_ratio; },
-                sm::description("Ratio of dispatch rate to completion rate. Is expected to be 1.0+ growing larger on reactor stalls or (!) disk problems"),
-                { owner_l, mnt_l, group_l }),
-    });
+    if (cfg.with_metrics) {
+        namespace sm = seastar::metrics;
+        auto owner_l = sm::shard_label(this_shard_id());
+        auto mnt_l = sm::label("mountpoint")(mountpoint());
+        auto group_l = sm::label("iogroup")(to_sstring(_group->_allocated_on));
+        _metric_groups.add_group("io_queue", {
+            sm::make_gauge("flow_ratio", [this] { return _flow_ratio; },
+                    sm::description("Ratio of dispatch rate to completion rate. Is expected to be 1.0+ growing larger on reactor stalls or (!) disk problems"),
+                    { owner_l, mnt_l, group_l }),
+        });
+    }
 }
 
 io_throttler::config io_group::configure_throttler(const io_queue::config& qcfg) noexcept {
@@ -839,6 +841,10 @@ std::vector<seastar::metrics::impl::metric_definition_impl> io_queue::priority_c
 }
 
 void io_queue::register_stats(sstring name, priority_class_data& pc) {
+    if (!get_config().with_metrics) {
+        return;
+    }
+
     namespace sm = seastar::metrics;
     seastar::metrics::metric_groups new_metrics;
 

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -80,6 +80,10 @@ seastar_add_test (smp_submit_to
   SOURCES smp_submit_to_perf.cc
   NO_SEASTAR_PERF_TESTING_LIBRARY)
 
+seastar_add_test (io_queue_latency
+    SOURCES io_queue_latency.cc
+    NO_SEASTAR_PERF_TESTING_LIBRARY)
+
 seastar_add_test (thread_context_switch
   SOURCES thread_context_switch_test.cc
   NO_SEASTAR_PERF_TESTING_LIBRARY)

--- a/tests/perf/io_queue_latency.cc
+++ b/tests/perf/io_queue_latency.cc
@@ -1,0 +1,155 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB
+ */
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/io_queue.hh>
+#include <seastar/core/internal/io_request.hh>
+#include <seastar/core/internal/io_sink.hh>
+
+using namespace seastar;
+using namespace std::chrono;
+
+static seastar::logger testlog("testlog");
+
+struct io_queue_for_tests {
+    struct io_group_for_tests {
+        io_group_ptr group;
+
+        io_group_for_tests(const io_queue::config& cfg, unsigned nr_queues)
+            : group(std::make_shared<io_group>(cfg, nr_queues))
+        {
+        }
+    };
+
+    internal::io_sink sink;
+    io_queue queue;
+
+    io_queue_for_tests(io_group_for_tests& group)
+        : queue(group.group, sink)
+    {
+    }
+
+    void poll_once() {
+        queue.poll_io_queue();
+        sink.drain([] (const internal::io_request& rq, io_completion* desc) -> bool {
+            const auto& op = rq.as<internal::io_request::operation::write>();
+            desc->complete_with(op.size);
+            return true;
+        });
+    }
+
+    future<> enqueue(scheduling_group sg, size_t req_size) {
+        return queue.queue_request(internal::priority_class(sg),
+            internal::io_direction_and_length(internal::io_direction_and_length::read_idx, req_size),
+            internal::io_request::make_read(0, 0, nullptr, req_size, false),
+            nullptr, {}).discard_result();
+    }
+
+    future<> enqueue(scheduling_group sg, unsigned nr, size_t req_size) {
+        return parallel_for_each(std::views::iota(0u, nr), [this, sg, req_size] (auto i) -> future<> {
+            return enqueue(sg, req_size);
+        });
+    }
+};
+
+int main(int ac, char** av) {
+    app_template at;
+    namespace bpo = boost::program_options;
+    at.add_options()
+            ("iterations", bpo::value<unsigned>()->default_value(7), "Number of iterations")
+            ("nr-queues", bpo::value<unsigned>()->default_value(4), "Number of queues to simulate")
+            ("iops", bpo::value<unsigned>()->default_value(10000), "IOPS")
+            ("bandwidth-mb", bpo::value<unsigned>()->default_value(100), "Bandwidth in MB/s")
+            ("concurrency", bpo::value<unsigned>()->default_value(4), "Concurrency of competing low-prio group")
+            ("fg-concurrency", bpo::value<unsigned>()->default_value(1), "Concurrency of foreground group (burst size)")
+            ("poll-interval-us", bpo::value<unsigned>()->default_value(250), "Interval between queue polls")
+        ;
+
+    return at.run(ac, av, [&at] {
+        auto nr_iterations = at.configuration()["iterations"].as<unsigned>();
+        auto nr_queues = at.configuration()["nr-queues"].as<unsigned>();
+        auto iops = at.configuration()["iops"].as<unsigned>();
+        auto bandwidth_mb = at.configuration()["bandwidth-mb"].as<unsigned>();
+        auto bg_concurrency = at.configuration()["concurrency"].as<unsigned>();
+        auto fg_concurrency = at.configuration()["fg-concurrency"].as<unsigned>();
+        auto poll_interval = microseconds(at.configuration()["poll-interval-us"].as<unsigned>());
+
+        return async([nr_iterations, iops, bandwidth_mb, nr_queues, bg_concurrency, fg_concurrency, poll_interval] {
+            const size_t bg_req_size = 128*1024;
+            const size_t fg_req_size = 4*1024;
+
+            auto bg_sg = create_scheduling_group("bg", 200).get();
+            auto fg_sg = create_scheduling_group("fg", 1000).get();
+
+            io_queue::config cfg{0};
+            cfg.req_count_rate = io_queue::read_request_base_count * iops;
+            cfg.blocks_count_rate = io_queue::read_request_base_count * ((bandwidth_mb << 20) >> io_queue::block_size_shift);
+            cfg.with_metrics = false;
+            io_queue_for_tests::io_group_for_tests group(cfg, nr_queues);
+            std::vector<std::unique_ptr<io_queue_for_tests>> queues;
+            for (unsigned i = 0; i < nr_queues; i++) {
+                queues.emplace_back(std::make_unique<io_queue_for_tests>(group));
+            }
+
+            std::chrono::duration<double> total_delay(0);
+            double total_bg_iops = 0;
+            const unsigned bg_reqs_per_iter = nr_queues * bg_concurrency;
+            for (unsigned iter = 0; iter < nr_iterations; iter++) {
+                std::vector<future<>> bgv;
+                auto bg_start = steady_clock::now();
+                for (auto& q : queues) {
+                    auto f = q->enqueue(bg_sg, bg_concurrency, bg_req_size);
+                    bgv.push_back(std::move(f));
+                }
+                auto bg = when_all(bgv.begin(), bgv.end()).then([bg_start, bg_reqs_per_iter, &total_bg_iops] (auto) {
+                    auto elapsed = duration_cast<std::chrono::duration<double>>(steady_clock::now() - bg_start);
+                    double iops = bg_reqs_per_iter / elapsed.count();
+                    total_bg_iops += iops;
+                    testlog.info("BG IOPS {:.0f}", iops);
+                    return make_ready_future<std::tuple<>>();
+                });
+                auto start = steady_clock::now();
+                auto fg = queues[0]->enqueue(fg_sg, fg_concurrency, fg_req_size).then([start, &total_delay] {
+                    auto delay = steady_clock::now() - start;
+                    total_delay += delay;
+                    testlog.info("FG delay {:.3f} ms", duration_cast<std::chrono::duration<double, std::milli>>(delay).count());
+                    return make_ready_future<>();
+                });
+                while (!bg.available() || !fg.available()) {
+                    for (unsigned i = 1; i < nr_queues; i++) {
+                        queues[i]->poll_once();
+                    }
+                    // Poll 0th queue last to let all other queues grab tokens from
+                    // shared bucket for their front requests
+                    queues[0]->poll_once();
+                    seastar::sleep(poll_interval).get();
+                }
+            }
+            testlog.info("Average FG delay {:.3f} ms", duration_cast<std::chrono::duration<double, std::milli>>(total_delay).count() / nr_iterations);
+            testlog.info("Average BG IOPS {:.0f}", total_bg_iops / nr_iterations);
+        });
+    });
+}


### PR DESCRIPTION
This pulls out just the new perf test from the larger io_queue max-latency
rework (#3295) so it can be reviewed and land independently of that series.

When shards contend on a shared token bucket, they cannot preempt each
other, so a high-priority request can be stuck waiting for tokens for a
long time. The new io_queue_latency perf test deliberately constructs this
worst case: it lines up several low-priority queues ahead of a
high-priority one so they all grab tokens first, then measures how long
the high-priority request has to wait behind them.

Two small io_queue prerequisites are included: an option to create a
queue without metrics (used by the test to run many queues on one shard)
and the indentation fix that follows it.