### PR TITLE
rpc: do not destroy a stream connection while its loop is still running

### DIFF
--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -251,7 +251,8 @@ protected:
     std::optional<socket_and_buffers> _connected;
     std::optional<shared_promise<>> _negotiated = shared_promise<>();
     // Resolved when the connection's loop is over.  It is a shared_promise
-    // because more than one owner may need to wait for the connection to stop.
+    // because more than one owner may need to wait for the connection to stop
+    // before releasing it, see client::_streams_gate.
     shared_promise<> _stopped;
     // Waits for the connection's loop to be over, without aborting it.
     future<> get_stopped_future() noexcept {
@@ -562,6 +563,9 @@ private:
     socket_address _server_addr, _local_addr;
     client_options _options;
     weak_ptr<client> _parent; // for stream clients
+    // Tracks the background waits that keep this client's stream connections
+    // alive until their loops are over, see make_stream_sink().
+    gate _streams_gate;
 
     metrics _metrics;
 
@@ -639,6 +643,9 @@ public:
                 }
                 xshard_connection_ptr s = make_lw_shared(make_foreign(static_pointer_cast<rpc::connection>(c)));
                 this->register_stream(c->get_connection_id(), s);
+                // Keep the stream connection alive until its loop is over.
+                auto gh = _streams_gate.hold();
+                (void)c->get_stopped_future().finally([c, gh = std::move(gh)] {});
                 return sink<Out...>(make_shared<internal::sink_impl<Serializer, Out...>>(std::move(s)));
             }).handle_exception([c] (std::exception_ptr eptr) {
                 // If await_connection fails we need to stop the client

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -626,7 +626,14 @@ public:
     }
     template<typename Serializer, typename... Out>
     future<sink<Out...>> make_stream_sink(socket socket) {
-        return await_connection().then([this, socket = std::move(socket)] () mutable {
+        // Hold the gate for as long as the stream connection is being created,
+        // so that this client cannot finish stopping, and be destroyed, while
+        // a stream of its own is still coming up and referring back to it.
+        auto gh = _streams_gate.try_hold();
+        if (!gh) {
+            return make_exception_future<sink<Out...>>(closed_error());
+        }
+        return await_connection().then([this, socket = std::move(socket), gh = std::move(*gh)] () mutable {
             if (!this->get_connection_id()) {
                 return make_exception_future<sink<Out...>>(std::runtime_error("Streaming is not supported by the server"));
             }
@@ -637,14 +644,14 @@ public:
             auto c = make_shared<client>(_logger, _serializer, o, std::move(socket), _server_addr, _local_addr);
             c->_parent = this->weak_from_this();
             c->_is_stream = true;
-            return c->await_connection().then([c, this] {
+            return c->await_connection().then([c, this, gh = std::move(gh)] () mutable {
                 if (_error) {
                     throw closed_error();
                 }
                 xshard_connection_ptr s = make_lw_shared(make_foreign(static_pointer_cast<rpc::connection>(c)));
                 this->register_stream(c->get_connection_id(), s);
-                // Keep the stream connection alive until its loop is over.
-                auto gh = _streams_gate.hold();
+                // Hand the holder over to keep the stream connection alive
+                // until its loop is over.
                 (void)c->get_stopped_future().finally([c, gh = std::move(gh)] {});
                 return sink<Out...>(make_shared<internal::sink_impl<Serializer, Out...>>(std::move(s)));
             }).handle_exception([c] (std::exception_ptr eptr) {

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -253,6 +253,10 @@ protected:
     // Resolved when the connection's loop is over.  It is a shared_promise
     // because more than one owner may need to wait for the connection to stop.
     shared_promise<> _stopped;
+    // Waits for the connection's loop to be over, without aborting it.
+    future<> get_stopped_future() noexcept {
+        return _stopped.get_shared_future();
+    }
     stats _stats;
     const logger& _logger;
     // The owner of the pointer below is an instance of rpc::protocol<typename Serializer> class.

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -250,7 +250,9 @@ protected:
     bool _error = false;
     std::optional<socket_and_buffers> _connected;
     std::optional<shared_promise<>> _negotiated = shared_promise<>();
-    promise<> _stopped;
+    // Resolved when the connection's loop is over.  It is a shared_promise
+    // because more than one owner may need to wait for the connection to stop.
+    shared_promise<> _stopped;
     stats _stats;
     const logger& _logger;
     // The owner of the pointer below is an instance of rpc::protocol<typename Serializer> class.

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -1064,6 +1064,13 @@ future<> client::loop(client_options ops, const socket_address& addr, const sock
     } else {
         abort_all_streams();
     }
+    // The _streams map and the application's sink and source handles may all
+    // have released the stream connections aborted above while their loops are
+    // still winding down.  This client owns them until then, so wait for them
+    // here, before anything can drop the last reference to a connection that is
+    // still running.  This is also what makes client::stop() wait for them: it
+    // waits for _stopped, which is only set below.
+    co_await _streams_gate.close();
     if (_compressor) {
         co_await _compressor->close();
     }

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -347,6 +347,14 @@ void connection::abort() {
     if (!_error) {
         _error = true;
         _connected->fd.shutdown_input();
+        if (is_stream()) {
+            // A stream connection's loop may be parked waiting for the
+            // application to consume what it has already received, and
+            // shutting the input down does not wake it up.  Break the
+            // backpressure too, otherwise the loop never ends.
+            _stream_queue.abort(std::make_exception_ptr(stream_closed()));
+            _stream_sem.broken(stream_closed());
+        }
     }
 }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -356,7 +356,7 @@ future<> connection::stop() noexcept {
     } catch (...) {
         log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
     }
-    return _stopped.get_shared_future();
+    return get_stopped_future();
 }
 
 template<typename Connection>
@@ -827,7 +827,7 @@ future<> client::stop() noexcept {
     } catch(...) {
         log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
     }
-    return _stopped.get_shared_future();
+    return get_stopped_future();
 }
 
 void client::abort_all_streams() {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -356,7 +356,7 @@ future<> connection::stop() noexcept {
     } catch (...) {
         log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
     }
-    return _stopped.get_future();
+    return _stopped.get_shared_future();
 }
 
 template<typename Connection>
@@ -827,7 +827,7 @@ future<> client::stop() noexcept {
     } catch(...) {
         log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
     }
-    return _stopped.get_future();
+    return _stopped.get_shared_future();
 }
 
 void client::abort_all_streams() {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -741,6 +741,149 @@ SEASTAR_TEST_CASE(test_stream_negotiation_error) {
     });
 }
 
+// Reproduces a use-after-free of an rpc stream connection that is destroyed
+// while it is still running.
+//
+// The application below closes its sink but never reads its source, which is
+// all it can do: rpc::source has no close(), and the only places that mark a
+// source closed are inside source_impl::operator(), on eof or on a failed
+// read.  connection::_source_closed therefore stays false, so close_sink()
+// does not see the stream as two-way closed and connection::stream_close() --
+// which stops the connection -- is never called.  The stream connection is
+// left referenced only by the parent client's _streams map.
+//
+// Without the fix, client::abort_all_streams() then erases that reference
+// while the connection's receive loop is still running and its output stream
+// was never closed, and this test aborts either in the destroyed connection's
+// receive loop:
+//
+//   __cxa_pure_virtual ()
+//   seastar::rpc::log_exception (seastar::rpc::connection&, ...)
+//   seastar::rpc::client::loop (...)
+//
+// or, when a batched flush is still outstanding at destruction time, in
+//
+//   seastar::internal::assert_fail (...)          "Was this stream properly closed?"
+//   seastar::output_stream<char>::~output_stream (...)
+//   seastar::rpc::connection::socket_and_buffers::~socket_and_buffers (...)
+//   seastar::rpc::connection::~connection (...)
+//   seastar::rpc::client::~client (...)
+//
+// The latter is what is seen in the field, where the application drops the
+// last reference to the stream connection itself rather than the parent
+// client's _streams map doing it.
+SEASTAR_TEST_CASE(test_stream_drop_unclosed_source) {
+    rpc::server_options so;
+    so.streaming_domain = rpc::streaming_domain_type(1);
+    rpc_test_config cfg;
+    cfg.server_options = so;
+    return rpc_test_env<>::do_with_thread(cfg, [] (rpc_test_env<>& env) {
+        test_rpc_proto::client c(env.proto(), {}, env.make_socket(), ipv4_addr());
+
+        future<> server_done = make_ready_future<>();
+        env.register_handler(1, [&] (int i, rpc::source<int> source) {
+            BOOST_REQUIRE_EQUAL(i, 666);
+            auto sink = source.make_sink<serializer, sstring>();
+            // Drain the peer's stream and close this side of it, so that the
+            // server end of the stream is torn down cleanly whatever the
+            // client does with its own end.
+            server_done = seastar::async([source, sink] () mutable {
+                try {
+                    while (source().get()) {}
+                } catch (...) {
+                    // the client side may be gone already
+                }
+                try {
+                    sink.close().get();
+                } catch (...) {
+                    // ditto
+                }
+            });
+            return sink;
+        }).get();
+        auto call = env.proto().make_client<rpc::source<sstring> (int, rpc::sink<int>)>(1);
+
+        {
+            auto sink = c.make_stream_sink<serializer, int>(env.make_socket()).get();
+            auto source = call(c, 666, sink).get();
+            sink(1).get();
+            // The application is done with the stream.  It closes its sink,
+            // but never reads its source, so the source is not closed and the
+            // stream connection is not stopped.
+            sink.close().get();
+            // sink and source are dropped here.
+        }
+
+        // The stream connection is still referenced by c's _streams map.
+        // Stopping c calls abort_all_streams(), which erases that reference;
+        // without the fix that destroys the stream connection while its loop
+        // is still running.
+        c.stop().get();
+
+        server_done.get();
+    });
+}
+
+// Aborting a stream connection has to make its loop end, even when the loop is
+// parked on the backpressure of an application that stopped reading its
+// source: connection::abort() only shuts the input down, which does not wake a
+// loop waiting on _stream_sem or _stream_queue.  A client waits for its stream
+// connections to stop before it stops itself, so a loop that never ends hangs
+// client::stop() forever.
+SEASTAR_TEST_CASE(test_stream_stop_client_with_unread_source) {
+    rpc::server_options so;
+    so.streaming_domain = rpc::streaming_domain_type(1);
+    rpc_test_config cfg;
+    cfg.server_options = so;
+    return rpc_test_env<>::do_with_thread(cfg, [] (rpc_test_env<>& env) {
+        test_rpc_proto::client c(env.proto(), {}, env.make_socket(), ipv4_addr());
+
+        // The server floods the client with more than it can buffer.
+        int sent = 0;
+        future<> server_done = make_ready_future<>();
+        env.register_handler(1, [&] (int i, rpc::source<int> source) {
+            auto sink = source.make_sink<serializer, sstring>();
+            server_done = seastar::async([sink, &sent] () mutable {
+                try {
+                    for (int j = 0; j < 500; j++) {
+                        sent++;
+                        sink(sstring(4096, 'x')).get();
+                    }
+                } catch (...) {
+                    // the client side is gone
+                }
+                try {
+                    sink.close().get();
+                } catch (...) {
+                    // ditto
+                }
+            });
+            return sink;
+        }).get();
+        auto call = env.proto().make_client<rpc::source<sstring> (int, rpc::sink<int>)>(1);
+
+        {
+            auto sink = c.make_stream_sink<serializer, int>(env.make_socket()).get();
+            auto source = call(c, 666, sink).get();
+            sink(1).get();
+            // Wait until the peer has handed the sink more than this side can
+            // buffer (max_queued_stream_buffers frames, max_stream_buffers_memory
+            // bytes), so that the stream connection's loop is parked on its own
+            // backpressure.  The source is never read.
+            while (sent < 64) {
+                sleep(std::chrono::milliseconds(1)).get();
+            }
+            sink.close().get();
+            // sink and source are dropped here.
+        }
+
+        // Without abort() breaking the stream backpressure this never returns.
+        c.stop().get();
+
+        server_done.get();
+    });
+}
+
 static future<> test_rpc_connection_send_glitch(bool on_client) {
     struct context {
         int limit;


### PR DESCRIPTION
An rpc stream connection can be destroyed while its own loop is still running, which shows up either as a use-after-free in that loop or as `"Was this stream properly closed?"` in `~output_stream()`. The latter is what was seen in the field, and what #3653 was opened for.

### The problem

A stream connection is created by `client::make_stream_sink()` and is referenced by the parent client's `_streams` map and by the `rpc::sink` and `rpc::source` handles handed to the application. None of them stops the connection before dropping its reference, and the application may drop its handles whenever it likes.

Closing the stream does not protect against this. `close_sink()`/`close_source()` set their flag *first* and only then call `stream_close()`, and on a connection that is already in error `stream_close()` leaves the write buffer to `stop_send_loop()` and only waits for the loop to stop. Waiting on `stop()` holds no reference. So a stream that was closed correctly can still have its connection freed while `stop_send_loop()` is in flight and its write buffer is still queued in the batch flush poller — exactly the state captured in the issue's core dump (`_sink_closed = true`, `_source_closed = true`, `_error = true`, `_batch_flushes = true`, `_zc_len = 141`, still linked in the flush poller, with a pending waiter on `_stopped`).

The same window is reachable from the parent, whose `abort_all_streams()` aborts a stream connection and erases the `_streams` entry right away, and from the connection's own loop, whose `deregister_this_stream()` erases that entry from inside the loop.

Server-side stream connections are not affected: `server::connection::process()` opens with `// hold onto connection pointer until the while loop exits`. The client side has no equivalent and relies on an owner calling `stop()` before dropping the client, which for a stream client nobody does.

### The fix

Rather than have the connection keep itself alive, the ownership is made explicit where the reference is taken: the parent client owns its stream connections for as long as their loops are running. `make_stream_sink()` takes a holder on a new `_streams_gate` and keeps it, together with a reference to the connection, until the connection has stopped; `loop()` closes that gate once it has aborted them all, before resolving `_stopped` — which is also what makes `client::stop()` wait for them. `_streams` is then just a lookup index that anyone may erase from at any time, so `abort_all_streams()` and `deregister_this_stream()` are unchanged, and stay public and `void`.

The first two commits are prerequisites: `stop()` handed out `_stopped.get_future()` unconditionally, so only one owner could ever wait for a connection to stop (`promise::get_future()` asserts `!_future`; with the assert compiled out the first waiter is silently orphaned, which is a hang rather than a crash).

### Testing

`test_stream_drop_unclosed_source` drops the stream handles while the connection is still running and then stops the parent client. On master it aborts deterministically — 5/5 at `-c1`, 10/10 at `-c2` — in the destroyed connection's own receive loop:

```
pure virtual method called
#4  __cxa_pure_virtual ()
#5  seastar::rpc::log_exception (seastar::rpc::connection&, ...)
#6  seastar::rpc::client::loop (...)
```

With the series it passes 10/10. Each commit was built and run separately:

| | dev `-c1` | dev `-c2` | debug (ASan/UBSan/LSan) `-c2` |
| --- | --- | --- | --- |
| full `rpc_test` | pass | pass | all pass |
| new test | pass | pass | pass, no leaks |

The debug run leaves the pre-existing baseline untouched: 2 leaked blocks in `loopback_data_sink_impl::put` and one startup UBSan report, identical with and without the series.

Fixes #3653
Fixes #3657
