### PR TITLE
build: record Seastar_LTTNG for the installed CMake package

### DIFF
--- a/cmake/SeastarConfig.cmake.in
+++ b/cmake/SeastarConfig.cmake.in
@@ -56,6 +56,7 @@ include (SeastarDependencies)
 set (Seastar_DPDK @Seastar_DPDK@)
 set (Seastar_IO_URING @Seastar_IO_URING@)
 set (Seastar_HWLOC @Seastar_HWLOC@)
+set (Seastar_LTTNG @Seastar_LTTNG@)
 seastar_find_dependencies ()
 
 if (NOT TARGET Seastar::seastar)


### PR DESCRIPTION
A static Seastar exports its `PRIVATE` link dependencies as
`$<LINK_ONLY:...>` entries in `Seastar::seastar`'s interface, so every one of
them has to exist as a target by the time a consumer runs
`find_package (Seastar)`. `SeastarDependencies` finds them all, but the ones
behind a condition need the condition too, and while `SeastarConfig.cmake.in`
passes on `Seastar_DPDK`, `Seastar_IO_URING` and `Seastar_HWLOC`, it never
mentioned `Seastar_LTTNG`. A consumer of a static build with LTTng enabled
therefore failed to configure:

```
CMake Error at .../lib/cmake/Seastar/SeastarTargets.cmake:61 (set_target_properties):
  The link interface of target "Seastar::seastar" contains:

    LTTng::UST

  but the target was not found.
```

Pass it on like the others.

Shared builds were unaffected, which is why this went unnoticed -- `PRIVATE`
dependencies stay out of the exported interface there. Found while adding an
installed-consumer build test in #3548, which is the first thing in the tree to
consume the installed CMake package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)