### PR TITLE
sstring: fix operator+ ambiguity with std::basic_string in C++26

### DIFF
--- a/include/seastar/core/sstring.hh
+++ b/include/seastar/core/sstring.hh
@@ -705,6 +705,52 @@ string_type uninitialized_string(size_t size) {
     }
 }
 
+namespace internal {
+template <class T> struct is_std_basic_string : std::false_type {};
+template <typename char_type, typename traits, typename Alloc>
+struct is_std_basic_string<std::basic_string<char_type, traits, Alloc>> : std::true_type {};
+
+template <typename T, typename char_type>
+concept std_basic_string_of = is_std_basic_string<std::remove_cvref_t<T>>::value
+        && std::same_as<typename std::remove_cvref_t<T>::value_type, char_type>;
+}
+
+// Concatenation with std::basic_string needs explicit overloads. Without them
+// the expression is ambiguous since C++26: std::basic_string gained
+//     operator+(type_identity_t<basic_string_view>, const basic_string&)
+//     operator+(type_identity_t<basic_string_view>, basic_string&&)
+// and the two mirrored forms (P2591R5). Those are reachable via basic_sstring's
+// conversion to basic_string_view, and they tie with basic_sstring::operator+,
+// which is reachable via basic_sstring's constructor from basic_string.
+//
+// The std::basic_string operand is taken by forwarding reference so that these
+// bind it exactly as well as the standard overloads do, including the rvalue
+// ones; the basic_sstring operand then needs no conversion at all, which makes
+// these strictly better matches.
+template <typename char_type, typename size_type, size_type Max, bool NulTerminate, typename String>
+requires internal::std_basic_string_of<String, char_type>
+inline
+basic_sstring<char_type, size_type, Max, NulTerminate>
+operator+(const basic_sstring<char_type, size_type, Max, NulTerminate>& x, String&& y) {
+    using sstring_type = basic_sstring<char_type, size_type, Max, NulTerminate>;
+    sstring_type ret(typename sstring_type::initialized_later(), x.size() + y.size());
+    auto p = std::copy(x.begin(), x.end(), ret.begin());
+    std::copy(y.begin(), y.end(), p);
+    return ret;
+}
+
+template <typename char_type, typename size_type, size_type Max, bool NulTerminate, typename String>
+requires internal::std_basic_string_of<String, char_type>
+inline
+basic_sstring<char_type, size_type, Max, NulTerminate>
+operator+(String&& x, const basic_sstring<char_type, size_type, Max, NulTerminate>& y) {
+    using sstring_type = basic_sstring<char_type, size_type, Max, NulTerminate>;
+    sstring_type ret(typename sstring_type::initialized_later(), x.size() + y.size());
+    auto p = std::copy(x.begin(), x.end(), ret.begin());
+    std::copy(y.begin(), y.end(), p);
+    return ret;
+}
+
 template <typename char_type, typename size_type, size_type Max, size_type N, bool NulTerminate>
 inline
 basic_sstring<char_type, size_type, Max, NulTerminate>

--- a/tests/unit/sstring_test.cc
+++ b/tests/unit/sstring_test.cc
@@ -325,3 +325,78 @@ BOOST_AUTO_TEST_CASE(test_fmt) {
     std::ignore = fmt::format("{}", strings);
 }
 
+
+// A std::allocator lookalike, only to check that operator+ accepts a
+// std::basic_string with an allocator other than the default one.
+template <typename T>
+struct tracking_allocator : std::allocator<T> {
+    using std::allocator<T>::allocator;
+    template <typename U> struct rebind { using other = tracking_allocator<U>; };
+};
+
+BOOST_AUTO_TEST_CASE(test_concat_with_std_string) {
+    sstring a = "ab";
+    const sstring ca = "ab";
+    std::string b = "cd";
+    const std::string cb = "cd";
+
+    // Every combination of lvalue/const lvalue/rvalue on either side has to
+    // resolve. Since C++26 std::basic_string has operator+ overloads taking a
+    // string_view-convertible operand, and those are reachable from
+    // basic_sstring, so they can tie with basic_sstring's own operator+ unless
+    // sstring provides better matches.
+    BOOST_REQUIRE_EQUAL(a + b, sstring("abcd"));
+    BOOST_REQUIRE_EQUAL(ca + cb, sstring("abcd"));
+    BOOST_REQUIRE_EQUAL(a + std::string("cd"), sstring("abcd"));
+    BOOST_REQUIRE_EQUAL(sstring("ab") + b, sstring("abcd"));
+    BOOST_REQUIRE_EQUAL(sstring("ab") + std::string("cd"), sstring("abcd"));
+
+    BOOST_REQUIRE_EQUAL(b + a, sstring("cdab"));
+    BOOST_REQUIRE_EQUAL(cb + ca, sstring("cdab"));
+    BOOST_REQUIRE_EQUAL(std::string("cd") + a, sstring("cdab"));
+    BOOST_REQUIRE_EQUAL(b + sstring("ab"), sstring("cdab"));
+    BOOST_REQUIRE_EQUAL(std::string("cd") + sstring("ab"), sstring("cdab"));
+
+    // The most common shape in practice.
+    BOOST_REQUIRE_EQUAL(sstring("n=") + std::to_string(7), sstring("n=7"));
+    BOOST_REQUIRE_EQUAL(a + ":" + std::to_string(7), sstring("ab:7"));
+
+    // The result is an sstring, not a std::string, whichever side it is on.
+    static_assert(std::is_same_v<decltype(a + b), sstring>);
+    static_assert(std::is_same_v<decltype(b + a), sstring>);
+    static_assert(std::is_same_v<decltype(std::string("cd") + a), sstring>);
+
+    // Concatenating two sstrings, or a literal and an sstring, is unaffected.
+    static_assert(std::is_same_v<decltype(a + a), sstring>);
+    BOOST_REQUIRE_EQUAL(a + a, sstring("abab"));
+    BOOST_REQUIRE_EQUAL("x" + a, sstring("xab"));
+
+    // Embedded NULs are not treated as terminators.
+    std::string nul("a\0b", 3);
+    BOOST_REQUIRE_EQUAL((sstring("z") + nul).size(), 4u);
+    BOOST_REQUIRE_EQUAL((nul + sstring("z")).size(), 4u);
+
+    // An empty operand on either side.
+    BOOST_REQUIRE_EQUAL(a + std::string(), sstring("ab"));
+    BOOST_REQUIRE_EQUAL(std::string() + a, sstring("ab"));
+    BOOST_REQUIRE_EQUAL(sstring() + b, sstring("cd"));
+
+    // A long result, so that the sstring is externally allocated.
+    std::string long_b(1000, 'y');
+    BOOST_REQUIRE_EQUAL((a + long_b).size(), 1002u);
+    BOOST_REQUIRE_EQUAL((long_b + a).size(), 1002u);
+    BOOST_REQUIRE_EQUAL(a + long_b, sstring("ab") + sstring(long_b));
+
+    // A non-default char_type and a non-NUL-terminated sstring.
+    using schar_sstring = basic_sstring<signed char, uint32_t, 15, false>;
+    schar_sstring s(reinterpret_cast<const signed char*>("ab"), 2);
+    std::basic_string<signed char> t(reinterpret_cast<const signed char*>("cd"), 2);
+    BOOST_REQUIRE_EQUAL((s + t).size(), 4u);
+    BOOST_REQUIRE_EQUAL((t + s).size(), 4u);
+    static_assert(std::is_same_v<decltype(s + t), schar_sstring>);
+
+    // A std::basic_string with a non-default allocator is still accepted.
+    std::basic_string<char, std::char_traits<char>, tracking_allocator<char>> alloc_b = "cd";
+    BOOST_REQUIRE_EQUAL(a + alloc_b, sstring("abcd"));
+    BOOST_REQUIRE_EQUAL(alloc_b + a, sstring("cdab"));
+}


### PR DESCRIPTION
C++26 added string_view-convertible operator+ overloads to std::basic_string (P2591R5):

    operator+(type_identity_t<basic_string_view<C, T>>, const basic_string&)
    operator+(type_identity_t<basic_string_view<C, T>>, basic_string&&)

and the two mirrored forms. basic_sstring converts to basic_string_view, so those are viable for `sstring + std::string`, and basic_sstring constructs from basic_string, so basic_sstring::operator+ is viable too. Neither is better than the other -- each needs one user-defined conversion, on the operand the other takes exactly -- so every such expression is now ambiguous:

    error: use of overloaded operator '+' is ambiguous (with operand types
    'sstring' and 'std::string')

Add operator+ overloads taking a basic_sstring and a std::basic_string directly. The std::basic_string operand is a forwarding reference so these bind it exactly as well as the standard overloads do, the rvalue ones included; matching `const&` only is not enough, since for an rvalue operand the standard's `basic_string&&` overload binds better and the ambiguity remains. The basic_sstring operand then needs no conversion at all, which makes these strictly better matches than either contender.

The result stays an sstring, which is what basic_sstring::operator+ produced before, so no expression changes meaning -- only the ones that stopped compiling start working again.