### PR TITLE
fixes for libc++

### DIFF
--- a/include/seastar/core/circular_buffer_fixed_capacity.hh
+++ b/include/seastar/core/circular_buffer_fixed_capacity.hh
@@ -130,6 +130,9 @@ public:
             _idx -= n;
             return *this;
         }
+        ValueType& operator[](difference_type n) const {
+            return _start[mask(_idx + n)].data;
+        }
         bool operator==(const cbiterator& rhs) const {
             return _idx == rhs._idx;
         }

--- a/include/seastar/util/spinlock.hh
+++ b/include/seastar/util/spinlock.hh
@@ -24,6 +24,7 @@
 #include <seastar/util/assert.hh>
 
 #include <atomic>
+#include <new>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <xmmintrin.h>
@@ -92,7 +93,6 @@ namespace util {
 // Async-signal safe.
 // unlock() "synchronizes with" lock().
 #ifdef __cpp_lib_hardware_interference_size
-#include <new>
 class alignas(std::hardware_constructive_interference_size) spinlock {
 #else
 // x86-64 cache line size

--- a/tests/perf/metrics_perf.cc
+++ b/tests/perf/metrics_perf.cc
@@ -40,13 +40,18 @@ auto irange(size_t upper_bound) {
 }
 
 void remove_existing_metrics() {
-    const auto& map = seastar::metrics::impl::get_value_map();
-
-    for (auto& family : map) {
-        auto name = family.first;
-        for (auto& series: family.second) {
-            seastar::metrics::impl::unregister_metric(series.second->get_id());
+    // Unregistering invalidates iterators into the value map, so collect
+    // the metric ids first and only then remove them.
+    std::vector<seastar::metrics::impl::metric_id> ids;
+    for (const auto& family : seastar::metrics::impl::get_value_map()) {
+        for (const auto& series : family.second) {
+            if (series.second) {
+                ids.push_back(series.second->get_id());
+            }
         }
+    }
+    for (const auto& id : ids) {
+        seastar::metrics::impl::unregister_metric(id);
     }
 
     assert(seastar::metrics::impl::get_value_map().size() == 0);

--- a/tests/unit/exception_logging_test.cc
+++ b/tests/unit/exception_logging_test.cc
@@ -87,10 +87,20 @@ void exception_generator(uint32_t test_instance, int nesting_level) {
 // thrown by the  exception generator function with a specific output.
 std::string exception_generator_str(uint32_t test_instance,int nesting_level) {
     std::ostringstream ret;
+#ifdef _LIBCPP_VERSION
+    // libc++'s throw_with_nested() uses its own __nested<T> wrapper class.
+    // Type names are taken verbatim from the demangler, which may or may not
+    // include the inline ABI namespace depending on the class.
+    const std::string runtime_err_str = "std::runtime_error";
+    const std::string unknown_obj_str = "unknown_obj";
+    const std::string nested_exception_with_unknown_obj_str = "std::__nested<unknown_obj>";
+    const std::string nested_exception_with_runtime_err_str = "std::__nested<std::runtime_error>";
+#else
     const std::string runtime_err_str = "std::runtime_error";
     const std::string unknown_obj_str = "unknown_obj";
     const std::string nested_exception_with_unknown_obj_str = "std::_Nested_exception<unknown_obj>";
     const std::string nested_exception_with_runtime_err_str = "std::_Nested_exception<std::runtime_error>";
+#endif
 
     for(; nesting_level > 0; nesting_level--) {
         if (test_instance & 1) {
@@ -171,7 +181,11 @@ BOOST_AUTO_TEST_CASE(nested_exception_logging3) {
         }
     }
 
+#ifdef _LIBCPP_VERSION
+    std::string expected_string("std::__nested<unknown_obj>: std::__nested<std::__1::system_error> (error generic:1, my error: Operation not permitted): very_important_exception (very important information)");
+#else
     std::string expected_string("std::_Nested_exception<unknown_obj>: std::_Nested_exception<std::system_error> (error generic:1, my error: Operation not permitted): very_important_exception (very important information)");
+#endif
 
     BOOST_REQUIRE_EQUAL(log_msg.str(), expected_string);
 }
@@ -222,7 +236,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+    auto regex_str = "backtraced<std::runtime_error> \\(throw_with_backtrace_exception_logging Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-z]+\\))?\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }
@@ -240,7 +254,14 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "std::_Nested_exception<unknown_obj>.*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)";
+#ifdef _LIBCPP_VERSION
+    // libc++'s throw_with_nested() uses its own __nested<T> wrapper class.
+    static const char* nested_exception_re = "std::__nested<unknown_obj>";
+#else
+    static const char* nested_exception_re = "std::_Nested_exception<unknown_obj>";
+#endif
+
+    auto regex_str = std::string(nested_exception_re) + ".*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-z]+\\))?\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }
@@ -264,7 +285,7 @@ BOOST_AUTO_TEST_CASE(throw_with_backtrace_seastar_nested_exception_logging) {
     }
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
+    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-z]+\\))?\\)"
             " \\(while cleaning up after unknown_obj\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
@@ -290,8 +311,8 @@ BOOST_AUTO_TEST_CASE(double_throw_with_backtrace_seastar_nested_exception_loggin
     BOOST_TEST_MESSAGE(log_msg.str());
 
 #ifndef SEASTAR_BACKTRACE_UNIMPLEMENTED
-    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)"
-            " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-f]+\\))?\\)\\)";
+    auto regex_str = "seastar::nested_exception:.*backtraced<std::runtime_error> \\(inner Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-z]+\\))?\\)"
+            " \\(while cleaning up after .*backtraced<std::runtime_error> \\(outer Backtrace:(\\s+(\\S+\\+)?0x[0-9a-f]+)+(\\s+\\(BuildId: [0-9a-z]+\\))?\\)\\)";
     check_regex_match(log_msg.str(), regex_str);
 #endif
 }

--- a/tests/unit/file_io_test.cc
+++ b/tests/unit/file_io_test.cc
@@ -1255,8 +1255,8 @@ SEASTAR_THREAD_TEST_CASE(test_posix_file_dma_read_bulk) {
     static constexpr size_t data_size = 5 * test_posix_file_impl::block_size + 123;
     temporary_buffer<char> data(data_size);
     auto random_engine = testing::local_random_engine;
-    auto dist = std::uniform_int_distribution<char>();
-    std::ranges::generate(data.get_write(), data.end(), [&] { return dist(random_engine); });
+    auto dist = std::uniform_int_distribution<int>(0, 255);
+    std::ranges::generate(data.get_write(), data.end(), [&] { return static_cast<char>(dist(random_engine)); });
     auto f = std::make_unique<test_posix_file_impl>(data);
 
     auto read_and_validate = [&] (size_t offset, size_t length) {

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -49,13 +49,18 @@ thread_local auto impl_ = sm::impl::get_local_impl();
 
 namespace {
 [[maybe_unused]] void remove_existing_metrics() {
-    const auto& map = seastar::metrics::impl::get_value_map();
-
-    for (auto& family : map) {
-        auto name = family.first;
-        for (auto& series: family.second) {
-            seastar::metrics::impl::unregister_metric(series.second->get_id());
+    // Unregistering invalidates iterators into the value map, so collect
+    // the metric ids first and only then remove them.
+    std::vector<mi::metric_id> ids;
+    for (const auto& family : seastar::metrics::impl::get_value_map()) {
+        for (const auto& series : family.second) {
+            if (series.second) {
+                ids.push_back(series.second->get_id());
+            }
         }
+    }
+    for (const auto& id : ids) {
+        seastar::metrics::impl::unregister_metric(id);
     }
 
     assert(seastar::metrics::impl::get_value_map().size() == 0);


### PR DESCRIPTION
Fixes for compilation under bazel, clang 22 with libc++, see commit messages for more details.

`operator[]` on circular buffer - [boost::sort in tests](https://github.com/crackcomm/seastar/blob/push-qwwsmuvuskzn/tests/unit/circular_buffer_fixed_capacity_test.cc#L148-L149).