### PR TITLE
build: name OpenSSL among seastar.pc's private requirements

### DIFF
--- a/pkgconfig/seastar.pc.in
+++ b/pkgconfig/seastar.pc.in
@@ -34,7 +34,7 @@ seastar_cflags=${seastar_include_flags} $<JOIN:$<TARGET_PROPERTY:seastar,INTERFA
 seastar_libs=${libdir}/$<TARGET_FILE_NAME:seastar> @Seastar_SPLIT_DWARF_FLAG@ $<JOIN:@Seastar_Sanitizers_OPTIONS@, >
 
 Requires: liblz4 >= 1.7.3
-Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >yaml-cpp >= 0.5.1
+Requires.private: gnutls >= 3.2.26, protobuf >= 2.5.0, hwloc >= 1.11.2, $<$<BOOL:@Seastar_IO_URING@>:liburing $<ANGLE-R>= 2.0, >$<$<BOOL:@Seastar_OPENSSL@>:libssl $<ANGLE-R>= 3.0, libcrypto $<ANGLE-R>= 3.0, >yaml-cpp >= 0.5.1
 Conflicts:
 Cflags: @Seastar_CXX_COMPILE_OPTION@ ${boost_cflags} ${c_ares_cflags} ${fmt_cflags} ${liburing_cflags} ${lksctp_tools_cflags} ${seastar_cflags}
 Libs: ${seastar_libs} ${boost_program_options_libs} ${c_ares_libs} ${fmt_libs}


### PR DESCRIPTION
Seastar's OpenSSL TLS and crypto backend links libssl and libcrypto, but
`seastar.pc` never said so, so linking a static libseastar through pkg-config
ended in

```
libseastar.a(crypto_openssl.cc.o): in function `seastar::internal::crypto::(anonymous namespace)::openssl_md5_finalize(unsigned char*)':
crypto_openssl.cc:107: undefined reference to `EVP_DigestFinal_ex'
crypto_openssl.cc:120: undefined reference to `EVP_MD_CTX_free'
```

Add them to `Requires.private`, conditional on `Seastar_OPENSSL` the way
liburing already is.

Only static consumers were affected: a shared libseastar carries its own
`DT_NEEDED` entries, and pkg-config hands `Libs.private` and
`Requires.private` out only when asked for a static link. Found while adding an
installed-consumer build test in #3548, which is the first thing in the tree to
link against the installed `seastar.pc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)