### PR TITLE
httpd: reject requests with both Transfer-Encoding and Content-Length

### DIFF
--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -157,6 +157,7 @@ future<> connection::read() {
 static input_stream<char> make_content_stream(http::request* req, input_stream<char>& buf) {
     // Create an input stream based on the requests body encoding or lack thereof
     if (seastar::internal::case_insensitive_cmp()(req->get_header("Transfer-Encoding"), "chunked")) {
+        req->content_length = 0;
         return input_stream<char>(data_source(std::make_unique<internal::chunked_source_impl>(buf, req->chunk_extensions, req->trailing_headers)));
     } else {
         return input_stream<char>(data_source(std::make_unique<internal::content_length_source_impl>(buf, req->content_length)));
@@ -224,6 +225,11 @@ future<> connection::read_one() {
                 req->_version = "1.1";
             }
             generate_error_reply_and_close(std::move(req), http::reply::status_type::bad_request, "Can't parse the request");
+            return make_ready_future<>();
+        }
+
+        if (req->_headers.contains("Transfer-Encoding") && req->_headers.contains("Content-Length")) {
+            generate_error_reply_and_close(std::move(req), http::reply::status_type::bad_request, "Conflicting Transfer-Encoding and Content-Length headers");
             return make_ready_future<>();
         }
 

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1866,6 +1866,27 @@ SEASTAR_TEST_CASE(test_bad_chunk_length) {
     }, {"400 Bad Request", "Can't parse chunk size and extensions"}, true, new echo_stream_handler());
 }
 
+SEASTAR_TEST_CASE(test_conflicting_transfer_encoding_and_content_length) {
+    return check_http_reply({
+        "POST /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n",
+        "5\r\nhello\r\n",
+        "0\r\n\r\n"
+    }, {"400 Bad Request", "Connection: close", "Conflicting Transfer-Encoding and Content-Length headers"}, false, new echo_string_handler()).then([] {
+        return check_http_reply({
+            "POST /test HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n",
+            "5\r\nhello\r\n",
+            "0\r\n\r\n"
+        }, {"400 Bad Request", "Connection: close", "Conflicting Transfer-Encoding and Content-Length headers"}, true, new echo_stream_handler());
+    }).then([] {
+        // Also test case-insensitivity of header names
+        return check_http_reply({
+            "POST /test HTTP/1.1\r\nHost: test\r\ntransfer-encoding: chunked\r\ncontent-length: 1\r\n\r\n",
+            "5\r\nhello\r\n",
+            "0\r\n\r\n"
+        }, {"400 Bad Request", "Connection: close", "Conflicting Transfer-Encoding and Content-Length headers"}, false, new echo_string_handler());
+    });
+}
+
 SEASTAR_TEST_CASE(test_close_response) {
     return check_http_reply({
         "GET /test HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"


### PR DESCRIPTION
### Problem

Fixes #3648

Seastar's HTTP server previously accepted requests containing both `Transfer-Encoding: chunked` and `Content-Length: <value>`. When receiving both headers:
- `make_content_stream()` selected the chunked decoder, but `request::content_length` retained the parsed `Content-Length` value.
- This exposed applications to inconsistent framing metadata and potential HTTP request smuggling (HRS) / desync vulnerabilities.
- In downstream applications like ScyllaDB Alternator, this enabled an unauthenticated memory-admission bypass: a client could send `Content-Length: 1` with a chunked body, reserving only 1 byte during admission control while delivering up to 16 MiB.

### Standards Compliance (RFC 9112)

According to **RFC 9112 (HTTP/1.1)**:
- **§6.1 & §6.2**: *"A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."*
- **§6.1**: *"A server MAY reject a request that contains both Content-Length and Transfer-Encoding or process such a request in accordance with the Transfer-Encoding alone. Regardless, the server MUST close the connection after responding to such a request to avoid the potential attacks."*
- **§6.3 (Item 3)**: *"If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length. Such a message might indicate an attempt to perform request smuggling (Section 11.2) or response splitting (Section 11.1) and ought to be handled as an error."*

### Solution

1. **Reject Conflicting Headers in `connection::read_one()`**:
   Before processing the body, check if both `Transfer-Encoding` and `Content-Length` headers are present. If so, immediately respond with `400 Bad Request`, add `Connection: close`, and close the connection (`_done = true`).
2. **Defensive Length Reset in `make_content_stream()`**:
   Inside `make_content_stream()`, ensure `req->content_length = 0` whenever `Transfer-Encoding: chunked` is selected so no downstream handler can observe conflicting length metadata on chunked streams.

### Testing

Added regression test `test_conflicting_transfer_encoding_and_content_length` in `tests/unit/httpd_test.cc`:
- Asserts that requests containing both headers are rejected with `400 Bad Request` and `Connection: close`.
- Tests across both non-streaming (`streaming = false`) and streaming (`streaming = true`) server modes.
- Tests case-insensitive header name matching (`transfer-encoding` and `content-length`).
