### PR TITLE
tls: allow configuring the number of TLS1.3 session tickets sent

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -332,6 +332,14 @@ namespace tls {
         void set_session_resume_mode(session_resume_mode);
 
         /**
+         * As above, but also sets the number of session tickets issued
+         * per handshake (default is the backend default, typically 2).
+         * Useful for clients that will open several connections (e.g. one
+         * per shard) and want a spare ticket for each.
+        */
+        void set_session_resume_mode(session_resume_mode, unsigned num_tickets);
+
+        /**
          * Sets Application-Layer Protocol Name (ALPN) supported by the server,
          * in preference order.
          */
@@ -379,6 +387,9 @@ namespace tls {
          * simply call this method again to regenerate the key.
          */
         void set_session_resume_mode(session_resume_mode);
+
+        /// As above, but also sets the number of session tickets issued per handshake.
+        void set_session_resume_mode(session_resume_mode, unsigned num_tickets);
 
         /**
          * Sets Application-Layer Protocol Name (ALPN) supported by the server,
@@ -611,6 +622,16 @@ namespace tls {
      * delay this call to sometime before shutting down/closing the socket.
     */
     future<session_data> get_session_resume_data(connected_socket&);
+
+    /**
+     * Returns the number of extra TLS1.3 session tickets explicitly sent by
+     * the server post-handshake, if a non-default count was requested via
+     * set_session_resume_mode(session_resume_mode, unsigned). Returns
+     * std::nullopt if no such manual send occurred (e.g. default count,
+     * client socket, or non-gnutls backend).
+     * Mainly for testing purposes.
+    */
+    future<std::optional<unsigned>> get_session_tickets_sent(connected_socket&);
 
     /**
      * Gets the Application-Layer Protocol Name (ALPN) selected during the TLS handshake.

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -306,12 +306,31 @@ void tls::server_credentials::set_session_resume_mode(session_resume_mode m) {
     _impl->set_session_resume_mode(m);
 }
 
+void tls::server_credentials::set_session_resume_mode(session_resume_mode m, unsigned num_tickets) {
+    _impl->set_session_resume_mode(m, {}, num_tickets);
+}
+
 void tls::server_credentials::set_alpn_protocols(const std::vector<sstring>& protocols) {
     _impl->set_alpn_protocols(protocols);
 }
 
+// Stored in _blobs (not a data member) to avoid an ABI-breaking layout
+// change to the public credentials_builder value type.
+static unsigned get_num_session_tickets(const std::multimap<std::string_view, std::any>& blobs) {
+    auto i = blobs.find(num_session_tickets_key);
+    return i == blobs.end() ? 0u : std::any_cast<unsigned>(i->second);
+}
+
 void tls::credentials_builder::set_session_resume_mode(session_resume_mode m) {
+    set_session_resume_mode(m, 0);
+}
+
+void tls::credentials_builder::set_session_resume_mode(session_resume_mode m, unsigned num_tickets) {
     _session_resume_mode = m;
+    _blobs.erase(num_session_tickets_key);
+    if (num_tickets != 0) {
+        _blobs.emplace(num_session_tickets_key, num_tickets);
+    }
     if (m != session_resume_mode::NONE) {
         _session_resume_key = internal::crypto::provider().get_tls_backend().generate_session_ticket_key();
     }
@@ -392,7 +411,7 @@ void tls::credentials_builder::apply_to(certificate_credentials& creds) const {
 
     creds._impl->set_client_auth(_client_auth);
     // Note: this causes server session key rotation on cert reload
-    creds._impl->set_session_resume_mode(_session_resume_mode, std::span{_session_resume_key.begin(), _session_resume_key.end()});
+    creds._impl->set_session_resume_mode(_session_resume_mode, std::span{_session_resume_key.begin(), _session_resume_key.end()}, get_num_session_tickets(_blobs));
 
     if (!_alpn_protocols.empty()) {
         creds._impl->set_alpn_protocols(_alpn_protocols);
@@ -559,7 +578,7 @@ public:
                 return;
             }
             try {
-                set_session_resume_mode(_session_resume_mode);
+                set_session_resume_mode(_session_resume_mode, get_num_session_tickets(_blobs));
                 if (_creds) {
                     _creds->rebuild(*this);
                 }
@@ -780,6 +799,10 @@ future<bool> tls::check_session_is_resumed(connected_socket& socket) {
 
 future<tls::session_data> tls::get_session_resume_data(connected_socket& socket) {
     return get_tls_socket(socket)->get_session_resume_data();
+}
+
+future<std::optional<unsigned>> tls::get_session_tickets_sent(connected_socket& socket) {
+    return get_tls_socket(socket)->get_session_tickets_sent();
 }
 
 future<std::optional<sstring>> tls::get_selected_alpn_protocol(connected_socket& socket) {

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -76,6 +76,7 @@ constexpr auto x509_crl_key = std::string_view("x509_crl");
 constexpr auto x509_key_key = std::string_view("x509_key");
 constexpr auto pkcs12_key = std::string_view("pkcs12");
 constexpr auto system_trust = std::string_view("system_trust");
+constexpr auto num_session_tickets_key = std::string_view("num_session_tickets");
 
 struct x509_simple {
     buffer_type data;
@@ -145,7 +146,7 @@ public:
     virtual void set_dn_verification_callback(dn_callback) = 0;
     virtual void set_enable_certificate_verification(bool) = 0;
     virtual void set_client_auth(client_auth) = 0;
-    virtual void set_session_resume_mode(session_resume_mode, std::span<const uint8_t> key = {}) = 0;
+    virtual void set_session_resume_mode(session_resume_mode, std::span<const uint8_t> key = {}, unsigned num_tickets = 0) = 0;
     virtual void set_alpn_protocols(const std::vector<sstring>&) = 0;
     virtual void set_dh_params(const tls::dh_params&) = 0;
 
@@ -187,6 +188,8 @@ public:
     virtual future<sstring> get_cipher_suite() = 0;
     virtual future<sstring> get_protocol_version() = 0;
     virtual future<> force_rehandshake() = 0;
+    // Backend-specific; only gnutls tracks this. Used by tests.
+    virtual std::optional<unsigned> get_session_tickets_sent() { return std::nullopt; }
 };
 
 /// Shared-ownership wrapper for session_impl.
@@ -278,6 +281,9 @@ public:
     }
     future<session_data> get_session_resume_data() {
         return _session->get_session_resume_data();
+    }
+    future<std::optional<unsigned>> get_session_tickets_sent() {
+        return make_ready_future<std::optional<unsigned>>(_session->get_session_tickets_sent());
     }
     future<std::optional<sstring>> get_selected_alpn_protocol() {
         return _session->get_selected_alpn_protocol();

--- a/src/net/tls_gnutls.cc
+++ b/src/net/tls_gnutls.cc
@@ -378,8 +378,9 @@ public:
     client_auth get_client_auth() const {
         return _client_auth;
     }
-    void set_session_resume_mode(session_resume_mode m, std::span<const uint8_t> key = {}) override {
+    void set_session_resume_mode(session_resume_mode m, std::span<const uint8_t> key = {}, unsigned num_tickets = 0) override {
         _session_resume_mode = m;
+        _num_session_tickets = num_tickets;
         // (re-)generate session key
         if (m != session_resume_mode::NONE) {
             _session_resume_key = {};
@@ -396,6 +397,9 @@ public:
     }
     const gnutls_datum_t* get_session_resume_key() const {
         return &_session_resume_key;
+    }
+    unsigned get_num_session_tickets() const {
+        return _num_session_tickets;
     }
     void set_priority_string(const sstring& prio) override {
         const char * err = prio.c_str();
@@ -444,6 +448,7 @@ private:
     std::unique_ptr<std::remove_pointer_t<gnutls_priority_t>, void(*)(gnutls_priority_t)> _priority;
     client_auth _client_auth = client_auth::NONE;
     session_resume_mode _session_resume_mode = session_resume_mode::NONE;
+    unsigned _num_session_tickets = 0; // 0 == gnutls default
     semaphore _system_trust_sem {1};
     dn_callback _dn_callback;
     bool _enable_certificate_verification = true;
@@ -478,9 +483,14 @@ public:
             : _type(t), _sock(std::move(sock)), _creds(static_pointer_cast<gnutls_provider_certificate_credentials_impl>(creds->_impl)),
                     _in(_sock->source()), _out(_sock->sink()),
                     _in_sem(1), _out_sem(1), _options(std::move(options)), _output_pending(
-                    make_ready_future<>()), _session([t] {
+                    make_ready_future<>()), _session([t, num_tickets = _num_session_tickets] {
                 gnutls_session_t session;
-                gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
+                uint32_t flags = GNUTLS_NONBLOCK|uint32_t(t);
+                // Non-default ticket count must be sent manually post-handshake.
+                if (t == type::SERVER && num_tickets != 0) {
+                    flags |= GNUTLS_NO_AUTO_SEND_TICKET;
+                }
+                gtls_chk(gnutls_init(&session, flags));
                 return session;
             }(), &gnutls_deinit) {
         gtls_chk(gnutls_set_default_priority(*this));
@@ -501,7 +511,7 @@ public:
                     break;
             }
             // Maybe set up server session ticket support
-            switch (_creds->get_session_resume_mode()) {
+            switch (_resume_mode) {
                 case session_resume_mode::NONE:
                 default:
                     break;
@@ -568,10 +578,12 @@ public:
         return s;
     }
 
-    future<> send_alert(gnutls_alert_level_t level, gnutls_alert_description_t desc) {
-        return repeat([this, level, desc]() {
-            auto res = gnutls_alert_send(*this, level, desc);
-            switch(res) {
+    // Retries a gnutls send call until it succeeds or fails with a non-recoverable error.
+    template<typename SendOnce>
+    future<> retry_gnutls_send(SendOnce send_once) {
+        return repeat([this, send_once = std::move(send_once)] {
+            auto res = send_once();
+            switch (res) {
             case GNUTLS_E_SUCCESS:
                 return wait_for_output().then([] {
                     return make_ready_future<stop_iteration>(stop_iteration::yes);
@@ -586,6 +598,23 @@ public:
                     return make_ready_future<stop_iteration>(stop_iteration::yes);
                 });
             }
+        });
+    }
+    future<> send_session_tickets(unsigned num_tickets) {
+        // Best-effort: a failure here must not fail an otherwise successful,
+        // already-verified handshake, nor leave the session marked as broken.
+        return retry_gnutls_send([this, num_tickets] {
+            return gnutls_session_ticket_send(*this, num_tickets, 0);
+        }).then([this, num_tickets] {
+            _tickets_sent = num_tickets;
+        }).handle_exception([this](std::exception_ptr) {
+            _error = {};
+            return make_ready_future<>();
+        });
+    }
+    future<> send_alert(gnutls_alert_level_t level, gnutls_alert_description_t desc) {
+        return retry_gnutls_send([this, level, desc] {
+            return gnutls_alert_send(*this, level, desc);
         });
     }
 
@@ -640,6 +669,11 @@ public:
                 verify();
             }
             _connected = true;
+            if (_type == type::SERVER && _num_session_tickets != 0
+                    && _resume_mode == session_resume_mode::TLS13_SESSION_TICKET
+                    && gnutls_protocol_get_version(*this) == GNUTLS_TLS1_3) {
+                return send_session_tickets(_num_session_tickets);
+            }
             // make sure we reset output_pending
             return wait_for_output();
         } catch (...) {
@@ -1167,6 +1201,9 @@ public:
             return gnutls_session_is_resumed(*this) != 0;
         });
     }
+    std::optional<unsigned> get_session_tickets_sent() override {
+        return _tickets_sent;
+    }
     future<session_data> get_session_resume_data() override {
         return state_checked_access([this] {
             /**
@@ -1344,6 +1381,11 @@ private:
 
     std::unique_ptr<net::connected_socket_impl> _sock;
     shared_ptr<gnutls_provider_certificate_credentials_impl> _creds;
+    // Snapshotted at construction so a concurrent credentials_builder reload
+    // can't change these mid-session and disagree with the GNUTLS_NO_AUTO_SEND_TICKET
+    // flag decision already baked into the gnutls session at that point.
+    session_resume_mode _resume_mode = _creds->get_session_resume_mode();
+    unsigned _num_session_tickets = _creds->get_num_session_tickets();
     data_source _in;
     data_sink _out;
 
@@ -1355,6 +1397,8 @@ private:
     bool _shutdown = false;
     bool _connected = false;
     std::exception_ptr _error;
+    // Set when a non-default ticket count is sent manually post-handshake. Used by tests.
+    std::optional<unsigned> _tickets_sent;
 
     future<> _output_pending;
     buf_type _input;

--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -595,8 +595,9 @@ public:
     tls::client_auth get_client_auth() const {
         return _client_auth;
     }
-    void set_session_resume_mode(tls::session_resume_mode m, std::span<const uint8_t> key = {}) override {
+    void set_session_resume_mode(tls::session_resume_mode m, std::span<const uint8_t> key = {}, unsigned num_tickets = 0) override {
         _session_resume_mode = m;
+        _num_session_tickets = num_tickets;
         if (m != tls::session_resume_mode::NONE) {
             _session_ticket_keys = {};
             if (key.empty()) {
@@ -614,6 +615,10 @@ public:
 
     const session_ticket_keys & get_session_ticket_keys() const {
         return _session_ticket_keys;
+    }
+
+    unsigned get_num_session_tickets() const {
+        return _num_session_tickets;
     }
 
     void set_dn_verification_callback(tls::dn_callback cb) override {
@@ -725,6 +730,7 @@ private:
 
     tls::client_auth _client_auth = tls::client_auth::NONE;
     tls::session_resume_mode _session_resume_mode = tls::session_resume_mode::NONE;
+    unsigned _num_session_tickets = 0; // 0 == OpenSSL default
     bool _enable_server_precedence = false;
     bool _enable_tls_renegotiation = false;
     bool _crl_check_flag_set = false;
@@ -1954,6 +1960,11 @@ private:
                     // By default, SSL contexts have server size cache enabled
                     if (1 != SSL_CTX_set_tlsext_ticket_key_evp_cb(ssl_ctx.get(), &session_ticket_cb)) {
                         throw make_openssl_error("Failed to set session ticket callback function");
+                    }
+                    if (auto n = _creds->get_num_session_tickets(); n != 0) {
+                        if (1 != SSL_CTX_set_num_tickets(ssl_ctx.get(), n)) {
+                            throw make_openssl_error("Failed to set number of session tickets");
+                        }
                     }
                     break;
             }

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1677,12 +1677,12 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
     }
 }
 
-static void do_test_tls13_session_tickets(bool reset_server) {
+static void do_test_tls13_session_tickets(bool reset_server, unsigned num_tickets = 0) {
     tls::credentials_builder b;
 
     b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
     b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
-    b.set_session_resume_mode(tls::session_resume_mode::TLS13_SESSION_TICKET);
+    b.set_session_resume_mode(tls::session_resume_mode::TLS13_SESSION_TICKET, num_tickets);
     b.set_priority_string("SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.3");
 
     auto creds = b.build_certificate_credentials();
@@ -1728,6 +1728,17 @@ static void do_test_tls13_session_tickets(bool reset_server) {
         // get ticket data
         sess_data = tls::get_session_resume_data(c).get();
         BOOST_REQUIRE(!sess_data.empty());
+
+        // verify the requested non-default ticket count was actually sent.
+        // Only gnutls sends extra tickets manually post-handshake; openssl
+        // configures the count via SSL_CTX_set_num_tickets and doesn't track it here.
+        auto tickets_sent = tls::get_session_tickets_sent(s.connection).get();
+        if (using_gnutls() && num_tickets != 0) {
+            BOOST_REQUIRE(tickets_sent);
+            BOOST_REQUIRE_EQUAL(*tickets_sent, num_tickets);
+        } else {
+            BOOST_REQUIRE(!tickets_sent);
+        }
 
         in.close().get();
         out.close().get();
@@ -1795,6 +1806,10 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
 
 SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets_retain_session_key) {
     do_test_tls13_session_tickets(true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets_custom_count) {
+    do_test_tls13_session_tickets(false, 4);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets_invalidated_by_reload) {


### PR DESCRIPTION
## Summary

GnuTLS and OpenSSL both default to sending 2 session tickets on the server
side, but a client that will open multiple connections (e.g. one per shard)
can benefit from requesting more, so it has a spare ticket for each
subsequent connection.

Specific intended use case: a ScyllaDB CQL client that will open TLS connections to all shards does not need to do the whole negotiation, if it can get enough session tickets for all shards it is going to connect to.

Adds a new overload of `set_session_resume_mode()` taking a ticket count on
both `server_credentials` and `credentials_builder` (a new overload, not a
default argument, to avoid an ABI break on the existing symbol). OpenSSL maps
this directly to `SSL_CTX_set_num_tickets()`. GnuTLS has no equivalent
context-wide knob; this disables its auto-send behavior and sends the
requested count explicitly after the handshake, but only when TLS1.3 was
actually negotiated, since `gnutls_session_ticket_send()` is only valid under
TLS1.3.

Fixes #3688

## Test plan
- [x] New unit test `test_tls13_session_tickets_custom_count` in `tests/unit/tls_test.cc`
- [x] Full `tls_test` suite passes (54/55 cases, 1 pre-existing skip, 371/371 assertions)
- [x] Verified end-to-end against a live ScyllaDB build: patched a throwaway config knob into `db/config.cc`, stood up a 4-shard TLS cluster, and confirmed via a standalone raw-TLS Go client that the server sends exactly the configured number of `NewSessionTicket` messages per handshake (verified at both 4 and 7 configured tickets)


CC @Lorak-mmk 