### PR TITLE
thread: allow a thread to switch its own scheduling group

### DIFF
--- a/include/seastar/core/thread.hh
+++ b/include/seastar/core/thread.hh
@@ -121,6 +121,7 @@ public:
     bool should_yield() const;
     void reschedule();
     void yield();
+    scheduling_group switch_to(scheduling_group new_sg);
     task* waiting_task() noexcept override { return _done.waiting_task(); }
     friend class thread;
     friend void thread_impl::switch_in(thread_context*);
@@ -173,6 +174,36 @@ public:
     /// Gives other threads/fibers a chance to run on current CPU.
     /// The current thread will resume execution promptly.
     static void yield();
+    /// \brief Switch the current thread to a different scheduling group.
+    ///
+    /// Moves the currently running thread to \c new_sg: subsequent execution
+    /// of this thread (including the remainder of the calling function) is
+    /// accounted for, and scheduled as, \c new_sg instead of whatever group
+    /// the thread was created or last switched into.
+    ///
+    /// If \c new_sg is already the thread's current scheduling group, this
+    /// call is a no-op: it returns immediately without yielding. Otherwise,
+    /// it is equivalent to \ref yield() into the new group: other
+    /// threads/fibers get a chance to run before this thread resumes.
+    ///
+    /// This is the \ref thread counterpart of \ref coroutine::switch_to,
+    /// which does the same for coroutines.
+    ///
+    /// \param new_sg the scheduling group to switch to
+    /// \return the scheduling group the thread was in before the switch, so
+    ///         the caller can switch back later if desired.
+    ///
+    /// Example:
+    /// \code
+    ///    seastar::thread th([sg] {
+    ///        ... // do some preliminary work
+    ///        auto prev_sg = seastar::thread::switch_to(sg);
+    ///        ... // do some work accounted to sg
+    ///        seastar::thread::switch_to(prev_sg);
+    ///        ... // do some more work
+    ///    });
+    /// \endcode
+    static scheduling_group switch_to(scheduling_group new_sg);
     /// \brief Checks whether this thread ought to call yield() now.
     ///
     /// Useful where we cannot call yield() immediately because we

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -301,6 +301,17 @@ thread_context::yield() {
     switch_out();
 }
 
+scheduling_group
+thread_context::switch_to(scheduling_group new_sg) {
+    auto prev_sg = group();
+    if (new_sg == prev_sg) {
+        return prev_sg;
+    }
+    set_scheduling_group(new_sg);
+    yield();
+    return prev_sg;
+}
+
 void
 thread_context::reschedule() {
     schedule(this);
@@ -374,6 +385,10 @@ void init() {
 
 void thread::yield() {
     thread_impl::get()->yield();
+}
+
+scheduling_group thread::switch_to(scheduling_group new_sg) {
+    return thread_impl::get()->switch_to(new_sg);
 }
 
 }

--- a/tests/unit/thread_test.cc
+++ b/tests/unit/thread_test.cc
@@ -21,6 +21,7 @@
  */
 
 #include <seastar/core/thread.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -102,6 +103,51 @@ SEASTAR_TEST_CASE(test_thread_async_nested) {
     }).then([] (int three) {
         BOOST_REQUIRE_EQUAL(three, 3);
     });
+}
+
+SEASTAR_TEST_CASE(test_thread_switch_to) {
+    auto other_sg0 = co_await create_scheduling_group("thread switch_to sg0", 10.f);
+    auto other_sg1 = co_await create_scheduling_group("thread switch_to sg1", 10.f);
+    std::exception_ptr ex;
+
+    try {
+        auto base_sg = current_scheduling_group();
+        co_await async([base_sg, other_sg0, other_sg1] {
+            BOOST_REQUIRE(current_scheduling_group() == base_sg);
+
+            auto prev_sg = thread::switch_to(other_sg0);
+            BOOST_REQUIRE(current_scheduling_group() == other_sg0);
+            BOOST_REQUIRE(prev_sg == base_sg);
+
+            // A yield() reschedules the thread without touching its
+            // scheduling group, so it should still be other_sg0 afterwards.
+            thread::yield();
+            BOOST_REQUIRE(current_scheduling_group() == other_sg0);
+
+            // Switching to the group the thread is already in is a no-op:
+            // it still returns that same group as the "previous" one.
+            auto same_sg = thread::switch_to(other_sg0);
+            BOOST_REQUIRE(current_scheduling_group() == other_sg0);
+            BOOST_REQUIRE(same_sg == other_sg0);
+
+            auto prev_sg2 = thread::switch_to(other_sg1);
+            BOOST_REQUIRE(current_scheduling_group() == other_sg1);
+            BOOST_REQUIRE(prev_sg2 == other_sg0);
+
+            auto back_sg = thread::switch_to(base_sg);
+            BOOST_REQUIRE(current_scheduling_group() == base_sg);
+            BOOST_REQUIRE(back_sg == other_sg1);
+        });
+        BOOST_REQUIRE(current_scheduling_group() == base_sg);
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    co_await destroy_scheduling_group(other_sg1);
+    co_await destroy_scheduling_group(other_sg0);
+    if (ex) {
+        std::rethrow_exception(std::move(ex));
+    }
 }
 
 void compute(float& result, bool& done, uint64_t& ctr) {


### PR DESCRIPTION
Code running in a seastar::thread had no way to change which scheduling group it is accounted and scheduled under once the thread was already running: thread_attributes::sched_group only sets the group at construction time, and task::set_scheduling_group() is protected and not reachable from outside.

This matters for the same reason coroutine::switch_to() exists: a long-running fiber may want part of its work billed to a different scheduling group than the rest (e.g. a background/low-priority group for a large chunk of work, switching back to the caller's group afterwards), without spawning a separate thread just to get a different group.

Add thread::switch_to(scheduling_group), the thread counterpart of coroutine::switch_to(): it moves the calling thread to the given group and returns the group it was previously in, so the caller can switch back later. Like coroutine::switch_to(), switching to the group the thread is already in is a no-op and doesn't yield.

The underlying machinery already generalizes to this with almost no new code: thread_context is itself a task, and yield() already does "schedule(this); switch_out();" to reschedule the task and hand control back to the reactor. The only missing piece was calling the already-available (but private to task) set_scheduling_group() before that reschedule, so the thread's task gets requeued under the new group instead of its old one, and exposing that through thread_context and thread as a public switch_to().

Add test_thread_switch_to to tests/unit/thread_test.cc, mirroring coroutines_test.cc's test_switch_to: switch a running thread across two freshly-created scheduling groups and back, checking current_scheduling_group() and the returned "previous group" at each step, including that switching to the current group is a no-op and that an unrelated yield() in between doesn't reset the group.