### PR TITLE
[Alt] Use a separate syscall thread for aio fallbacks

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2628,7 +2628,10 @@ void reactor::register_metrics() {
 
     auto io_fallback_counter = [this](const sstring& reason_str, internal::thread_pool_submit_reason r) {
         static auto reason_label = sm::label("reason");
-        return sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::count, _thread_pool.get(), r),
+        thread_pool* aio_pool = _backend->aio_thread_pool();
+        thread_pool* pool = (r == internal::thread_pool_submit_reason::aio_fallback && aio_pool)
+                ? aio_pool : _thread_pool.get();
+        return sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::count, pool, r),
                 sm::description("Total number of io-threaded-fallbacks operations"), { reason_label(reason_str), });
     };
 
@@ -3080,26 +3083,26 @@ public:
 };
 
 class reactor::syscall_pollfn final : public reactor::pollfn {
-    reactor& _r;
+    thread_pool& _p;
 public:
-    syscall_pollfn(reactor& r) : _r(r) {}
+    syscall_pollfn(thread_pool& p) : _p(p) {}
     virtual bool poll() final override {
-        return _r._thread_pool->complete();
+        return _p.complete();
     }
     virtual bool pure_poll() override final {
         return poll(); // actually performs work, but triggers no user continuations, so okay
     }
     virtual bool try_enter_interrupt_mode() override {
-        _r._thread_pool->enter_interrupt_mode();
+        _p.enter_interrupt_mode();
         if (poll()) {
             // raced
-            _r._thread_pool->exit_interrupt_mode();
+            _p.exit_interrupt_mode();
             return false;
         }
         return true;
     }
     virtual void exit_interrupt_mode() override final {
-        _r._thread_pool->exit_interrupt_mode();
+        _p.exit_interrupt_mode();
     }
 };
 
@@ -3393,7 +3396,11 @@ int reactor::do_run() {
         });
     }
 
-    poller syscall_poller(std::make_unique<syscall_pollfn>(*this));
+    poller syscall_poller(std::make_unique<syscall_pollfn>(*_thread_pool));
+    std::optional<poller> aio_syscall_poller;
+    if (auto* aio_pool = _backend->aio_thread_pool()) {
+        aio_syscall_poller = poller(std::make_unique<syscall_pollfn>(*aio_pool));
+    }
 
     poller drain_cross_cpu_freelist(std::make_unique<drain_cross_cpu_freelist_pollfn>());
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -51,6 +51,7 @@
 
 #include "core/reactor_backend.hh"
 #include "core/thread_pool.hh"
+#include <seastar/core/format.hh>
 #include "core/syscall_result.hh"
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/internal/iovec_utils.hh>
@@ -137,7 +138,8 @@ aio_storage_context::iocb_pool::iocb_pool() {
 
 aio_storage_context::aio_storage_context(reactor& r)
     : _r(r)
-    , _io_context(0) {
+    , _io_context(0)
+    , _aio_thread_pool(std::make_unique<thread_pool>(seastar::format("aio-syscall-{}", r._id), r._notify_eventfd)) {
     static_assert(max_aio >= reactor::max_queues * reactor::max_queues,
                   "Mismatch between maximum allowed io and what the IO queues can produce");
     internal::setup_aio_context(max_aio, &_io_context);
@@ -148,6 +150,8 @@ aio_storage_context::aio_storage_context(reactor& r)
 }
 
 aio_storage_context::~aio_storage_context() {
+    // Join the syscall thread before destroying the aio context it submits against.
+    _aio_thread_pool.reset();
     internal::io_destroy(_io_context);
 }
 
@@ -354,7 +358,7 @@ future<> aio_storage_context::retry_loop() {
             }
             syscall_result<int> result(0, 0);
             try {
-                result = co_await _r._thread_pool->submit<syscall_result<int>>(
+                result = co_await _aio_thread_pool->submit<syscall_result<int>>(
                         internal::thread_pool_submit_reason::aio_fallback, [this] () mutable {
                     auto r = io_submit(_io_context, _aio_retries.size(), _aio_retries.data());
                     return wrap_syscall<int>(r);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -60,6 +60,7 @@
 namespace seastar {
 
 class reactor;
+class thread_pool;
 // FIXME: merge it with storage context below. At this point the
 // main thing to do is unify the iocb list
 struct aio_general_context {
@@ -116,6 +117,9 @@ class aio_storage_context {
     void signal_retry_loop();
     void reap_pending_retries();
 
+    // Dedicated syscall thread for this context's blocking io_submit() fallbacks.
+    std::unique_ptr<thread_pool> _aio_thread_pool;
+
 public:
     explicit aio_storage_context(reactor& r);
     ~aio_storage_context();
@@ -124,6 +128,8 @@ public:
     bool submit_work();
     bool can_sleep() const;
     future<> stop() noexcept;
+
+    thread_pool* aio_thread_pool() noexcept { return _aio_thread_pool.get(); }
 };
 
 class completion_with_iocb {
@@ -263,6 +269,10 @@ public:
 
     virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) = 0;
 
+    // Some backends create and manage their own thread pool for aio fallbacks.
+    // This should return a pointer to one if it exists, or nullptr otherwise.
+    virtual thread_pool* aio_thread_pool() noexcept { return nullptr; }
+
 protected:
     reactor_backend(uses_blocking_io blocking_io, supports_aio_fdatasync aio_fdatasync)
         : _blocking_io(blocking_io)
@@ -337,6 +347,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    thread_pool* aio_thread_pool() noexcept override { return _storage_context.aio_thread_pool(); }
 };
 
 class reactor_backend_aio : public reactor_backend {
@@ -389,6 +401,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    thread_pool* aio_thread_pool() noexcept override { return _storage_context.aio_thread_pool(); }
 };
 
 class reactor_backend_uring;


### PR DESCRIPTION
Alternative implementation of https://github.com/scylladb/seastar/pull/3645 . This version uses a separate thread pool for the aio fallbacks instead of having the existing thread pool manage multiple threads. The new thread pool is owned by `aio_storage_context` as it's the sole user of the pool.

There is a third alternative implementation that involves the reactor owning the pool object directly. However, this introduces some odd/fragile interfaces between the reactor and `aio_storage_context`. I.e, there are two ways I can think of implementing it this way:
- The `reactor_backend` needs to expose a new virtual method `virtual bool uses_aio_syscall_thread() const` that every backend that uses `aio_storage_context` would need to overwrite to return true so that the reactor knows to construct a aio syscall thread in its constructor.
- The reactor would need to lazily construct the aio syscall thread on first use. Then the `aio_storage_context` would need to make sure that the aio syscall thread is constructed before the pollers were registered. 

Both seem to suffer from fragile contracts that aren't easily enforceable in code. 
