### PR TITLE
util: move assert_fail to assert.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,6 +800,7 @@ add_library (seastar
   src/rpc/lz4_fragmented_compressor.cc
   src/rpc/rpc.cc
   src/util/alloc_failure_injector.cc
+  src/util/assert.cc
   src/util/backtrace.cc
   src/util/conversions.cc
   src/util/exceptions.cc

--- a/src/util/assert.cc
+++ b/src/util/assert.cc
@@ -26,7 +26,7 @@
 namespace seastar::internal {
 [[noreturn]] void assert_fail(const char *msg, const char *file, int line,
                               const char *func) {
-    fprintf(stderr, "%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
+    fprintf(stderr, "%s:%d: %s: Assertion `%s` failed.\n", file, line, func, msg);
     std::fflush(stderr);
     std::terminate();
 }

--- a/src/util/assert.cc
+++ b/src/util/assert.cc
@@ -1,0 +1,33 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+#include <cstdio>
+#include <exception>
+
+#include <seastar/util/assert.hh>
+
+namespace seastar::internal {
+[[noreturn]] void assert_fail(const char *msg, const char *file, int line,
+                              const char *func) {
+    fprintf(stderr, "%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
+    std::fflush(stderr);
+    std::terminate();
+}
+} // namespace seastar::internal

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -116,12 +116,6 @@ namespace seastar {
 
 namespace internal {
 
-[[noreturn]] void assert_fail(const char* msg, const char* file, int line, const char* func) {
-    fprintf(stderr, "%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
-    std::fflush(stderr);
-    std::terminate();
-}
-
 void log_buf::free_buffer() noexcept {
     if (_own_buf) {
         delete[] _begin;


### PR DESCRIPTION
It fixes linking issues when using parts of seastar in wasm, also, makes more sense than having it in log.cc.