### PR TITLE
scripts: prevent debuginfod lookups from hanging addr2line

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -20,6 +20,7 @@
 
 import bisect
 import collections
+import os
 import re
 import sys
 import subprocess
@@ -66,6 +67,7 @@ class Addr2Line:
         binary: str,
         concise: bool = False,
         cmd_path: str = "llvm-addr2line",
+        use_debuginfod: bool = False,
     ):
         self._parent = parent
         self._binary = binary
@@ -78,6 +80,10 @@ class Addr2Line:
         if s.find('ELF') >= 0 and s.find('debug_info', len(self._binary)) < 0:
             print('{}'.format(s))
 
+        env = dict(os.environ)
+        if not use_debuginfod:
+            env.pop('DEBUGINFOD_URLS', None)
+
         args = [cmd_path, f"-{'C' if not concise else ''}fpia", "-e", self._binary]
         self._parent.debug(f"Addr2line invoking: {' '.join(args)}")
         self._input_proc = subprocess.Popen(
@@ -85,6 +91,7 @@ class Addr2Line:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             universal_newlines=True,
+            env=env,
         )
         if concise:
             self._output_proc = subprocess.Popen(
@@ -356,6 +363,7 @@ class BacktraceResolver:
         cmd_path: str = 'addr2line',
         debug: bool = False,
         timing: bool = False,
+        use_debuginfod: bool = False,
     ):
         self._debug = debug
         self._timing = timing
@@ -375,6 +383,7 @@ class BacktraceResolver:
         self._verbose = verbose
         self._concise = concise
         self._cmd_path = cmd_path
+        self._use_debuginfod = use_debuginfod
         self._known_modules: dict[str, Union[Addr2Line, KernelResolver]] = {}
         self._get_resolver_for_module(
             self._executable
@@ -403,7 +412,13 @@ class BacktraceResolver:
             if module == KERNEL_MODULE:
                 resolver = KernelResolver(self, kallsyms=self._kallsyms)
             else:
-                resolver = Addr2Line(self, module, self._concise, self._cmd_path)
+                resolver = Addr2Line(
+                    self,
+                    module,
+                    self._concise,
+                    self._cmd_path,
+                    use_debuginfod=self._use_debuginfod,
+                )
             self.debug(f'Adding resolver {resolver} for module: {module}')
             self._known_modules[module] = resolver
         return self._known_modules[module]

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -456,6 +456,16 @@ There are three operational modes:
     )
 
     cmdline_parser.add_argument(
+        '--use-debuginfod',
+        action='store_true',
+        default=False,
+        help='Let the symbolizer download missing debug info via DEBUGINFOD_URLS.'
+        ' Disabled by default: a lookup that stalls takes the resolver down with'
+        ' it, because the dummy address that terminates each frame is resolved the'
+        ' same way and so never replies.',
+    )
+
+    cmdline_parser.add_argument(
         '-v',
         '--verbose',
         action='store_true',
@@ -513,6 +523,7 @@ There are three operational modes:
         cmd_path=args.addr2line,
         debug=args.debug,
         timing=args.timing,
+        use_debuginfod=args.use_debuginfod,
     ) as resolve:
         resolve_start = resolve.timing_now()
         for line in lines:

--- a/scripts/stall-analyser.py
+++ b/scripts/stall-analyser.py
@@ -52,6 +52,10 @@ def get_command_line_parser():
     parser.add_argument('-a', '--addr2line', default='llvm-addr2line',
                         help='The path or name of the addr2line command, which should behave as and '
                             'accept the same options as binutils addr2line or llvm-addr2line (the default).')
+    parser.add_argument('--use-debuginfod', action='store_true', default=False,
+                        help='Let the symbolizer download missing debug info via'
+                             ' DEBUGINFOD_URLS. Disabled by default: a lookup that'
+                             ' stalls hangs the resolver.')
     parser.add_argument('file', nargs='?',
                         type=argparse.FileType('r'),
                         default=sys.stdin,
@@ -412,7 +416,8 @@ def main():
     if args.executable:
         resolver = addr2line.BacktraceResolver(executable=args.executable,
                                                concise=not args.full_function_names,
-                                               cmd_path=args.addr2line)
+                                               cmd_path=args.addr2line,
+                                               use_debuginfod=args.use_debuginfod)
     if args.format == 'graph':
         render = Graph(resolver)
     else:


### PR DESCRIPTION
`seastar-addr2line` and `stall-analyser.py` appear to hang outright for anyone who has `DEBUGINFOD_URLS` set, which some distributions arrange out of the box: on Ubuntu the `elfutils` package ships `/etc/debuginfod/elfutils.urls` along with the profile snippet that exports it.

The cause is an interaction between debuginfod and the way these scripts read `addr2line` output. `llvm-addr2line` is a symlink to `llvm-symbolizer`, which consults `DEBUGINFOD_URLS` and tries to download the debug info for any module it cannot find it for locally. Where the server is unreachable or filtered, each attempt blocks for `DEBUGINFOD_TIMEOUT` (default 90 seconds) before giving up.

That is worse than merely slow. Every address is bracketed with a dummy one whose invalid-address reply serves as the end-of-frame marker, so while a lookup is outstanding the marker does not arrive, `Addr2Line.__init__`'s liveness probe blocks in `readline()`, and the script prints nothing at all rather than looking like it is waiting on the network. A resolver is created per module, so a backtrace crossing several modules without local debug info pays the timeout once per module, silently. Any module lacking local debug info triggers it, which covers both the stripped binaries these scripts exist to symbolize and the system libraries a backtrace passes through.

The fix hands the `addr2line` subprocess an environment with `DEBUGINFOD_URLS` removed. Remote debug info is occasionally what you want, for frames in system libraries that are not installed locally, so a `--use-debuginfod` flag on both scripts (and a `use_debuginfod` argument on `BacktraceResolver` and `Addr2Line` for programmatic callers) restores the previous behaviour on request. The demangler subprocess keeps the inherited environment, since `c++filt` does no symbol lookup of its own.

Note this is a distinct failure from the ones addressed in 4e6ce2d27 and 8ca37ec70, which corrected what the terminating reply looks like. Here the reply is matched correctly but never arrives in time.

Measured with `llvm-addr2line` 22 against a stripped binary with no local debug info: 90s before the change, 0.05s after. With `--use-debuginfod` and `DEBUGINFOD_TIMEOUT=5` it takes 5.05s, confirming the opt-out still passes the variable through. The existing self-tests pass.