### PR TITLE
cooking: pin the DPDK ingredient libdir to lib

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -270,6 +270,13 @@ cooking_ingredient (c-ares
 
 set (dpdk_args
   --default-library=static
+  # meson derives libdir from the host: lib/<multiarch> if dpkg-architecture is
+  # installed, lib64 if /usr/lib64 is a real directory, lib otherwise. Only the
+  # first two are on the PKG_CONFIG_PATH that cmake's FindPkgConfig builds from
+  # CMAKE_PREFIX_PATH on a debian-like system, so a host without dpkg-dev but
+  # with a real /usr/lib64 installs libdpdk.pc where find_package (dpdk) will
+  # not look. Pin the layout instead of inheriting the guess.
+  --libdir=lib
   -Dc_args="-Wno-error"
   -Denable_docs=false
   -Denable_apps=dpdk-testpmd


### PR DESCRIPTION
Build fix for dpdk. The short explanation is "apt stuff", the medium explanation is upstream dependency changes to libbz2 caused `dpkg-dev` not not be installed (as we don't list it directly in install-dependencies.sh, it only comes in via recommends).

There are various fixes, I went with this `--libdir=lib` one as it has the lowest external impact, affecting dpdk only.

Full story is below if you care to read it (cue claude):

The `dpdk` CI job has been failing on every master push since 2026-08-31
([run 33399727679](https://github.com/scylladb/seastar/actions/runs/33399727679/job/99607317800)),
in `./configure.py --cook dpdk`:

```
-- Checking for module 'libdpdk'
--   Package 'libdpdk' not found
-- Could NOT find dpdk (missing: dpdk_BUS_PCI_LIBRARY ... dpdk_EAL_LIBRARY ...)
CMake Error at CMakeLists.txt:944 (target_link_libraries):
  Target "seastar" links to:
    DPDK::dpdk
  but the target was not found.
```

DPDK itself builds and installs fine; what fails is seastar's `find_package (dpdk)`
afterwards, because the `.pc` file is not where cmake looks.

## Cause

`dpdk_args` in `cooking_recipe.cmake` passes no `--libdir`, so meson derives it
from the host. `default_libdir()` tries `dpkg-architecture -qDEB_HOST_MULTIARCH`
first and returns `lib/<multiarch>`; failing that it returns `lib64` when
`/usr/lib64` is a real directory, and only then `lib`.

cmake's `FindPkgConfig` builds `PKG_CONFIG_PATH` from `CMAKE_PREFIX_PATH` using
`lib/\${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig` and `lib/pkgconfig` when
`/etc/debian_version` exists; `lib64/pkgconfig` is only appended on non-debian
hosts (`Modules/FindPkgConfig.cmake`, the `# is this a debian system ?` branch).

So on a debian-like host with no `dpkg-dev` but a real `/usr/lib64`, DPDK installs
`libdpdk.pc` into `_cooking/installed/lib64/pkgconfig`, which is on nobody's search
path.

`ubuntu:26.04` is that host. `/usr/lib64` is a real directory in the image, and
`dpkg-dev` is not installed: nothing in `install-dependencies.sh` depends on it,
`meson` only `Recommends` it, and apt stopped pulling that recommend in between
2026-08-30 and 2026-08-31. Diffing the last green run against the first red one
shows the whole `build-essential`/`dpkg-dev` closure dropping out of the
transaction, and the DPDK install prefix flipping from
`_cooking/stow/dpdk/lib/x86_64-linux-gnu` to `_cooking/stow/dpdk/lib64`.

## Fix

Pass `--libdir=lib` so the layout does not depend on what the host happens to have
installed. `lib` was already meson's choice on any host without
`dpkg-architecture` and without `/usr/lib64`, so it is a layout the recipe has
always been exercised with.

## Verification

In an `ubuntu:26.04` container matching the CI job (`install-dependencies.sh`,
`clang-22`, `--cook fmt --cook dpdk --dpdk-machine corei7-avx --enable-dpdk`,
`--mode release`, C++23):

- before: the CI failure reproduces verbatim, `libdpdk.pc` lands in
  `_cooking/stow/dpdk/lib64/pkgconfig`, configure exits 1.
- after: `symlink-drivers-solibs.sh lib`, `-- Found dpdk:
  .../\_cooking/installed/include`, every `dpdk_*_LIBRARY` resolves under
  `_cooking/installed/lib`, configure exits 0.