### PR TITLE
prometheus: cache per-series aggregation key instead of rebuilding it every scrape

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -358,6 +358,42 @@ public:
 using value_map = std::map<sstring, metric_family>;
 
 /*!
+ * \brief build the prometheus aggregate-by-labels key for a label set.
+ *
+ * Concatenates the labels() entries not in aggregate_labels as "name\nvalue\n".
+ * Shared by metric_series_metadata's cache and prometheus::label_key so both
+ * produce identical keys.
+ */
+inline sstring build_aggregation_key(const labels_type& labels, const std::vector<std::string>& aggregate_labels) {
+    sstring key;
+    for (auto& [lkey, lvalue] : labels) {
+        if (std::find(aggregate_labels.begin(), aggregate_labels.end(), lkey) == aggregate_labels.end()) {
+            key += lkey;
+            key += "\n";
+            key += lvalue.value();
+            key += "\n";
+        }
+    }
+    return key;
+}
+
+/*!
+ * \brief identify which aggregate_labels configuration a cached aggregation key was built from.
+ *
+ * The scrape-wide aggregate_labels list is picked from one shard's family metadata
+ * (metric_family_iterator) while series metadata (and its cache) comes from every shard,
+ * so a per-series cache can be stale relative to the current scrape's config. This hash
+ * lets consumers cheaply detect that mismatch instead of comparing the full vectors.
+ */
+inline size_t hash_aggregate_labels(const std::vector<std::string>& aggregate_labels) {
+    size_t h = 0;
+    for (auto& l : aggregate_labels) {
+        boost::hash_combine(h, std::hash<std::string>{}(l));
+    }
+    return h;
+}
+
+/*!
  * \brief Subset of the per series metadata that is shared via get_values to other shards.
  *
  * Allows omitting metadata that is already stored elsewhere or not needed by
@@ -370,11 +406,35 @@ class metric_series_metadata {
     // metric name separately. metric_family_info only stores the merged and
     // filtered name so we have to duplicate it here.
     metric_id _id;
+    // Cache for the prometheus aggregate-by-labels feature: labels() with aggregate_labels
+    // removed, precomputed once when metadata is rebuilt instead of on every scrape.
+    // Heap-allocated so non-aggregated series (the common case) pay only a null pointer.
+    struct aggregation_cache {
+        sstring aggregation_key;
+        size_t aggregation_key_hash = 0;
+        // hash of the aggregate_labels list this key was built from; lets a consumer
+        // detect a stale cache from a different (e.g. other shard's) configuration.
+        size_t config_hash = 0;
+    };
+    std::unique_ptr<aggregation_cache> _aggregation_cache;
     skip_when_empty _should_skip_when_empty;
+
+    void compute_aggregation_cache(const std::vector<std::string>& aggregate_labels) {
+        if (aggregate_labels.empty()) {
+            return;
+        }
+        auto cache = std::make_unique<aggregation_cache>();
+        cache->aggregation_key = build_aggregation_key(_id.labels(), aggregate_labels);
+        cache->aggregation_key_hash = std::hash<std::string_view>{}(std::string_view(cache->aggregation_key));
+        cache->config_hash = hash_aggregate_labels(aggregate_labels);
+        _aggregation_cache = std::move(cache);
+    }
 public:
     metric_series_metadata() = default;
-    metric_series_metadata(metric_id id, skip_when_empty should_skip_when_empty)
+    metric_series_metadata(metric_id id, skip_when_empty should_skip_when_empty,
+            const std::vector<std::string>& aggregate_labels)
         : _id(std::move(id)), _should_skip_when_empty(should_skip_when_empty) {
+        compute_aggregation_cache(aggregate_labels);
     }
 
     metric_series_metadata(const metric_series_metadata&) = delete;
@@ -397,6 +457,30 @@ public:
 
     group_name_type name() const {
         return _id.name();
+    }
+
+    // True once compute_aggregation_cache() has populated a cache, i.e. this series'
+    // family had non-empty aggregate_labels as of the last metadata rebuild. Callers
+    // that can race a cross-shard aggregate_labels change should check this, and that
+    // aggregation_key_config_hash() matches the current scrape's config, before
+    // calling the accessors below rather than assume it's always set and current.
+    bool has_aggregation_cache() const {
+        return static_cast<bool>(_aggregation_cache);
+    }
+
+    // Only valid when has_aggregation_cache() is true.
+    const sstring& aggregation_key() const {
+        return _aggregation_cache->aggregation_key;
+    }
+
+    size_t aggregation_key_hash() const {
+        return _aggregation_cache->aggregation_key_hash;
+    }
+
+    // hash of the aggregate_labels list the cached key was built from. Only valid
+    // when has_aggregation_cache() is true.
+    size_t aggregation_key_config_hash() const {
+        return _aggregation_cache->config_hash;
     }
 };
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -479,7 +479,7 @@ void impl::update_metrics_if_needed() {
             _current_metrics[i].clear();
             for (auto&& m : mf.second) {
                 if (m.second && m.second->is_enabled()) {
-                    metrics.emplace_back(m.second->info().id, m.second->info().should_skip_when_empty);
+                    metrics.emplace_back(m.second->info().id, m.second->info().should_skip_when_empty, mf.second.info().aggregate_labels);
                     _current_metrics[i].emplace_back(m.second->get_function());
                 }
             }
@@ -598,22 +598,9 @@ void impl::set_metric_family_configs(const std::vector<metric_family_config>& fa
         }
     }
 
-    if (!_metadata) {
-        // The metadata structure may not have been built yet,
-        // or it may rebuild right now, in this case just return
-        // and it will be updated the next time, setting the dirty to true
-        // is just in case we are somehow in the middle of rebuilding the
-        // metadata.
-        dirty();
-        return;
-    }
-    for (auto& mf_metadata: *_metadata) {
-        for  (const auto& fc : family_config) {
-            if (fc.name == mf_metadata.mf.name || fc.regex_name.match(mf_metadata.mf.name)) {
-                mf_metadata.mf.aggregate_labels = fc.aggregate_labels;
-            }
-        }
-    }
+    // Per-series metadata caches an aggregation key derived from aggregate_labels;
+    // force a rebuild so it doesn't go stale.
+    dirty();
 }
 }
 

--- a/src/core/prometheus-impl.hh
+++ b/src/core/prometheus-impl.hh
@@ -54,18 +54,17 @@ struct label_key {
     }
 
     void construct(const metrics::impl::labels_type& labels, const label_list& aggr_labels) {
-        key.clear();
-        for (auto& [lkey, lvalue] : labels) {
-            std::string_view key_view = lkey;
-            if (!internal::is_aggregated(aggr_labels, key_view)) {
-                key += key_view;
-                key += '\n';
-                key += lvalue.value();
-                key += '\n';
-            }
-        }
+        auto k = metrics::impl::build_aggregation_key(labels, aggr_labels);
+        key.assign(k.data(), k.size());
+        hash = std::hash<std::string_view>{}(std::string_view(key));
+    }
 
-        hash = std::hash<std::string>{}(key);
+    // Fast path: adopt a key/hash that was already computed once, e.g. by
+    // metrics::impl::metric_series_metadata when metadata was last rebuilt, instead of
+    // re-filtering labels and rebuilding the key string on every scrape.
+    void assign(std::string_view precomputed_key, size_t precomputed_hash) {
+        key.assign(precomputed_key);
+        hash = precomputed_hash;
     }
 
     bool operator==(const label_key& o) const noexcept {
@@ -114,10 +113,25 @@ public:
     using label_list_type = std::vector<std::string>;
     using map_type = std::unordered_map<label_key, labels_value>;
     const label_list_type& _labels_to_aggregate_by;
+    // identifies this scrape's aggregate_labels config, to detect a per-series cache
+    // built under a different (e.g. other shard's, mid-reconfiguration) config.
+    size_t _labels_to_aggregate_by_hash;
     label_key scratch_key;
     map_type _values;
+
+    labels_type build_aggregated_labels(const labels_type& input_labels) const {
+        labels_type labels;
+        for (auto& l : input_labels) {
+            if (!internal::is_aggregated(_labels_to_aggregate_by, l.first)) {
+                labels.insert(l);
+            }
+        }
+        return labels;
+    }
 public:
-    metric_aggregate_by_labels(const label_list_type& labels) : _labels_to_aggregate_by(labels) {
+    metric_aggregate_by_labels(const label_list_type& labels)
+        : _labels_to_aggregate_by(labels)
+        , _labels_to_aggregate_by_hash(metrics::impl::hash_aggregate_labels(labels)) {
     }
     /*!
      * \brief add a metric
@@ -132,13 +146,35 @@ public:
         scratch_key.construct(input_labels, _labels_to_aggregate_by);
         auto i = _values.find(scratch_key);
         if (i == _values.end()) {
-            labels_type labels;
-            for (auto& l : input_labels) {
-                if (!internal::is_aggregated(_labels_to_aggregate_by, l.first)) {
-                    labels.insert(l);
-                }
-            }
-            _values.emplace(scratch_key, labels_value{std::move(labels), m});
+            _values.emplace(scratch_key, labels_value{build_aggregated_labels(input_labels), m});
+        } else {
+            i->second.m += m;
+        }
+    }
+
+    /*!
+     * \brief add a metric using a precomputed aggregation key
+     *
+     * Same as add() above, but uses the aggregation key already cached on value_info (see
+     * metrics::impl::metric_series_metadata) instead of rebuilding it from the full label
+     * set on every call. The post-aggregation label set is only ever needed once per unique
+     * output group, so it's built here on a cache miss rather than cached per input series.
+     * This is the path used by the prometheus scrape handlers; the label-based add() above
+     * is kept for direct testing of this class and any other caller.
+     */
+    void add(const seastar::metrics::impl::metric_value& m, const seastar::metrics::impl::metric_series_metadata& value_info) noexcept {
+        if (value_info.has_aggregation_cache() && value_info.aggregation_key_config_hash() == _labels_to_aggregate_by_hash) [[likely]] {
+            scratch_key.assign(value_info.aggregation_key(), value_info.aggregation_key_hash());
+        } else {
+            // Rare: either this shard's metadata hasn't picked up an aggregate_labels
+            // change yet (no cache), or it rebuilt under a different config than the
+            // one driving this scrape (stale cache, cross-shard reconfiguration race).
+            // Recompute instead of trusting a cache that isn't there or doesn't match.
+            scratch_key.construct(value_info.labels(), _labels_to_aggregate_by);
+        }
+        auto i = _values.find(scratch_key);
+        if (i == _values.end()) {
+            _values.emplace(scratch_key, labels_value{build_aggregated_labels(value_info.labels()), m});
         } else {
             i->second.m += m;
         }

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -939,7 +939,7 @@ future<> write_context::write_text_representation() {
                     found = true;
                 }
                 if (should_aggregate) {
-                    aggregated_values.add(value, value_info.labels());
+                    aggregated_values.add(value, value_info);
                 } else if (value.type() == mi::data_type::SUMMARY) {
                     write_summary(s, ctx, name, value.get_histogram(), value_info.labels());
                 } else if (value.type() == mi::data_type::HISTOGRAM) {
@@ -990,7 +990,7 @@ future<> write_context::write_protobuf_representation() {
                 return;
             }
             if (should_aggregate) {
-                aggregated_values.add(value, value_info.labels());
+                aggregated_values.add(value, value_info);
             } else {
                 fill_metric(mtf, value, value_info.labels(), ctx);
                 empty_metric = false;

--- a/tests/unit/prometheus_text_test.cc
+++ b/tests/unit/prometheus_text_test.cc
@@ -193,6 +193,25 @@ struct prometheus_test_fixture {
             fmt::format("actual output doesn't match expected\nexpected output:\n{}\nactual output:\n{}",
             expected, ss.str()));
     }
+
+    // Like run_metrics_test, but doesn't (re)register any metrics: lets a caller scrape
+    // multiple times against whatever is currently registered, to exercise cache
+    // invalidation across registration changes between scrapes.
+    static future<sstring> scrape_aggregated() {
+        std::stringstream ss;
+        output_stream<char> out{data_sink{std::make_unique<testing::memory_data_sink_impl>(ss, 10)}};
+        using access = prometheus::details::test_access;
+        co_await access{}.write_body({},
+            sp::details::write_body_args{
+                .filter = always_true,
+                .family_filter = [](std::string_view) { return true; },
+                .use_protobuf_format = false,
+                .show_help = false,
+                .enable_aggregation = true
+            },
+            std::move(out));
+        co_return sstring(ss.str());
+    }
 };
 
 SEASTAR_TEST_CASE(test_basic_counter) {
@@ -676,6 +695,106 @@ SEASTAR_TEST_CASE(test_metric_aggregate_by_labels_same_metric_added_twice) {
     BOOST_REQUIRE_EQUAL(it->second.m.d(), 250);
 
     return make_ready_future<>();
+}
+
+// metric_aggregate_by_labels::add(value, value_info) builds the post-aggregation label set
+// lazily on its cache-miss path (first series seen for a given aggregation key) and just
+// sums on a cache-hit (a later series sharing that key). Exercise both: two series share
+// "extra=a" (miss then hit into one group) and a third has "extra=b" (a second, independent
+// miss) so a bug that mixes up the hit and miss paths - e.g. a hit rebuilding/overwriting
+// labels from the wrong series, or a miss reusing a stale key from another group - would
+// show up as wrong labels or a wrong sum on one of the two groups.
+SEASTAR_TEST_CASE(test_aggregation_cache_hit_and_miss) {
+    co_await smp::invoke_on_all([] {
+        remove_existing_metrics();
+    });
+
+    sm::metric_groups test_metrics;
+    sm::label extra("extra");
+    // "sub" only exists to give the two "extra=a" series distinct pre-aggregation identities
+    // (a single-shard test can't register two series with otherwise-identical labels); it's
+    // aggregated away too, so both still collapse into one "extra=a" output group.
+    sm::label sub("sub");
+
+    auto impl_a1 = sm::make_counter("metric", sm::description("d"), {extra("a"), sub("x")}, [] { return 1; });
+    impl_a1.aggregate({sm::shard_label, sub});
+    auto impl_a2 = sm::make_counter("metric", sm::description("d"), {extra("a"), sub("y")}, [] { return 2; });
+    impl_a2.aggregate({sm::shard_label, sub});
+    auto impl_b = sm::make_counter("metric", sm::description("d"), {extra("b"), sub("x")}, [] { return 5; });
+    impl_b.aggregate({sm::shard_label, sub});
+    test_metrics.add_group("group", {impl_a1, impl_a2, impl_b});
+
+    auto result = co_await prometheus_test_fixture::scrape_aggregated();
+    BOOST_REQUIRE_MESSAGE(result.find(R"(seastar_group_metric{extra="a"} 3)") != sstring::npos, result);
+    BOOST_REQUIRE_MESSAGE(result.find(R"(seastar_group_metric{extra="b"} 5)") != sstring::npos, result);
+}
+
+// The per-series aggregation key (see metric_series_metadata::aggregation_key()) is cached
+// when metadata is rebuilt, not on every scrape. These tests prove the cache is correctly
+// regenerated when the registration set changes: a metric is added or removed after an
+// initial scrape, and a following scrape reflects the new set.
+SEASTAR_TEST_CASE(test_aggregation_cache_invalidated_on_new_registration) {
+    co_await smp::invoke_on_all([] {
+        remove_existing_metrics();
+    });
+
+    sm::metric_groups test_metrics;
+    sm::label extra("extra");
+
+    auto impl_a = sm::make_counter("metric", sm::description("d"), {extra("a")}, [] { return 1; });
+    impl_a.aggregate({sm::shard_label});
+    test_metrics.add_group("group", {impl_a});
+
+    auto first = co_await prometheus_test_fixture::scrape_aggregated();
+    BOOST_REQUIRE_MESSAGE(first.find(R"(seastar_group_metric{extra="a"} 1)") != sstring::npos, first);
+    BOOST_REQUIRE_MESSAGE(first.find("extra=\"b\"") == sstring::npos, first);
+
+    // Register a second series in the same (aggregated) family after the cache for the
+    // first scrape was already built; a stale cache would keep reporting only "a".
+    auto impl_b = sm::make_counter("metric", sm::description("d"), {extra("b")}, [] { return 2; });
+    impl_b.aggregate({sm::shard_label});
+    test_metrics.add_group("group", {impl_b});
+
+    auto second = co_await prometheus_test_fixture::scrape_aggregated();
+    BOOST_REQUIRE_MESSAGE(second.find(R"(seastar_group_metric{extra="a"} 1)") != sstring::npos, second);
+    BOOST_REQUIRE_MESSAGE(second.find(R"(seastar_group_metric{extra="b"} 2)") != sstring::npos, second);
+
+    // Unregistering everything should also invalidate the cache: a following scrape must
+    // not keep reporting the now-removed series.
+    test_metrics.clear();
+    auto third = co_await prometheus_test_fixture::scrape_aggregated();
+    BOOST_REQUIRE_MESSAGE(third.find("seastar_group_metric") == sstring::npos, third);
+}
+
+// metric_family_iterator (src/core/prometheus.cc) picks a single shard's family metadata
+// as the scrape-wide aggregate_labels config, while series metadata (and its per-series
+// aggregation key cache) comes from every shard independently. During a cross-shard
+// aggregate_labels reconfiguration, two shards can both have has_aggregation_cache() ==
+// true but built from DIFFERENT configs. metric_aggregate_by_labels::add() must detect
+// that mismatch (via aggregation_key_config_hash()) and recompute rather than trust a
+// stale cached key. A genuine multi-shard race isn't reproducible in this single-process
+// test binary, so this exercises the comparison directly: a value_info whose cache was
+// built under an old config must not be trusted by an aggregator using a new one.
+BOOST_AUTO_TEST_CASE(test_aggregation_cache_stale_config_not_trusted) {
+    mi::labels_type labels{{"extra", mi::labels_type::mapped_type("a")}, {"shard", mi::labels_type::mapped_type("0")}};
+    auto labels_ref = make_lw_shared<const mi::labels_type>(labels);
+    mi::metric_id id("group", "metric", labels_ref);
+
+    // Cache built as if this shard's family metadata still had the OLD config ({"shard"}).
+    mi::metric_series_metadata stale(id, sm::skip_when_empty::no, {"shard"});
+    BOOST_REQUIRE(stale.has_aggregation_cache());
+
+    // The scrape driving this add() call aggregates by "extra" instead.
+    labels_list_type current_config{"extra"};
+    sp::metric_aggregate_by_labels aggregator(current_config);
+    aggregator.add(mi::metric_value{}, stale);
+
+    // Had the stale "shard"-config cache been trusted, "shard" would still be present in
+    // the output labels and "extra" would not have been aggregated away.
+    BOOST_REQUIRE_EQUAL(aggregator.get_values().size(), 1u);
+    auto& out_labels = aggregator.get_values().begin()->second.labels;
+    BOOST_REQUIRE(out_labels.find("extra") == out_labels.end());
+    BOOST_REQUIRE(out_labels.find("shard") != out_labels.end());
 }
 
 // Tests for family_filter functionality


### PR DESCRIPTION
## Motivation
`metric_aggregate_by_labels::add()` rebuilt a reduced label key (filtering out the aggregate-by labels, concatenating name+value pairs, hashing) for every metric instance on every Prometheus scrape, even though a series' label set and its family's `aggregate_labels` are stable between scrapes.

## Change
Precompute the aggregation key and post-aggregation label set once in `metric_series_metadata`, when metadata is (re)built (`impl::update_metrics_if_needed`, gated by the existing `_dirty` mechanism). A scrape now reuses the cached key via a new `metric_aggregate_by_labels::add()` overload instead of rebuilding it; the original `add(value, labels_type)` is unchanged and still used directly by unit tests.

`set_metric_family_configs` used to patch `aggregate_labels` on an already-built metadata in place without going through `_dirty`, which would have left the new per-series cache stale; it now calls `dirty()` so the same regeneration path that rebuilds the cache also covers this.

Each cached entry also stores a hash of the `aggregate_labels` config it was built from, and the scrape only trusts a cached key when that hash matches the current scrape's config — otherwise it falls back to rebuilding the key on the spot. This covers a cross-shard race: `aggregate_labels` changes are applied per-shard, non-atomically, so a scrape could otherwise combine keys built under different label sets from different shards.

## Results
`metrics_perf`, master vs. this branch, release build, quiet machine:

| Test | inst/op: master → PR | allocs/op: master → PR |
|---|---|---|
| test_large_families_int_aggr | 857.8 → 373.5 (**-56.5%**) | 0.158 → 0.268 (+0.110) |
| test_many_families_int_aggr | 4668.6 → 4423.5 (**-5.3%**) | 12.289 → 12.399 (+0.110) |
| test_histogram_aggr | 245.0 → 226.6 (**-7.5%**) | 0.113 → 0.118 (+0.005) |

The allocs/op rise is the cache itself (one `unique_ptr<aggregation_cache>` + a heap-backed key string per aggregated series), paid **once** at metadata-rebuild time, not per scrape — the fixed absolute cost (+0.110) is identical across the two 10k-series cases and just reads as a bigger percentage against the smaller baseline. In exchange, scrape-time cost drops from an O(labels) rebuild per series per scrape to a cached lookup.

## Tests
- `metrics_test`, `prometheus_text_test`, `prometheus_http_test` pass under `dbuild`.
- `test_aggregation_cache_invalidated_on_new_registration` — cache regenerates correctly when a metric is registered/unregistered after an earlier scrape already built it.
- `test_aggregation_cache_hit_and_miss` — cache hit vs. miss paths produce correct grouping and sums.
- `test_aggregation_cache_stale_config_not_trusted` — a cached key built under a different `aggregate_labels` config is rejected, not silently reused.