### PR TITLE
prometheus: make scrape output independent of the serving shard

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -1056,10 +1056,16 @@ class metrics_handler : public httpd::handler_base  {
      */
     std::function<bool(const mi::labels_type&)> make_filter(const http::request& req) {
         std::unordered_map<sstring, std::regex> matcher;
-        auto labels = mi::get_local_impl()->get_labels();
         for (auto&& qp : req.get_query_params()) {
-            if (labels.find(qp.first) != labels.end()) {
-                matcher.emplace(qp.first, std::regex(qp.second.back().c_str()));
+            // Control parameters ("__name__", "__help__", ...) are not label
+            // filters; treat every other query parameter as one. Consulting
+            // the shard-local label registry instead would make the result
+            // depend on which shard serves the scrape, since labels do not
+            // have to be registered uniformly on all shards.
+            const auto& name = qp.first;
+            const bool control_param = name.size() >= 2 && name[0] == '_' && name[1] == '_';
+            if (!control_param) {
+                matcher.emplace(name, std::regex(qp.second.back().c_str()));
             }
         }
         return (matcher.empty()) ? _true_function : [matcher](const mi::labels_type& labels) {

--- a/tests/unit/metrics_tester.cc
+++ b/tests/unit/metrics_tester.cc
@@ -134,6 +134,7 @@ int main(int ac, char** av) {
         ("listen", bpo::value<sstring>()->default_value("0.0.0.0"), "address to start Prometheus server on")
         ("port", bpo::value<uint16_t>()->default_value(9180), "Prometheus port")
         ("conf", bpo::value<sstring>()->default_value("./conf.yaml"), "config with jobs and options")
+        ("serve-on-shard", bpo::value<unsigned>(), "pin serving HTTP connections to this shard; lets tests scrape from a shard other than the one the metrics are registered on")
     ;
     httpd::http_server_control prometheus_server;
 
@@ -178,7 +179,13 @@ int main(int ac, char** av) {
             prometheus::config pctx;
             pctx.allow_protobuf = true;
             prometheus::start(prometheus_server, pctx).get();
-            prometheus_server.listen(socket_address{listen, port}).handle_exception([] (auto ep) {
+            listen_options lo;
+            // matches what the listen_options-less http_server::listen() overload does
+            lo.reuse_address = true;
+            if (opts.count("serve-on-shard")) {
+                lo.set_fixed_cpu(opts["serve-on-shard"].as<unsigned>());
+            }
+            prometheus_server.listen(socket_address{listen, port}, lo).handle_exception([] (auto ep) {
                 return make_exception_future<>(ep);
             }).get();
 

--- a/tests/unit/prometheus_test.py
+++ b/tests/unit/prometheus_test.py
@@ -216,9 +216,15 @@ class Metrics:
 
 
 class TestPrometheus(unittest.TestCase):
+    # The base class runs against an exporter with the default connection
+    # load balancing, which in practice serves every scrape from shard 0 -
+    # the shard the metrics are registered on. See
+    # TestPrometheusNonMetricsShard for the variant where the serving
+    # shard holds no metrics state.
     exporter_path = None
     exporter_process = None
     exporter_config = None
+    serve_on_shard: Optional[int] = None
     port = 10001
     prometheus = None
     prometheus_scrape_interval = 15
@@ -229,6 +235,8 @@ class TestPrometheus(unittest.TestCase):
                 '--port', f'{cls.port}',
                 '--conf', cls.exporter_config,
                 '--smp=2']
+        if cls.serve_on_shard is not None:
+            args += ['--serve-on-shard', f'{cls.serve_on_shard}']
         cls.exporter_process = subprocess.Popen(args,
                                                 stdout=subprocess.PIPE,
                                                 stderr=subprocess.DEVNULL,
@@ -374,6 +382,15 @@ class TestPrometheus(unittest.TestCase):
                                          metric_name,
                                          metric_type)
             self.assertEqual(res, e.value)
+
+
+class TestPrometheusNonMetricsShard(TestPrometheus):
+    # Serve every scrape from a shard other than the one the metrics,
+    # their labels and the family configs are registered on (shard 0),
+    # so results that depend on the serving shard fail instead of
+    # passing by accident.
+    serve_on_shard = 1
+    port = 10002
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The prometheus scrape handler could produce different output depending on which shard served the connection: `make_filter()` consulted the serving shard's label set to decide whether a query parameter is a label filter, so a filter on a label registered only on other shards was silently ignored.

This went unnoticed because the conntrack load balancer virtually always hands the first connection of an idle server to shard 0 - the shard the metrics are registered on. It surfaced while testing #3526, which changes that tie-breaking: `prometheus_test.py` failed whenever the scrape landed on shard 1.

It can be reproduced on master independently of #3526: run `metrics_tester --smp 2` and issue two concurrent `/metrics?private=1` requests - the connection distributed to shard 1 returns unfiltered output, because the metrics (and the `private` label) are registered on shard 0 only.

The first patch fixes this by treating every query parameter not prefixed with the reserved `__` as a label filter. Note the deliberate behavior change, spelled out in the commit message: a filter on a label name that no metric uses is no longer silently ignored; each series is matched against its (empty) value for that label instead.

The second patch makes `prometheus_test.py` run its whole assertion suite twice: once against an exporter with the default load balancing (scrapes served by shard 0 - the previously exercised behaviour) and once with scrapes pinned, via a new `--serve-on-shard` metrics_tester option, to a shard holding no metrics state. The pinned variant fails its label-filtering tests without the fix.

Note for earlier reviewers: a previous revision carried a third change, setting the metric family configs on all shards in metrics_tester. It was dropped as having no effect - aggregation labels travel with the metric family metadata collected from the shard that registers the metrics, so the serving shard's config is never consulted and the plain shard-0 call was already correct.
