### PR TITLE
io_tester: fail on short I/O, and stop issuing requests that run off the end of the file

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -523,7 +523,7 @@ protected:
         } else {
             pos = _next_seq_pos;
             _next_seq_pos += req_size();
-            if (_next_seq_pos >= _config.file_size) {
+            if (_next_seq_pos + req_size() > _config.file_size) {
                 _overflows++;
                 if (req_type() != request_type::append) {
                     _next_seq_pos = 0;
@@ -533,10 +533,18 @@ protected:
         return pos + _offset;
     }
 
+    // Index i denotes the request-size-aligned offset i * request_size, so the
+    // largest index that still leaves a whole request inside the file is one
+    // below the number of requests the file holds.
+    static uint64_t max_pos_index(const job_config& cfg) {
+        uint64_t requests = cfg.file_size / cfg.shard_info.request_size;
+        return requests > 0 ? requests - 1 : 0;
+    }
+
 public:
     io_class_data(job_config cfg)
             : class_data(std::move(cfg))
-            , _pos_distribution(0,  _config.file_size / _config.shard_info.request_size)
+            , _pos_distribution(0, max_pos_index(_config))
             , _alignment(_config.shard_info.request_size >= 4096 ? 4096 : 512)
             , _queue_length_timer([this] { update_queue_length(); })
             , _disk_queue_lengths(extended_p_square_probabilities = quantiles_short)

--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -502,13 +502,25 @@ protected:
     timer<> _queue_length_timer;
     accumulator_type _disk_queue_lengths;
 
-    future<size_t> on_io_completed(future<size_t> f) {
-        if (!_is_dev_null) {
-            return f;
+    future<size_t> on_io_completed(uint64_t pos, future<size_t> f) {
+        if (_is_dev_null) {
+            // /dev/null completes every request with 0 bytes, report the
+            // request size instead to keep the throughput stats meaningful.
+            return f.then([this] (auto size_f) {
+                return make_ready_future<size_t>(this->req_size());
+            });
         }
 
-        return f.then([this] (auto size_f) {
-            return make_ready_future<size_t>(this->req_size());
+        return f.then([this, pos] (size_t size) {
+            if (size != req_size()) {
+                // Every request is aligned and within the file, so the kernel
+                // either completes it in full or fails it. A partial transfer
+                // means the numbers this job reports are not the workload it
+                // was configured to run.
+                throw std::runtime_error(format("{}: short I/O at offset {}: requested {} bytes, completed {}",
+                        name(), pos, req_size(), size));
+            }
+            return make_ready_future<size_t>(size);
         });
     }
 
@@ -710,8 +722,9 @@ public:
     }
 
     future<size_t> issue_request(io_intent* intent) override {
-        auto f = _file.dma_read(this->get_pos(), _buf.get(), this->req_size(), intent);
-        return on_io_completed(std::move(f));
+        auto pos = this->get_pos();
+        auto f = _file.dma_read(pos, _buf.get(), this->req_size(), intent);
+        return on_io_completed(pos, std::move(f));
     }
 };
 
@@ -724,8 +737,9 @@ public:
     }
 
     future<size_t> issue_request(io_intent* intent) override {
-        auto f = _file.dma_write(this->get_pos(), _buf.get(), this->req_size(), intent);
-        return on_io_completed(std::move(f));
+        auto pos = this->get_pos();
+        auto f = _file.dma_write(pos, _buf.get(), this->req_size(), intent);
+        return on_io_completed(pos, std::move(f));
     }
 };
 
@@ -776,7 +790,7 @@ public:
         auto pos = this->get_pos();
         std::vector<iovec> iovs = _iovecs;
         auto f = _file.dma_write(pos, std::move(iovs), intent);
-        return on_io_completed(std::move(f));
+        return on_io_completed(pos, std::move(f));
     }
 };
 
@@ -794,7 +808,7 @@ public:
         auto pos = this->get_pos();
         std::vector<iovec> iovs = _iovecs;
         auto f = _file.dma_read(pos, std::move(iovs), intent);
-        return on_io_completed(std::move(f));
+        return on_io_completed(pos, std::move(f));
     }
 };
 


### PR DESCRIPTION
io_tester treats a short read or write as a normal completion: the returned
size is folded into the statistics and the run continues, so the job silently
reports numbers for a workload other than the configured one. Since io_tester
controls every parameter of the requests it issues (aligned offset, aligned
length, inside a preallocated file or a block device region), the kernel either
completes a direct request in full or fails it, and a partial transfer is never
benign. Make it a hard error.

Turning the check on surfaced two pre-existing position bugs immediately, so
they are fixed first:

* the random position distribution's upper bound is inclusive, so `randread`
  and `randwrite` can pick offset `file_size` itself. A `randread` job on a
  64MB file dies on the check within a second of starting:

  ```
  randread: short I/O at offset 67108864: requested 131072 bytes, completed 0
  ```

* the sequential position wraps when the *next* offset reaches EOF, so a
  request size that does not divide the file size makes the last request of
  every pass straddle the end of the file:

  ```
  seqread_96k: short I/O at offset 67043328: requested 98304 bytes, completed 65536
  ```

  (64MB file, `reqsize: 96kB`). For the usual case of a request size that
  divides the file size the wrap point does not move.

Both were previously invisible: the short transfer was counted as a request,
with its near-zero latency landing in the latency quantiles.

The check is also a backstop for configurations nothing else validates. A
request size larger than the file, which today reports a fraction of the
requested throughput without comment, now says:

```
randread_toobig: short I/O at offset 0: requested 2097152 bytes, completed 1048576
```

`/dev/null` is excluded, as it completes everything with 0 bytes and the job
already substitutes the request size there.

It is a `runtime_error` rather than an assert so that the message survives in
release builds, which is what benchmarks run.

## Testing

Built `dev` mode with clang-22 and ran the app against a directory:

* `seqread` / `randread` / `randwrite` / vectorized `randwrite`
  (`reqsize: 128kB`, 64MB per job): clean before and after.
* `seqread` / `overwrite` / `append` / `randread` with a non-dividing
  `reqsize: 96kB`: fails on the tail read without the sequential fix, clean
  with it.
* `--storage /dev/null`: unaffected.
* `reqsize: 2MB` against a 1MB file: fails with the message above.
