### PR TITLE
fstream: keep the write position aligned after a partial dma_write()

### DIFF
--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -462,8 +462,16 @@ private:
                 [this, pos, buf = std::move(buf), truncate, buf_size] (size_t size) mutable {
             // short write handling
             if (size < buf_size) {
-                buf.trim_front(size);
-                return do_put(pos + size, std::move(buf)).then([this, truncate] {
+                // A write completes a multiple of the disk alignment only when it
+                // goes through O_DIRECT; a buffered one (which is what the reactor
+                // does with the kernel page cache enabled) can complete any amount.
+                // Resume from the last aligned boundary, writing the partially
+                // completed block again: dma_write() requires an aligned position,
+                // and padding an unaligned tail as above would spill over the end
+                // of this request.
+                auto done = align_down<size_t>(size, _file.disk_write_dma_alignment());
+                buf.trim_front(done);
+                return do_put(pos + done, std::move(buf)).then([this, truncate] {
                     if (truncate) {
                         return _file.truncate(_pos);
                     }

--- a/tests/unit/fstream_test.cc
+++ b/tests/unit/fstream_test.cc
@@ -539,3 +539,37 @@ SEASTAR_TEST_CASE(test_close_error) {
 }
 
 #endif // SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
+
+// dma_write() may complete a request only partially. For O_DIRECT files the
+// completed amount is always a multiple of the disk write alignment, but for
+// buffered writes -- which is what the reactor does with the kernel page cache
+// enabled -- it can be anything. The output stream has to resume such a write
+// from an aligned position, otherwise it violates dma_write()'s alignment
+// requirement and writes zero padding past the end of the request.
+SEASTAR_TEST_CASE(test_fstream_short_write) {
+    return seastar::async([] {
+        constexpr size_t buffer_size = 8192;
+        // Enough to fill the stream buffer a few times and leave an unaligned
+        // tail for the final flush.
+        std::vector<char> data(3 * buffer_size + 1000);
+        for (size_t i = 0; i < data.size(); i++) {
+            data[i] = char(i % 251);
+        }
+
+        for (auto write_behind : {0u, 4u}) {
+            for (auto completed : {size_t(1), size_t(100), size_t(4095), size_t(4096), size_t(4097), buffer_size - 1}) {
+                auto mf = make_shared<mock_write_only_file>();
+                mf->complete_partially({completed, completed});
+
+                file_output_stream_options options;
+                options.buffer_size = buffer_size;
+                options.write_behind = write_behind;
+                auto out = make_file_output_stream(file(mf), options).get();
+                out.write(data.data(), data.size()).get();
+                out.close().get();
+
+                BOOST_REQUIRE_EQUAL(mf->contents(), std::string_view(data.data(), data.size()));
+            }
+        }
+    });
+}

--- a/tests/unit/mock_file.hh
+++ b/tests/unit/mock_file.hh
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#include <deque>
 #include <numeric>
+#include <string_view>
+#include <vector>
 
 #include <seastar/testing/seastar_test.hh>
 #include <seastar/core/file.hh>
@@ -111,6 +114,79 @@ public:
     virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent*) noexcept override {
         auto length = verify_read(offset, range_size);
         return make_ready_future<temporary_buffer<uint8_t>>(temporary_buffer<uint8_t>(length));
+    }
+};
+
+// A write-only file keeping its contents in memory, which can be told to
+// complete write requests only partially, the way a buffered (non-O_DIRECT)
+// write may do. Every request is checked to start at a DMA-aligned position,
+// which is what a writer using dma_write() has to guarantee.
+class mock_write_only_file final : public file_impl {
+    std::vector<char> _data;
+    std::deque<size_t> _partial_writes;
+    bool _closed = false;
+public:
+    // The next write requests complete only the given number of bytes each.
+    // Once the list is exhausted, writes complete in full again.
+    void complete_partially(std::initializer_list<size_t> lengths) {
+        _partial_writes.insert(_partial_writes.end(), lengths.begin(), lengths.end());
+    }
+    std::string_view contents() const noexcept {
+        return {_data.data(), _data.size()};
+    }
+
+    virtual future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent*) noexcept override {
+        BOOST_CHECK(!_closed);
+        BOOST_CHECK_EQUAL(pos % _disk_write_dma_alignment, 0u);
+        auto written = len;
+        if (!_partial_writes.empty()) {
+            written = std::min(len, _partial_writes.front());
+            _partial_writes.pop_front();
+        }
+        if (_data.size() < pos + written) {
+            _data.resize(pos + written);
+        }
+        std::copy_n(static_cast<const char*>(buffer), written, _data.begin() + pos);
+        return make_ready_future<size_t>(written);
+    }
+    virtual future<size_t> write_dma(uint64_t, std::vector<iovec>, io_intent*) noexcept override {
+        return make_exception_future<size_t>(std::bad_function_call());
+    }
+    virtual future<size_t> read_dma(uint64_t, void*, size_t, io_intent*) noexcept override {
+        return make_exception_future<size_t>(std::bad_function_call());
+    }
+    virtual future<size_t> read_dma(uint64_t, std::vector<iovec>, io_intent*) noexcept override {
+        return make_exception_future<size_t>(std::bad_function_call());
+    }
+    virtual future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t, size_t, io_intent*) noexcept override {
+        return make_exception_future<temporary_buffer<uint8_t>>(std::bad_function_call());
+    }
+    virtual future<> flush() noexcept override {
+        return make_ready_future<>();
+    }
+    virtual future<struct stat> stat() noexcept override {
+        return make_exception_future<struct stat>(std::bad_function_call());
+    }
+    virtual future<> truncate(uint64_t length) noexcept override {
+        _data.resize(length);
+        return make_ready_future<>();
+    }
+    virtual future<> discard(uint64_t, uint64_t) noexcept override {
+        return make_exception_future<>(std::bad_function_call());
+    }
+    virtual future<> allocate(uint64_t, uint64_t) noexcept override {
+        return make_exception_future<>(std::bad_function_call());
+    }
+    virtual future<uint64_t> size() noexcept override {
+        return make_ready_future<uint64_t>(_data.size());
+    }
+    virtual future<> close() noexcept override {
+        BOOST_CHECK(!_closed);
+        _closed = true;
+        return make_ready_future<>();
+    }
+    virtual subscription<directory_entry> list_directory(std::function<future<> (directory_entry de)>) override {
+        throw std::bad_function_call();
     }
 };
 


### PR DESCRIPTION
`file_data_sink_impl::do_put()` resumes a partially completed write at `pos + size`, where `size` is what `dma_write()` reported written. That position is DMA-aligned only if the write completed a whole number of blocks. O_DIRECT transfers in whole blocks, so it always does; a buffered write does not, and `--kernel-page-cache 1` (passed by dtest, and in the reporter's trigger list) makes `open_file_dma()` skip `O_DIRECT` while everything above it still speaks the aligned `dma_write()` API. The retry then asserts:

```
seastar/src/core/fstream.cc:434: future<> seastar::file_data_sink_impl::do_put(uint64_t, temporary_buffer<char>): Assertion `!(pos & (_file.disk_write_dma_alignment() - 1))' failed.
```

Getting past the assertion would be worse than the crash: the retry buffer would no longer be a multiple of the alignment, so `do_put()` would zero-pad it and write past the end of the request, over a concurrent `write_behind` write.

Resume from the last aligned boundary instead and write the partially completed block again. Rewriting it is harmless - same bytes, and `commit_size()` only grows - and since `buf_size` is always a multiple of the alignment, so is `buf_size - done`, so the retry can never take the zero-padding path. A write completing less than one block still makes no progress and is simply retried, as was already the case for one completing nothing at all.

### Test

`test_fstream_short_write`, on a new `mock_write_only_file` that completes write requests only partially and checks every request starts DMA-aligned: it writes `3 * buffer_size + 1000` bytes for several partially-completed sizes (1, 100, 4095, 4096, 4097, `buffer_size - 1`), each applied to two consecutive requests, with and without `write_behind`, and compares the resulting contents.

It reproduces the crash above without the fix; with it, `fstream`, `output_stream`, `file_io` and `file_utils` pass.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1646