### PR TITLE
on_internal_error.hh: add missing include <cstdint>

### DIFF
--- a/include/seastar/core/on_internal_error.hh
+++ b/include/seastar/core/on_internal_error.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <string_view>
 


### PR DESCRIPTION
on_internal_error.hh names uint64_t, so it needs to import <cstdint>.