### PR TITLE
rpc: Remove deprecated boost::type<> read_via_type_marker() overload

### DIFF
--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -31,8 +31,6 @@
 #include <seastar/util/log.hh>
 #include <seastar/core/deleter.hh>
 
-#include <boost/type.hpp> // for compatibility
-
 #include <concepts>
 
 namespace seastar {
@@ -285,25 +283,11 @@ template <typename Serializer, typename Input, typename... T>
 std::tuple<T...> do_unmarshall(connection& c, Input& in);
 
 // The protocol to call the serializer is read(serializer, stream, rpc::type<T>).
-// However, some users (ahem) used boost::type instead of rpc::type when the two
-// types were aliased, preventing us from moving to the newer std::type_identity.
-// To preserve compatibility, calls to read() are routed through
-// read_via_type_marker(), of which there are two variants, one for
-// boost::type (marked as deprecated) and one for std::type_identity.
-
 template <typename T, typename... Args>
 requires requires (Args... args, type<T> t) { read(std::forward<Args>(args)..., t); }
 auto
 read_via_type_marker(Args&&... args) {
     return read(std::forward<Args>(args)..., type<T>());
-}
-
-template <typename T, typename... Args>
-requires requires (Args... args, boost::type<T> t) { read(std::forward<Args>(args)..., t); }
-[[deprecated("Use rpc::type<> instead of boost::type<>")]]
-auto
-read_via_type_marker(Args&&... args) {
-    return read(std::forward<Args>(args)..., boost::type<T>());
 }
 
 template<typename Serializer, typename Input>


### PR DESCRIPTION
The boost::type<> overload was deprecated by e8968e558be on 2024-10-21, over a year ago, when rpc::type<> switched from boost::type to std::type_identity. No in-tree callers remain (ScyllaDB, for example, migrated off the pattern in ee92784098). Drop the deprecated overload along with the now-unused <boost/type.hpp> include.