### PR TITLE
Use a separate syscall thread for aio fallbacks

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1115,7 +1115,7 @@ reactor::reactor(std::shared_ptr<seastar::smp> smp, alien::instance& alien, unsi
     , _id(id)
     , _cpu_stall_detector(internal::make_cpu_stall_detector())
     , _cpu_sched(nullptr, 0)
-    , _thread_pool(std::make_unique<thread_pool>(seastar::format("syscall-{}", id), _notify_eventfd)) {
+    , _thread_pool(std::make_unique<thread_pool>(id, _notify_eventfd, rbs.name() == "linux-aio")) {
     /*
      * The _backend assignment is here, not on the initialization list as
      * the chosen backend constructor may want to handle signals and thus

--- a/src/core/thread_pool.cc
+++ b/src/core/thread_pool.cc
@@ -28,14 +28,31 @@
 #include <signal.h>
 
 #include "core/thread_pool.hh"
+#include <seastar/core/format.hh>
 #include <seastar/util/assert.hh>
 
 namespace seastar {
 
-thread_pool::thread_pool(sstring name, file_desc& notify) : _notify_eventfd(notify), _worker_thread([this, name] { work(name); }) {
+thread_pool::thread_pool(unsigned id, file_desc& notify, bool separate_aio_queue)
+        : _notify_eventfd(notify)
+        , _main_worker(make_worker(seastar::format("syscall-{}", id))) {
+    if (separate_aio_queue) {
+        try {
+            _aio_worker = make_worker(seastar::format("syscall-aio-{}", id));
+        } catch (...) {
+            stop_worker(*_main_worker);
+            throw;
+        }
+    }
 }
 
-void thread_pool::work(sstring name) {
+std::unique_ptr<thread_pool::worker> thread_pool::make_worker(sstring name) {
+    auto w = std::make_unique<worker>();
+    w->thread.emplace([this, wp = w.get(), name] { work(name, *wp); });
+    return w;
+}
+
+void thread_pool::work(sstring name, worker& w) {
     pthread_setname_np(pthread_self(), name.c_str());
     sigset_t mask;
     sigfillset(&mask);
@@ -44,23 +61,23 @@ void thread_pool::work(sstring name) {
     std::array<syscall_work_queue::work_item*, syscall_work_queue::queue_length> tmp_buf;
     while (true) {
         uint64_t count;
-        auto r = ::read(inter_thread_wq._start_eventfd.get_read_fd(), &count, sizeof(count));
+        auto r = ::read(w.inter_thread_wq._start_eventfd.get_read_fd(), &count, sizeof(count));
         SEASTAR_ASSERT(r == sizeof(count));
-        if (_stopped.load(std::memory_order_relaxed)) {
+        if (w.stopped.load(std::memory_order_relaxed)) {
             break;
         }
         auto end = tmp_buf.data();
-        inter_thread_wq._pending.consume_all([&] (syscall_work_queue::work_item* wi) {
+        w.inter_thread_wq._pending.consume_all([&] (syscall_work_queue::work_item* wi) {
             *end++ = wi;
         });
         for (auto p = tmp_buf.data(); p != end; ++p) {
             auto wi = *p;
             wi->process();
-            inter_thread_wq._completed.push(wi);
+            w.inter_thread_wq._completed.push(wi);
 
-            // Prevent the following load of _main_thread_idle to be hoisted before the writes to _completed above.
+            // Prevent the following load of main_thread_idle to be hoisted before the writes to _completed above.
             std::atomic_thread_fence(std::memory_order_seq_cst);
-            if (_main_thread_idle.load(std::memory_order_relaxed)) {
+            if (w.main_thread_idle.load(std::memory_order_relaxed)) {
                 uint64_t one = 1;
                 auto res = ::write(_notify_eventfd.get(), &one, 8);
                 SEASTAR_ASSERT(res == 8 && "write(2) failed on _reactor._notify_eventfd");
@@ -69,10 +86,14 @@ void thread_pool::work(sstring name) {
     }
 }
 
+void thread_pool::stop_worker(worker& w) noexcept {
+    w.stopped.store(true, std::memory_order_relaxed);
+    w.inter_thread_wq._start_eventfd.signal(1);
+    w.thread->join();
+}
+
 thread_pool::~thread_pool() {
-    _stopped.store(true, std::memory_order_relaxed);
-    inter_thread_wq._start_eventfd.signal(1);
-    _worker_thread.join();
+    for_each_worker([this] (worker& w) { stop_worker(w); });
 }
 
 }

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -23,6 +23,10 @@
 
 #include "syscall_work_queue.hh"
 
+#include <atomic>
+#include <memory>
+#include <optional>
+
 namespace seastar {
 
 class file_desc;
@@ -53,37 +57,70 @@ public:
 } // namespace internal
 
 class thread_pool {
+    struct worker {
+        syscall_work_queue inter_thread_wq;
+        std::atomic<bool> stopped = { false };
+        std::atomic<bool> main_thread_idle = { false };
+        // Initialized right after construction (see make_worker) so the thread's
+        // body can capture the owning thread_pool and this worker by reference.
+        std::optional<posix_thread> thread;
+    };
+
     file_desc& _notify_eventfd;
     internal::submit_metrics metrics;
-    syscall_work_queue inter_thread_wq;
-    posix_thread _worker_thread;
-    std::atomic<bool> _stopped = { false };
-    std::atomic<bool> _main_thread_idle = { false };
+    // Drains every blocking syscall except AIO submission fallbacks.
+    std::unique_ptr<worker> _main_worker;
+    // Drains blocking AIO read/write (io_submit) fallbacks. Only created when
+    // the reactor uses the linux-aio backend.
+    std::unique_ptr<worker> _aio_worker;
 public:
-    explicit thread_pool(sstring thread_name, file_desc& notify);
+    explicit thread_pool(unsigned id, file_desc& notify, bool separate_aio_queue);
     ~thread_pool();
     template <typename T, typename Func>
     future<T> submit(internal::thread_pool_submit_reason reason, Func func) noexcept {
         metrics.record_reason(reason);
-        return inter_thread_wq.submit<T>(std::move(func));
+        return select_worker(reason).inter_thread_wq.submit<T>(std::move(func));
     }
     uint64_t count(internal::thread_pool_submit_reason r) const { return metrics.count_for(r); }
 
-    unsigned complete() { return inter_thread_wq.complete(); }
+    unsigned complete() {
+        unsigned n = 0;
+        for_each_worker([&] (worker& w) { n += w.inter_thread_wq.complete(); });
+        return n;
+    }
     // Before we enter interrupt mode, we must make sure that the syscall thread will properly
     // generate signals to wake us up. This means we need to make sure that all modifications to
     // the pending and completed fields in the inter_thread_wq are visible to all threads.
     //
     // Simple release-acquire won't do because we also need to serialize all writes that happens
     // before the syscall thread loads this value, so we'll need full seq_cst.
-    void enter_interrupt_mode() { _main_thread_idle.store(true, std::memory_order_seq_cst); }
+    void enter_interrupt_mode() {
+        for_each_worker([] (worker& w) { w.main_thread_idle.store(true, std::memory_order_seq_cst); });
+    }
     // When we exit interrupt mode, however, we can safely used relaxed order. If any reordering
     // takes place, we'll get an extra signal and complete will be called one extra time, which is
     // harmless.
-    void exit_interrupt_mode() { _main_thread_idle.store(false, std::memory_order_relaxed); }
+    void exit_interrupt_mode() {
+        for_each_worker([] (worker& w) { w.main_thread_idle.store(false, std::memory_order_relaxed); });
+    }
 
 private:
-    void work(sstring thread_name);
+    template <typename Func>
+    void for_each_worker(Func&& fn) {
+        fn(*_main_worker);
+        if (_aio_worker) {
+            fn(*_aio_worker);
+        }
+    }
+    std::unique_ptr<worker> make_worker(sstring thread_name);
+    void stop_worker(worker& w) noexcept;
+    worker& select_worker(internal::thread_pool_submit_reason reason) noexcept {
+        if (_aio_worker && reason == internal::thread_pool_submit_reason::aio_fallback) {
+            return *_aio_worker;
+        }
+        return *_main_worker;
+    }
+    void work(sstring thread_name, worker& w);
 };
 
 


### PR DESCRIPTION
The lazy-time mode ctime patch does fix the AIO write fallbacks for most workloads in kernel 7.0+. However, for append-heavy workloads that often issue writes that span a written to unwritten extent boundary(from overwrites for alignment) this isn't the case. XFS currently considers writes across two extents to be potentially blocking as it requires a submission of multiple bio requests and subsequent retries if one fails. In internal testing we found that the ctime patch reduces fallbacks of our common workloads from ~67% to ~50%, with the remaining 50% of the fallbacks being due to the aforementioned issue.

We've tried a number of fixes for this:
- Submitting overwrites separately from newly written data ends up costing more than failing a unifed write request and retrying on the syscall thread.
- Submitting AIO write ops without the non-blocking flag. This was seastar's chosen solution before the ctime patch landed. However, the risk here is that an actually blocking AIO call can cause the reactor thread to stall.
- Support for the `FALLOC_FL_WRITE_ZEROES` fallocate flag landed in the v7.3 kernel for XFS. However, this solution suffers from having a span of kernel versions that doesn't support it.
- We're currently getting a kernel patch in that fixes this so that writes over multiple extents can be coalesced into a single bio request if the extents are logically and physically contiguous. However, same as the falloc flag above this too suffers from a span of kernel versions that don't support it.

From our testing failing a non-blocking aio call and having to fallback doesn't introduce noticeable overhead outside of microbenchmarks. Where it does introduce a lot of pain is when other non-aio syscalls on the thread actually block for an extended period of time(1ms+). In these cases tail latency for aio requests increases to the point that e2e latency of a client request also noticeably increases. Hence the solution to this issue that this PR implements is to have a separate syscall thread dedicated to only handling AIO requests. 

We ran this change in the `io_tester` with the following workload:
```yaml
  - name: appender
    shards: all
    type: append
    data_size: 4GB
    shard_info: { parallelism: 16, reqsize: 4kB, rps: 1000 }
    options: { fallocate: false }
  - name: slow_syscall
    shards: all
    type: blocking_sleep
    shard_info: { parallelism: 1, rps: 1, execution_time: 10ms }
```
`slow_syscall` request type was added to simulate blocking syscalls with high latency via a simple sleep. The 10ms is close to what we've seen in the wild. The implementation of this will be in a separate follow-up PR.

`io_tester` ran against a locally mounted XFS volume with the above workload and the following flags:
```
      --smp 2 \
      --duration 12 \
      --reactor-backend=linux-aio \
      --linux-aio-nowait 1
```
The `base` build is tip-of-dev seastar without any changes and the `change` build is with this PR applied. The raw results of the test are:

| build  | rep | p50 | p95  | p99  | p999  | max   | aio_retries |
  |--------|-----|-----|------|------|-------|-------|-------------|
  | base   | 1   | 94  | 397  | 5414 | 15828 | 17127 | 101488      |
  | base   | 2   | 82  | 1162 | 7268 | 15479 | 27675 | 120826      |
  | base   | 3   | 100 | 6611 | 7947 | 18112 | 21659 | 103460      |
  | base   | 4   | 74  | 4858 | 5950 | 17374 | 18761 | 104655      |
  | change | 1   | 89  | 137  | 1003 | 17816 | 19278 | 102577      |
  | change | 2   | 90  | 587  | 5617 | 19838 | 24720 | 102580      |
  | change | 3   | 65  | 111  | 895  | 24830 | 29686 | 99281       |
  | change | 4   | 70  | 94   | 902  | 19486 | 24464 | 103889      |
  
The p50 latency is unchanged and the p99 drops from ~5-8ms in the base to ~1ms with the change. The p999 and max stay roughly the same for both builds as at that point they're dominated by the reactor being saturated rather than the syscall thread.