### PR TITLE
reactor: export the shard's host cpu as a metric

### DIFF
--- a/include/seastar/core/smp.hh
+++ b/include/seastar/core/smp.hh
@@ -327,6 +327,7 @@ class smp : public std::enable_shared_from_this<smp> {
     static thread_local smp_message_queue**_qs;
     static thread_local std::thread::id _tmain;
     static inline thread_local smp* _this_smp = nullptr;
+    static inline thread_local int _pinned_cpu_id = -1;
     bool _using_dpdk = false;
     std::vector<unsigned> _shard_to_numa_node_mapping;
 
@@ -517,6 +518,12 @@ public:
     }
     static smp& this_smp() noexcept {
         return *_this_smp;
+    }
+    /// The host cpu this shard's thread is pinned to, or -1 if it is not
+    /// pinned - with --overprovisioned (thread-affinity disabled), or under
+    /// dpdk, which pins by itself.
+    static int pinned_cpu_id() noexcept {
+        return _pinned_cpu_id;
     }
 private:
     void start_all_queues();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2631,6 +2631,12 @@ void reactor::register_metrics() {
             sm::make_counter("polls", _polls, sm::description("Number of times pollers were executed")),
             sm::make_gauge("timers_pending", std::bind(&decltype(_timers)::size, &_timers), sm::description("Number of tasks in the timer-pending queue")),
             sm::make_gauge("utilization", [this] { return (1-_load)  * 100; }, sm::description("CPU utilization")),
+            // The value is 1 so that the cpu label can be applied to a host
+            // metric by joining it with this one using multiplication and
+            // "group_left" on (instance, cpu).
+            sm::make_gauge("location_info", [] { return 1; },
+                    sm::description("An info metric that exposes the shard's corresponding host cpu ID in the cpu label."),
+                    { sm::label_instance("cpu", smp::pinned_cpu_id()) }),
             sm::make_counter("cpu_busy_ms", [this] () -> int64_t { return total_busy_time() / 1ms; },
                     sm::description("Total cpu busy time in milliseconds")),
             sm::make_counter("sleep_time_ms_total", [this] () -> int64_t { return _total_sleep / 1ms; },
@@ -4162,6 +4168,7 @@ void smp::pin(unsigned cpu_id) {
         return;
     }
     pin_this_thread(cpu_id);
+    _pinned_cpu_id = cpu_id;
 }
 
 void smp::arrive_at_event_loop_end() {


### PR DESCRIPTION
Per-shard metrics cannot be correlated with the host's per-cpu counters, as nothing reports which cpu a shard's reactor runs on, and the mapping is not guessable: with --smp=4 on a 16 core machine shards 0-3 land on cpus 0, 2, 4 and 6.

Add reactor_location, a constant metric whose payload is its cpu label. Joining on the cpu gives a host counter a shard label, so it can be filtered and aggregated like any other per-shard metric:

    rate(node_cpu_seconds_total{mode="steal"}[2m])
        * on (instance, cpu) group_left(shard) scylla_reactor_location

smp::pin() records the cpu it pinned to, so the label reports what seastar decided rather than wherever the thread happens to sit when the metric is registered. It is -1 when the reactor is not pinned, which cannot be mistaken for a real cpu.