### PR TITLE
Refactor IO priority class and group plumbing

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -209,15 +209,15 @@ public:
     unsigned id() const noexcept { return _id; }
 
     void update_shares_for_class(scheduling_group sg, size_t new_shares);
-    void update_shares_for_class_group(unsigned index, size_t new_shares);
+    void update_shares_for_class_group(scheduling_supergroup ssg, size_t new_shares);
     future<> update_bandwidth_for_class(scheduling_group sg, uint64_t new_bandwidth);
-    future<> update_bandwidth_for_class_group(unsigned group_index, uint64_t new_bandwidth);
+    future<> update_bandwidth_for_class_group(scheduling_supergroup ssg, uint64_t new_bandwidth);
     void rename_priority_class(scheduling_group sg, sstring new_name);
     void destroy_priority_class(scheduling_group sg) noexcept;
     void throttle_priority_class(const priority_class_data& pc) noexcept;
     void unthrottle_priority_class(const priority_class_data& pc) noexcept;
-    void throttle_priority_class_group(unsigned group) noexcept;
-    void unthrottle_priority_class_group(unsigned group) noexcept;
+    void throttle_priority_class_group(scheduling_supergroup ssg) noexcept;
+    void unthrottle_priority_class_group(scheduling_supergroup ssg) noexcept;
 
     struct request_limits {
         size_t max_read;
@@ -414,9 +414,9 @@ private:
 
     static io_throttler::config configure_throttler(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(scheduling_group sg);
-    priority_class_data& find_or_create_class(scheduling_group sg, std::optional<unsigned> group_index);
-    priority_class_group_data& find_or_create_class_group(unsigned group_index);
-    priority_class_group_data& find_or_create_class_group_locked(unsigned group_index);
+    priority_class_data& find_or_create_class(scheduling_group sg, scheduling_supergroup ssg);
+    priority_class_group_data& find_or_create_class_group(scheduling_supergroup ssg);
+    priority_class_group_data& find_or_create_class_group_locked(scheduling_supergroup ssg);
 
     inline size_t max_request_length(int dnl_idx) const noexcept {
         return _max_request_length[dnl_idx];

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -62,15 +62,6 @@ class io_group;
 using io_group_ptr = std::shared_ptr<io_group>;
 using iovec_keeper = std::vector<::iovec>;
 
-namespace internal {
-class priority_class {
-    unsigned _id;
-public:
-    explicit priority_class(const scheduling_group& sg) noexcept;
-    unsigned id() const noexcept { return _id; }
-};
-}
-
 class io_queue {
 public:
     class priority_class_data;
@@ -133,9 +124,9 @@ private:
     friend struct ::io_queue_for_tests;
     friend const io_throttler& internal::get_throttler(const io_queue& ioq, unsigned stream);
 
-    priority_class_data& find_or_create_class(internal::priority_class pc);
-    future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
-    future<size_t> queue_one_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
+    priority_class_data& find_or_create_class(scheduling_group sg);
+    future<size_t> queue_request(scheduling_group sg, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
+    future<size_t> queue_one_request(scheduling_group sg, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept;
 
     // The fields below are going away, they are just here so we can implement deprecated
     // functions that used to be provided by the fair_queue and are going away (from both
@@ -217,12 +208,12 @@ public:
     sstring mountpoint() const;
     unsigned id() const noexcept { return _id; }
 
-    void update_shares_for_class(internal::priority_class pc, size_t new_shares);
+    void update_shares_for_class(scheduling_group sg, size_t new_shares);
     void update_shares_for_class_group(unsigned index, size_t new_shares);
-    future<> update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth);
+    future<> update_bandwidth_for_class(scheduling_group sg, uint64_t new_bandwidth);
     future<> update_bandwidth_for_class_group(unsigned group_index, uint64_t new_bandwidth);
-    void rename_priority_class(internal::priority_class pc, sstring new_name);
-    void destroy_priority_class(internal::priority_class pc) noexcept;
+    void rename_priority_class(scheduling_group sg, sstring new_name);
+    void destroy_priority_class(scheduling_group sg) noexcept;
     void throttle_priority_class(const priority_class_data& pc) noexcept;
     void unthrottle_priority_class(const priority_class_data& pc) noexcept;
     void throttle_priority_class_group(unsigned group) noexcept;
@@ -422,8 +413,8 @@ private:
     const shard_id _allocated_on;
 
     static io_throttler::config configure_throttler(const io_queue::config& qcfg) noexcept;
-    priority_class_data& find_or_create_class(internal::priority_class pc);
-    priority_class_data& find_or_create_class(internal::priority_class pc, std::optional<unsigned> group_index);
+    priority_class_data& find_or_create_class(scheduling_group sg);
+    priority_class_data& find_or_create_class(scheduling_group sg, std::optional<unsigned> group_index);
     priority_class_group_data& find_or_create_class_group(unsigned group_index);
     priority_class_group_data& find_or_create_class_group_locked(unsigned group_index);
 

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -120,7 +120,6 @@ namespace internal {
 class reactor_stall_sampler;
 class cpu_stall_detector;
 class buffer_allocator;
-class priority_class;
 class poller;
 
 size_t scheduling_group_count();
@@ -501,10 +500,10 @@ public:
     std::string_view get_backend_name() const;
 
 private:
-    future<> update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth);
+    future<> update_bandwidth_for_queues(scheduling_group sg, uint64_t bandwidth);
     future<> update_bandwidth_for_queues(unsigned group_index, uint64_t bandwidth);
-    void rename_queues(internal::priority_class pc, sstring new_name);
-    void update_shares_for_queues(internal::priority_class pc, uint32_t shares);
+    void rename_queues(scheduling_group sg, sstring new_name);
+    void update_shares_for_queues(scheduling_group sg, uint32_t shares);
     void update_group_shares_for_queues(unsigned, uint32_t shares);
 
 public:

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -501,10 +501,10 @@ public:
 
 private:
     future<> update_bandwidth_for_queues(scheduling_group sg, uint64_t bandwidth);
-    future<> update_bandwidth_for_queues(unsigned group_index, uint64_t bandwidth);
+    future<> update_bandwidth_for_queues(scheduling_supergroup ssg, uint64_t bandwidth);
     void rename_queues(scheduling_group sg, sstring new_name);
     void update_shares_for_queues(scheduling_group sg, uint32_t shares);
-    void update_group_shares_for_queues(unsigned, uint32_t shares);
+    void update_group_shares_for_queues(scheduling_supergroup ssg, uint32_t shares);
 
 public:
     server_socket listen(socket_address sa, listen_options opts = {});

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -21,6 +21,7 @@
 
 
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <mutex>
 #include <utility>
@@ -53,6 +54,23 @@ using namespace std::chrono_literals;
 using io_direction_and_length = internal::io_direction_and_length;
 static constexpr auto io_direction_read = io_direction_and_length::read_idx;
 static constexpr auto io_direction_write = io_direction_and_length::write_idx;
+
+// Returns the object sitting in slot \p id of \p slots, calling \p create to
+// make one if that slot is still empty. The vector grows as needed and the
+// slots skipped on the way stay empty -- ids are sparse, as priority classes
+// and groups get created and destroyed in arbitrary order.
+template <typename T, std::invocable Creator>
+requires std::same_as<std::invoke_result_t<Creator>, std::unique_ptr<T>>
+static T& find_or_create(std::vector<std::unique_ptr<T>>& slots, size_t id, Creator&& create) {
+    if (id >= slots.size()) {
+        slots.resize(id + 1);
+    }
+    auto& slot = slots[id];
+    if (!slot) {
+        slot = create();
+    }
+    return *slot;
+}
 
 struct default_io_exception_factory {
     static auto cancelled() {
@@ -871,12 +889,8 @@ void io_queue::register_stats(sstring name, priority_class_data& pc) {
 }
 
 io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority_class pc) {
-    auto id = pc.id();
-    if (id >= _priority_classes.size()) {
-        _priority_classes.resize(id + 1);
-    }
-    if (!_priority_classes[id]) {
-        auto sg = internal::scheduling_group_from_index(id);
+    return find_or_create(_priority_classes, pc.id(), [this, pc] {
+        auto sg = internal::scheduling_group_from_index(pc.id());
         auto ssg = internal::scheduling_supergroup_for(sg);
 
         // A note on naming:
@@ -911,9 +925,8 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
         }
         register_stats(sg.name(), *pc_data);
 
-        _priority_classes[id] = std::move(pc_data);
-    }
-    return *_priority_classes[id];
+        return pc_data;
+    });
 }
 
 io_group::priority_class_group_data& io_group::find_or_create_class_group(unsigned group_index) {
@@ -922,14 +935,9 @@ io_group::priority_class_group_data& io_group::find_or_create_class_group(unsign
 }
 
 io_group::priority_class_group_data& io_group::find_or_create_class_group_locked(unsigned id) {
-    if (id >= _priority_groups.size()) {
-        _priority_groups.resize(id + 1);
-    }
-    if (!_priority_groups[id]) {
-        auto pg = std::make_unique<priority_class_group_data>(nullptr);
-        _priority_groups[id] = std::move(pg);
-    }
-    return *_priority_groups[id];
+    return find_or_create(_priority_groups, id, [] {
+        return std::make_unique<priority_class_group_data>(nullptr);
+    });
 }
 
 io_group::priority_class_data& io_group::find_or_create_class(internal::priority_class pc) {
@@ -950,16 +958,9 @@ io_group::priority_class_data& io_group::find_or_create_class(internal::priority
         parent = &find_or_create_class_group_locked(*group_index);
     }
 
-    auto id = pc.id();
-    if (id >= _priority_classes.size()) {
-        _priority_classes.resize(id + 1);
-    }
-    if (!_priority_classes[id]) {
-        auto pg = std::make_unique<priority_class_data>(parent);
-        _priority_classes[id] = std::move(pg);
-    }
-
-    return *_priority_classes[id];
+    return find_or_create(_priority_classes, pc.id(), [parent] {
+        return std::make_unique<priority_class_data>(parent);
+    });
 }
 
 stream_id io_queue::request_stream(io_direction_and_length dnl) const noexcept {

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -148,7 +148,7 @@ struct io_group::priority_class_data {
 
 class io_queue::priority_class_data {
     io_queue& _queue;
-    const internal::priority_class _pc;
+    const scheduling_group _sg;
     uint32_t _shares;
     struct {
         size_t bytes = 0;
@@ -226,9 +226,9 @@ public:
         _shares = std::max(shares, 1u);
     }
 
-    priority_class_data(internal::priority_class pc, uint32_t shares, io_queue& q, io_group::priority_class_data& pg, std::optional<unsigned> group_index)
+    priority_class_data(scheduling_group sg, uint32_t shares, io_queue& q, io_group::priority_class_data& pg, std::optional<unsigned> group_index)
         : _queue(q)
-        , _pc(pc)
+        , _sg(sg)
         , _shares(shares)
         , _nr_queued(0)
         , _nr_executing(0)
@@ -304,7 +304,7 @@ public:
         _nr_executing.checkpoint();
     }
 
-    fair_queue::class_id fq_class() const noexcept { return _pc.id(); }
+    fair_queue::class_id fq_class() const noexcept { return internal::scheduling_group_index(_sg); }
 
     std::vector<seastar::metrics::impl::metric_definition_impl> metrics();
     metrics::metric_groups metric_groups;
@@ -432,9 +432,6 @@ public:
 };
 
 namespace internal {
-
-priority_class::priority_class(const scheduling_group& sg) noexcept : _id(internal::scheduling_group_index(sg))
-{ }
 
 cancellable_queue::cancellable_queue(cancellable_queue&& o) noexcept
         : _first(std::exchange(o._first, nullptr))
@@ -888,9 +885,8 @@ void io_queue::register_stats(sstring name, priority_class_data& pc) {
     pc.metric_groups = std::exchange(new_metrics, {});
 }
 
-io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority_class pc) {
-    return find_or_create(_priority_classes, pc.id(), [this, pc] {
-        auto sg = internal::scheduling_group_from_index(pc.id());
+io_queue::priority_class_data& io_queue::find_or_create_class(scheduling_group sg) {
+    return find_or_create(_priority_classes, internal::scheduling_group_index(sg), [this, sg] {
         auto ssg = internal::scheduling_supergroup_for(sg);
 
         // A note on naming:
@@ -916,10 +912,10 @@ io_queue::priority_class_data& io_queue::find_or_create_class(internal::priority
             }
         }
 
-        auto& pg = _group->find_or_create_class(pc, group_index);
+        auto& pg = _group->find_or_create_class(sg, group_index);
 
         auto shares = sg.get_shares();
-        auto pc_data = std::make_unique<priority_class_data>(pc, shares, *this, pg, group_index);
+        auto pc_data = std::make_unique<priority_class_data>(sg, shares, *this, pg, group_index);
         for (auto&& s : _streams) {
             s.fq.register_priority_class(pc_data->fq_class(), shares, group_index);
         }
@@ -940,17 +936,16 @@ io_group::priority_class_group_data& io_group::find_or_create_class_group_locked
     });
 }
 
-io_group::priority_class_data& io_group::find_or_create_class(internal::priority_class pc) {
-    auto sg = internal::scheduling_group_from_index(pc.id());
+io_group::priority_class_data& io_group::find_or_create_class(scheduling_group sg) {
     auto ssg = internal::scheduling_supergroup_for(sg);
     std::optional<unsigned> group_index;
     if (!ssg.is_root()) {
         group_index = ssg.index();
     }
-    return find_or_create_class(pc, group_index);
+    return find_or_create_class(sg, group_index);
 }
 
-io_group::priority_class_data& io_group::find_or_create_class(internal::priority_class pc, std::optional<unsigned> group_index) {
+io_group::priority_class_data& io_group::find_or_create_class(scheduling_group sg, std::optional<unsigned> group_index) {
     std::lock_guard _(_lock);
 
     priority_class_group_data* parent = nullptr;
@@ -958,7 +953,7 @@ io_group::priority_class_data& io_group::find_or_create_class(internal::priority
         parent = &find_or_create_class_group_locked(*group_index);
     }
 
-    return find_or_create(_priority_classes, pc.id(), [parent] {
+    return find_or_create(_priority_classes, internal::scheduling_group_index(sg), [parent] {
         return std::make_unique<priority_class_data>(parent);
     });
 }
@@ -1011,16 +1006,16 @@ std::chrono::duration<double> io_queue::get_io_latency_goal() const noexcept {
     return _group->io_latency_goal();
 }
 
-future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-    return futurize_invoke([pc = std::move(pc), dnl = std::move(dnl), req = std::move(req), this, intent, iovs = std::move(iovs)] () mutable {
+future<size_t> io_queue::queue_one_request(scheduling_group sg, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+    return futurize_invoke([sg, dnl = std::move(dnl), req = std::move(req), this, intent, iovs = std::move(iovs)] () mutable {
         // First time will hit here, and then we create the class. It is important
         // that we create the shared pointer in the same shard it will be used at later.
-        auto& pclass = find_or_create_class(pc);
+        auto& pclass = find_or_create_class(sg);
         auto cap = request_capacity(dnl);
         auto queued_req = std::make_unique<queued_io_request>(std::move(req), *this, cap, pclass, std::move(dnl), std::move(iovs));
         auto fut = queued_req->get_future();
         if (intent != nullptr) {
-            auto& cq = intent->find_or_create_cancellable_queue(_id, pc.id());
+            auto& cq = intent->find_or_create_cancellable_queue(_id, internal::scheduling_group_index(sg));
             queued_req->set_intent(cq);
         }
 
@@ -1032,11 +1027,11 @@ future<size_t> io_queue::queue_one_request(internal::priority_class pc, io_direc
     });
 }
 
-future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+future<size_t> io_queue::queue_request(scheduling_group sg, io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
     size_t max_length = _group->_max_request_length[dnl.rw_idx()];
 
     if (__builtin_expect(dnl.length() <= max_length, true)) {
-        return queue_one_request(std::move(pc), dnl, std::move(req), intent, std::move(iovs));
+        return queue_one_request(sg, dnl, std::move(req), intent, std::move(iovs));
     }
 
     std::vector<internal::io_request::part> parts;
@@ -1046,7 +1041,7 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
         parts = req.split(max_length);
         p = make_lw_shared<std::vector<future<size_t>>>();
         p->reserve(parts.size());
-        find_or_create_class(pc).on_split(dnl);
+        find_or_create_class(sg).on_split(dnl);
         reactor::io_stats::local().aio_outsizes++;
     } catch (...) {
         return current_exception_as_future<size_t>();
@@ -1055,7 +1050,7 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
     // No exceptions from now on. If queue_one_request fails it will resolve
     // into exceptional future which will be picked up by when_all() below
     for (auto&& part : parts) {
-        auto f = queue_one_request(pc, io_direction_and_length(dnl.rw_idx(), part.size), std::move(part.req), intent, std::move(part.iovecs));
+        auto f = queue_one_request(sg, io_direction_and_length(dnl.rw_idx(), part.size), std::move(part.req), intent, std::move(part.iovecs));
         p->push_back(std::move(f));
     }
 
@@ -1092,19 +1087,17 @@ future<size_t> io_queue::queue_request(internal::priority_class pc, io_direction
 }
 
 future<size_t> io_queue::submit_io_read(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-    internal::priority_class pc = internal::priority_class(current_scheduling_group());
     auto& io_stats = reactor::io_stats::local();
     ++io_stats.aio_reads;
     io_stats.aio_read_bytes += len;
-    return queue_request(std::move(pc), io_direction_and_length(io_direction_read, len), std::move(req), intent, std::move(iovs));
+    return queue_request(current_scheduling_group(), io_direction_and_length(io_direction_read, len), std::move(req), intent, std::move(iovs));
 }
 
 future<size_t> io_queue::submit_io_write(size_t len, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-    internal::priority_class pc = internal::priority_class(current_scheduling_group());
     auto& io_stats = reactor::io_stats::local();
     ++io_stats.aio_writes;
     io_stats.aio_write_bytes += len;
-    return queue_request(std::move(pc), io_direction_and_length(io_direction_write, len), std::move(req), intent, std::move(iovs));
+    return queue_request(current_scheduling_group(), io_direction_and_length(io_direction_write, len), std::move(req), intent, std::move(iovs));
 }
 
 // This function is called by the shard on every poll.
@@ -1202,8 +1195,8 @@ io_queue::clock_type::time_point io_queue::next_pending_aio() const noexcept {
 }
 
 void
-io_queue::update_shares_for_class(internal::priority_class pc, size_t new_shares) {
-    auto& pclass = find_or_create_class(pc);
+io_queue::update_shares_for_class(scheduling_group sg, size_t new_shares) {
+    auto& pclass = find_or_create_class(sg);
     pclass.update_shares(new_shares);
     for (auto&& s : _streams) {
         s.fq.update_shares_for_class(pclass.fq_class(), new_shares);
@@ -1217,12 +1210,12 @@ void io_queue::update_shares_for_class_group(unsigned index, size_t new_shares) 
     }
 }
 
-future<> io_queue::update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth) {
-    return futurize_invoke([this, pc, new_bandwidth] {
+future<> io_queue::update_bandwidth_for_class(scheduling_group sg, uint64_t new_bandwidth) {
+    return futurize_invoke([this, sg, new_bandwidth] {
         if (_group->_allocated_on == this_shard_id()) {
-            auto& pclass = _group->find_or_create_class(pc);
+            auto& pclass = _group->find_or_create_class(sg);
             pclass.update_bandwidth(new_bandwidth);
-            io_log.debug("Updated {} class bandwidth to {}MB/s", pc.id(), new_bandwidth >> 20);
+            io_log.debug("Updated {} class bandwidth to {}MB/s", internal::scheduling_group_index(sg), new_bandwidth >> 20);
         }
     });
 }
@@ -1238,11 +1231,11 @@ future<> io_queue::update_bandwidth_for_class_group(unsigned group_index, uint64
 }
 
 void
-io_queue::rename_priority_class(internal::priority_class pc, sstring new_name) {
-    if (_priority_classes.size() > pc.id() &&
-            _priority_classes[pc.id()]) {
+io_queue::rename_priority_class(scheduling_group sg, sstring new_name) {
+    auto id = internal::scheduling_group_index(sg);
+    if (_priority_classes.size() > id && _priority_classes[id]) {
         try {
-            register_stats(new_name, *_priority_classes[pc.id()]);
+            register_stats(new_name, *_priority_classes[id]);
         } catch (metrics::double_registration &e) {
             // we need to ignore this exception, since it can happen that
             // a class that was already created with the new name will be
@@ -1252,9 +1245,10 @@ io_queue::rename_priority_class(internal::priority_class pc, sstring new_name) {
     }
 }
 
-void io_queue::destroy_priority_class(internal::priority_class pc) noexcept {
-    if (_priority_classes.size() > pc.id() && _priority_classes[pc.id()]) {
-        auto& pc_ptr = _priority_classes[pc.id()];
+void io_queue::destroy_priority_class(scheduling_group sg) noexcept {
+    auto id = internal::scheduling_group_index(sg);
+    if (_priority_classes.size() > id && _priority_classes[id]) {
+        auto& pc_ptr = _priority_classes[id];
         for (auto&& s : _streams) {
             s.fq.unregister_priority_class(pc_ptr->fq_class());
         }

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -171,20 +171,20 @@ class io_queue::priority_class_data {
         io_group::priority_class_data::token_bucket_t& _tb;
         uint64_t _replenish_head;
         priority_class_data& _pc;
-        std::optional<unsigned> _group;
+        scheduling_supergroup _ssg;
         timer<lowres_clock> _replenish;
 
         void throttle() noexcept {
-            if (_group) {
-                _pc._queue.throttle_priority_class_group(*_group);
+            if (!_ssg.is_root()) {
+                _pc._queue.throttle_priority_class_group(_ssg);
             } else {
                 _pc._queue.throttle_priority_class(_pc);
             }
         }
 
         void unthrottle() noexcept {
-            if (_group) {
-                _pc._queue.unthrottle_priority_class_group(*_group);
+            if (!_ssg.is_root()) {
+                _pc._queue.unthrottle_priority_class_group(_ssg);
             } else {
                 _pc._queue.unthrottle_priority_class(_pc);
             }
@@ -201,10 +201,10 @@ class io_queue::priority_class_data {
         }
 
     public:
-        bandwidth_throttler(io_group::priority_class_data& pg, priority_class_data& pc, std::optional<unsigned> g) noexcept
+        bandwidth_throttler(io_group::priority_class_data& pg, priority_class_data& pc, scheduling_supergroup ssg) noexcept
                 : _tb(pg.tb)
                 , _pc(pc)
-                , _group(g)
+                , _ssg(ssg)
                 , _replenish([this] { try_to_replenish(); })
         {}
 
@@ -226,7 +226,7 @@ public:
         _shares = std::max(shares, 1u);
     }
 
-    priority_class_data(scheduling_group sg, uint32_t shares, io_queue& q, io_group::priority_class_data& pg, std::optional<unsigned> group_index)
+    priority_class_data(scheduling_group sg, uint32_t shares, io_queue& q, io_group::priority_class_data& pg, scheduling_supergroup ssg)
         : _queue(q)
         , _sg(sg)
         , _shares(shares)
@@ -237,9 +237,11 @@ public:
         , _total_execution_time(0)
         , _starvation_time(0)
     {
-        _bw.emplace_back(pg, *this, std::nullopt);
+        // The per-class throttler is not tied to any supergroup, so it throttles
+        // the class itself -- hence the root supergroup here
+        _bw.emplace_back(pg, *this, scheduling_supergroup());
         if (pg.parent != nullptr) {
-            _bw.emplace_back(*pg.parent, *this, group_index);
+            _bw.emplace_back(*pg.parent, *this, ssg);
         }
     }
     priority_class_data(const priority_class_data&) = delete;
@@ -904,18 +906,20 @@ io_queue::priority_class_data& io_queue::find_or_create_class(scheduling_group s
         // This conveys all the information we need and allows one to easily group all classes from
         // the same I/O queue (by filtering by shard)
 
+        // fair_queue addresses both classes and groups by raw index, with an
+        // empty index standing for "no group", so convert here
         std::optional<unsigned> group_index;
         if (!ssg.is_root()) {
             group_index = ssg.index();
             for (auto&& s : _streams) {
-                s.fq.ensure_priority_group(*group_index, ssg.get_shares());
+                s.fq.ensure_priority_group(ssg.index(), ssg.get_shares());
             }
         }
 
-        auto& pg = _group->find_or_create_class(sg, group_index);
+        auto& pg = _group->find_or_create_class(sg, ssg);
 
         auto shares = sg.get_shares();
-        auto pc_data = std::make_unique<priority_class_data>(sg, shares, *this, pg, group_index);
+        auto pc_data = std::make_unique<priority_class_data>(sg, shares, *this, pg, ssg);
         for (auto&& s : _streams) {
             s.fq.register_priority_class(pc_data->fq_class(), shares, group_index);
         }
@@ -925,32 +929,27 @@ io_queue::priority_class_data& io_queue::find_or_create_class(scheduling_group s
     });
 }
 
-io_group::priority_class_group_data& io_group::find_or_create_class_group(unsigned group_index) {
+io_group::priority_class_group_data& io_group::find_or_create_class_group(scheduling_supergroup ssg) {
     std::lock_guard _(_lock);
-    return find_or_create_class_group_locked(group_index);
+    return find_or_create_class_group_locked(ssg);
 }
 
-io_group::priority_class_group_data& io_group::find_or_create_class_group_locked(unsigned id) {
-    return find_or_create(_priority_groups, id, [] {
+io_group::priority_class_group_data& io_group::find_or_create_class_group_locked(scheduling_supergroup ssg) {
+    return find_or_create(_priority_groups, ssg.index(), [] {
         return std::make_unique<priority_class_group_data>(nullptr);
     });
 }
 
 io_group::priority_class_data& io_group::find_or_create_class(scheduling_group sg) {
-    auto ssg = internal::scheduling_supergroup_for(sg);
-    std::optional<unsigned> group_index;
-    if (!ssg.is_root()) {
-        group_index = ssg.index();
-    }
-    return find_or_create_class(sg, group_index);
+    return find_or_create_class(sg, internal::scheduling_supergroup_for(sg));
 }
 
-io_group::priority_class_data& io_group::find_or_create_class(scheduling_group sg, std::optional<unsigned> group_index) {
+io_group::priority_class_data& io_group::find_or_create_class(scheduling_group sg, scheduling_supergroup ssg) {
     std::lock_guard _(_lock);
 
     priority_class_group_data* parent = nullptr;
-    if (group_index.has_value()) {
-        parent = &find_or_create_class_group_locked(*group_index);
+    if (!ssg.is_root()) {
+        parent = &find_or_create_class_group_locked(ssg);
     }
 
     return find_or_create(_priority_classes, internal::scheduling_group_index(sg), [parent] {
@@ -1204,9 +1203,9 @@ io_queue::update_shares_for_class(scheduling_group sg, size_t new_shares) {
 }
 
 
-void io_queue::update_shares_for_class_group(unsigned index, size_t new_shares) {
+void io_queue::update_shares_for_class_group(scheduling_supergroup ssg, size_t new_shares) {
     for (auto&& s : _streams) {
-        s.fq.ensure_priority_group(index, new_shares);
+        s.fq.ensure_priority_group(ssg.index(), new_shares);
     }
 }
 
@@ -1220,12 +1219,12 @@ future<> io_queue::update_bandwidth_for_class(scheduling_group sg, uint64_t new_
     });
 }
 
-future<> io_queue::update_bandwidth_for_class_group(unsigned group_index, uint64_t new_bandwidth) {
-    return futurize_invoke([this, group_index, new_bandwidth] {
+future<> io_queue::update_bandwidth_for_class_group(scheduling_supergroup ssg, uint64_t new_bandwidth) {
+    return futurize_invoke([this, ssg, new_bandwidth] {
         if (_group->_allocated_on == this_shard_id()) {
-            auto& pclass = _group->find_or_create_class_group(group_index);
+            auto& pclass = _group->find_or_create_class_group(ssg);
             pclass.update_bandwidth(new_bandwidth);
-            io_log.debug("Updated {} class group bandwidth to {}MB/s", group_index, new_bandwidth >> 20);
+            io_log.debug("Updated {} class group bandwidth to {}MB/s", ssg.index(), new_bandwidth >> 20);
         }
     });
 }
@@ -1268,15 +1267,15 @@ void io_queue::unthrottle_priority_class(const priority_class_data& pc) noexcept
     }
 }
 
-void io_queue::throttle_priority_class_group(unsigned group) noexcept {
+void io_queue::throttle_priority_class_group(scheduling_supergroup ssg) noexcept {
     for (auto&& s : _streams) {
-        s.fq.unplug_class_group(group);
+        s.fq.unplug_class_group(ssg.index());
     }
 }
 
-void io_queue::unthrottle_priority_class_group(unsigned group) noexcept {
+void io_queue::unthrottle_priority_class_group(scheduling_supergroup ssg) noexcept {
     for (auto&& s : _streams) {
-        s.fq.plug_class_group(group);
+        s.fq.plug_class_group(ssg.index());
     }
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -192,9 +192,9 @@ namespace seastar {
 seastar::logger seastar_logger("seastar");
 
 
-void reactor::update_shares_for_queues(internal::priority_class pc, uint32_t shares) {
+void reactor::update_shares_for_queues(scheduling_group sg, uint32_t shares) {
     for (auto&& q : _io_queues) {
-        q.second->update_shares_for_class(pc, shares);
+        q.second->update_shares_for_class(sg, shares);
     }
 }
 
@@ -204,10 +204,10 @@ void reactor::update_group_shares_for_queues(unsigned index, uint32_t shares) {
     }
 }
 
-future<> reactor::update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth) {
-    return smp::invoke_on_all([pc, bandwidth = bandwidth / _num_io_groups] {
-        return parallel_for_each(engine()._io_queues, [pc, bandwidth] (auto& queue) {
-            return queue.second->update_bandwidth_for_class(pc, bandwidth);
+future<> reactor::update_bandwidth_for_queues(scheduling_group sg, uint64_t bandwidth) {
+    return smp::invoke_on_all([sg, bandwidth = bandwidth / _num_io_groups] {
+        return parallel_for_each(engine()._io_queues, [sg, bandwidth] (auto& queue) {
+            return queue.second->update_bandwidth_for_class(sg, bandwidth);
         });
     });
 }
@@ -220,9 +220,9 @@ future<> reactor::update_bandwidth_for_queues(unsigned group_index, uint64_t ban
     });
 }
 
-void reactor::rename_queues(internal::priority_class pc, sstring new_name) {
+void reactor::rename_queues(scheduling_group sg, sstring new_name) {
     for (auto&& queue : _io_queues) {
-        queue.second->rename_priority_class(pc, new_name);
+        queue.second->rename_priority_class(sg, new_name);
     }
 }
 
@@ -5220,7 +5220,7 @@ reactor::destroy_scheduling_group(scheduling_group sg) noexcept {
         get_sg_data(sg).queue_is_initialized = false;
         _task_queues[sg._id].reset();
         for (auto&& queue : _io_queues) {
-            queue.second->destroy_priority_class(internal::priority_class(sg));
+            queue.second->destroy_priority_class(sg);
         }
     });
 
@@ -5289,11 +5289,11 @@ float scheduling_supergroup::get_shares() const noexcept {
 void
 scheduling_group::set_shares(float shares) noexcept {
     engine()._task_queues[_id]->set_shares(shares);
-    engine().update_shares_for_queues(internal::priority_class(*this), shares);
+    engine().update_shares_for_queues(*this, shares);
 }
 
 future<> scheduling_group::update_io_bandwidth(uint64_t bandwidth) const {
-    return engine().update_bandwidth_for_queues(internal::priority_class(*this), bandwidth);
+    return engine().update_bandwidth_for_queues(*this, bandwidth);
 }
 
 future<> scheduling_supergroup::update_io_bandwidth(uint64_t bandwidth) const {
@@ -5436,7 +5436,7 @@ rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_short
     return smp::invoke_on_all([sg, new_name, new_shortname] {
         engine()._task_queues[internal::scheduling_group_index(sg)]->rename(new_name, new_shortname);
         internal::execution_stage_manager::get().update_scheduling_group_name(sg);
-        engine().rename_queues(internal::priority_class(sg), new_name);
+        engine().rename_queues(sg, new_name);
         return engine().rename_scheduling_group_specific_data(sg);
     });
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -198,9 +198,9 @@ void reactor::update_shares_for_queues(scheduling_group sg, uint32_t shares) {
     }
 }
 
-void reactor::update_group_shares_for_queues(unsigned index, uint32_t shares) {
+void reactor::update_group_shares_for_queues(scheduling_supergroup ssg, uint32_t shares) {
     for (auto&& q : _io_queues) {
-        q.second->update_shares_for_class_group(index, shares);
+        q.second->update_shares_for_class_group(ssg, shares);
     }
 }
 
@@ -212,10 +212,10 @@ future<> reactor::update_bandwidth_for_queues(scheduling_group sg, uint64_t band
     });
 }
 
-future<> reactor::update_bandwidth_for_queues(unsigned group_index, uint64_t bandwidth) {
-    return smp::invoke_on_all([group_index, bandwidth = bandwidth / _num_io_groups] {
-        return parallel_for_each(engine()._io_queues, [group_index, bandwidth] (auto& queue) {
-            return queue.second->update_bandwidth_for_class_group(group_index, bandwidth);
+future<> reactor::update_bandwidth_for_queues(scheduling_supergroup ssg, uint64_t bandwidth) {
+    return smp::invoke_on_all([ssg, bandwidth = bandwidth / _num_io_groups] {
+        return parallel_for_each(engine()._io_queues, [ssg, bandwidth] (auto& queue) {
+            return queue.second->update_bandwidth_for_class_group(ssg, bandwidth);
         });
     });
 }
@@ -5298,13 +5298,13 @@ future<> scheduling_group::update_io_bandwidth(uint64_t bandwidth) const {
 
 future<> scheduling_supergroup::update_io_bandwidth(uint64_t bandwidth) const {
     SEASTAR_ASSERT(!is_root());
-    return engine().update_bandwidth_for_queues(index(), bandwidth);
+    return engine().update_bandwidth_for_queues(*this, bandwidth);
 }
 
 void scheduling_supergroup::set_shares(float shares) noexcept {
     if (!is_root()) {
         engine()._supergroups[index()]->set_shares(shares);
-        engine().update_group_shares_for_queues(index(), shares);
+        engine().update_group_shares_for_queues(*this, shares);
     }
 }
 

--- a/tests/perf/io_queue_latency.cc
+++ b/tests/perf/io_queue_latency.cc
@@ -62,7 +62,7 @@ struct io_queue_for_tests {
     }
 
     future<> enqueue(scheduling_group sg, size_t req_size) {
-        return queue.queue_request(internal::priority_class(sg),
+        return queue.queue_request(sg,
             internal::io_direction_and_length(internal::io_direction_and_length::read_idx, req_size),
             internal::io_request::make_read(0, 0, nullptr, req_size, false),
             nullptr, {}).discard_result();

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -100,8 +100,8 @@ struct io_queue_for_tests {
         }
     }
 
-    future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
-        return queue.queue_request(pc, dnl, std::move(req), intent, std::move(iovs));
+    future<size_t> queue_request(scheduling_group sg, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
+        return queue.queue_request(sg, dnl, std::move(req), intent, std::move(iovs));
     }
 
     size_t max_request_length(int dnl_idx) const noexcept {
@@ -112,21 +112,22 @@ struct io_queue_for_tests {
         return io_group::request_length_limit;
     }
 
-    void find_or_create_class(internal::priority_class pc) {
-        queue.find_or_create_class(pc);
+    void find_or_create_class(scheduling_group sg) {
+        queue.find_or_create_class(sg);
     }
 
     fair_queue& get_fair_queue() {
         return queue._streams[0].fq;
     }
 
-    bool is_class_registered(internal::priority_class pc) const noexcept {
-        return queue._priority_classes.size() > pc.id() && (queue._priority_classes[pc.id()] != nullptr);
+    bool is_class_registered(scheduling_group sg) const noexcept {
+        auto id = internal::scheduling_group_index(sg);
+        return queue._priority_classes.size() > id && (queue._priority_classes[id] != nullptr);
     }
 };
 
-internal::priority_class get_default_pc() {
-    return internal::priority_class(current_scheduling_group());
+scheduling_group get_default_pc() {
+    return current_scheduling_group();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_basic_flow) {
@@ -274,8 +275,6 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
     });
 
     io_queue_for_tests tio;
-    auto pc0 = internal::priority_class(sg0);
-    auto pc1 = internal::priority_class(sg1);
 
     size_t idx = 0;
     int val = 100;
@@ -285,9 +284,9 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
     std::vector<future<>> finished;
     std::vector<future<>> cancelled;
 
-    auto queue_legacy_request = [&] (io_queue_for_tests& q, internal::priority_class pc) {
+    auto queue_legacy_request = [&] (io_queue_for_tests& q, scheduling_group sg) {
         auto buf = std::make_unique<int>(val);
-        auto f = q.queue_request(pc, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), nullptr, {})
+        auto f = q.queue_request(sg, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), nullptr, {})
             .then([&file, idx, val, buf = std::move(buf)] (size_t len) {
                 BOOST_REQUIRE(file.data[idx] == val);
                 return make_ready_future<>();
@@ -297,9 +296,9 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
         val++;
     };
 
-    auto queue_live_request = [&] (io_queue_for_tests& q, internal::priority_class pc) {
+    auto queue_live_request = [&] (io_queue_for_tests& q, scheduling_group sg) {
         auto buf = std::make_unique<int>(val);
-        auto f = q.queue_request(pc, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), &live, {})
+        auto f = q.queue_request(sg, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), &live, {})
             .then([&file, idx, val, buf = std::move(buf)] (size_t len) {
                 BOOST_REQUIRE(file.data[idx] == val);
                 return make_ready_future<>();
@@ -309,9 +308,9 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
         val++;
     };
 
-    auto queue_dead_request = [&] (io_queue_for_tests& q, internal::priority_class pc) {
+    auto queue_dead_request = [&] (io_queue_for_tests& q, scheduling_group sg) {
         auto buf = std::make_unique<int>(val);
-        auto f = q.queue_request(pc, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), &dead, {})
+        auto f = q.queue_request(sg, internal::io_direction_and_length(internal::io_direction_and_length::write_idx, 0), file.make_write_req(idx, buf.get()), &dead, {})
             .then_wrapped([buf = std::move(buf)] (auto&& f) {
                 try {
                     f.get();
@@ -335,13 +334,13 @@ SEASTAR_THREAD_TEST_CASE(test_io_cancellation) {
         int pc = dice(reng) % 2;
         if (dice(reng) < 3) {
             fmt::print("queue live req to pc {}\n", pc);
-            queue_live_request(tio, pc == 0 ? pc0 : pc1);
+            queue_live_request(tio, pc == 0 ? sg0 : sg1);
         } else if (dice(reng) < 5) {
             fmt::print("queue dead req to pc {}\n", pc);
-            queue_dead_request(tio, pc == 0 ? pc0 : pc1);
+            queue_dead_request(tio, pc == 0 ? sg0 : sg1);
         } else {
             fmt::print("queue legacy req to pc {}\n", pc);
-            queue_legacy_request(tio, pc == 0 ? pc0 : pc1);
+            queue_legacy_request(tio, pc == 0 ? sg0 : sg1);
         }
     }
 
@@ -629,8 +628,8 @@ public:
         return _fq._priority_groups[index]->_parent == &_fq._root;
     }
 
-    std::optional<unsigned> get_parent_index(internal::priority_class pc) {
-        auto& pe = reinterpret_cast<fair_queue::priority_entry&>(*_fq._priority_classes[pc.id()]);
+    std::optional<unsigned> get_parent_index(scheduling_group sg) {
+        auto& pe = reinterpret_cast<fair_queue::priority_entry&>(*_fq._priority_classes[internal::scheduling_group_index(sg)]);
         if (pe._parent == &_fq._root) {
             return {};
         }
@@ -661,9 +660,9 @@ SEASTAR_THREAD_TEST_CASE(test_nested_priority_classes_basic_linkage) {
         destroy_scheduling_group(sg2).get();
     });
 
-    tio.find_or_create_class(internal::priority_class(sg0));
-    tio.find_or_create_class(internal::priority_class(sg1));
-    tio.find_or_create_class(internal::priority_class(sg2));
+    tio.find_or_create_class(sg0);
+    tio.find_or_create_class(sg1);
+    tio.find_or_create_class(sg2);
 
     seastar::testing::fair_queue_test fq(tio.get_fair_queue());
 
@@ -674,18 +673,17 @@ SEASTAR_THREAD_TEST_CASE(test_nested_priority_classes_basic_linkage) {
     BOOST_CHECK(fq.is_root_group(0));
     BOOST_CHECK(fq.is_root_group(1));
 
-    BOOST_CHECK(!fq.get_parent_index(internal::priority_class(sg0)));
-    BOOST_CHECK(fq.get_parent_index(internal::priority_class(sg1)) == 0);
-    BOOST_CHECK(fq.get_parent_index(internal::priority_class(sg2)) == 1);
+    BOOST_CHECK(!fq.get_parent_index(sg0));
+    BOOST_CHECK(fq.get_parent_index(sg1) == 0);
+    BOOST_CHECK(fq.get_parent_index(sg2) == 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_destroy_priority_class_with_requests) {
     io_queue_for_tests tio;
 
     auto sg = create_scheduling_group("a", 100).get();
-    auto pc = internal::priority_class(sg);
 
-    auto fx = tio.queue_request(pc,
+    auto fx = tio.queue_request(sg,
         internal::io_direction_and_length(internal::io_direction_and_length::read_idx, 0),
         internal::io_request::make_write(0, 0, nullptr, 1, false),
         nullptr, {});
@@ -698,10 +696,10 @@ SEASTAR_THREAD_TEST_CASE(test_destroy_priority_class_with_requests) {
     });
     BOOST_REQUIRE_EQUAL(fx.get(), 1);
 
-    BOOST_REQUIRE(tio.is_class_registered(pc));
-    tio.queue.destroy_priority_class(internal::priority_class(sg));
+    BOOST_REQUIRE(tio.is_class_registered(sg));
+    tio.queue.destroy_priority_class(sg);
     destroy_scheduling_group(sg).get();
-    BOOST_REQUIRE(!tio.is_class_registered(pc));
+    BOOST_REQUIRE(!tio.is_class_registered(sg));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_gauge_integrator_test) {
@@ -773,14 +771,14 @@ static constexpr size_t bw_slack = 128*1024;
 // the burst no longer dominates the comparison; min_window puts a floor on the
 // measured interval for those. The default preserves the historical behaviour of
 // returning on the first sample that meets the goal.
-static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, internal::priority_class pc, size_t bandwidth_goal, unsigned parallelizm = 1, std::chrono::seconds min_window = std::chrono::seconds(1), size_t req_size = 128*1024) {
-    fmt::print("Run {} workload\n", pc.id());
+static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, scheduling_group sg, size_t bandwidth_goal, unsigned parallelizm = 1, std::chrono::seconds min_window = std::chrono::seconds(1), size_t req_size = 128*1024) {
+    fmt::print("Run {} workload\n", internal::scheduling_group_index(sg));
     bool keep_going = true;
     uint64_t nr_requests = 0;
 
     auto submitter = parallel_for_each(std::views::iota(0u, parallelizm), [&] (auto i) {
         return do_until([&keep_going] { return !keep_going; }, [&] {
-            return tio.queue_request(pc,
+            return tio.queue_request(sg,
                 internal::io_direction_and_length(internal::io_direction_and_length::read_idx, req_size),
                 internal::io_request::make_write(0, 0, nullptr, req_size, false),
                 nullptr, {}).then([&nr_requests] (auto size) {
@@ -799,7 +797,7 @@ static future<size_t> run_and_check_bandwidth(io_queue_for_tests& tio, internal:
         co_await seastar::sleep(std::chrono::seconds(1));
         auto now = std::chrono::steady_clock::now();
         real_bandwidth = (nr_requests * req_size) / std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
-        fmt::print("Measured for {} {} MB/s, goal {} MB/s\n", pc.id(), real_bandwidth >> 20, bandwidth_goal >> 20);
+        fmt::print("Measured for {} {} MB/s, goal {} MB/s\n", internal::scheduling_group_index(sg), real_bandwidth >> 20, bandwidth_goal >> 20);
         if ((real_bandwidth >= bandwidth_goal && now >= start + min_window) || now >= stop) {
             break;
         }
@@ -848,12 +846,11 @@ SEASTAR_THREAD_TEST_CASE(test_class_bandwidth_throttler) {
     const size_t bandwidth = 100*1024*1024;
 
     auto sg = create_scheduling_group("a", 100).get();
-    auto pc = internal::priority_class(sg);
-    tio.queue.update_bandwidth_for_class(pc, bandwidth).get();
+    tio.queue.update_bandwidth_for_class(sg, bandwidth).get();
 
     background_drain drain(tio);
 
-    auto bw = run_and_check_bandwidth(tio, pc, bandwidth * 0.9).get();
+    auto bw = run_and_check_bandwidth(tio, sg, bandwidth * 0.9).get();
     BOOST_REQUIRE_LE(bw, bandwidth * 1.15);
 
     drain.stop().get();
@@ -867,12 +864,11 @@ SEASTAR_THREAD_TEST_CASE(test_class_group_bandwidth_throttler) {
     const size_t bandwidth = 100*1024*1024;
     auto ssg = create_scheduling_supergroup(100).get();
     auto sg = create_scheduling_group("a", "a", 100, ssg).get();
-    auto pc = internal::priority_class(sg);
     tio.queue.update_bandwidth_for_class_group(ssg.index(), bandwidth).get();
 
     background_drain drain(tio);
 
-    auto bw = run_and_check_bandwidth(tio, pc, bandwidth * 0.9).get();
+    auto bw = run_and_check_bandwidth(tio, sg, bandwidth * 0.9).get();
     BOOST_REQUIRE_LE(bw, bandwidth + burst + bw_slack);
 
     drain.stop().get();
@@ -889,20 +885,18 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler) {
 
     auto ssg = create_scheduling_supergroup(100).get();
     auto sg0 = create_scheduling_group("a", "a", 100, ssg).get();
-    auto pc0 = internal::priority_class(sg0);
     auto sg1 = create_scheduling_group("b", "b", 100, ssg).get();
-    auto pc1 = internal::priority_class(sg1);
 
-    tio.queue.update_bandwidth_for_class(pc0, bandwidth).get();
-    tio.queue.update_bandwidth_for_class(pc1, bandwidth).get();
+    tio.queue.update_bandwidth_for_class(sg0, bandwidth).get();
+    tio.queue.update_bandwidth_for_class(sg1, bandwidth).get();
     tio.queue.update_bandwidth_for_class_group(ssg.index(), group_bandwidth).get();
 
     background_drain drain(tio);
 
     // Set goal to be 40% of the maximum, as both classes will hit
     // the group limit and won't reach their personal limits
-    auto f0 = run_and_check_bandwidth(tio, pc0, bandwidth * 0.4);
-    auto f1 = run_and_check_bandwidth(tio, pc1, bandwidth * 0.4);
+    auto f0 = run_and_check_bandwidth(tio, sg0, bandwidth * 0.4);
+    auto f1 = run_and_check_bandwidth(tio, sg1, bandwidth * 0.4);
 
     auto bw0 = f0.get();
     auto bw1 = f1.get();
@@ -928,19 +922,17 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_1_unlimited) {
 
     auto ssg = create_scheduling_supergroup(100).get();
     auto sg0 = create_scheduling_group("a", "a", 100, ssg).get();
-    auto pc0 = internal::priority_class(sg0);
     auto sg1 = create_scheduling_group("b", "b", 100, ssg).get();
-    auto pc1 = internal::priority_class(sg1);
 
-    tio.queue.update_bandwidth_for_class(pc0, bandwidth).get();
+    tio.queue.update_bandwidth_for_class(sg0, bandwidth).get();
     tio.queue.update_bandwidth_for_class_group(ssg.index(), group_bandwidth).get();
 
     background_drain drain(tio);
 
     // Set goal to be 40% of the maximum, as both classes will hit
     // the group limit and won't reach their personal limits
-    auto f0 = run_and_check_bandwidth(tio, pc0, bandwidth * 0.4);
-    auto f1 = run_and_check_bandwidth(tio, pc1, group_bandwidth * 0.4);
+    auto f0 = run_and_check_bandwidth(tio, sg0, bandwidth * 0.4);
+    auto f1 = run_and_check_bandwidth(tio, sg1, group_bandwidth * 0.4);
 
     auto bw0 = f0.get();
     auto bw1 = f1.get();
@@ -966,9 +958,7 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
 
     auto ssg = create_scheduling_supergroup(200).get();
     auto sg0 = create_scheduling_group("a", "a", 400, ssg).get();
-    auto pc0 = internal::priority_class(sg0);
     auto sg1 = create_scheduling_group("b", "b", 100, ssg).get();
-    auto pc1 = internal::priority_class(sg1);
 
     tio.queue.update_bandwidth_for_class_group(ssg.index(), bandwidth).get();
 
@@ -980,8 +970,8 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
     // in how it lands between the two classes moves the ratio further than the
     // check allows. Four seconds dilutes the burst term, and the quantisation of
     // the measurement itself, by 4x.
-    auto f0 = run_and_check_bandwidth(tio, pc0, bandwidth * 0.8 * 0.95, 4, std::chrono::seconds(4));
-    auto f1 = run_and_check_bandwidth(tio, pc1, bandwidth * 0.2 * 0.95, 4, std::chrono::seconds(4));
+    auto f0 = run_and_check_bandwidth(tio, sg0, bandwidth * 0.8 * 0.95, 4, std::chrono::seconds(4));
+    auto f1 = run_and_check_bandwidth(tio, sg1, bandwidth * 0.2 * 0.95, 4, std::chrono::seconds(4));
     auto bw0 = f0.get();
     auto bw1 = f1.get();
 

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -864,7 +864,7 @@ SEASTAR_THREAD_TEST_CASE(test_class_group_bandwidth_throttler) {
     const size_t bandwidth = 100*1024*1024;
     auto ssg = create_scheduling_supergroup(100).get();
     auto sg = create_scheduling_group("a", "a", 100, ssg).get();
-    tio.queue.update_bandwidth_for_class_group(ssg.index(), bandwidth).get();
+    tio.queue.update_bandwidth_for_class_group(ssg, bandwidth).get();
 
     background_drain drain(tio);
 
@@ -889,7 +889,7 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler) {
 
     tio.queue.update_bandwidth_for_class(sg0, bandwidth).get();
     tio.queue.update_bandwidth_for_class(sg1, bandwidth).get();
-    tio.queue.update_bandwidth_for_class_group(ssg.index(), group_bandwidth).get();
+    tio.queue.update_bandwidth_for_class_group(ssg, group_bandwidth).get();
 
     background_drain drain(tio);
 
@@ -925,7 +925,7 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_1_unlimited) {
     auto sg1 = create_scheduling_group("b", "b", 100, ssg).get();
 
     tio.queue.update_bandwidth_for_class(sg0, bandwidth).get();
-    tio.queue.update_bandwidth_for_class_group(ssg.index(), group_bandwidth).get();
+    tio.queue.update_bandwidth_for_class_group(ssg, group_bandwidth).get();
 
     background_drain drain(tio);
 
@@ -960,7 +960,7 @@ SEASTAR_THREAD_TEST_CASE(test_2_class_group_bandwidth_throttler_fair_shares) {
     auto sg0 = create_scheduling_group("a", "a", 400, ssg).get();
     auto sg1 = create_scheduling_group("b", "b", 100, ssg).get();
 
-    tio.queue.update_bandwidth_for_class_group(ssg.index(), bandwidth).get();
+    tio.queue.update_bandwidth_for_class_group(ssg, bandwidth).get();
 
     background_drain drain(tio);
 


### PR DESCRIPTION
A preparatory cleanup of how io_queue addresses its priority classes and
supergroups, ahead of the shard-aware dispatch work. No functional change.

internal::priority_class used to be the compatibility glue between the
unified and the non-unified scheduling class hierarchies. The latter is
gone, so it now only hides the scheduling_group it was made of -- to the
point where find_or_create_class() had to convert the index back with
scheduling_group_from_index() to get that group again. The same applies to
supergroups, which the queue described with an optional<unsigned> index,
and in places with a raw unsigned one: scheduling_supergroup already says
exactly that, its .index() being valid precisely when the optional<> was
engaged.

So pass the scheduling_group and the scheduling_supergroup around, and
take an index only where one is really needed -- at the fair_queue
boundary, which addresses classes and groups by raw index anyway.

On top of that, give the queue a shard-local priority_class_group_data to
mirror a supergroup, the way priority_class_data mirrors a scheduling
group, and collect the find-or-create boilerplate the three lookups shared.
