### PR TITLE
rpc_test: tolerate a cut-short peer drain in test_stream_send_after_stream_close

### DIFF
--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -1985,7 +1985,14 @@ SEASTAR_THREAD_TEST_CASE(test_stream_send_after_stream_close) {
             server_done = seastar::async([sink, source] () mutable {
                 sink("seastar").get();
                 sink.close().get();
-                while (source().get()) {
+                try {
+                    while (source().get()) {
+                    }
+                } catch (const rpc::stream_closed&) {
+                    // Closing the second half of a stream stops its
+                    // connection, and a stream connection that stops aborts
+                    // its receive queue, so this drain can be cut short by the
+                    // client's teardown rather than reach eof.
                 }
             });
             return sink;


### PR DESCRIPTION
`test_stream_send_after_stream_close`, added in #3664, is flaky. Its peer drains its source while the test tears the stream connection down, and the two race: closing the second half of a stream stops its connection, and a stream connection that stops aborts its receive queue, so the peer's source can fail with `stream_closed` instead of reaching eof. The peer's drain then throws out of the test:

```
unknown location(0): fatal error: in "test_stream_send_after_stream_close":
seastar::rpc::stream_closed: rpc stream was closed by peer
```

It showed up on an unrelated CI run. It reproduces 8 times out of 40 in the release build with `-c2`, and never in the debug build, which is why it was missed.

Being cut short that way is expected for a peer whose stream is torn down under it, and it is not what this test is about, so the peer's drain now catches it. The test's own check — that nothing was written to the stream's output after it was closed — is unaffected: it is decided while the connection is parked, before any of this.

Verification, per configuration, 100 runs each:

| | release -c1 | release -c2 | debug (ASan/UBSan) -c2 |
| --- | --- | --- | --- |
| before this patch | passes | **8/40 fail** | passes |
| after this patch | 100/100 pass | 100/100 pass | 100/100 pass |

The test still catches what it is for: with `rpc: refuse to send on a stream connection once stream_close() has begun` reverted, it fails 30 out of 30 runs in release `-c2` (the unpatched test failed 24 of those 30 for the right reason and 6 on the race above).

The full `rpc_test` suite passes on 1 and 2 shards in both builds.

Refs #3663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
